### PR TITLE
feat(contacts): open sidebar entity drawers from the left and add channels while creating a contact

### DIFF
--- a/app/[locale]/(protected)/contacts/components/__tests__/add-channel.store.test.ts
+++ b/app/[locale]/(protected)/contacts/components/__tests__/add-channel.store.test.ts
@@ -1,0 +1,96 @@
+import type { RootStore } from "@/core/stores/root.store";
+import type { IdentifierInput } from "@/features/contacts/contact.schema";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessagingProvider } from "@/generated/prisma";
+
+const contactActions = vi.hoisted(() => ({
+  checkChannelConflictAction: vi.fn(),
+  getContactsAction: vi.fn(),
+  searchChannelCandidatesAction: vi.fn(),
+}));
+const inboxActions = vi.hoisted(() => ({ resolveProviderProfileAction: vi.fn() }));
+
+vi.mock("../../actions", () => contactActions);
+vi.mock("../../../inbox/actions", () => inboxActions);
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { AddChannelStore } from "../add-channel.store";
+
+function makeStore(channels: IdentifierInput[]): AddChannelStore {
+  const root = {
+    contactDetailStore: { channels, addChannel: vi.fn() },
+    connectedAccountsStore: { ensureLoaded: vi.fn(), usableSendersFor: () => [] },
+    userStore: { user: null, can: () => true, canManage: () => true, canAccess: () => true },
+  } as unknown as RootStore;
+  return new AddChannelStore(root);
+}
+
+const EMAIL = "shared@example.com";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AddChannelStore.addAsNewOptions", () => {
+  it("offers Mail for an address the contact does not have", () => {
+    const store = makeStore([]);
+    store.query = EMAIL;
+
+    expect(store.addAsNewOptions).toEqual([MessagingProvider.mail]);
+  });
+
+  it("suppresses Mail when the contact already holds the address under google", () => {
+    const store = makeStore([{ provider: MessagingProvider.google, value: EMAIL }]);
+    store.query = EMAIL;
+
+    expect(store.addAsNewOptions).toEqual([]);
+  });
+
+  it("suppresses Mail when the contact already holds the address under outlook", () => {
+    const store = makeStore([{ provider: MessagingProvider.outlook, value: EMAIL }]);
+    store.query = EMAIL;
+
+    expect(store.addAsNewOptions).toEqual([]);
+  });
+
+  it("suppresses Mail when the contact already holds the address under mail", () => {
+    const store = makeStore([{ provider: MessagingProvider.mail, value: EMAIL }]);
+    store.query = EMAIL;
+
+    expect(store.addAsNewOptions).toEqual([]);
+  });
+
+  it("still offers Mail when the contact holds a different address", () => {
+    const store = makeStore([{ provider: MessagingProvider.google, value: "someone-else@example.com" }]);
+    store.query = EMAIL;
+
+    expect(store.addAsNewOptions).toEqual([MessagingProvider.mail]);
+  });
+
+  it("suppresses WhatsApp when the contact already holds the number", () => {
+    const store = makeStore([{ provider: MessagingProvider.whatsapp, value: "+4915150799170" }]);
+    store.query = "+4915150799170";
+
+    expect(store.addAsNewOptions).toEqual([]);
+  });
+
+  it("does not suppress a handle that merely matches another provider's handle", () => {
+    const store = makeStore([{ provider: MessagingProvider.telegram, value: "jane" }]);
+    store.query = "jane";
+
+    expect(store.addAsNewOptions).toContain(MessagingProvider.linkedin);
+    expect(store.addAsNewOptions).not.toContain(MessagingProvider.telegram);
+  });
+});
+
+describe("AddChannelStore.contactChannelKeys", () => {
+  it("keys staged channels by channel class so email providers collapse", () => {
+    const store = makeStore([
+      { provider: MessagingProvider.google, value: EMAIL },
+      { provider: MessagingProvider.whatsapp, value: "+4915150799170" },
+    ]);
+
+    expect([...store.contactChannelKeys]).toEqual([`email:${EMAIL}`, "phone:+4915150799170"]);
+  });
+});

