### PR TITLE
ci(policy): unify the ci check name and refresh the policy pin

### DIFF
--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -17,4 +17,4 @@ jobs:
       contents: read
       pull-requests: read
       statuses: write
-    uses: customermates/.github/.github/workflows/repository-policy.yml@33b086c450fb512493227ebb465bee15de792b2e
+    uses: customermates/.github/.github/workflows/repository-policy.yml@2af0536c426fd2f2d9353b63e97a5ddf8e639520

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  ci:
+    name: ci
     runs-on: ubuntu-latest
     env:
       APP_MODE: self-hosted


### PR DESCRIPTION
## Summary

- Rename the test workflow's job to `ci` so every organization repository emits the identical required check, and bump the pinned shared-policy workflow to the current audited commit that includes the dependabot body-validation exemption.

## Context

The organization consolidated branch protection into org-level rulesets on 2026-07-20; moving the required-check pair (`ci`, `repository-policy`) to the organization layer needs all repositories to emit the same check names, and this repository still reported `test`.

## Validation

- Both workflow files parse as YAML; the job body is unchanged apart from its identifier and display name.
- The pinned commit `2af0536c426fd2f2d9353b63e97a5ddf8e639520` is verified as the current `customermates/.github` main, whose validator passes its self-test.
- This pull request's own head emits the renamed `ci` check, satisfying the repository's required-checks ruleset.

## Impact and rollback

Future pull requests report `ci` instead of `test`; no test content or Docker behavior changes. Roll back by reverting the squash commit and restoring `test` to the required-checks ruleset.
