### PR TITLE
fix(navigation): keep the active locale on internal links, app-wide + enforced

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,6 +71,12 @@
       }
     },
     {
+      "files": ["components/shared/app-link.tsx"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    },
+    {
       "files": [
         "components/shared/language-selector.tsx",
         "**/profile-settings-form.tsx",
@@ -130,6 +136,11 @@
           {
             "message": "Use <AppModal> from '@/components/modal' so every modal shares the AppCard chrome, sizing, and unsaved-changes guard. The raw Dialog primitives are only allowed inside components/modal/app-modal.tsx (where AppModal wraps them) and components/ui/command.tsx (cmdk plumbing).",
             "name": "@/components/ui/dialog"
+          },
+          {
+            "importNames": ["default"],
+            "message": "Use <AppLink> from '@/components/shared/app-link' for text links, or IntlLink from '@/i18n/navigation' inside styled or asChild wrappers, so internal links keep the active locale (next-intl localePrefix is 'always'). next/link's default Link export is only allowed in components/shared/app-link.tsx, the external-link wrapper; the named useLinkStatus hook is unaffected.",
+            "name": "next/link"
           }
         ]
       }

--- a/app/[locale]/(static)/blog/[slug]/page.tsx
+++ b/app/[locale]/(static)/blog/[slug]/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { Calendar, ChevronLeft } from "lucide-react";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { BlogPostCard } from "../blog-post-card";
 
+import { IntlLink } from "@/i18n/navigation";
 import { blogPostsSource } from "@/core/fumadocs/source";
 import { ShowcaseFrame } from "@/components/marketing/showcase-frame";
 import { Footer } from "@/app/components/footer";
@@ -81,11 +81,11 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
 
       <section className="pt-12 md:pt-16 pb-16 md:pb-24 w-full">
         <article className="max-w-6xl mx-auto px-4 flex-1">
-          <Link className="inline-flex items-center text-subdued mb-8" href={`/${locale}/blog`}>
+          <IntlLink className="inline-flex items-center text-subdued mb-8" href="/blog">
             <Icon className="mr-2" icon={ChevronLeft} size="sm" />
 
             {backToBlog}
-          </Link>
+          </IntlLink>
 
           <header>
             <ShowcaseFrame className="mb-8">

--- a/app/[locale]/(static)/docs/components/docs-sidebar.tsx
+++ b/app/[locale]/(static)/docs/components/docs-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode, SVGProps } from "react";
 
