### PR TITLE
feat(seed): add empty-demo sandbox that seeds identity only

### DIFF
--- a/prisma/seeds/empty-demo.ts
+++ b/prisma/seeds/empty-demo.ts
@@ -1,0 +1,14 @@
+// Sandbox demo environments whose database must stay empty of business records.
+// These deploy from `sandbox/<slug>` branches and expose `<slug>.customermates.com`;
+// the seed still provisions identity (company, login users, roles, subscription) so
+// the environment is signable-in, but skips every synthetic fixture.
+const EMPTY_DEMO_REFS = new Set<string>(["sandbox/sell-ai-projects"]);
+
+// Returns true when the current build must seed identity only and leave the CRM empty.
+// Keyed on the Vercel branch ref (with a DEMO_EMPTY=1 escape hatch) so the default
+// seed path — and every test that runs it without these vars — is untouched.
+export function isEmptyDemo(): boolean {
+  if (process.env.DEMO_EMPTY === "1") return true;
+  const ref = process.env.VERCEL_GIT_COMMIT_REF?.trim();
+  return ref !== undefined && EMPTY_DEMO_REFS.has(ref);
+}

--- a/prisma/seeds/run.ts
+++ b/prisma/seeds/run.ts
@@ -8,6 +8,7 @@ import type { TaskSeedData } from "./tasks";
 import { seedContacts } from "./contacts";
 import { seedCustomFields } from "./custom-fields";
 import { seedDeals } from "./deals";
+import { isEmptyDemo } from "./empty-demo";
 import { seedIdentity } from "./identity";
 import { seedDemoMessagingFixtures } from "./messaging/seed";
 import { seedSyntheticAuditLogs } from "./audit-logs";
@@ -21,8 +22,22 @@ import { seedWidgets } from "./widgets";
 
 export type SyntheticSeedData = OrganizationSeedData & ContactSeedData & DealSeedData & ServiceSeedData & TaskSeedData;
 
+const EMPTY_SEED_DATA: SyntheticSeedData = {
+  contactDefinitions: [],
+  contacts: [],
+  dealDefinitions: [],
+  deals: [],
+  organizations: [],
+  services: [],
+  taskDefinitions: [],
+  tasks: [],
+};
+
 export async function runSyntheticSeed(context: SeedContext): Promise<SyntheticSeedData> {
   await seedIdentity(context);
+
+  // Empty-demo sandboxes get a signable-in company with no business records.
+  if (isEmptyDemo()) return EMPTY_SEED_DATA;
 
   const organizationData = await seedOrganizations(context);
   const contactData = await seedContacts(context, organizationData.organizations);


### PR DESCRIPTION
## Summary

Gate `runSyntheticSeed` so the `sandbox/sell-ai-projects` branch seeds identity only — a signable-in company (login users, roles, subscription) with zero business records — backing an empty `sell-ai-projects.customermates.com` demo environment.

## Context

We need a persistent, empty Customermates demo at `sell-ai-projects.customermates.com`: a clean CRM a prospect can be walked through from zero. The synthetic seed otherwise always populates the full demo fixture set (orgs, contacts, deals, services, tasks, custom fields, widgets, messaging). This adds an opt-in empty path keyed on the deploy branch ref, without disturbing the default seed.

## Validation

- Vercel preview build went READY — a clean build proves `prisma migrate deploy` + `prisma/seed.ts` ran the identity-only seed without error.
- Verified the deploy serves the app: `https://sell-ai-projects.customermates.com` returns HTTP 200 and `/login` returns 200.
- `isEmptyDemo()` keys on `VERCEL_GIT_COMMIT_REF` (with a `DEMO_EMPTY=1` escape hatch); both are unset under `yarn test` and CI, so `runSyntheticSeed` takes its existing full-seed path there — the default seed and existing seed tests are unchanged. The empty-mode early return fills all eight `SyntheticSeedData` fields with empty arrays.

## Impact and rollback

- Runtime impact is limited to the `sandbox/sell-ai-projects` deploy; the seed used by the Demo environment, other previews, and tests is unaffected.
- Rollback: revert this commit, or delete the `sandbox/sell-ai-projects` branch to retire the demo environment.
