### PR TITLE
fix(auth): keep the active locale on server-side guard redirects

### DIFF
--- a/features/auth/next/require.ts
+++ b/features/auth/next/require.ts
@@ -1,24 +1,29 @@
 import "server-only";
 
 import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
 
 import { getAuthService, getRouteGuardService } from "@/core/di";
 import { isRedirect } from "../auth-outcome";
 
 import type { AccessOptions } from "../route-guard.service";
 
+function localePath(locale: string, path: string): string {
+  return path === "/" ? `/${locale}` : `/${locale}${path}`;
+}
+
 export async function requireAccess(options?: AccessOptions): Promise<void> {
   const result = await getRouteGuardService().resolveAccess(options);
-  if (result) redirect(result.redirect);
+  if (result) redirect(localePath(await getLocale(), result.redirect));
 }
 
 export async function requireUnauthenticated(): Promise<void> {
   const result = await getRouteGuardService().resolveUnauthenticated();
-  if (result) redirect(result.redirect);
+  if (result) redirect(localePath(await getLocale(), result.redirect));
 }
 
 export async function requireSession() {
   const result = await getAuthService().resolveSession();
-  if (isRedirect(result)) redirect(result.redirect);
+  if (isRedirect(result)) redirect(localePath(await getLocale(), result.redirect));
   return result.session;
 }


### PR DESCRIPTION
## Summary

The server-side auth route guards in `features/auth/next/require.ts` called `redirect()` from `next/navigation` with **locale-less** internal paths (`/auth/signin`, `/auth/verify-email`, `/onboarding/wizard`, `/subscription-expired`, `/auth/error?type=inactiveUser`, `/auth/pending`, `/`). With next-intl `localePrefix: "always"`, each guard redirect hit the middleware and was **307→308** redirected to add the locale — an extra navigation hop, the same class of bug fixed for the sidebar/top-bar links in #19.

The fix resolves the active locale with `getLocale()` (`next-intl/server`) and prepends it before redirecting:

```ts
function localePath(locale: string, path: string): string {
  return path === "/" ? `/${locale}` : `/${locale}${path}`;
}
// if (result) redirect(localePath(await getLocale(), result.redirect));
```

`redirect()` is kept from `next/navigation` so it stays a synchronous `never`-returning call, preserving the type narrowing in `requireSession`.

## Context

Importing `redirect` from `@/i18n/navigation` (the obvious first choice) was **tried and rejected**: that shared navigation object's server `redirect` does not resolve the locale in this app's setup and produced a broken `/undefinedundefined` target. Verified locally by instrumenting a real RSC route:

| redirect source | resulting target |
| --- | --- |
| `@/i18n/navigation` (server) | `/undefinedundefined` |
| `next/navigation` + `getLocale()` prefix | `/en/auth/signin` |

## Validation

Local, isolated worktree, `yarn dev`, demo mode:

- End-to-end on the real guard: set the demo user `status=inactive`, loaded `/en/dashboard` → `requireAccess()` now redirects to `/en/auth/error?type=inactiveUser`; `/de/dashboard` → `/de/auth/error?type=inactiveUser` (correct locale, query string preserved). Before the fix the target was locale-less and took the middleware 308 hop.
- `yarn typecheck` passes.
- `yarn vitest run features/auth features/user tests/conventions/i18n-key-resolution.test.ts` → 25 passed.
- `eslint` on the changed file and the full-repo pre-commit lint pass.

## Impact and rollback

- Behavior-only change to guard redirect targets; the redirect string set is unchanged, only locale-prefixed. No schema, API, or data impact.
- Rollback: revert this commit. Guards fall back to locale-less targets (still functional via the middleware hop, just with the extra redirect).

Follows #19 and the KB rule to verify against a locally-run instance in an isolated worktree.