--- a/app/[locale]/(protected)/contacts/components/__tests__/contact-detail.store.test.ts
+++ b/app/[locale]/(protected)/contacts/components/__tests__/contact-detail.store.test.ts
@@ -1,0 +1,207 @@
+import type { RootStore } from "@/core/stores/root.store";
+import type { ContactDto } from "@/features/contacts/contact.schema";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessagingProvider } from "@/generated/prisma";
+
+const contactActions = vi.hoisted(() => ({
+  getContactByIdAction: vi.fn(),
+  createContactAction: vi.fn(),
+  updateContactAction: vi.fn(),
+  deleteContactAction: vi.fn(),
+}));
+
+vi.mock("../../actions", () => contactActions);
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { ContactDetailStore } from "../contact-detail.store";
+
+const CONTACT_ID = "40000000-0000-4000-8000-000000000001";
+const TASK_ID = "50000000-0000-4000-8000-000000000001";
+
+function stubRoot(): RootStore {
+  return {
+    registerModalStore: vi.fn(),
+    contactsStore: {
+      customColumns: [],
+      setCustomColumns: vi.fn(),
+      refreshCustomColumns: vi.fn().mockResolvedValue(undefined),
+      upsertItem: vi.fn().mockResolvedValue(undefined),
+      removeItem: vi.fn().mockResolvedValue(undefined),
+    },
+    loadingOverlayStore: { withLoading: (fn: () => unknown) => fn() },
+    globalSearchModalStore: { pushRecentItem: vi.fn(), removeRecentItem: vi.fn() },
+    activitiesStore: { refreshFor: vi.fn() },
+    localeStore: { locale: "en", getTranslation: (key: string) => key },
+  } as unknown as RootStore;
+}
+
+function makeStore(): ContactDetailStore {
+  return new ContactDetailStore(stubRoot());
+}
+
+function contactWithTasks(): ContactDto {
+  return {
+    id: CONTACT_ID,
+    firstName: "Existing",
+    lastName: "Contact",
+    notes: null,
+    avatarUrl: null,
+    customFieldValues: [],
+    organizations: [],
+    users: [],
+    deals: [],
+    tasks: [{ id: TASK_ID }],
+    identifiers: [{ provider: MessagingProvider.mail, value: "existing@example.com" }],
+  } as unknown as ContactDto;
+}
+
+const mail = (value: string) => ({ provider: MessagingProvider.mail, value });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ContactDetailStore.addChannel", () => {
+  it("appends distinct channels in order", () => {
+    const store = makeStore();
+    store.addChannel(mail("a@example.com"));
+    store.addChannel({ provider: MessagingProvider.whatsapp, value: "+4915150799170" });
+    store.addChannel({ provider: MessagingProvider.linkedin, value: "jane-doe" });
+
+    expect(store.channels.map((c) => c.value)).toEqual(["a@example.com", "+4915150799170", "jane-doe"]);
+  });
+
+  it("suppresses an exact repeat", () => {
+    const store = makeStore();
+    store.addChannel(mail("a@example.com"));
+    store.addChannel(mail("a@example.com"));
+
+    expect(store.channels).toHaveLength(1);
+  });
+
+  it("suppresses the same address under a sibling email provider", () => {
+    const store = makeStore();
+    store.addChannel(mail("a@example.com"));
+    store.addChannel({ provider: MessagingProvider.google, value: "a@example.com" });
+
+    expect(store.channels).toHaveLength(1);
+    expect(store.channels[0].provider).toBe(MessagingProvider.mail);
+  });
+
+  it("does not suppress the same raw value across different channel classes", () => {
+    const store = makeStore();
+    store.addChannel({ provider: MessagingProvider.telegram, value: "jane" });
+    store.addChannel({ provider: MessagingProvider.linkedin, value: "jane" });
+
+    expect(store.channels).toHaveLength(2);
+  });
+
+  it("marks the form dirty when a channel is staged", () => {
+    const store = makeStore();
+    expect(store.hasUnsavedChanges).toBe(false);
+
+    store.addChannel(mail("a@example.com"));
+    expect(store.hasUnsavedChanges).toBe(true);
+  });
+});
+
+describe("ContactDetailStore.removeChannel", () => {
+  it("removes the channel at the given index", () => {
+    const store = makeStore();
+    store.addChannel(mail("a@example.com"));
+    store.addChannel(mail("b@example.com"));
+    store.addChannel(mail("c@example.com"));
+
+    store.removeChannel(1);
+
+    expect(store.channels.map((c) => c.value)).toEqual(["a@example.com", "c@example.com"]);
+  });
+
+  it("leaves the list untouched for an out-of-range index", () => {
+    const store = makeStore();
+    store.addChannel(mail("a@example.com"));
+
+    store.removeChannel(5);
+
+    expect(store.channels).toHaveLength(1);
+  });
+});
+
+describe("ContactDetailStore create draft", () => {
+  it("clears identifiers and taskIds carried over from a previously loaded contact", async () => {
+    const store = makeStore();
+    store.hydrate(contactWithTasks(), []);
+
+    expect(store.form.taskIds).toEqual([TASK_ID]);
+    expect(store.channels).toHaveLength(1);
+
+    await store.add();
+
+    expect(store.form.taskIds).toEqual([]);
+    expect(store.channels).toEqual([]);
+    expect(store.form.organizationIds).toEqual([]);
+    expect(store.form.dealIds).toEqual([]);
+    expect(store.form.userIds).toEqual([]);
+    expect(store.form.id).toBeUndefined();
+    expect(store.fetchedEntity).toBeNull();
+  });
+
+  it("starts clean so closing an untouched draft does not prompt", async () => {
+    const store = makeStore();
+    await store.add();
+
+    expect(store.hasUnsavedChanges).toBe(false);
+  });
+});
+
+describe("ContactDetailStore.onSubmit", () => {
+  it("sends staged channels through a single create call", async () => {
+    const store = makeStore();
+    contactActions.createContactAction.mockResolvedValue({
+      ok: true,
+      data: { ...contactWithTasks(), id: CONTACT_ID },
+    });
+
+    await store.add();
+    store.onChange("firstName", "Draft");
+    store.addChannel(mail("a@example.com"));
+    store.addChannel({ provider: MessagingProvider.linkedin, value: "jane-doe" });
+
+    await store.onSubmit();
+
+    expect(contactActions.createContactAction).toHaveBeenCalledTimes(1);
+    expect(contactActions.updateContactAction).not.toHaveBeenCalled();
+
+    const payload = contactActions.createContactAction.mock.calls[0][0];
+    expect(payload.id).toBeUndefined();
+    expect(payload.identifiers.map((i: { value: string }) => i.value)).toEqual(["a@example.com", "jane-doe"]);
+  });
+
+  it("sends an empty identifier list when no channel was staged", async () => {
+    const store = makeStore();
+    contactActions.createContactAction.mockResolvedValue({ ok: true, data: contactWithTasks() });
+
+    await store.add();
+    store.onChange("firstName", "Draft");
+    await store.onSubmit();
+
+    expect(contactActions.createContactAction.mock.calls[0][0].identifiers).toEqual([]);
+  });
+
+  it("keeps the draft recoverable when the create fails", async () => {
+    const store = makeStore();
+    contactActions.createContactAction.mockResolvedValue({ ok: false, error: { errors: ["boom"] } });
+
+    await store.add();
+    store.onChange("firstName", "Draft");
+    store.addChannel(mail("a@example.com"));
+
+    await store.onSubmit();
+
+    expect(store.channels).toHaveLength(1);
+    expect(store.form.firstName).toBe("Draft");
+    expect(store.isOpen).toBe(true);
+    expect(store.isLoading).toBe(false);
+  });
+});

--- a/app/[locale]/(protected)/contacts/components/add-channel-popover.tsx
+++ b/app/[locale]/(protected)/contacts/components/add-channel-popover.tsx
@@ -19,7 +19,7 @@ const SOURCE_HINT_KEYS = {
   lookup: "EntityChannels.addChannel.sourceLookup",
 } as const;
 
