### PR TITLE
test(auth): cover trial-expiry route-guard convergence and adjacent states

### DIFF
--- a/ee/subscription/__tests__/entitlements.test.ts
+++ b/ee/subscription/__tests__/entitlements.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { SubscriptionStatus } from "@/generated/prisma";
+
+import { isSubscriptionExpired, isSubscriptionUsable } from "../entitlements";
+
+const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000);
+const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+describe("isSubscriptionExpired", () => {
+  it("treats unpaid and expired statuses as expired regardless of trial date", () => {
+    expect(isSubscriptionExpired({ status: SubscriptionStatus.unPaid, trialEndDate: null })).toBe(true);
+    expect(isSubscriptionExpired({ status: SubscriptionStatus.expired, trialEndDate: FUTURE })).toBe(true);
+  });
+
+  it("treats a trial whose end date has passed as expired", () => {
+    expect(isSubscriptionExpired({ status: SubscriptionStatus.trial, trialEndDate: PAST })).toBe(true);
+  });
+
+  it("does not treat an active subscription or a live/open trial as expired", () => {
+    expect(isSubscriptionExpired({ status: SubscriptionStatus.active, trialEndDate: null })).toBe(false);
+    expect(isSubscriptionExpired({ status: SubscriptionStatus.trial, trialEndDate: FUTURE })).toBe(false);
+    expect(isSubscriptionExpired({ status: SubscriptionStatus.trial, trialEndDate: null })).toBe(false);
+  });
+});
+
+describe("isSubscriptionUsable", () => {
+  it("is usable while active or on a live/open trial", () => {
+    expect(isSubscriptionUsable({ status: SubscriptionStatus.active, trialEndDate: null })).toBe(true);
+    expect(isSubscriptionUsable({ status: SubscriptionStatus.trial, trialEndDate: FUTURE })).toBe(true);
+    expect(isSubscriptionUsable({ status: SubscriptionStatus.trial, trialEndDate: null })).toBe(true);
+  });
+
+  it("is not usable once the trial lapses or the subscription is unpaid/expired", () => {
+    expect(isSubscriptionUsable({ status: SubscriptionStatus.trial, trialEndDate: PAST })).toBe(false);
+    expect(isSubscriptionUsable({ status: SubscriptionStatus.unPaid, trialEndDate: null })).toBe(false);
+    expect(isSubscriptionUsable({ status: SubscriptionStatus.expired, trialEndDate: null })).toBe(false);
+  });
+});

--- a/features/auth/__tests__/route-guard.service.test.ts
+++ b/features/auth/__tests__/route-guard.service.test.ts
@@ -1,0 +1,144 @@
+import type { ExtendedUser } from "@/features/user/user.types";
+import type { AuthService } from "../auth.service";
+import type { UserService } from "../../user/user.service";
+import type { RouteGuardSubscriptionRepo } from "../route-guard.service";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({ APP_MODE: "cloud" as "cloud" | "demo" | "self-hosted" }));
+
+vi.mock("@/env", () => ({ env: mockEnv }));
+
+import { Action, Resource, Status, SubscriptionStatus } from "@/generated/prisma";
+
+import { RouteGuardService } from "../route-guard.service";
+
+const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000);
+const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+const mocks = {
+  resolveSession: vi.fn(),
+  getUser: vi.fn(),
+  getSubscriptionOrThrowUnscoped: vi.fn(),
+};
+
+function makeService() {
+  return new RouteGuardService(
+    { resolveSession: mocks.resolveSession } as unknown as AuthService,
+    { getUser: mocks.getUser } as unknown as UserService,
+    { getSubscriptionOrThrowUnscoped: mocks.getSubscriptionOrThrowUnscoped } as unknown as RouteGuardSubscriptionRepo,
+  );
+}
+
+function user(overrides: Record<string, unknown> = {}): ExtendedUser {
+  return {
+    id: "user-1",
+    email: "max@example.com",
+    companyId: "company-1",
+    status: Status.active,
+    onboardingWizardCompletedAt: new Date(),
+    role: { isSystemRole: true, permissions: [] },
+    ...overrides,
+  } as unknown as ExtendedUser;
+}
+
+function subscription(status: SubscriptionStatus, trialEndDate: Date | null = null) {
+  return { status, trialEndDate };
+}
+
+describe("RouteGuardService.resolveAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.APP_MODE = "cloud";
+    mocks.resolveSession.mockResolvedValue({ session: {} });
+    mocks.getUser.mockResolvedValue(user());
+    mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.active));
+  });
+
+  it("redirects to sign-in when there is no valid session", async () => {
+    mocks.resolveSession.mockResolvedValue({ redirect: "/auth/signin" });
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/auth/signin" });
+    expect(mocks.getUser).not.toHaveBeenCalled();
+  });
+
+  it("sends a session without a product user to the onboarding wizard", async () => {
+    mocks.getUser.mockResolvedValue(null);
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/onboarding/wizard" });
+  });
+
+  it("routes an inactive user to the inactive-account error, never the expiry page", async () => {
+    mocks.getUser.mockResolvedValue(user({ status: Status.inactive }));
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/auth/error?type=inactiveUser" });
+    expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("routes a pending-authorization user to the pending page", async () => {
+    mocks.getUser.mockResolvedValue(user({ status: Status.pendingAuthorization }));
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/auth/pending" });
+  });
+
+  it("sends a system-role user with incomplete onboarding to the wizard", async () => {
+    mocks.getUser.mockResolvedValue(user({ onboardingWizardCompletedAt: null }));
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/onboarding/wizard" });
+  });
+
+  it("routes an active user whose trial has expired to the subscription-expired page", async () => {
+    mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.trial, PAST));
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/subscription-expired" });
+  });
+
+  it("routes an active user on an unpaid subscription to the subscription-expired page", async () => {
+    mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.unPaid));
+
+    expect(await makeService().resolveAccess()).toEqual({ redirect: "/subscription-expired" });
+  });
+
+  it("lets an active user on an active subscription through", async () => {
+    expect(await makeService().resolveAccess()).toBeNull();
+  });
+
+  it("lets an active user on a not-yet-expired trial through", async () => {
+    mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.trial, FUTURE));
+
+    expect(await makeService().resolveAccess()).toBeNull();
+  });
+
+  it("skips the subscription check in demo mode", async () => {
+    mockEnv.APP_MODE = "demo";
+    mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.trial, PAST));
+
+    expect(await makeService().resolveAccess()).toBeNull();
+    expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("skips the subscription check when skipSubscriptionCheck is set (the expiry page's own guard)", async () => {
+    mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.trial, PAST));
+
+    expect(await makeService().resolveAccess({ resource: Resource.company, skipSubscriptionCheck: true })).toBeNull();
+    expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("denies a non-system-role user without the required resource permission", async () => {
+    mocks.getUser.mockResolvedValue(user({ role: { isSystemRole: false, permissions: [] } }));
+
+    expect(await makeService().resolveAccess({ resource: Resource.contacts })).toEqual({ redirect: "/" });
+  });
+
+  it("allows a non-system-role user holding the required resource permission", async () => {
+    mocks.getUser.mockResolvedValue(
+      user({ role: { isSystemRole: false, permissions: [{ resource: Resource.contacts, action: Action.readOwn }] } }),
+    );
+
+    expect(await makeService().resolveAccess({ resource: Resource.contacts })).toBeNull();
+  });
+
+  it("lets a system-role user bypass the resource permission check", async () => {
+    expect(await makeService().resolveAccess({ resource: Resource.contacts })).toBeNull();
+  });
+});


