### PR TITLE
fix(seed): use E.164 phone numbers for synthetic contact custom fields

### DIFF
--- a/prisma/__tests__/seed-convergence.test.ts
+++ b/prisma/__tests__/seed-convergence.test.ts
@@ -258,7 +258,7 @@ describe("synthetic seed convergence after UI edits", () => {
     expect(reconciled).toEqual([
       expect.objectContaining({
         id: "18000000-0000-4000-8000-000000000001",
-        value: "+1 202-555-0100",
+        value: "+12025550100",
       }),
     ]);
     expectStalePrune(customColumn, "16000000-", Object.values(SYNTHETIC_CUSTOM_COLUMN_IDS).length);

--- a/prisma/__tests__/synthetic-custom-field-validity.test.ts
+++ b/prisma/__tests__/synthetic-custom-field-validity.test.ts
@@ -1,0 +1,94 @@
+import type { PrismaClient } from "@/generated/prisma";
+import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
+import type { z } from "zod";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { validateCustomFieldValues } from "@/core/validation/validate-custom-field-values";
+
+import { seedCustomFields } from "../seeds/custom-fields";
+import { SEED_IDS } from "../seeds/context";
+
+// The synthetic seed writes custom-field values that the application re-validates on every
+// write (`ContactWritePrecheckInteractor` and siblings run `validateCustomFieldValues`). If a
+// seeded value does not pass its own column-type validator, every save of that record is
+// rejected server-side — e.g. a "Phones" value like "+1 202-555-0100" fails `z.e164()` and
+// blocks even an unrelated first-name edit. This test drives the real seed generator and the
+// real validators so that class of drift fails in CI instead of silently in the product.
+
+function context(prisma: PrismaClient) {
+  return {
+    prisma,
+    ids: SEED_IDS,
+    seedUserEmail: "max.bergmann@customermates.com",
+    sharedUserPassword: "local-demo-password",
+  };
+}
+
+function entities() {
+  const organizations = Array.from({ length: 19 }, (_, index) => ({
+    id: `organization-${index}`,
+    website: `https://company-${index}.example`,
+  }));
+  const contacts = Array.from({ length: 30 }, (_, index) => ({ id: `contact-${index}` }));
+  const deals = Array.from({ length: 10 }, (_, index) => ({ id: `deal-${index}` }));
+  const services = Array.from({ length: 43 }, (_, index) => ({ id: `service-${index}`, amount: index + 1 }));
+  const tasks = Array.from({ length: 15 }, (_, index) => ({ id: `task-${index}` }));
+
+  return {
+    organizations,
+    contacts,
+    deals,
+    services,
+    tasks,
+    // Only the singleSelect option index (deal[3] / task[5]) is read for custom-field seeding.
+    dealDefinitions: deals.map(() => ["Deal", 0, [], 0]),
+    taskDefinitions: tasks.map(() => ["Task", [], [], [], [], 0]),
+  };
+}
+
+function captureUpsert<T>() {
+  const created: T[] = [];
+  const delegate = {
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    upsert: vi.fn(({ create }: { create: T }) => {
+      created.push(create);
+      return Promise.resolve(create);
+    }),
+  };
+  return { created, delegate };
+}
+
+describe("synthetic seed custom-field values", () => {
+  it("every seeded value passes its column-type validator", async () => {
+    const columns = captureUpsert<CustomColumnDto>();
+    const values = captureUpsert<{ columnId: string; value: string | null }>();
+
+    const prisma = {
+      customColumn: columns.delegate,
+      customFieldValue: values.delegate,
+    } as unknown as PrismaClient;
+
+    await seedCustomFields(context(prisma), entities() as never);
+
+    expect(columns.created.length).toBeGreaterThan(0);
+    expect(values.created.length).toBeGreaterThan(0);
+
+    const failures: string[] = [];
+    for (const row of values.created) {
+      const issues: unknown[] = [];
+      const ctx = { addIssue: (issue: unknown) => issues.push(issue) } as unknown as z.RefinementCtx;
+
+      validateCustomFieldValues([{ columnId: row.columnId, value: row.value }], columns.created, ctx, ["value"]);
+
+      if (issues.length > 0) {
+        const column = columns.created.find((candidate) => candidate.id === row.columnId);
+        failures.push(`${column?.label ?? row.columnId} (${column?.type ?? "unknown"}) = ${JSON.stringify(row.value)}`);
+      }
+    }
+
+    expect(failures, `Seeded custom-field values rejected by their own validators:\n${failures.join("\n")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/prisma/seeds/custom-fields.ts
+++ b/prisma/seeds/custom-fields.ts
@@ -396,7 +396,9 @@ export async function seedCustomFields(
         contactId: contact.id,
         entityType: "contact",
         type: "phone",
-        value: `+1 202-555-${String(100 + index).padStart(4, "0")}`,
+        // Phone custom fields validate against E.164 (`z.e164()`): a leading `+` and digits only,
+        // no spaces or dashes. Keep this value E.164 or every seeded contact fails to save.
+        value: `+1202555${String(100 + index).padStart(4, "0")}`,
       }),
       customFieldValue({
         columnId: SYNTHETIC_CUSTOM_COLUMN_IDS.contactSalesPipeline,


### PR DESCRIPTION
## Summary

Fix the synthetic seed so contact "Phones" custom-field values are valid E.164, and add a regression test that runs every seeded custom-field value through the real validators. No production code changes.

## Context

CUS-112. Editing any field on a seeded contact and clicking **Save** was rejected server-side and silently failed to persist — even a first-name-only edit.

Root cause: the seed wrote the "Phones" custom field as `+1 202-555-0100` (spaces + dashes), but phone custom fields validate against `z.e164()`, which requires digits only (`+12025550100`). A contact write re-validates **every** custom field via `validateCustomFieldValues`, so the untouched, mis-seeded phone value failed and the whole update was rejected. Under the intended error UX (red field indicator + toast) this read as a confusing "nothing happened", because the blocked field was one the user never touched.

This is a **seed-data** defect — the validators and the red-indicator/toast surfacing are working as designed.

## Validation

- Changed files: `prisma/seeds/custom-fields.ts` (E.164 values + a comment), new `prisma/__tests__/synthetic-custom-field-validity.test.ts`, `prisma/__tests__/seed-convergence.test.ts` (one expected value).
- `yarn test` prisma suite **42/42**, including the new guard; the guard was proven to **fail** on the old value and pass on the fix.
- `yarn typecheck` ✓ · `yarn lint` (changed files) ✓ · pre-commit hooks ✓.
- End-to-end in a local `APP_MODE=cloud` app against a re-seeded DB: opened a seeded contact, edited the first name, clicked Save → persists cleanly with no red field and no error toast, confirmed by re-reading the row. Before the fix the same action was rejected and did not persist.
- Unrelated: `features/mcp-tools/__tests__/docs-mcp-tools.test.ts > finds REST operations when source is api` also fails on clean `origin/main` locally — a local docs/openapi generation-state artifact, independent of this change.

## Impact and rollback

- Impact: synthetic **seed data only**. No production code, no schema or migration, no runtime behavior change. Local and preview databases pick up the E.164 values on their next seed/`db:reset`.
- Rollback: revert this PR. No data migration or stored-data change is required.

## Screenshots

No UI change. Behavior verified end-to-end in a local run (edit → Save persists, no error) with a DB re-read confirming the write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
