### PR TITLE
fix(auth): preserve social oauth origin

### DIFF
--- a/features/auth/__tests__/auth.service.test.ts
+++ b/features/auth/__tests__/auth.service.test.ts
@@ -9,6 +9,7 @@ vi.mock("next/headers", () => ({
   headers: () =>
     new Headers({
       host: "feat-inbox.customermates.com",
+      origin: "https://feat-inbox.customermates.com",
       "x-forwarded-proto": "https",
     }),
 }));
@@ -87,16 +88,22 @@ describe("AuthService callback URLs", () => {
     );
   });
 
-  it("lets the OAuth proxy infer Preview origin when social sign-in has no callback", async () => {
+  it("gives the OAuth proxy the current request origin and a safe default callback", async () => {
     await service.continueWithSocials({ provider: "google" });
 
     expect(mocks.signInSocial).toHaveBeenCalledWith({
+      request: expect.any(Request),
       headers: expect.any(Headers),
+      asResponse: false,
       body: {
         provider: "google",
+        callbackURL: "/",
         errorCallbackURL: "/auth/signin",
       },
     });
+    expect(mocks.signInSocial.mock.calls[0][0].request.url).toBe(
+      "https://feat-inbox.customermates.com/api/auth/sign-in/social",
+    );
   });
 
   it("preserves explicit social callback and error URLs", async () => {
@@ -108,6 +115,7 @@ describe("AuthService callback URLs", () => {
 
     expect(mocks.signInSocial).toHaveBeenCalledWith(
       expect.objectContaining({
+        request: expect.any(Request),
         body: {
           provider: "microsoft",
           callbackURL: "https://feat-inbox.customermates.com/en/inbox",

--- a/features/auth/auth.service.ts
+++ b/features/auth/auth.service.ts
@@ -176,11 +176,20 @@ export class AuthService {
     callbackURL?: string;
     errorCallbackURL?: string;
   }) {
+    const requestHeaders = await headers();
+    const requestOrigin = requestHeaders.get("origin") ?? env.BASE_URL;
+    const request = new Request(new URL("/api/auth/sign-in/social", requestOrigin), {
+      method: "POST",
+      headers: requestHeaders,
+    });
+
     const res = await auth.api.signInSocial({
-      headers: await headers(),
+      request,
+      headers: requestHeaders,
+      asResponse: false,
       body: {
         provider: args.provider,
-        ...(args.callbackURL ? { callbackURL: args.callbackURL } : {}),
+        callbackURL: args.callbackURL ?? "/",
         errorCallbackURL: args.errorCallbackURL ?? "/auth/signin",
       },
     });


### PR DESCRIPTION
# Pull Request

## Summary

- Preserve the original Server Action → interactor → AuthService social sign-in flow.
- Give Better Auth the incoming browser request origin so its OAuth Proxy distinguishes Production from vanity Preview domains.
- Default an absent social callback to `/` so completed sign-ins return to the application rather than `/api/auth`.
- Keep Better Auth's object return contract explicit with `asResponse: false`.

## Business context

Google sign-in on Production could finish at `/api/auth`, while Microsoft sign-in could finish on a generated Vercel deployment hostname. The direct Better Auth API call had the request headers but no native request URL, so the OAuth Proxy fell back to Vercel's generated URL.

## Screenshots (optional)

Not applicable; this changes OAuth request routing without changing the UI.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation

## Test plan

- `yarn typecheck`
- `yarn lint`
- `yarn test` — 101 files, 781 tests
- Local Google OAuth authorization URL smoke test
- Local Microsoft OAuth authorization URL smoke test
- Deployed Production and vanity Preview callback verification before merge

## Checklist

- [x] The change follows project conventions and standards
- [x] I reviewed the changes before requesting review
- [x] I validated the change locally
- [x] I updated documentation when required