### PR DESCRIPTION
Refs [CUS-65](https://linear.app/customermates/issue/CUS-65). Source ref: `origin/main` @ `c6bbc11`.

## Summary

CUS-65 was an **unconfirmed** report ("trial expiry may throw an error when resuming a stale browser"). After reproducing it locally, the routing **already converges correctly** and no error/loop/data-render was reproducible: `RouteGuardService` / `requireAccess` redirects an authenticated **active** user whose trial has lapsed to the canonical `/subscription-expired` page, server-authoritatively, on every real navigation. So this PR **adds deterministic regression coverage** for that convergence and the adjacent auth/subscription states, per the issue's "if no longer reproducible, document + add regression coverage" path. **No production/behavior change — tests only.**

(An earlier revision of this branch added a proxy-level entitlement check to also suppress a cosmetic soft-navigation artifact; we reverted it — it added a DB read to the middleware hot path to paper over a non-error, and didn't close the real gap. See *Impact and rollback* for the follow-up option.)

## Context

- **Affected state:** valid Better Auth session + `User.status === active` + `Subscription.status === trial` with a past `trialEndDate` (`isSubscriptionExpired === true`), in `cloud`/`self-hosted`. This is the window *before* the lifecycle job deactivates a trial user (~6–7 days after trial end); after that the user is `inactive`, which is [CUS-63](https://linear.app/customermates/issue/CUS-63)'s domain.
- **Reproduced** locally (cloud mode, synthetic user, `trialEndDate` flipped into the past as a controllable clock):
  - refresh / deep link / new-tab / direct sign-in → clean server redirect to `/subscription-expired`, no protected data rendered;
  - renewal/reactivation → access restored, no stale expired state;
  - an inactive user → `/auth/error?type=inactiveUser` (**not** the expiry page) — CUS-63 boundary intact.
- **What was *not* reproducible:** any unhandled client/server error, redirect loop, or protected-content (data) render. The only residue was a cosmetic App-Router soft-nav artifact (the target route's chrome + a Vercel Analytics page-view flash during the RSC round-trip before the page-guard redirect resolves). That is not the reported symptom and not worth a middleware DB hit on every navigation.

## Validation

- **New — `features/auth/__tests__/route-guard.service.test.ts` (14 cases):** no session → sign-in; no product user → onboarding wizard; **inactive → `/auth/error?type=inactiveUser` (never the expiry page)**; pending → `/auth/pending`; incomplete onboarding → wizard; **active + expired trial → `/subscription-expired`**; active + unpaid → `/subscription-expired`; active + active/live-trial → allowed; check skipped in demo mode; check skipped under `skipSubscriptionCheck` (the expiry page's own guard); resource-permission allow/deny + system-role bypass.
- **New — `ee/subscription/__tests__/entitlements.test.ts` (5 cases):** `isSubscriptionExpired` / `isSubscriptionUsable` matrices.
- Rebased onto latest `main` (`c6bbc11`). Gates: `yarn typecheck` ✅ · `yarn lint` ✅ · `yarn vitest run tests/conventions` ✅ · new tests 19/19 ✅ · full `yarn test` + `yarn build` via CI.

## Impact and rollback

- **No runtime change.** Zero TTFB impact. Rollback = revert this commit; behavior is identical either way.
- **Known, out of scope (follow-up):** protected data access is not subscription-gated at the data layer — server actions, REST (`/api/v1`), and MCP still serve an expired-trial company (the page guard only fences *pages*). If we want expired trials fully fenced out of data everywhere, the right place is the interactor boundary (`TenantInteractor`), which all reads/writes flow through — worth a separate ticket rather than a middleware check that only covers browser navigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