-export const AddChannelPopover = observer(({ contactId }: { contactId: string }) => {
+export const AddChannelPopover = observer(({ contactId }: { contactId?: string }) => {
   const t = useTranslations();
   const { addChannelStore: store } = useRootStore();
   const containerRef = useRef<HTMLDivElement>(null);

--- a/app/[locale]/(protected)/contacts/components/add-channel.store.ts
+++ b/app/[locale]/(protected)/contacts/components/add-channel.store.ts
@@ -12,8 +12,9 @@ import { checkChannelConflictAction, getContactsAction, searchChannelCandidatesA
 import { resolveProviderProfileAction } from "../../inbox/actions";
 
 import { BaseFormStore } from "@/core/base/base-form.store";
-import { channelClass, isHandleProvider } from "@/ee/messaging/provider";
+import { isHandleProvider } from "@/ee/messaging/provider";
 import { inferChannelProviders, normalizeChannelValue, parseChannelHandle } from "@/features/contacts/channel-value";
+import { identifierKey } from "@/features/contacts/upsert/validate-identifiers";
 import { Debouncer, SEARCH_DEBOUNCE_MS } from "@/core/utils/debounce";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 
@@ -25,10 +26,6 @@ type TaggedCandidate = { candidate: ChannelCandidateDto; source: CandidateSource
 const SOURCE_PRIORITY: Record<CandidateSource, number> = { lookup: 0, contact: 1, conversation: 2 };
 
 type AddChannelForm = { value: string };
-
-function channelKey(provider: MessagingProvider, value: string): string {
-  return `${channelClass(provider)}:${value}`;
-}
 
 export class AddChannelStore extends BaseFormStore<AddChannelForm> {
   open = false;
@@ -65,7 +62,7 @@ export class AddChannelStore extends BaseFormStore<AddChannelForm> {
     });
   }
 
-  setContactId = (contactId: string) => {
+  setContactId = (contactId: string | undefined) => {
     this.contactId = contactId;
   };
 
@@ -75,14 +72,14 @@ export class AddChannelStore extends BaseFormStore<AddChannelForm> {
   };
 
   get contactChannelKeys(): Set<string> {
-    return new Set(this.rootStore.contactDetailStore.channels.map((c) => channelKey(c.provider, c.value)));
+    return new Set(this.rootStore.contactDetailStore.channels.map((c) => identifierKey(c.provider, c.value)));
   }
 
   get mergedCandidates(): TaggedCandidate[] {
     const contactKeys = this.contactChannelKeys;
     const byKey = new Map<string, TaggedCandidate>();
     for (const tagged of [...this.candidates, ...(this.liveCandidate ? [this.liveCandidate] : [])]) {
-      const key = channelKey(tagged.candidate.provider, tagged.candidate.value);
+      const key = identifierKey(tagged.candidate.provider, tagged.candidate.value);
       if (contactKeys.has(key)) continue;
       const existing = byKey.get(key);
       if (!existing || SOURCE_PRIORITY[tagged.source] < SOURCE_PRIORITY[existing.source]) byKey.set(key, tagged);
@@ -93,12 +90,12 @@ export class AddChannelStore extends BaseFormStore<AddChannelForm> {
   get addAsNewOptions(): MessagingProvider[] {
     const contactKeys = this.contactChannelKeys;
     const candidateKeys = new Set(
-      this.mergedCandidates.map((t) => channelKey(t.candidate.provider, t.candidate.value)),
+      this.mergedCandidates.map((t) => identifierKey(t.candidate.provider, t.candidate.value)),
     );
     return inferChannelProviders(this.query).filter((provider) => {
       const value = normalizeChannelValue(provider, this.query);
       if (!value) return false;
-      const key = channelKey(provider, value);
+      const key = identifierKey(provider, value);
       return !candidateKeys.has(key) && !contactKeys.has(key);
     });
   }

--- a/app/[locale]/(protected)/contacts/components/contact-channels.tsx
+++ b/app/[locale]/(protected)/contacts/components/contact-channels.tsx
@@ -69,7 +69,7 @@ export const ContactChannels = observer(({ contactId, emptyHint }: Props) => {
         )}
       </div>
 
-      {identifiers.length === 0 && !canEditChannels && (
+      {contactId && identifiers.length === 0 && !canEditChannels && (
         <p className="text-muted-foreground text-xs italic">{emptyHint ?? t("EntityChannels.emptyHint")}</p>
       )}
 

--- a/app/[locale]/(protected)/contacts/components/contact-channels.tsx
+++ b/app/[locale]/(protected)/contacts/components/contact-channels.tsx
@@ -24,7 +24,7 @@ import { AddChannelPopover } from "./add-channel-popover";
 import { ContactComposePopover } from "./contact-compose-popover";
 
 type Props = {
-  contactId: string;
+  contactId?: string;
   emptyHint?: string;
 };
 
@@ -34,7 +34,7 @@ export const ContactChannels = observer(({ contactId, emptyHint }: Props) => {
   const { userStore, contactDetailStore, threadComposeStore, connectedAccountsStore } = rootStore;
   const copy = useCopyToClipboard();
   const [composeKey, setComposeKey] = useState<string | null>(null);
-  const canEditChannels = userStore.can(Resource.contacts, Action.update);
+  const canEditChannels = userStore.can(Resource.contacts, contactId ? Action.update : Action.create);
   const canStartThread = userStore.can(Resource.inboxMessages, Action.create) && rootStore.appMode !== "self-hosted";
   const identifiers = contactDetailStore.channels;
 
@@ -60,7 +60,7 @@ export const ContactChannels = observer(({ contactId, emptyHint }: Props) => {
       <div className="flex items-center gap-1.5">
         <span className="text-muted-foreground text-xs font-normal">{t("EntityChannels.heading")}</span>
 
-        {identifiers.length > 0 && rootStore.appMode !== "self-hosted" && (
+        {contactId && identifiers.length > 0 && rootStore.appMode !== "self-hosted" && (
           <IconButton
             href={`/inbox?filters=${encodeURIComponent(`participantContactId:in:${contactId}`)}`}
             icon={ExternalLink}

--- a/app/[locale]/(protected)/contacts/components/contact-detail-view.tsx
+++ b/app/[locale]/(protected)/contacts/components/contact-detail-view.tsx
@@ -32,7 +32,7 @@ export const ContactDetailView = observer(({ layout = "drawer" }: Props) => {
         <FormInput id="lastName" />
       </div>
 
-      {fetchedEntity && <ContactChannels contactId={fetchedEntity.id} />}
+      <ContactChannels contactId={fetchedEntity?.id} />
 
       <EntityRelationField
         currentEntityId={fetchedEntity?.id}

--- a/app/[locale]/(protected)/contacts/components/contact-detail.store.tsx
+++ b/app/[locale]/(protected)/contacts/components/contact-detail.store.tsx
@@ -8,6 +8,7 @@ import { Resource } from "@/generated/prisma";
 import { deleteContactAction, getContactByIdAction, createContactAction, updateContactAction } from "../actions";
 
 import { BaseCustomColumnEntityModalStore } from "@/core/base/base-custom-column-entity-modal.store";
+import { identifierKey } from "@/features/contacts/upsert/validate-identifiers";
 
 function toIdentifierInput(identifier: ContactIdentifierDto): IdentifierInput {
   return {
@@ -59,9 +60,8 @@ export class ContactDetailStore extends BaseCustomColumnEntityModalStore<
   }
 
   addChannel = (identifier: IdentifierInput): void => {
-    const exists = this.channels.some(
-      (existing) => existing.provider === identifier.provider && existing.value === identifier.value,
-    );
+    const key = identifierKey(identifier.provider, identifier.value);
+    const exists = this.channels.some((existing) => identifierKey(existing.provider, existing.value) === key);
     if (exists) return;
 
     this.onChange("identifiers", [...this.channels, identifier]);
@@ -97,6 +97,7 @@ export class ContactDetailStore extends BaseCustomColumnEntityModalStore<
       organizationIds: [],
       userIds: [],
       dealIds: [],
+      taskIds: [],
       identifiers: [],
     };
   }

--- a/app/components/app-sidebar.tsx
+++ b/app/components/app-sidebar.tsx
@@ -6,7 +6,7 @@ import type { SubscriptionPlan, SubscriptionStatus } from "@/generated/prisma";
 import type { NavGroup } from "./navigation/nav-main";
 import type { NavSecondaryItem } from "./navigation/nav-secondary";
 
-import { useEffect, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import { usePathname as useIntlPathname, useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
@@ -332,8 +332,10 @@ export const AppSidebar = observer(
           open={isAddPickerOpen}
           onOpenChange={setIsAddPickerOpen}
           onPick={(entity) => {
-            setIsAddPickerOpen(false);
-            openEntity(entity, "new");
+            startTransition(() => {
+              setIsAddPickerOpen(false);
+              openEntity(entity, "new");
+            });
           }}
         />
       </>
@@ -361,7 +363,7 @@ function AddPickerDrawer({
   const t = useTranslations();
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="sm:max-w-[420px]" side="right">
+      <SheetContent className="sm:max-w-[420px]" side="left">
         <SheetHeader className="px-6 pt-6">
           <SheetTitle>{t("NavigationBar.addPickerTitle")}</SheetTitle>
 

--- a/components/entity-detail/entity-drawer.tsx
+++ b/components/entity-detail/entity-drawer.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { observer } from "mobx-react-lite";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { VisuallyHidden } from "radix-ui";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { useEntityDrawerStack } from "@/components/entity-detail/hooks/use-entity-drawer-stack";
 import { ENTITY_DETAIL } from "@/components/entity-detail/entity-detail.registry";
+import { UnsavedChangesGuard } from "@/components/modal/unsaved-changes-guard";
 
 export const EntityDrawer = observer(() => {
   const { top, popTop } = useEntityDrawerStack();
   const rootStore = useRootStore();
   const lastLoadedRef = useRef<string | null>(null);
+  const [isConfirmingClose, setIsConfirmingClose] = useState(false);
 
   useEffect(() => {
     if (!top) {
@@ -29,20 +31,42 @@ export const EntityDrawer = observer(() => {
   }, [top, rootStore]);
 
   function handleOpenChange(open: boolean) {
-    if (!open) popTop();
+    if (open || !top) return;
+
+    const store = ENTITY_DETAIL[top.entityType].store(rootStore);
+    if (store.withUnsavedChangesGuard && store.hasUnsavedChanges) {
+      setIsConfirmingClose(true);
+      return;
+    }
+
+    popTop();
+  }
+
+  function handleDiscard() {
+    setIsConfirmingClose(false);
+    if (top) ENTITY_DETAIL[top.entityType].store(rootStore).resetForm();
+    popTop();
   }
 
   const DetailView = top ? ENTITY_DETAIL[top.entityType].DetailView : null;
 
   return (
-    <Sheet open={Boolean(top)} onOpenChange={handleOpenChange}>
-      <SheetContent className="p-0 overflow-y-auto" side="right">
-        <VisuallyHidden.Root>
-          <SheetTitle>{top ? top.entityType : "Detail"}</SheetTitle>
-        </VisuallyHidden.Root>
+    <>
+      <Sheet open={Boolean(top)} onOpenChange={handleOpenChange}>
+        <SheetContent className="p-0 overflow-y-auto" side="left">
+          <VisuallyHidden.Root>
+            <SheetTitle>{top ? top.entityType : "Detail"}</SheetTitle>
+          </VisuallyHidden.Root>
 
-        {DetailView && <DetailView layout="drawer" />}
-      </SheetContent>
-    </Sheet>
+          {DetailView && <DetailView layout="drawer" />}
+        </SheetContent>
+      </Sheet>
+
+      <UnsavedChangesGuard
+        open={isConfirmingClose}
+        onCancel={() => setIsConfirmingClose(false)}
+        onConfirm={handleDiscard}
+      />
+    </>
   );
 });

--- a/components/entity-detail/hooks/__tests__/entity-drawer-stack.test.ts
+++ b/components/entity-detail/hooks/__tests__/entity-drawer-stack.test.ts
@@ -57,3 +57,19 @@ describe("serializeStack", () => {
     expect(serializeStack(parseOpenParam(raw))).toBe(raw);
   });
 });
+
+describe("popping the drawer stack", () => {
+  const pop = (raw: string) => serializeStack(parseOpenParam(raw).slice(0, -1));
+
+  it("returns to the parent entry instead of closing the whole stack", () => {
+    expect(pop("contact:new,organization:new")).toBe("contact:new");
+  });
+
+  it("unwinds a three-deep stack one entry at a time", () => {
+    expect(pop("contact:new,organization:new,deal:new")).toBe("contact:new,organization:new");
+  });
+
+  it("clears the param once the last entry is popped", () => {
+    expect(pop("contact:new")).toBeNull();
+  });
+});

--- a/components/entity-detail/hooks/__tests__/entity-drawer-stack.test.ts
+++ b/components/entity-detail/hooks/__tests__/entity-drawer-stack.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { EntityType } from "@/generated/prisma";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/contacts",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+import { parseOpenParam, serializeStack } from "../use-entity-drawer-stack";
+
+const CONTACT_ID = "60000000-0000-4000-8000-000000000001";
+
+describe("parseOpenParam", () => {
+  it("returns an empty stack for a missing or blank param", () => {
+    expect(parseOpenParam(null)).toEqual([]);
+    expect(parseOpenParam("")).toEqual([]);
+  });
+
+  it("parses a single entry", () => {
+    expect(parseOpenParam("contact:new")).toEqual([{ entityType: EntityType.contact, id: "new" }]);
+  });
+
+  it("preserves order across multiple entries", () => {
+    expect(parseOpenParam(`contact:${CONTACT_ID},deal:new`)).toEqual([
+      { entityType: EntityType.contact, id: CONTACT_ID },
+      { entityType: EntityType.deal, id: "new" },
+    ]);
+  });
+
+  it("drops unknown entity types and malformed tokens", () => {
+    expect(parseOpenParam("bogus:1,contact:new,:x,deal:")).toEqual([{ entityType: EntityType.contact, id: "new" }]);
+  });
+
+  it("accepts every entity type reachable from the sidebar Add flow", () => {
+    const raw = "contact:new,organization:new,deal:new,service:new,task:new";
+    expect(parseOpenParam(raw).map((entry) => entry.entityType)).toEqual([
+      EntityType.contact,
+      EntityType.organization,
+      EntityType.deal,
+      EntityType.service,
+      EntityType.task,
+    ]);
+  });
+});
+
+describe("serializeStack", () => {
+  it("returns null for an empty stack so the caller deletes the param", () => {
+    expect(serializeStack([])).toBeNull();
+  });
+
+  it("round-trips a parsed stack", () => {
+    const raw = `contact:${CONTACT_ID},organization:new`;
+    expect(serializeStack(parseOpenParam(raw))).toBe(raw);
+  });
+});

--- a/components/entity-detail/hooks/use-entity-drawer-stack.ts
+++ b/components/entity-detail/hooks/use-entity-drawer-stack.ts
@@ -10,14 +10,14 @@ import { useRouter as useGuardedIntlRouter } from "@/i18n/navigation";
 
 const OPEN_PARAM = "open";
 
-type EntityDrawerEntry = {
+export type EntityDrawerEntry = {
   entityType: EntityType;
   id: string;
 };
 
 const VALID_ENTITY_TYPES: readonly EntityType[] = RELATION_ENTITY_TYPES;
 
-function parseOpenParam(raw: string | null): EntityDrawerEntry[] {
+export function parseOpenParam(raw: string | null): EntityDrawerEntry[] {
   if (!raw) return [];
   return raw
     .split(",")
@@ -32,7 +32,7 @@ function parseOpenParam(raw: string | null): EntityDrawerEntry[] {
     .filter((x): x is EntityDrawerEntry => x !== null);
 }
 
-function serializeStack(stack: EntityDrawerEntry[]): string | null {
+export function serializeStack(stack: EntityDrawerEntry[]): string | null {
   if (stack.length === 0) return null;
   return stack.map((e) => `${e.entityType}:${e.id}`).join(",");
 }
@@ -71,7 +71,7 @@ export function useEntityDrawerStack() {
 
   const popTop = useCallback(() => {
     if (stack.length === 0) return;
-    writeStack(stack.slice(0, -1), "push");
+    writeStack(stack.slice(0, -1), "replace");
   }, [stack, writeStack]);
 
   return { stack, top, pushEntity, popTop };

--- a/core/validation/__tests__/validators.test.ts
+++ b/core/validation/__tests__/validators.test.ts
@@ -661,13 +661,91 @@ describe("validateIdentifierConflicts", () => {
     expect(ctx.addIssue).toHaveBeenCalledTimes(1);
   });
 
-  it("passes when one batch row repeats its own identifier", () => {
+  it("rejects a repeated identifier inside one batch row", () => {
     const ctx = createMockCtx();
     validateIdentifierConflicts(
       [{ selfContactId: "batch-row:0", identifiers: [mailIdentifier("a@b.com"), mailIdentifier("a@b.com")] }],
       new Map<string, string>(),
       ctx,
       () => ["rows", 0],
+    );
+    expect(ctx.addIssue).toHaveBeenCalledTimes(1);
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { error: CustomErrorCode.duplicateChannel }, path: ["rows", 0, 1, "value"] }),
+    );
+  });
+
+  it("rejects a repeated identifier inside one create payload", () => {
+    const ctx = createMockCtx();
+    validateIdentifierConflicts(
+      [{ selfContactId: undefined, identifiers: [mailIdentifier("a@b.com"), mailIdentifier("a@b.com")] }],
+      new Map<string, string>(),
+      ctx,
+      () => ["identifiers"],
+    );
+    expect(ctx.addIssue).toHaveBeenCalledTimes(1);
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { error: CustomErrorCode.duplicateChannel } }),
+    );
+  });
+
+  it("rejects the same address listed under two email providers in one create payload", () => {
+    const ctx = createMockCtx();
+    validateIdentifierConflicts(
+      [
+        {
+          selfContactId: undefined,
+          identifiers: [
+            mailIdentifier("a@b.com"),
+            { provider: MessagingProvider.google, value: "a@b.com" } as IdentifierInput,
+          ],
+        },
+      ],
+      new Map<string, string>(),
+      ctx,
+      () => ["identifiers"],
+    );
+    expect(ctx.addIssue).toHaveBeenCalledTimes(1);
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { error: CustomErrorCode.duplicateChannel },
+        path: ["identifiers", 1, "value"],
+      }),
+    );
+  });
+
+  it("passes distinct identifiers in one create payload", () => {
+    const ctx = createMockCtx();
+    validateIdentifierConflicts(
+      [
+        {
+          selfContactId: undefined,
+          identifiers: [
+            mailIdentifier("a@b.com"),
+            { provider: MessagingProvider.linkedin, value: "handle" } as IdentifierInput,
+          ],
+        },
+      ],
+      new Map<string, string>(),
+      ctx,
+      () => ["identifiers"],
+    );
+    expect(ctx.addIssue).not.toHaveBeenCalled();
+  });
+
+  it("lets an existing contact re-claim its own identifier under a sibling email provider", () => {
+    const ctx = createMockCtx();
+    const owners = new Map([["email:a@b.com", "contact-1"]]);
+    validateIdentifierConflicts(
+      [
+        {
+          selfContactId: "contact-1",
+          identifiers: [{ provider: MessagingProvider.google, value: "a@b.com" } as IdentifierInput],
+        },
+      ],
+      owners,
+      ctx,
+      () => ["identifiers"],
     );
     expect(ctx.addIssue).not.toHaveBeenCalled();
   });

--- a/core/validation/validation.types.ts
+++ b/core/validation/validation.types.ts
@@ -15,6 +15,7 @@ export enum CustomErrorCode {
   customColumnTypeMismatch = "customColumnTypeMismatch",
   invalidChannelValue = "invalidChannelValue",
   channelAlreadyLinked = "channelAlreadyLinked",
+  duplicateChannel = "duplicateChannel",
   contactRefRequired = "contactRefRequired",
   relationNotAllowed = "relationNotAllowed",
   customFieldInvalidEmail = "customFieldInvalidEmail",

--- a/features/contacts/__tests__/check-channel-conflict.interactor.test.ts
+++ b/features/contacts/__tests__/check-channel-conflict.interactor.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { createMockUser } from "@/tests/helpers/mock-user";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockUser, createMockUserWithPermissions } from "@/tests/helpers/mock-user";
 import {
   MOCK_ENV_MODULE,
   createMockDiModule,
@@ -7,7 +7,7 @@ import {
   MOCK_PRISMA_DB_MODULE,
 } from "@/tests/helpers/interactor-test-setup";
 
-const mockUser = createMockUser();
+let mockUser = createMockUser();
 
 vi.mock("@/env", () => MOCK_ENV_MODULE);
 vi.mock("@/core/di", () => createMockDiModule(() => mockUser));
@@ -19,9 +19,15 @@ vi.mock("next-intl/server", () => ({
 }));
 
 import { CheckChannelConflictInteractor } from "../upsert/check-channel-conflict.interactor";
+import { Action, Resource } from "@/generated/prisma";
+import { ForbiddenError } from "@/core/errors/app-errors";
 
 const SELF = "00000000-0000-4000-8000-000000000001";
 const OTHER = "00000000-0000-4000-8000-000000000002";
+
+beforeEach(() => {
+  mockUser = createMockUser();
+});
 
 function makeInteractor(ownerId: string | undefined) {
   const owners = {
@@ -47,5 +53,37 @@ describe("CheckChannelConflictInteractor", () => {
   it("returns ok:true when the channel is already owned by the same contact", async () => {
     const result = await makeInteractor(SELF).invoke(input as never);
     expect(result).toMatchObject({ ok: true, data: true });
+  });
+
+  it("treats every owner as a conflict for a draft contact that has no id yet", async () => {
+    const result = await makeInteractor(OTHER).invoke({ provider: "telegram", value: "alice" } as never);
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.error.issues[0]?.path).toEqual(["value"]);
+  });
+
+  it("returns ok:true for a draft contact when no owner exists", async () => {
+    const result = await makeInteractor(undefined).invoke({ provider: "telegram", value: "alice" } as never);
+    expect(result).toMatchObject({ ok: true, data: true });
+  });
+});
+
+describe("CheckChannelConflictInteractor permissions", () => {
+  const input = { provider: "telegram", value: "alice" };
+
+  it("allows a user who may create contacts but not update them", async () => {
+    mockUser = createMockUserWithPermissions([{ resource: Resource.contacts, action: Action.create }]);
+    const result = await makeInteractor(undefined).invoke(input as never);
+    expect(result).toMatchObject({ ok: true, data: true });
+  });
+
+  it("allows a user who may update contacts but not create them", async () => {
+    mockUser = createMockUserWithPermissions([{ resource: Resource.contacts, action: Action.update }]);
+    const result = await makeInteractor(undefined).invoke(input as never);
+    expect(result).toMatchObject({ ok: true, data: true });
+  });
+
+  it("rejects a user with neither create nor update on contacts", async () => {
+    mockUser = createMockUserWithPermissions([{ resource: Resource.contacts, action: Action.readAll }]);
+    await expect(makeInteractor(undefined).invoke(input as never)).rejects.toBeInstanceOf(ForbiddenError);
   });
 });

--- a/features/contacts/__tests__/contact-interactors.test.ts
+++ b/features/contacts/__tests__/contact-interactors.test.ts
@@ -355,6 +355,91 @@ describe("CreateContactInteractor", () => {
       }),
     );
   });
+
+  function createWithIdentifiers(identifiers: unknown[], precheck = makeContactWritePrecheck()) {
+    const interactor = new CreateContactInteractor(
+      mockCreateRepo,
+      mockOrgRepo,
+      mockDealRepo,
+      mockTaskRepo,
+      mockEventService,
+      precheck,
+    );
+    return interactor.invoke({
+      firstName: "Jane",
+      lastName: "Doe",
+      organizationIds: [],
+      userIds: [],
+      dealIds: [],
+      taskIds: [],
+      customFieldValues: [],
+      identifiers,
+    } as any);
+  }
+
+  it("creates a contact with no identifiers", async () => {
+    const result: any = await createWithIdentifiers([]);
+
+    expect(result.ok).toBe(true);
+    expect(mockCreateRepo.createContactOrThrow).toHaveBeenCalledTimes(1);
+    expect(mockCreateRepo.createContactOrThrow.mock.calls[0][0].identifiers).toEqual([]);
+  });
+
+  it("normalizes and persists multiple identifiers in one create", async () => {
+    const result: any = await createWithIdentifiers([
+      { provider: "mail", value: "Jane@Example.COM" },
+      { provider: "linkedin", value: "jane-doe" },
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(mockCreateRepo.createContactOrThrow).toHaveBeenCalledTimes(1);
+    expect(mockCreateRepo.createContactOrThrow.mock.calls[0][0].identifiers).toEqual([
+      expect.objectContaining({ provider: "mail", value: "jane@example.com" }),
+      expect.objectContaining({ provider: "linkedin", value: "jane-doe" }),
+    ]);
+  });
+
+  it("rejects an invalid identifier without writing or publishing", async () => {
+    const result: any = await createWithIdentifiers([{ provider: "mail", value: "not-an-email" }]);
+
+    expect(result.ok).toBe(false);
+    expect(mockCreateRepo.createContactOrThrow).not.toHaveBeenCalled();
+    expect(mockEventService.publish).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate within the submitted draft without writing or publishing", async () => {
+    const result: any = await createWithIdentifiers([
+      { provider: "mail", value: "jane@example.com" },
+      { provider: "google", value: "jane@example.com" },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(mockCreateRepo.createContactOrThrow).not.toHaveBeenCalled();
+    expect(mockEventService.publish).not.toHaveBeenCalled();
+  });
+
+  it("rejects an identifier already owned by another contact without writing", async () => {
+    const owningRepo = {
+      findIds: vi.fn().mockResolvedValue(new Map()),
+      findIdentifierOwnersCompanyWide: vi.fn().mockResolvedValue(new Map([["email:jane@example.com", CONTACT_ID_2]])),
+    };
+    const precheck = new ContactWritePrecheckInteractor(
+      new ValidateOrganizationIdsInteractor(getOrganizationRepo()),
+      new ValidateUserIdsInteractor(getUserRepo()),
+      new ValidateDealIdsInteractor(getDealRepo()),
+      new ValidateTaskIdsInteractor(getTaskRepo()),
+      new ValidateContactIdsInteractor(getContactRepo()),
+      new ValidateCustomFieldValuesInteractor(getCustomColumnRepo()),
+      new ValidateAssigneeGuardInteractor(getUserService() as unknown as UserService),
+      new ValidateIdentifierConflictsInteractor(owningRepo as any),
+      getContactRepo(),
+    );
+
+    const result: any = await createWithIdentifiers([{ provider: "mail", value: "jane@example.com" }], precheck);
+
+    expect(result.ok).toBe(false);
+    expect(mockCreateRepo.createContactOrThrow).not.toHaveBeenCalled();
+  });
 });
 
 describe("DeleteContactInteractor", () => {

--- a/features/contacts/upsert/check-channel-conflict.interactor.ts
+++ b/features/contacts/upsert/check-channel-conflict.interactor.ts
@@ -34,8 +34,11 @@ const Schema = IdentifierInputSchema.pick({
 export type CheckChannelConflictData = Data<typeof Schema>;
 
 @TenantInteractor({
-  resource: Resource.contacts,
-  action: Action.update,
+  permissions: [
+    { resource: Resource.contacts, action: Action.create },
+    { resource: Resource.contacts, action: Action.update },
+  ],
+  condition: "OR",
 })
 export class CheckChannelConflictInteractor extends AuthenticatedInteractor<CheckChannelConflictData, boolean> {
   constructor(private owners: ContactIdentifierOwnersRepo) {

--- a/features/contacts/upsert/validate-identifiers.ts
+++ b/features/contacts/upsert/validate-identifiers.ts
@@ -63,8 +63,19 @@ export function validateIdentifierConflicts(
   const claimedBy = new Map<string, string | undefined>(owners);
 
   contacts.forEach(({ selfContactId, identifiers }, index) => {
+    const claimedInPayload = new Set<string>();
+
     (identifiers ?? []).forEach((identifier, i) => {
       const keys = channelStrings(identifier).map((value) => identifierKey(identifier.provider, value));
+
+      if (keys.some((key) => claimedInPayload.has(key))) {
+        ctx.addIssue({
+          code: "custom",
+          params: { error: CustomErrorCode.duplicateChannel },
+          path: [...basePathFor(index), i, "value"],
+        });
+        return;
+      }
 
       if (keys.some((key) => claimedBy.has(key) && claimedBy.get(key) !== selfContactId)) {
         ctx.addIssue({
@@ -75,7 +86,10 @@ export function validateIdentifierConflicts(
         return;
       }
 
-      for (const key of keys) claimedBy.set(key, selfContactId);
+      for (const key of keys) {
+        claimedBy.set(key, selfContactId);
+        claimedInPayload.add(key);
+      }
     });
   });
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -316,6 +316,7 @@
       "customFieldInvalidUrl": "Der URL-Wert ist ungültig. Muss ein gültiges URL-Format haben (z.B. https://example.com). Bei mehreren URLs durch Komma trennen (z.B. https://example.com, https://example.org).",
       "dealNotFound": "Deal-ID nicht gefunden oder nicht zugänglich.",
       "draftMessageNotFound": "Dieser Entwurf wurde nicht gefunden. Möglicherweise wurde er bereits gesendet oder verworfen.",
+      "duplicateChannel": "Dieser Kanal ist mehrfach vorhanden. Füge jede E-Mail-Adresse, Telefonnummer und jeden Benutzernamen nur einmal hinzu.",
       "duplicateOutboundSuppressed": "Eine identische Nachricht wurde gerade eben an diesen Thread gesendet. Ändere den Text oder warte eine Minute, bevor du es erneut versuchst.",
       "duplicateWebhookEvents": "Doppelte Ereignisse sind nicht erlaubt.",
       "emailAlreadyExists": "Ein Konto mit dieser E-Mail-Adresse existiert bereits.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -316,6 +316,7 @@
       "customFieldInvalidUrl": "The URL value is invalid. Must be a valid URL format (e.g., https://example.com). For multiple URLs, separate by comma (e.g., https://example.com, https://example.org).",
       "dealNotFound": "Deal ID not found or not accessible.",
       "draftMessageNotFound": "That draft could not be found. It may have already been sent or discarded.",
+      "duplicateChannel": "This channel is listed more than once. Add each email address, phone number, or handle only once.",
       "duplicateOutboundSuppressed": "An identical message was sent to this thread moments ago. Change the text or wait a minute before retrying.",
       "duplicateWebhookEvents": "Duplicate events are not allowed.",
       "emailAlreadyExists": "An account with this email already exists.",

--- a/tests/conventions/drawer-side.test.ts
+++ b/tests/conventions/drawer-side.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, it, expect } from "vitest";
+
+import { REPO_ROOT } from "./walk";
+
+/**
+ * CUS-61 moved the sidebar Add picker and the shared entity drawer to the left edge.
+ * These are source-level tripwires: the repo has no DOM test environment, so rendered
+ * placement is covered by the browser acceptance pass instead. What this guards is that
+ * nobody silently flips the two moved surfaces back, and that unrelated sheets keep
+ * their intentional side.
+ */
+const ENFORCED = true;
+
+function read(relativePath: string): string {
+  return readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
+
+describe("drawer side placement", () => {
+  it("opens the sidebar Add picker from the left", () => {
+    if (!ENFORCED) return;
+    const source = read("app/components/app-sidebar.tsx");
+
+    expect(source).toContain('side="left"');
+    expect(source).not.toContain('side="right"');
+  });
+
+  it("opens the shared entity drawer from the left", () => {
+    if (!ENFORCED) return;
+    const source = read("components/entity-detail/entity-drawer.tsx");
+
+    expect(source).toContain('side="left"');
+    expect(source).not.toContain('side="right"');
+  });
+
+  it("keeps the public marketing navbar menu on the right", () => {
+    if (!ENFORCED) return;
+    const source = read("app/components/public-navbar.tsx");
+
+    expect(source).toContain('side="right"');
+  });
+
+  it("keeps both sides available on the shared Sheet primitive", () => {
+    if (!ENFORCED) return;
+    const source = read("components/ui/sheet.tsx");
+
+    expect(source).toContain('side === "left"');
+    expect(source).toContain('side === "right"');
+    expect(source).toContain('side = "right"');
+  });
+});


### PR DESCRIPTION
Linear: [CUS-61](https://linear.app/customermates/issue/CUS-61). Not using a closing keyword: the issue closes only after production deployment is verified.

## Summary

The sidebar Add picker and the shared entity drawer now open from the left edge, matching the sidebar they belong to. One change covers all five entity types because they share a single `EntityDrawer`.

Contact channels can now be added while creating a contact. `contact-detail-view` rendered `ContactChannels` only when `fetchedEntity` existed, and that is `null` during create, so the whole section was structurally unreachable until after the first save. The section now renders in the draft and staged identifiers commit atomically with the contact through the existing create contract. Only the inbox deep-link, which genuinely needs a persisted id, is withheld before the first save.

Four defects found in exactly this path are fixed alongside:

- The new-contact reset omitted `taskIds`, so tasks from a previously viewed contact silently attached to the next contact created.
- Client dedupe keyed on exact `provider + value` while the database unique key is `(companyId, channelClass, value)`, so one address added under two email providers passed the client check and then lost a channel on write.
- `validateIdentifierConflicts` never rejected duplicates within a single create payload, because `selfContactId` is `undefined` there and the guard compared `undefined` to `undefined`.
- `popTop` pushed a history entry instead of replacing, so open, close, Back reopened a closed drawer. Closing a dirty drawer also bypassed the unsaved-changes guard entirely.

## Context

The backend already supported everything needed: `BaseCreateContactSchema.identifiers` accepts the array, `validateIdentifiers` normalizes it, `ContactWritePrecheckInteractor.create` already passes `selfContactId: undefined`, and `PrismaContactRepo.createContactOrThrow` writes contact plus identifiers inside one `@Transaction` with a per-company advisory lock. No data model, schema, or transaction work was needed, and no client-side create-then-link sequence was added.

Design decisions worth a reviewer's attention:

- **Channel permission is now mode-aware.** Draft mode requires `contacts:create`, editing keeps requiring `contacts:update`. `CheckChannelConflictInteractor` was widened from `action: update` to `{permissions: [create, update], condition: "OR"}` using the existing decorator shape. This is necessary because `TenantInteractor` throws `ForbiddenError` rather than returning `ok:false`, so a create-only user previously got an unhandled server-action error. It leaks nothing new: the interactor returns a bare boolean, the owners lookup is `companyId`-filtered, and the same signal is already obtainable by submitting the create.
- **The close guard is scoped to the drawer's own store**, held in local state in `entity-drawer.tsx`, rather than routing `writeStack` through the guarded router. `.eslintrc.json` documents the raw router in `use-entity-drawer-stack.ts` as intentional; routing through the intl router would also guard drawer *opening* (both go through `writeStack`) and would double the locale prefix, since `writeStack` builds its URL from `next/navigation`'s `usePathname()` which already includes `/en`.
- **`popTop` uses `replace`, not `router.back()`.** `back()` is correct for open-then-close, but on a deep link straight to `?open=contact:new` it either does nothing (drawer stuck open) or leaves the app. `replace` is correct in all three traces at the cost of one visually inert Back press.
- **A new `duplicateChannel` error code** rather than reusing `channelAlreadyLinked`, whose message says "already linked to **another contact**" and is actively misleading when the duplicate is in the draft you are looking at.

Deliberately out of scope: the `slide-in-from-*` classes in `sheet.tsx` are dead code (`tailwindcss-animate` is not installed), so nothing animates today and "opens from the left" means resting position plus border edge. Enabling them would switch on animation for every Sheet and Dialog app-wide. `components/ui/sheet.tsx` is untouched, including its `side = "right"` default, which the mobile sidebar and public navbar rely on.

**One existing test was intentionally inverted.** `core/validation/__tests__/validators.test.ts` had `it("passes when one batch row repeats its own identifier")` asserting `addIssue` was never called, pinning the duplicate bug as expected behavior. It now expects `duplicateChannel`. Flagging this explicitly rather than leaving it to be discovered in review.

## Validation

All gates green on this branch:

| Gate | Result |
| --- | --- |
| `yarn typecheck` | pass |
| `yarn lint` | pass, 0 warnings |
| `yarn vitest run tests/conventions` | 14 files, 63 tests |
| `yarn test` | 115 files, **924 tests** |
| `yarn build` | pass |

(The issue's criteria name `yarn lint:check`, which does not exist; `yarn lint` was run.)

Browser acceptance was driven against a local instance in an isolated worktree with a disposable PostgreSQL 16 container, synthetic seed only, `APP_MODE="cloud"`. The change was stashed to `origin/main` mid-session and the same steps re-run, so the baseline is measured rather than assumed:

| Behavior | Baseline | After |
| --- | --- | --- |
| Entity drawer | `left: 640, right: 1280`, slide-from-right | `left: 0, right: 640`, slide-from-left |
| Channels in create drawer | absent | present |
| Dirty drawer close | closes silently | prompts; Discard resets |
| Open, close, Back | reopens | stays closed |

Highlights:

- A mutation observer armed before the picker click recorded **0 frames** containing `slide-in-from-right`, and exactly one sheet panel mounted at any sample, so no double overlay and no cross-screen flash.
- One save persisted the contact plus both identifiers (`channelClass` `email` and `phone`); a full reload showed both. Zero rows existed before the save.
- Forced a mid-transaction failure via a temporary `CHECK` constraint: 0 contacts, 0 identifiers, 0 orphans, and the form stayed recoverable.
- At 375x812 the mobile off-canvas sidebar (itself a left Sheet) hands off to the now-left Add picker with exactly one panel and one overlay at 0/150/350/800ms, no horizontal overflow, and a real tap on Save created a contact.
- Public marketing navbar still opens from the right.

Full evidence, including the residual items below, is attached to CUS-61.

Known, verified as pre-existing on the `origin/main` baseline and not introduced here: a dev-only Radix `useId` hydration mismatch in the sidebar, and focus returning to `document.body` after the drawer closes (the drawer has no `SheetTrigger` for Radix to restore to).

## Impact and rollback

No migration, no schema change, no data repair. The create contract and its transaction boundary are unchanged.

Two behavior changes a reviewer should weigh:

1. Closing a drawer with unsaved edits now prompts. This is the contract every other modal in the app already follows and matters more now that channels can be staged before save, but it is new friction on a path that previously closed silently.
2. Identifiers duplicated within one create or update payload are now rejected instead of silently collapsing. Previously the second `upsert` took the update branch without writing `provider`, so a channel vanished without feedback. API and MCP callers that were unknowingly sending duplicates will now get a validation error.

Rollback: revert this commit. The drawer-side change, the draft-capable channels UI, the guard, and their tests are one coherent unit. If only the create-mode Channels section proves problematic, re-adding the `fetchedEntity &&` guard at `contact-detail-view.tsx` restores the previous behavior while keeping everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

