### PR TITLE
feat(data-view): clearable search badge + URL persistence on webhooks, deliveries & audit logs

### DIFF
--- a/app/[locale]/(protected)/company/audit-logs/page.tsx
+++ b/app/[locale]/(protected)/company/audit-logs/page.tsx
@@ -4,12 +4,23 @@ import { AuditLogsCard } from "../components/audit-log/audit-logs-card";
 
 import { getGetAuditLogsInteractor } from "@/core/di";
 import { requireAccess } from "@/features/auth/next/require";
+import { decodeGetParams } from "@/core/utils/get-params";
 import { PageContainer } from "@/components/shared/page-container";
 
-export default async function CompanyAuditLogsPage() {
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function CompanyAuditLogsPage({ searchParams }: Props) {
   await requireAccess({ resource: Resource.auditLog });
 
-  const auditLogs = await getGetAuditLogsInteractor().invoke({ p13nId: "audit-logs-card-store" });
+  const params = await searchParams;
+  const auditLogParams = decodeGetParams(params);
+
+  const auditLogs = await getGetAuditLogsInteractor().invoke({
+    ...auditLogParams,
+    p13nId: "audit-logs-card-store",
+  });
 
   return (
     <PageContainer padded={false}>

--- a/app/[locale]/(protected)/company/components/audit-log/audit-logs-card.tsx
+++ b/app/[locale]/(protected)/company/components/audit-log/audit-logs-card.tsx
@@ -6,10 +6,10 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import { getEntityName } from "@/features/event/entity-name.utils";
-import { DataViewContainer } from "@/components/data-view";
+import { DataViewContainer, useDataViewSync } from "@/components/data-view";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { AppChip } from "@/components/chip/app-chip";
 import { CopyableChip } from "@/components/chip/copyable-chip";
@@ -23,7 +23,7 @@ export const AuditLogsCard = observer(({ initialAuditLogs }: Props) => {
   const t = useTranslations();
   const { auditLogModalStore, auditLogsStore, intlStore, userModalStore } = useRootStore();
 
-  useEffect(() => auditLogsStore.setItems(initialAuditLogs), [initialAuditLogs]);
+  useDataViewSync(auditLogsStore, initialAuditLogs);
 
   const columns = useMemo<ColumnDef<AuditLogDto>[]>(() => {
     return [

--- a/app/[locale]/(protected)/company/components/webhook/webhook-deliveries-card.tsx
+++ b/app/[locale]/(protected)/company/components/webhook/webhook-deliveries-card.tsx
@@ -6,11 +6,11 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import { WEBHOOK_DELIVERY_QUEUE_STATUS_CHIP_COLOR } from "@/features/webhook/webhook-delivery-chip-colors";
 import { getEntityName } from "@/features/event/entity-name.utils";
-import { DataViewContainer } from "@/components/data-view";
+import { DataViewContainer, useDataViewSync } from "@/components/data-view";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { AppChip } from "@/components/chip/app-chip";
 type Props = {
@@ -21,7 +21,7 @@ export const WebhookDeliveriesCard = observer(({ initialDeliveries }: Props) => 
   const t = useTranslations();
   const { webhookDeliveryModalStore, webhookDeliveriesStore, intlStore } = useRootStore();
 
-  useEffect(() => webhookDeliveriesStore.setItems(initialDeliveries), [initialDeliveries]);
+  useDataViewSync(webhookDeliveriesStore, initialDeliveries);
 
   const columns = useMemo<ColumnDef<WebhookDeliveryDto>[]>(() => {
     return [

--- a/app/[locale]/(protected)/company/components/webhook/webhooks-card.tsx
+++ b/app/[locale]/(protected)/company/components/webhook/webhooks-card.tsx
@@ -6,9 +6,9 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
-import { DataViewContainer } from "@/components/data-view";
+import { DataViewContainer, useDataViewSync } from "@/components/data-view";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { AppChipStack } from "@/components/chip/app-chip-stack";
 import { AppChip } from "@/components/chip/app-chip";
@@ -21,7 +21,7 @@ export const WebhooksCard = observer(({ initialWebhooks }: Props) => {
   const t = useTranslations();
   const { webhookModalStore, webhooksStore, intlStore } = useRootStore();
 
-  useEffect(() => webhooksStore.setItems(initialWebhooks), [initialWebhooks]);
+  useDataViewSync(webhooksStore, initialWebhooks);
 
   const columns = useMemo<ColumnDef<WebhookDto>[]>(() => {
     return [

--- a/app/[locale]/(protected)/company/webhook-deliveries/page.tsx
+++ b/app/[locale]/(protected)/company/webhook-deliveries/page.tsx
@@ -4,12 +4,23 @@ import { WebhookDeliveriesCard } from "../components/webhook/webhook-deliveries-
 
 import { getGetWebhookDeliveriesInteractor } from "@/core/di";
 import { requireAccess } from "@/features/auth/next/require";
+import { decodeGetParams } from "@/core/utils/get-params";
 import { PageContainer } from "@/components/shared/page-container";
 
-export default async function CompanyWebhookDeliveriesPage() {
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function CompanyWebhookDeliveriesPage({ searchParams }: Props) {
   await requireAccess({ resource: Resource.api });
 
-  const deliveries = await getGetWebhookDeliveriesInteractor().invoke({ p13nId: "webhook-deliveries-card-store" });
+  const params = await searchParams;
+  const deliveryParams = decodeGetParams(params);
+
+  const deliveries = await getGetWebhookDeliveriesInteractor().invoke({
+    ...deliveryParams,
+    p13nId: "webhook-deliveries-card-store",
+  });
 
   return (
     <PageContainer padded={false}>

--- a/components/data-view/header/active-filters-bar.tsx
+++ b/components/data-view/header/active-filters-bar.tsx
@@ -2,11 +2,12 @@
 
 import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store";
 
-import { BookmarkIcon, XIcon } from "lucide-react";
+import { BookmarkIcon, SearchIcon, XIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
+import { AppChip } from "@/components/chip/app-chip";
 import { ClickableChip } from "@/components/chip/clickable-chip";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { FilterChipValue, getFilterLabel } from "@/components/data-view/filter-modal/filter-chip-display";
@@ -28,8 +29,11 @@ export const DataViewActiveFiltersBar = observer(function DataViewActiveFiltersB
 
   const filters = store.filters ?? [];
   const presets = store.savedFilterPresets ?? [];
+  const searchTerm = store.searchTerm?.trim() ? store.searchTerm : undefined;
+  const hasFilters = filters.length > 0;
+  const hasSearch = Boolean(searchTerm);
 
-  if (filters.length === 0) {
+  if (!hasFilters && !hasSearch) {
     if (presets.length === 0) return null;
 
     return (
@@ -51,6 +55,33 @@ export const DataViewActiveFiltersBar = observer(function DataViewActiveFiltersB
 
   return (
     <div className="flex flex-wrap gap-1.5 items-center px-4 py-2 border-b border-border">
+      {hasSearch && (
+        <AppChip
+          className="max-w-md"
+          endContent={
+            <button
+              aria-label={t("Common.filters.clearSearch")}
+              className="ml-0.5 opacity-50 transition-[opacity,transform] hover:opacity-100 active:scale-[0.97] motion-reduce:transition-none"
+              tabIndex={-1}
+              type="button"
+              onClick={() => store.setQueryOptions({ searchTerm: "" })}
+            >
+              <XIcon className="size-3" />
+            </button>
+          }
+          startContent={<SearchIcon className="size-3 opacity-70" />}
+          variant="default"
+        >
+          <span className="truncate text-[11px]">
+            <span className="font-medium">{t("Common.filters.searchLabel")}</span>
+
+            <span className="mx-1 font-normal">:</span>
+
+            {searchTerm}
+          </span>
+        </AppChip>
+      )}
+
       {filters.map((filter, index) => {
         const label = getFilterLabel(filter, store.customColumns, t);
         const operator = t(`Common.filters.operators.${filter.operator}`);
@@ -86,15 +117,17 @@ export const DataViewActiveFiltersBar = observer(function DataViewActiveFiltersB
         );
       })}
 
-      <Button
-        className="h-auto py-0.5 px-2 text-[11px]"
-        size="xs"
-        type="button"
-        variant="secondary"
-        onClick={() => store.changeFilterPreset(undefined)}
-      >
-        {t("Common.filters.clearAll")}
-      </Button>
+      {(hasFilters || hasSearch) && (
+        <Button
+          className="h-auto py-0.5 px-2 text-[11px]"
+          size="xs"
+          type="button"
+          variant="secondary"
+          onClick={() => store.setQueryOptions({ filters: [], searchTerm: "" })}
+        >
+          {t("Common.filters.clearAll")}
+        </Button>
+      )}
     </div>
   );
 });

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -431,6 +431,7 @@
       "activeFilters": "Aktive Filter",
       "apply": "Anwenden",
       "clearAll": "Alle entfernen",
+      "clearSearch": "Suche löschen",
       "closeFilters": "Filter schließen",
       "daysPlaceholder": "Tage",
       "daysPreset": "{count, plural, =1 {1 Tag} other {# Tage}}",
@@ -491,6 +492,7 @@
         "none": "Kein Preset",
         "select": "Gespeicherte Filter"
       },
+      "searchLabel": "Suche",
       "selectOperator": "Bedingung auswählen…",
       "unavailableValue": "Filter nicht verfügbar"
     },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -431,6 +431,7 @@
       "activeFilters": "Active Filters",
       "apply": "Apply",
       "clearAll": "Clear All",
+      "clearSearch": "Clear search",
       "closeFilters": "Close Filters",
       "daysPlaceholder": "Days",
       "daysPreset": "{count, plural, =1 {1 day} other {# days}}",
@@ -491,6 +492,7 @@
         "none": "No preset",
         "select": "Saved filters"
       },
+      "searchLabel": "Search",
       "selectOperator": "Select a condition…",
       "unavailableValue": "Filter not available"
     },


### PR DESCRIPTION
## Summary

Two related improvements to the shared data-view surfaces:

1. **Mirror the active search in the UI.** The active-filters bar showed filter chips but not the search term — search only lived in the input box. It now renders a live, clearable **search badge** next to the filter chips. The badge appears/updates reactively as the search term changes; its **✕ clears just the search**, and **Clear All** clears filters *and* search in one refresh. The bar now shows whenever a search term **or** a filter is active (previously it hid when there were no filters).

2. **Extend URL persistence to the searchable list pages that were missing it.** Each affected page now keeps its own filter/search state in its own URL — page-specific, shareable, and restored on reload.

| Page | Before | Change |
|---|---|---|
| company/**webhooks** | client sync missing (server already decoded) | enable `useDataViewSync` |
| company/**webhook-deliveries** | both missing | client sync + `decodeGetParams` server-side |
| company/**audit-logs** | both missing | client sync + `decodeGetParams` server-side |

## Context

Filter/search-in-URL is already built into `BaseDataViewStore` (it syncs `searchTerm` + `filters` + sort + page to the URL via `replaceState`) and enabled through `useDataViewSync`. It was already active on tasks, contacts, organizations, services, deals, inbox and members, but three **searchable** company pages never called the hook (and two of them never decoded `searchParams` server-side), so their state didn't survive reload or sharing. Separately, the active-filters bar never surfaced the search term, so a user filtering by search had no chip to see or clear.

`decodeGetParams` values are validated/dropped against each entity's `filterableFields` / `searchableFields` (all three have real searchable fields: webhook `url`; delivery `event`/`url`; audit-log `entityId`), so no dead URL keys are introduced. No change to `BaseDataViewStore` was needed.

**Out of scope (intentional):** `roles` (`isSearchable={false}` — no search box); `api-keys` / `connected-accounts` (don't use the data-view container / active-filters bar).

Files: `components/data-view/header/active-filters-bar.tsx`; three `*-card.tsx` (`setItems` effect → `useDataViewSync`); two server `page.tsx` (`decodeGetParams`); `i18n/{en,de}.json` (`Common.filters.searchLabel` + `clearSearch`, symmetric).

## Validation

- Changed files pass `tsc --noEmit` and `eslint --max-warnings 0`.
- `tests/conventions/i18n-parity` and `i18n-key-resolution` pass (new keys are en/de-symmetric and resolve).
- Behavioral acceptance (badge live-update/clear; per-page URL round-trip on the three newly-wired pages) is best confirmed on the seeded **Vercel Preview** for this PR — this repo has no browser e2e in CI.

## Impact and rollback

Low risk and additive. The search badge is presentational and reuses existing chip primitives; the URL-sync change reuses the same proven `useDataViewSync` / `decodeGetParams` path already shipping on the entity pages. No schema, API, or store-contract changes. **Clear All** now also clears the search term, which is the only behavior change to an existing control. Rollback is a straight revert of this single commit with no migration or data implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)