-import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
@@ -25,6 +24,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { IntlLink } from "@/i18n/navigation";
 import { ROUTING_LOCALES } from "@/i18n/routing";
 
 export type DocSidebarItem = {
@@ -78,7 +78,7 @@ function DocItemRow({ item, isActive }: { item: DocSidebarItem; isActive: boolea
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
-        <NextLink href={item.url}>
+        <IntlLink href={item.url}>
           <Icon icon={item.icon} />
 
           <span className="truncate">{item.title}</span>
@@ -88,7 +88,7 @@ function DocItemRow({ item, isActive }: { item: DocSidebarItem; isActive: boolea
               {item.method}
             </AppChip>
           )}
-        </NextLink>
+        </IntlLink>
       </SidebarMenuButton>
     </SidebarMenuItem>
   );
@@ -110,7 +110,7 @@ export const DocsSidebar = observer(() => {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild size="lg">
-              <NextLink href="/">
+              <IntlLink href="/">
                 <AppImage
                   alt={logoAlt}
                   className="size-8 shrink-0 rounded-lg shadow-[0_0_10px_0] shadow-primary/10 dark:shadow-primary/20"
@@ -125,7 +125,7 @@ export const DocsSidebar = observer(() => {
 
                   <span className="truncate text-xs text-muted-foreground">Documentation</span>
                 </div>
-              </NextLink>
+              </IntlLink>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
@@ -176,11 +176,11 @@ export const DocsSidebar = observer(() => {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild tooltip={t("DocsSidebar.goBack")}>
-              <NextLink href="/">
+              <IntlLink href="/">
                 <Icon icon={ArrowLeft} />
 
                 <span>{t("DocsSidebar.goBack")}</span>
-              </NextLink>
+              </IntlLink>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/app/[locale]/(static)/docs/components/docs-topbar.tsx
+++ b/app/[locale]/(static)/docs/components/docs-topbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
+
+import { IntlLink } from "@/i18n/navigation";
 
 import {
   Breadcrumb,
@@ -40,7 +41,7 @@ export function DocsTopBar() {
           <BreadcrumbItem className="shrink-0">
             {activeTitle ? (
               <BreadcrumbLink asChild>
-                <NextLink href="/docs">{rootLabel}</NextLink>
+                <IntlLink href="/docs">{rootLabel}</IntlLink>
               </BreadcrumbLink>
             ) : (
               <BreadcrumbPage>{rootLabel}</BreadcrumbPage>

--- a/app/components/app-topbar.tsx
+++ b/app/components/app-topbar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo } from "react";
-import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
@@ -24,6 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useRootStore } from "@/core/stores/root-store.provider";
+import { IntlLink } from "@/i18n/navigation";
 
 import { ShellHeader } from "./shell-header";
 import { useTopBarActions } from "./topbar-actions-context";
@@ -114,13 +114,15 @@ export const AppTopBar = observer(() => {
                       <DropdownMenuContent align="start">
                         {c.siblings.map((s) => (
                           <DropdownMenuItem key={s.slug} asChild>
-                            <NextLink href={`/${section}/${s.slug}`}>{s.label}</NextLink>
+                            <IntlLink href={`/${section}/${s.slug}`}>{s.label}</IntlLink>
                           </DropdownMenuItem>
                         ))}
                       </DropdownMenuContent>
                     </DropdownMenu>
                   ) : c.href && !isLeaf ? (
-                    <BreadcrumbLink href={c.href}>{c.label}</BreadcrumbLink>
+                    <BreadcrumbLink asChild>
+                      <IntlLink href={c.href}>{c.label}</IntlLink>
+                    </BreadcrumbLink>
                   ) : (
                     <BreadcrumbPage className="flex min-w-0 items-center gap-1.5 truncate">
                       {isLeaf && c.isEntity && <Avatar name={c.label} size="sm" src={c.pictureUrl ?? null} />}

--- a/app/components/navigation/nav-header.tsx
+++ b/app/components/navigation/nav-header.tsx
@@ -2,11 +2,11 @@
 
 import type { ReactNode } from "react";
 
-import NextLink from "next/link";
 import { Plus, Search } from "lucide-react";
 
 import { AppImage } from "@/components/shared/app-image";
 import { SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import { IntlLink } from "@/i18n/navigation";
 
 type Props = {
   homeHref: string;
@@ -34,7 +34,7 @@ export function NavHeader({
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton asChild size="lg">
-            <NextLink href={homeHref}>
+            <IntlLink href={homeHref}>
               <AppImage
                 alt={logoAlt}
                 className="size-8 shrink-0 rounded-lg shadow-[0_0_10px_0] shadow-primary/10 dark:shadow-primary/20"
@@ -51,7 +51,7 @@ export function NavHeader({
                   {brandSubtitle}
                 </span>
               </span>
-            </NextLink>
+            </IntlLink>
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/app/components/navigation/nav-main.tsx
+++ b/app/components/navigation/nav-main.tsx
@@ -2,7 +2,7 @@
 
 import type { SVGProps } from "react";
 
-import NextLink, { useLinkStatus } from "next/link";
+import { useLinkStatus } from "next/link";
 import { ChevronRight } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useEffect, useState } from "react";
@@ -21,6 +21,7 @@ import {
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { Icon } from "@/components/shared/icon";
 import { useRootStore } from "@/core/stores/root-store.provider";
+import { IntlLink } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 
 type NavItem = {
@@ -109,13 +110,13 @@ function NavMainParent({ item, pathname, onNavigate, open, onOpenChange }: NavMa
                   )}
 
                   <SidebarMenuSubButton asChild isActive={subActive}>
-                    <NextLink href={sub.href} id={`nav-${sub.key}`} onClick={() => onNavigate(sub.key)}>
+                    <IntlLink href={sub.href} id={`nav-${sub.key}`} onClick={() => onNavigate(sub.key)}>
                       <NavLinkOverlayBridge />
 
                       <span>{sub.title}</span>
 
                       <NavBadge count={sub.badge ?? 0} />
-                    </NextLink>
+                    </IntlLink>
                   </SidebarMenuSubButton>
                 </SidebarMenuSubItem>
               );
@@ -162,7 +163,7 @@ export const NavMain = observer(({ groups, selectedKey, pathname, onNavigate }: 
     return (
       <SidebarMenuItem key={item.key}>
         <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
-          <NextLink href={item.href} id={`nav-${item.key}`} onClick={() => onNavigate(item.key)}>
+          <IntlLink href={item.href} id={`nav-${item.key}`} onClick={() => onNavigate(item.key)}>
             <NavLinkOverlayBridge />
 
             <Icon icon={item.icon} />
@@ -170,7 +171,7 @@ export const NavMain = observer(({ groups, selectedKey, pathname, onNavigate }: 
             <span className="min-w-0 truncate">{item.title}</span>
 
             <NavBadge count={item.badge ?? 0} />
-          </NextLink>
+          </IntlLink>
         </SidebarMenuButton>
       </SidebarMenuItem>
     );

--- a/app/components/navigation/nav-secondary.tsx
+++ b/app/components/navigation/nav-secondary.tsx
@@ -1,7 +1,5 @@
 import type { ComponentPropsWithoutRef, SVGProps } from "react";
 
-import NextLink from "next/link";
-
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -10,6 +8,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { Icon } from "@/components/shared/icon";
+import { IntlLink } from "@/i18n/navigation";
 
 export type NavSecondaryItem = {
   key: string;
@@ -32,11 +31,11 @@ export function NavSecondary({ items, ...props }: Props) {
             <SidebarMenuItem key={item.key}>
               {item.href ? (
                 <SidebarMenuButton asChild size="sm" tooltip={item.title}>
-                  <NextLink href={item.href} id={`nav-${item.key}`}>
+                  <IntlLink href={item.href} id={`nav-${item.key}`}>
                     <Icon icon={item.icon} />
 
                     <span>{item.title}</span>
-                  </NextLink>
+                  </IntlLink>
                 </SidebarMenuButton>
               ) : (
                 <SidebarMenuButton id={`nav-${item.key}`} size="sm" tooltip={item.title} onClick={item.onSelect}>

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -3,10 +3,9 @@
 import { Github, Menu, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
-import NextLink from "next/link";
 
 import { useRootStore } from "@/core/stores/root-store.provider";
-import { usePathname } from "@/i18n/navigation";
+import { IntlLink, usePathname } from "@/i18n/navigation";
 import { AppLink } from "@/components/shared/app-link";
 import { AppImage } from "@/components/shared/app-image";
 import { Button } from "@/components/ui/button";
@@ -65,13 +64,13 @@ export const PublicNavbar = observer(({ isAuthenticated, onboardingComplete }: P
   const showCta = pathname !== ctaTarget;
   const ctaButton = showCta ? (
     <Button asChild size="sm" variant="softPrimary" onClick={closeMenu}>
-      <NextLink href={ctaTarget}>{ctaLabel}</NextLink>
+      <IntlLink href={ctaTarget}>{ctaLabel}</IntlLink>
     </Button>
   ) : null;
 
   const contactButton = (
     <Button asChild className="bg-transparent shadow-none" size="sm" variant="outline" onClick={closeMenu}>
-      <NextLink href="/contact">{t("Common.actions.contact")}</NextLink>
+      <IntlLink href="/contact">{t("Common.actions.contact")}</IntlLink>
     </Button>
   );
 

--- a/components/marketing/cta-section.tsx
+++ b/components/marketing/cta-section.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from "react";
 
-import Link from "next/link";
-
 import { Button } from "@/components/ui/button";
 import { AppImage } from "@/components/shared/app-image";
+import { IntlLink } from "@/i18n/navigation";
 
 type Props = {
   action: string;
@@ -96,13 +95,13 @@ export function CTASection({
 
               <div className="mb-6 flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row md:mb-8 md:gap-6">
                 <Button asChild className="w-full sm:w-auto" size="lg" variant="default">
-                  <Link href={buttonLeftHref}>{buttonLeftText}</Link>
+                  <IntlLink href={buttonLeftHref}>{buttonLeftText}</IntlLink>
                 </Button>
 
                 <Button asChild className="w-full sm:w-auto" size="lg" variant="outline">
-                  <Link href={buttonRightHref} target="_blank">
+                  <IntlLink href={buttonRightHref} target="_blank">
                     {buttonRightText}
-                  </Link>
+                  </IntlLink>
                 </Button>
               </div>
 

--- a/components/marketing/page-hero.tsx
+++ b/components/marketing/page-hero.tsx
@@ -1,7 +1,6 @@
-import Link from "next/link";
-
 import { AppChip } from "@/components/chip/app-chip";
 import { Button } from "@/components/ui/button";
+import { IntlLink } from "@/i18n/navigation";
 
 import { AgplGithubBadge } from "./agpl-github-badge";
 import { WaveDecoration } from "./wave-decoration";
@@ -73,13 +72,13 @@ export function PageHero({
         <div className="my-8 flex flex-col items-center px-4 md:my-10">
           <div className="flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row md:gap-6">
             <Button asChild className="w-full sm:w-auto" size="lg" variant="default">
-              <Link href={buttonLeftHref}>{buttonLeftText}</Link>
+              <IntlLink href={buttonLeftHref}>{buttonLeftText}</IntlLink>
             </Button>
 
             <Button asChild className="w-full sm:w-auto" size="lg" variant="outline">
-              <Link href={buttonRightHref} target="_blank">
+              <IntlLink href={buttonRightHref} target="_blank">
                 {buttonRightText}
-              </Link>
+              </IntlLink>
             </Button>
           </div>
 


### PR DESCRIPTION
## Summary

With next-intl `localePrefix: "always"`, every internal app URL must carry a locale segment. Links rendered with plain `next/link` and locale-less hrefs (`/contacts`, `/docs`, `/auth/signup`, …) forced the middleware to **307→308** redirect to add the locale — an extra navigation hop on every click, in both the app shell and the public/marketing/docs pages.

This routes internal links through the locale-aware `IntlLink` from `@/i18n/navigation` (or `<AppLink>` for text links) app-wide, and adds a lint rule so it can't regress.

- **App shell**: `nav-main`, `nav-secondary`, `nav-header`, `app-topbar` (breadcrumb switcher + ancestor link; `BreadcrumbLink asChild` also fixes a full-page reload).
- **Public / marketing / docs**: `public-navbar` (CTA + contact), `marketing/page-hero` + `cta-section`, `blog/[slug]` back link, `docs-topbar` + `docs-sidebar`.

`IntlLink` prepends the active locale for internal hrefs and passes external URLs through unchanged, so mixed internal/external props and the demo-mode external home link are safe.

## Context

A `no-restricted-imports` rule now bans `next/link`'s default `Link` export, complementing the existing rule that steers `useRouter` to `@/i18n/navigation`. Text links use `<AppLink>`; styled/`asChild` wrappers use `IntlLink`. The only exception is `components/shared/app-link.tsx` — the external-link wrapper that owns the sole `next/link` import. The named `useLinkStatus` hook is unaffected.

Out of scope: server-side auth-guard redirects (same class of bug) are fixed in #21. `components/shared/error-page-view.tsx` keeps a plain `<a>` because it's shared with the top-level `global-error` boundary, which renders outside the locale provider and must stay framework-free.

Supersedes the earlier PR on branch `claude/sidebar-locale-links` (renamed to satisfy repository-policy).

## Validation

Local, isolated worktree, `yarn dev`, demo mode:

- Rendered link hrefs — zero locale-less internal links: `/en/dashboard` sidebar all `/en/…` (clicking Contacts goes straight to `GET /en/contacts?_rsc=… 200`, no `/contacts` 308); `/en/pricing` (86 anchors) and `/en/docs` (55 anchors) all internal `/en/…`; `/de/pricing` all `/de/…`. External links (GitHub, demo, LinkedIn) stay unprefixed.
- `yarn typecheck` passes.
- Full-repo `eslint --max-warnings 0` passes, including a negative test proving the new rule fires on a `next/link` default import.

## Impact and rollback

- UI/navigation-only change plus one eslint rule. No schema, API, or data impact.
- Rollback: revert the two commits on this branch. Links fall back to locale-less hrefs (still functional via the middleware hop) and the lint rule is removed.