### PR TITLE
fix(deployment): keep server env out of client bootstrap

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,20 +1,20 @@
 import * as Sentry from "@sentry/nextjs";
 
 import { isExpectedError } from "@/core/errors/app-errors";
-import { env } from "@/env";
 
-const sentryEnabled = Boolean(env.NEXT_PUBLIC_SENTRY_DSN);
+const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const sentryEnabled = Boolean(sentryDsn);
 
 if (sentryEnabled) {
   Sentry.init({
-    dsn: env.NEXT_PUBLIC_SENTRY_DSN,
+    dsn: sentryDsn,
     tracesSampleRate: 0,
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
     beforeSend(event, hint) {
       if (isExpectedError(hint?.originalException)) return null;
 
-      if (env.NODE_ENV !== "production") {
+      if (process.env.NODE_ENV !== "production") {
         console.error(hint?.originalException ?? event);
         return null;
       }

--- a/tests/conventions/env-config.test.ts
+++ b/tests/conventions/env-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { resolveAppMode } from "@/core/config/environment";
 
@@ -9,5 +9,29 @@ describe("application mode configuration", () => {
 
   it.each([undefined, "", " ", "production", "preview"])("rejects %s", (mode) => {
     expect(() => resolveAppMode({ APP_MODE: mode })).toThrow(/APP_MODE/);
+  });
+});
+
+vi.mock("@sentry/nextjs", () => ({
+  captureRouterTransitionStart: vi.fn(),
+  init: vi.fn(),
+}));
+vi.mock("@/env", () => {
+  throw new Error("client instrumentation imported the server environment");
+});
+
+describe("client instrumentation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("does not evaluate server-only application configuration", async () => {
+    vi.stubEnv("APP_MODE", "");
+    vi.stubEnv("NEXT_PUBLIC_SENTRY_DSN", "");
+
+    await expect(import("@/instrumentation-client")).resolves.toMatchObject({
+      onRouterTransitionStart: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- keep the server-wide environment module out of Next.js client instrumentation
- read only the public Sentry DSN and framework-provided `NODE_ENV` in the browser bootstrap
- add a regression test that fails if client instrumentation imports `@/env`

## Business context

Production currently fails before hydration because `instrumentation-client.ts` imports `@/env`, which eagerly validates server-only `APP_MODE` in the browser. Vercel has `APP_MODE` configured correctly; the browser intentionally cannot read an unprefixed server environment variable.

This restores the intended flow where the server validates `APP_MODE` and passes the resolved mode into client providers as a prop.

## Screenshots (optional)

Not applicable; this fixes the global client bootstrap before UI rendering.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation

## Test plan

- `yarn vitest run tests/conventions/env-config.test.ts`
- `yarn test` — 86 files, 671 tests
- `yarn lint:check`
- `yarn typecheck`
- production-mode `yarn build` using disposable localhost configuration
- scan generated client chunks for APP_MODE validation and server database/auth variable names
- verify the READY Vercel Preview serves `appMode: "cloud"`, retains Sentry instrumentation, and contains no APP_MODE exception in its global client chunks

## Checklist

- [x] The change follows project conventions and standards
- [x] I reviewed the changes before requesting review
- [x] I validated the change locally
- [x] Documentation is not required for this internal boundary fix
