### PR TITLE
fix(deployment): fail closed before the destructive Demo reset

### DIFF
--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,10 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Host and database of the endpoint Prisma will actually migrate against, with the
+# scheme and credentials stripped off. Mirrors the precedence in prisma.config.ts:
+# DIRECT_URL wins, DATABASE_URL is the fallback.
+migration_target() {
+  local url stripped hostport path
+  url="${DIRECT_URL:-${DATABASE_URL:-}}"
+  stripped="${url#*://}"
+  stripped="${stripped#*@}"
+  hostport="${stripped%%[/?]*}"
+  path="${stripped#"$hostport"}"
+  path="${path#/}"
+  printf '%s/%s' "${hostport%%:*}" "${path%%\?*}"
+}
+
 if [[ "${VERCEL_ENV:-}" == "preview" && "${VERCEL_TARGET_ENV:-}" == "demo" && "${APP_MODE:-}" == "demo" ]]; then
+  # `prisma migrate reset` drops the schema BEFORE it reapplies migrations, and it takes
+  # the advisory lock only in the reapply step. A failure in between leaves the database
+  # with no tables at all - which is exactly how the Demo environment went down on
+  # 2026-07-20 (P1002, lock wait timed out after the drop had already run).
+  #
+  # So every check below fails closed: a missing or mismatched variable aborts the build
+  # while the database is still intact. VERCEL_ENV/VERCEL_TARGET_ENV/APP_MODE above are
+  # only labels - none of them says anything about which database we are pointed at.
+  if [[ -z "${DIRECT_URL:-}" ]]; then
+    echo "ERROR: DIRECT_URL is not set on the Demo environment." >&2
+    echo "Migrations take a session-scoped advisory lock, which does not survive a" >&2
+    echo "transaction pooler. Point DIRECT_URL at the unpooled Demo endpoint." >&2
+    exit 1
+  fi
+
+  if [[ -z "${DEMO_DATABASE_HOST:-}" ]]; then
+    echo "ERROR: DEMO_DATABASE_HOST is not set; refusing to run a destructive reset." >&2
+    echo "Set it on the Demo environment only, to the host of DIRECT_URL." >&2
+    exit 1
+  fi
+
+  target="$(migration_target)"
+  if [[ "$target" != "$DEMO_DATABASE_HOST"/* ]]; then
+    echo "ERROR: refusing to reset ${target}." >&2
+    echo "It does not match DEMO_DATABASE_HOST, so this is not the Demo database." >&2
+    exit 1
+  fi
+
   npx --no-install prisma migrate reset --force
   npx --no-install tsx prisma/seed.ts
 else
+  if [[ -z "${DIRECT_URL:-}" ]]; then
+    echo "WARNING: DIRECT_URL is not set; migrating over the DATABASE_URL endpoint." >&2
+    echo "If that endpoint is a transaction pooler, the advisory lock this takes can" >&2
+    echo "time out (P1002). Point DIRECT_URL at the unpooled endpoint." >&2
+  fi
   npx --no-install prisma migrate deploy
   if [[ "${VERCEL_ENV:-}" == "preview" ]]; then
     npx --no-install tsx prisma/seed.ts

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Migrations need a direct (session-mode) connection: the advisory lock Prisma takes
+# is session-scoped and does not survive a transaction pooler, which times out as
+# P1002. DIRECT_URL is the provider-neutral override; when it is not set explicitly,
+# fall back to the unpooled URL the Neon integration provisions. The application
+# config (prisma.config.ts) stays provider-neutral - this shim exists only here.
+if [[ -z "${DIRECT_URL:-}" && -n "${DATABASE_URL_UNPOOLED:-}" ]]; then
+  export DIRECT_URL="$DATABASE_URL_UNPOOLED"
+fi
+
 # Host and database of the endpoint Prisma will actually migrate against, with the
 # scheme and credentials stripped off. Mirrors the precedence in prisma.config.ts:
 # DIRECT_URL wins, DATABASE_URL is the fallback.
@@ -25,9 +34,10 @@ if [[ "${VERCEL_ENV:-}" == "preview" && "${VERCEL_TARGET_ENV:-}" == "demo" && "$
   # while the database is still intact. VERCEL_ENV/VERCEL_TARGET_ENV/APP_MODE above are
   # only labels - none of them says anything about which database we are pointed at.
   if [[ -z "${DIRECT_URL:-}" ]]; then
-    echo "ERROR: DIRECT_URL is not set on the Demo environment." >&2
-    echo "Migrations take a session-scoped advisory lock, which does not survive a" >&2
-    echo "transaction pooler. Point DIRECT_URL at the unpooled Demo endpoint." >&2
+    echo "ERROR: no direct database endpoint on the Demo environment." >&2
+    echo "Neither DIRECT_URL nor DATABASE_URL_UNPOOLED is set, so the reset would run" >&2
+    echo "over the pooled endpoint, where the migration advisory lock times out (P1002)." >&2
+    echo "Set DIRECT_URL to the unpooled Demo endpoint, or restore the Neon integration." >&2
     exit 1
   fi
 
@@ -48,9 +58,9 @@ if [[ "${VERCEL_ENV:-}" == "preview" && "${VERCEL_TARGET_ENV:-}" == "demo" && "$
   npx --no-install tsx prisma/seed.ts
 else
   if [[ -z "${DIRECT_URL:-}" ]]; then
-    echo "WARNING: DIRECT_URL is not set; migrating over the DATABASE_URL endpoint." >&2
-    echo "If that endpoint is a transaction pooler, the advisory lock this takes can" >&2
-    echo "time out (P1002). Point DIRECT_URL at the unpooled endpoint." >&2
+    echo "WARNING: no direct database endpoint (DIRECT_URL / DATABASE_URL_UNPOOLED);" >&2
+    echo "migrating over the DATABASE_URL endpoint. If that is a transaction pooler," >&2
+    echo "the advisory lock this takes can time out (P1002)." >&2
   fi
   npx --no-install prisma migrate deploy
   if [[ "${VERCEL_ENV:-}" == "preview" ]]; then

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -10,47 +10,17 @@ if [[ -z "${DIRECT_URL:-}" && -n "${DATABASE_URL_UNPOOLED:-}" ]]; then
   export DIRECT_URL="$DATABASE_URL_UNPOOLED"
 fi
 
-# Host and database of the endpoint Prisma will actually migrate against, with the
-# scheme and credentials stripped off. Mirrors the precedence in prisma.config.ts:
-# DIRECT_URL wins, DATABASE_URL is the fallback.
-migration_target() {
-  local url stripped hostport path
-  url="${DIRECT_URL:-${DATABASE_URL:-}}"
-  stripped="${url#*://}"
-  stripped="${stripped#*@}"
-  hostport="${stripped%%[/?]*}"
-  path="${stripped#"$hostport"}"
-  path="${path#/}"
-  printf '%s/%s' "${hostport%%:*}" "${path%%\?*}"
-}
-
 if [[ "${VERCEL_ENV:-}" == "preview" && "${VERCEL_TARGET_ENV:-}" == "demo" && "${APP_MODE:-}" == "demo" ]]; then
-  # `prisma migrate reset` drops the schema BEFORE it reapplies migrations, and it takes
-  # the advisory lock only in the reapply step. A failure in between leaves the database
-  # with no tables at all - which is exactly how the Demo environment went down on
-  # 2026-07-20 (P1002, lock wait timed out after the drop had already run).
-  #
-  # So every check below fails closed: a missing or mismatched variable aborts the build
-  # while the database is still intact. VERCEL_ENV/VERCEL_TARGET_ENV/APP_MODE above are
-  # only labels - none of them says anything about which database we are pointed at.
+  # `prisma migrate reset` drops the schema BEFORE it reapplies migrations, and it
+  # takes the advisory lock only in the reapply step. Over a pooled endpoint that
+  # lock times out (P1002) after the drop has already run - which is exactly how the
+  # Demo environment went down on 2026-07-20, leaving a database with no tables.
+  # Fail closed while the database is still intact rather than reset over a pooler.
   if [[ -z "${DIRECT_URL:-}" ]]; then
     echo "ERROR: no direct database endpoint on the Demo environment." >&2
     echo "Neither DIRECT_URL nor DATABASE_URL_UNPOOLED is set, so the reset would run" >&2
-    echo "over the pooled endpoint, where the migration advisory lock times out (P1002)." >&2
-    echo "Set DIRECT_URL to the unpooled Demo endpoint, or restore the Neon integration." >&2
-    exit 1
-  fi
-
-  if [[ -z "${DEMO_DATABASE_HOST:-}" ]]; then
-    echo "ERROR: DEMO_DATABASE_HOST is not set; refusing to run a destructive reset." >&2
-    echo "Set it on the Demo environment only, to the host of DIRECT_URL." >&2
-    exit 1
-  fi
-
-  target="$(migration_target)"
-  if [[ "$target" != "$DEMO_DATABASE_HOST"/* ]]; then
-    echo "ERROR: refusing to reset ${target}." >&2
-    echo "It does not match DEMO_DATABASE_HOST, so this is not the Demo database." >&2
+    echo "over the pooled endpoint, where the migration advisory lock times out (P1002)" >&2
+    echo "after the schema drop. Set DIRECT_URL or restore the Neon integration." >&2
     exit 1
   fi
 

--- a/tests/conventions/vercel-build.test.ts
+++ b/tests/conventions/vercel-build.test.ts
@@ -30,6 +30,23 @@ describe("Vercel build safety", () => {
     expect(script).not.toMatch(/unipile/i);
   });
 
+  it("fails closed before the destructive Demo reset", () => {
+    const script = readFileSync(join(REPO_ROOT, "scripts", "vercel-build.sh"), "utf8");
+    const reset = script.indexOf("npx --no-install prisma migrate reset --force");
+    const directUrlGuard = script.indexOf('if [[ -z "${DIRECT_URL:-}" ]]; then');
+    const hostGuard = script.indexOf('if [[ -z "${DEMO_DATABASE_HOST:-}" ]]; then');
+    const targetGuard = script.indexOf('"$target" != "$DEMO_DATABASE_HOST"/*');
+
+    // The reset drops the schema before it reapplies migrations, so a guard that runs
+    // after it is worthless. Every one of these has to come first.
+    expect(directUrlGuard).toBeGreaterThan(-1);
+    expect(hostGuard).toBeGreaterThan(-1);
+    expect(targetGuard).toBeGreaterThan(-1);
+    expect(reset).toBeGreaterThan(directUrlGuard);
+    expect(reset).toBeGreaterThan(hostGuard);
+    expect(reset).toBeGreaterThan(targetGuard);
+  });
+
   it("keeps migration connection configuration provider-neutral", () => {
     const prismaConfig = readFileSync(join(REPO_ROOT, "prisma.config.ts"), "utf8");
 

--- a/tests/conventions/vercel-build.test.ts
+++ b/tests/conventions/vercel-build.test.ts
@@ -26,8 +26,20 @@ describe("Vercel build safety", () => {
     expect(preview).toBeGreaterThan(migrate);
     expect(previewSeed).toBeGreaterThan(preview);
     expect(build).toBeGreaterThan(previewSeed);
-    expect(script).not.toContain("DATABASE_URL_UNPOOLED");
     expect(script).not.toMatch(/unipile/i);
+  });
+
+  it("resolves a direct migration endpoint before touching any database", () => {
+    const script = readFileSync(join(REPO_ROOT, "scripts", "vercel-build.sh"), "utf8");
+    // Prisma's migration advisory lock is session-scoped and does not survive a
+    // transaction pooler (P1002). DIRECT_URL stays the provider-neutral override;
+    // the unpooled fallback is a build-script shim only and must never leak into
+    // prisma.config.ts (asserted below).
+    const fallback = script.indexOf('export DIRECT_URL="$DATABASE_URL_UNPOOLED"');
+    const firstPrisma = script.indexOf("npx --no-install prisma");
+
+    expect(fallback).toBeGreaterThan(-1);
+    expect(firstPrisma).toBeGreaterThan(fallback);
   });
 
   it("fails closed before the destructive Demo reset", () => {

--- a/tests/conventions/vercel-build.test.ts
+++ b/tests/conventions/vercel-build.test.ts
@@ -46,17 +46,13 @@ describe("Vercel build safety", () => {
     const script = readFileSync(join(REPO_ROOT, "scripts", "vercel-build.sh"), "utf8");
     const reset = script.indexOf("npx --no-install prisma migrate reset --force");
     const directUrlGuard = script.indexOf('if [[ -z "${DIRECT_URL:-}" ]]; then');
-    const hostGuard = script.indexOf('if [[ -z "${DEMO_DATABASE_HOST:-}" ]]; then');
-    const targetGuard = script.indexOf('"$target" != "$DEMO_DATABASE_HOST"/*');
 
-    // The reset drops the schema before it reapplies migrations, so a guard that runs
-    // after it is worthless. Every one of these has to come first.
+    // The reset drops the schema before it reapplies migrations, and only the reapply
+    // step takes the advisory lock - which times out (P1002) over a transaction
+    // pooler, stranding an empty database. The direct-endpoint guard must therefore
+    // run first; a guard after the reset is worthless.
     expect(directUrlGuard).toBeGreaterThan(-1);
-    expect(hostGuard).toBeGreaterThan(-1);
-    expect(targetGuard).toBeGreaterThan(-1);
     expect(reset).toBeGreaterThan(directUrlGuard);
-    expect(reset).toBeGreaterThan(hostGuard);
-    expect(reset).toBeGreaterThan(targetGuard);
   });
 
   it("keeps migration connection configuration provider-neutral", () => {


### PR DESCRIPTION
## Summary

The Demo build's `prisma migrate reset --force` dropped the Demo schema and then failed before reapplying migrations, leaving the database with no tables. Two changes, both confined to `scripts/vercel-build.sh`:

1. **Migrations run over a direct endpoint again.** Restores the fallback removed in e92ecac (#10): `DIRECT_URL` is exported from `DATABASE_URL_UNPOOLED` when not set explicitly. Prisma's migration advisory lock is session-scoped and does not survive Neon's transaction pooler — the likely cause of the P1002. The Vercel environments carry the Neon-provisioned pooled `DATABASE_URL` plus `DATABASE_URL_UNPOOLED` and no `DIRECT_URL`, and a manually maintained copy would drift on credential rotation, so the fallback beats requiring a new variable.
2. **The Demo reset fails closed without a direct endpoint.** If neither `DIRECT_URL` nor `DATABASE_URL_UNPOOLED` is set, the Demo build aborts *before* the drop instead of resetting over the pooled endpoint and stranding an empty database. Non-Demo environments warn instead of failing.

`prisma.config.ts` stays provider-neutral (reads only `DIRECT_URL`/`DATABASE_URL`); the Neon-compat shim lives solely in the build script. The convention tests now assert the shim resolves before any `prisma` command and the guard precedes the reset; the config-neutrality assertions are untouched. No new environment variable is introduced — a host-allowlist variant (`DEMO_DATABASE_HOST`) was considered and deliberately dropped.

Environment semantics are unchanged: Demo still resets + reseeds on every deploy (fresh, drift-free fixtures); branch previews still run forward-only `migrate deploy` + seed, so preview data persists across pushes on the same PR.

## Context

Demo build [dpl_H3HiXE3X](https://vercel.com/customermates/customermates/H3HiXE3X7xipavLB26EbsSQERJ4N), commit 118b39a, 2026-07-20 09:17 UTC:

```
09:17:43  Error: P1002
09:17:43  Context: Timed out trying to acquire a postgres advisory lock
          (SELECT pg_advisory_lock(72707369)). Timeout: 10000ms.
```

Prisma 7.0.1 runs `migrate.reset()` **then** `applyMigrations()`, and acquires the advisory lock inside `applyMigrations` — not inside `reset`. A P1002 on that lock therefore proves the drop had already run. The build log contains **zero** `Applying migration` lines, against 26 in the previous successful Demo build. `set -euo pipefail` then aborted before the seed.

Result: a Demo database with no tables, and the Demo alias still serving the last READY build against it — 100% 5xx with `P2021: The table 'public.AuthUser' does not exist in the current database`.

Since #10 removed the unpooled fallback (2026-07-19 19:21), every migration ran over the pooled endpoint; the failures began on the next push to `main`. Session-scoped advisory locks through PgBouncer are a known Prisma failure mode (prisma#16197, prisma#12999).

Production was never at risk: separate database, and it takes the non-destructive `migrate deploy` path. Its own 08:57 failure (P1001 at exactly 5.000s, the default connect timeout) was a transient connect failure consistent with a Neon cold start; the 09:17 push deployed production successfully.

## Validation

Ran the real script with stubbed `npx`/`yarn` so nothing touched a database:

| Case | Result |
| --- | --- |
| Demo: only pooled `DATABASE_URL`, no unpooled | blocked, exit 1, no reset |
| Demo: empty-string unpooled var | blocked, exit 1, no reset |
| Demo: Neon shape (pooled + `DATABASE_URL_UNPOOLED`) | proceeds, reset + seed |
| Demo: explicit `DIRECT_URL` wins over fallback | proceeds, reset + seed |
| Production with unpooled fallback | `migrate deploy` only |
| Production, pooled only | warns, `migrate deploy` only |
| Branch preview | `migrate deploy` + seed, no reset |
| Demo labels but `APP_MODE` unset | `migrate deploy` + seed, no reset |

Also verified the exported `DIRECT_URL` is inherited by the `prisma` child process (what `prisma.config.ts` reads).

```
yarn vitest run tests/conventions/     13 suites, 59 tests, all passing
bash -n scripts/vercel-build.sh        syntax OK
```

Guard logic verified against bash 3.2.57 for portability.

## Impact and rollback

**Impact.** Non-Demo paths keep their behaviour: production and branch previews run `migrate deploy` (+ preview seed) and build as before — now over the unpooled endpoint, as they did before #10. Production deploys still succeed if no unpooled variable exists (warning only), so this cannot break production.

**Restoring Demo:** verify `DATABASE_URL_UNPOOLED` is present on the Demo custom environment (the Neon integration provisions it; if the custom environment did not inherit it, set `DIRECT_URL` there manually to the Demo branch's unpooled connection string). Then merge and redeploy Demo — the normal reset + seed path rebuilds the schema. If no direct endpoint is available, the build fails closed with a clear error before dropping anything.

**Residual risk, accepted deliberately:** the reset's *targeting* still relies on the environment labels (`VERCEL_ENV`/`VERCEL_TARGET_ENV`/`APP_MODE`) plus environment-scoped connection variables. A host allowlist would have hedged against a mis-scoped connection string but requires a manually maintained variable; it was considered and dropped.

**Rollback.** Revert the squash commit. That restores migrating over the pooler and the unguarded reset, so prefer fixing forward.

**Out of scope**, from the same investigation: retry/backoff for Neon cold starts (P1001), closing the drop-to-reapply window entirely, and the `prisma/seeds/identity.ts:59-60` AuthUser delete/rewrite on preview seeding.

## Screenshots

None — build-script change with no user-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)