### PR TITLE
fix(demo): allow branch preview domains to frame the demo deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -53,7 +53,9 @@ const nextConfig: NextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              env.APP_MODE === "demo" ? "frame-ancestors 'self' https://customermates.com" : "frame-ancestors 'self'",
+              env.APP_MODE === "demo"
+                ? "frame-ancestors 'self' https://customermates.com https://*.customermates.com"
+                : "frame-ancestors 'self'",
           },
         ],
       },

--- a/tests/conventions/env-config.test.ts
+++ b/tests/conventions/env-config.test.ts
@@ -157,12 +157,14 @@ describe("environment configuration", () => {
     );
   });
 
-  it("allows only Production to frame Demo builds", () => {
+  it("allows only Production and its branch domains to frame Demo builds", () => {
     const config = readFileSync(new URL("../../next.config.ts", import.meta.url), "utf8");
     expect(config).toContain('env.APP_MODE === "demo"');
-    expect(config).toContain(`? "frame-ancestors 'self' https://customermates.com"`);
+    expect(config).toContain(`? "frame-ancestors 'self' https://customermates.com https://*.customermates.com"`);
     expect(config).toContain(`: "frame-ancestors 'self'"`);
     expect(config).not.toContain("test.customermates.com");
+    expect(config).not.toContain("frame-ancestors *");
+    expect(config).not.toContain("*.vercel.app");
   });
 
   it("uses the Better Auth host allowlist and dedicated OAuth proxy secret", () => {


### PR DESCRIPTION
## Summary

The demo deployment sent `frame-ancestors 'self' https://customermates.com`, an allowlist that matches the production apex origin only. `frame-ancestors` does not cover subdomains, so every deterministic branch domain under `customermates.com` was a foreign origin and the start-page hero iframe was refused there. This widens the demo allowlist to those branch domains and pins the new value with the existing convention test.

Closes CUS-149.

## Context

Reported on `https://feat-cus-80-activity-channel-filter.customermates.com/en`, which rendered the hero browser frame with "demo.customermates.com refused to connect" inside it.

- `app/[locale]/(static)/components/hero-demo-iframe.tsx:12` frames `https://demo.customermates.com/${locale}` in every environment.
- `next.config.ts` emitted the apex-only allowlist whenever `APP_MODE === "demo"`.
- Production is unaffected because it is served from the exact origin the header named.

Raw `*.vercel.app` deployment URLs stay unframeable, which matches `resolveAuthAllowedHosts` refusing `*.vercel.app`. Non-demo modes keep `frame-ancestors 'self'`, so production, cloud, and self-hosted app deployments remain unframeable.

The Demo environment tracks `main`, so the widened header goes live with the deploy that follows this merge.

## Validation

Local `next dev` in each mode, reading the response header:

```
APP_MODE=demo       -> Content-Security-Policy: frame-ancestors 'self' https://customermates.com https://*.customermates.com
APP_MODE=self-hosted -> Content-Security-Policy: frame-ancestors 'self'
```

- `yarn typecheck` passed.
- `yarn lint` passed.
- `yarn vitest run tests/conventions` passed, 13 files, 59 tests.

The updated convention test asserts the exact demo value and now also fails on `frame-ancestors *` and on `*.vercel.app`.

Browser-level proof on a preview host is only observable after the demo environment redeploys from `main`; before that the old header is still being served.

## Impact and rollback

Impact is limited to the framing allowlist of the demo deployment. It widens a clickjacking control from one Customermates origin to the Customermates-controlled branch domains under the same registrable domain; no other environment, route, data path, or migration is touched.

Roll back by reverting this commit and letting the demo environment redeploy. The header is the only stateful surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)