### PR TITLE
fix(dashboard): keep a widget's persisted metric through modal hydration

### DIFF
--- a/app/[locale]/(protected)/dashboard/components/widget-modal.store.ts
+++ b/app/[locale]/(protected)/dashboard/components/widget-modal.store.ts
@@ -23,6 +23,7 @@ export class WidgetModalStore extends BaseModalStore<UpsertWidgetData> {
   public groupByValue: string = WidgetGroupByType.none;
   public expandedSection: WidgetModalSection = "config";
   public expandedFilterField: string | undefined = undefined;
+  public isHydrating = false;
   private skipReactions = false;
   public filterableFieldsByEntityType: Record<EntityType, FilterableField[]> = {
     [EntityType.contact]: [],
@@ -90,6 +91,7 @@ export class WidgetModalStore extends BaseModalStore<UpsertWidgetData> {
       groupByValue: observable,
       expandedSection: observable,
       expandedFilterField: observable,
+      isHydrating: observable,
       filterableFieldsByEntityType: observable,
       customColumnsByEntityType: observable,
 
@@ -289,6 +291,9 @@ export class WidgetModalStore extends BaseModalStore<UpsertWidgetData> {
 
   loadById = async (id: string) => {
     this.setIsLoading(true);
+    runInAction(() => {
+      this.isHydrating = true;
+    });
     this.open();
 
     try {
@@ -331,6 +336,9 @@ export class WidgetModalStore extends BaseModalStore<UpsertWidgetData> {
       } else this.close();
     } finally {
       this.setIsLoading(false);
+      runInAction(() => {
+        this.isHydrating = false;
+      });
     }
   };
 

--- a/app/[locale]/(protected)/dashboard/components/widget-modal.store.ts
+++ b/app/[locale]/(protected)/dashboard/components/widget-modal.store.ts
@@ -344,6 +344,9 @@ export class WidgetModalStore extends BaseModalStore<UpsertWidgetData> {
 
   loadTemplate = async (widgetId: string) => {
     this.setIsLoading(true);
+    runInAction(() => {
+      this.isHydrating = true;
+    });
 
     try {
       const widget = await getWidgetByIdAction({ id: widgetId });
@@ -381,6 +384,9 @@ export class WidgetModalStore extends BaseModalStore<UpsertWidgetData> {
       }
     } finally {
       this.setIsLoading(false);
+      runInAction(() => {
+        this.isHydrating = false;
+      });
     }
   };
 

--- a/app/[locale]/(protected)/dashboard/components/widget-modal.tsx
+++ b/app/[locale]/(protected)/dashboard/components/widget-modal.tsx
@@ -81,157 +81,129 @@ export const WidgetModal = observer(({ customColumns, filterableFields }: Props)
             </div>
           </AppCardHeader>
 
-          <AppCardBody>
-            <Accordion
-              collapsible
-              className="w-full"
-              type="single"
-              value={widgetModalStore.expandedSection}
-              onValueChange={widgetModalStore.setExpandedSection}
-            >
-              <AccordionItem value="config">
-                <AccordionTrigger>{t("Dashboard.tabs.config")}</AccordionTrigger>
+          <AppCardBody className="min-h-40">
+            {!widgetModalStore.isHydrating && (
+              <Accordion
+                collapsible
+                className="w-full"
+                type="single"
+                value={widgetModalStore.expandedSection}
+                onValueChange={widgetModalStore.setExpandedSection}
+              >
+                <AccordionItem value="config">
+                  <AccordionTrigger>{t("Dashboard.tabs.config")}</AccordionTrigger>
 
-                <AccordionContent className="flex flex-col gap-4 pb-4 pt-2">
-                  {showTemplateSelection && (
+                  <AccordionContent className="flex flex-col gap-4 pb-4 pt-2">
+                    {showTemplateSelection && (
+                      <div className="space-y-1.5">
+                        <FormLabel htmlFor="template">{t("Common.inputs.template")}</FormLabel>
+
+                        <Select onValueChange={(key) => void widgetModalStore.loadTemplate(key)}>
+                          <SelectTrigger className="w-full" id="template">
+                            <SelectValue placeholder=" " />
+                          </SelectTrigger>
+
+                          <SelectContent>
+                            {companyWideWidgets.map((widget) => (
+                              <SelectItem key={widget.id} value={widget.id}>
+                                <div className="flex w-full gap-2 items-center justify-start">
+                                  <span>{widget.name}</span>
+
+                                  <AppChip
+                                    startContent={
+                                      <Avatar
+                                        name={[widget.firstName, widget.lastName]}
+                                        size="sm"
+                                        src={widget.avatarUrl}
+                                      />
+                                    }
+                                    variant="outline"
+                                  >
+                                    {`${widget.firstName} ${widget.lastName}`.trim()}
+                                  </AppChip>
+                                </div>
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+
+                        <p className="text-x-sm text-muted-foreground">
+                          {t("Dashboard.selectWidgetTemplateDescription")}
+                        </p>
+                      </div>
+                    )}
+
+                    <FormInput autoFocus required id="name" label={t("Common.inputs.name")} />
+
+                    <FormSelect
+                      required
+                      id="entityType"
+                      items={widgetModalStore.availableEntityTypes.map((entityType) => ({
+                        value: entityType,
+                        label: t(`Dashboard.entityTypes.${entityType}`),
+                      }))}
+                      label={t("Common.inputs.entityType")}
+                    />
+
+                    <FormSelect
+                      required
+                      id="aggregationType"
+                      items={widgetModalStore.aggregationTypeOptions.map(({ key }) => {
+                        const entityTypeName = t(`Dashboard.entityTypes.${form.entityType}`);
+                        const translationKey = `Dashboard.aggregationTypes.${key}`;
+                        const label =
+                          key === "count"
+                            ? t(translationKey, { entities: entityTypeName })
+                            : key === "dealValue"
+                              ? t(translationKey, { entity: entityTypeName })
+                              : t(translationKey);
+                        return { value: key, label };
+                      })}
+                      label={t("Common.inputs.aggregationType")}
+                    />
+
                     <div className="space-y-1.5">
-                      <FormLabel htmlFor="template">{t("Common.inputs.template")}</FormLabel>
+                      <FormLabel htmlFor="groupByValue">{t("Common.inputs.groupByValue")}</FormLabel>
 
-                      <Select onValueChange={(key) => void widgetModalStore.loadTemplate(key)}>
-                        <SelectTrigger className="w-full" id="template">
+                      <Select
+                        value={widgetModalStore.groupBySelectValue}
+                        onValueChange={(key) => widgetModalStore.onGroupByChange(key)}
+                      >
+                        <SelectTrigger className="w-full" id="groupByValue">
                           <SelectValue placeholder=" " />
                         </SelectTrigger>
 
                         <SelectContent>
-                          {companyWideWidgets.map((widget) => (
-                            <SelectItem key={widget.id} value={widget.id}>
-                              <div className="flex w-full gap-2 items-center justify-start">
-                                <span>{widget.name}</span>
-
-                                <AppChip
-                                  startContent={
-                                    <Avatar
-                                      name={[widget.firstName, widget.lastName]}
-                                      size="sm"
-                                      src={widget.avatarUrl}
-                                    />
-                                  }
-                                  variant="outline"
-                                >
-                                  {`${widget.firstName} ${widget.lastName}`.trim()}
-                                </AppChip>
-                              </div>
-                            </SelectItem>
-                          ))}
+                          {widgetModalStore.groupBySelectOptions.map((opt) => {
+                            const translationKey =
+                              opt.key.startsWith("custom:") && opt.label ? undefined : `Dashboard.groupBys.${opt.key}`;
+                            const label = translationKey ? t(translationKey as never) : (opt.label ?? String(opt.key));
+                            return (
+                              <SelectItem key={opt.key} value={opt.key}>
+                                {label}
+                              </SelectItem>
+                            );
+                          })}
                         </SelectContent>
                       </Select>
-
-                      <p className="text-x-sm text-muted-foreground">
-                        {t("Dashboard.selectWidgetTemplateDescription")}
-                      </p>
                     </div>
-                  )}
 
-                  <FormInput autoFocus required id="name" label={t("Common.inputs.name")} />
+                    <FormSwitch id="isTemplate" label={t("Common.inputs.isTemplate")} />
+                  </AccordionContent>
+                </AccordionItem>
 
-                  <FormSelect
-                    required
-                    id="entityType"
-                    items={widgetModalStore.availableEntityTypes.map((entityType) => ({
-                      value: entityType,
-                      label: t(`Dashboard.entityTypes.${entityType}`),
-                    }))}
-                    label={t("Common.inputs.entityType")}
-                  />
-
-                  <FormSelect
-                    required
-                    id="aggregationType"
-                    items={widgetModalStore.aggregationTypeOptions.map(({ key }) => {
-                      const entityTypeName = t(`Dashboard.entityTypes.${form.entityType}`);
-                      const translationKey = `Dashboard.aggregationTypes.${key}`;
-                      const label =
-                        key === "count"
-                          ? t(translationKey, { entities: entityTypeName })
-                          : key === "dealValue"
-                            ? t(translationKey, { entity: entityTypeName })
-                            : t(translationKey);
-                      return { value: key, label };
-                    })}
-                    label={t("Common.inputs.aggregationType")}
-                  />
-
-                  <div className="space-y-1.5">
-                    <FormLabel htmlFor="groupByValue">{t("Common.inputs.groupByValue")}</FormLabel>
-
-                    <Select
-                      value={widgetModalStore.groupBySelectValue}
-                      onValueChange={(key) => widgetModalStore.onGroupByChange(key)}
-                    >
-                      <SelectTrigger className="w-full" id="groupByValue">
-                        <SelectValue placeholder=" " />
-                      </SelectTrigger>
-
-                      <SelectContent>
-                        {widgetModalStore.groupBySelectOptions.map((opt) => {
-                          const translationKey =
-                            opt.key.startsWith("custom:") && opt.label ? undefined : `Dashboard.groupBys.${opt.key}`;
-                          const label = translationKey ? t(translationKey as never) : (opt.label ?? String(opt.key));
-                          return (
-                            <SelectItem key={opt.key} value={opt.key}>
-                              {label}
-                            </SelectItem>
-                          );
-                        })}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <FormSwitch id="isTemplate" label={t("Common.inputs.isTemplate")} />
-                </AccordionContent>
-              </AccordionItem>
-
-              <AccordionItem value="filters">
-                <AccordionTrigger>
-                  <div className="flex items-center gap-2">
-                    <span>
-                      {t("Dashboard.tabs.filters", {
-                        entityType: t(`Dashboard.entityTypes.${widgetModalStore.form.entityType}`),
-                      })}
-                    </span>
-
-                    {widgetModalStore.activeFiltersCount > 0 && (
-                      <AppChip className="size-5 min-w-5 min-h-5 p-0" variant="secondary">
-                        {widgetModalStore.activeFiltersCount}
-                      </AppChip>
-                    )}
-                  </div>
-                </AccordionTrigger>
-
-                <AccordionContent className="pt-0 pb-2">
-                  <FilterAccordion
-                    nested
-                    baseId="entityFilters"
-                    customColumns={widgetModalStore.customColumns}
-                    filterableFields={widgetModalStore.filterableFields}
-                    filters={widgetModalStore.form.entityFilters ?? []}
-                    value={
-                      widgetModalStore.expandedSection === "filters" ? widgetModalStore.expandedFilterField : undefined
-                    }
-                    onValueChange={widgetModalStore.setExpandedFilterField}
-                  />
-                </AccordionContent>
-              </AccordionItem>
-
-              {widgetModalStore.showDealFiltersTab && (
-                <AccordionItem value="dealFilters">
+                <AccordionItem value="filters">
                   <AccordionTrigger>
                     <div className="flex items-center gap-2">
-                      <span>{t("Dashboard.tabs.dealFilters")}</span>
+                      <span>
+                        {t("Dashboard.tabs.filters", {
+                          entityType: t(`Dashboard.entityTypes.${widgetModalStore.form.entityType}`),
+                        })}
+                      </span>
 
-                      {widgetModalStore.activeDealFiltersCount > 0 && (
+                      {widgetModalStore.activeFiltersCount > 0 && (
                         <AppChip className="size-5 min-w-5 min-h-5 p-0" variant="secondary">
-                          {widgetModalStore.activeDealFiltersCount}
+                          {widgetModalStore.activeFiltersCount}
                         </AppChip>
                       )}
                     </div>
@@ -240,12 +212,12 @@ export const WidgetModal = observer(({ customColumns, filterableFields }: Props)
                   <AccordionContent className="pt-0 pb-2">
                     <FilterAccordion
                       nested
-                      baseId="dealFilters"
-                      customColumns={widgetModalStore.customColumnsByEntityType[EntityType.deal]}
-                      filterableFields={widgetModalStore.dealFilterableFields}
-                      filters={widgetModalStore.form.dealFilters ?? []}
+                      baseId="entityFilters"
+                      customColumns={widgetModalStore.customColumns}
+                      filterableFields={widgetModalStore.filterableFields}
+                      filters={widgetModalStore.form.entityFilters ?? []}
                       value={
-                        widgetModalStore.expandedSection === "dealFilters"
+                        widgetModalStore.expandedSection === "filters"
                           ? widgetModalStore.expandedFilterField
                           : undefined
                       }
@@ -253,108 +225,144 @@ export const WidgetModal = observer(({ customColumns, filterableFields }: Props)
                     />
                   </AccordionContent>
                 </AccordionItem>
-              )}
 
-              <AccordionItem value="display">
-                <AccordionTrigger>{t("Dashboard.tabs.display")}</AccordionTrigger>
+                {widgetModalStore.showDealFiltersTab && (
+                  <AccordionItem value="dealFilters">
+                    <AccordionTrigger>
+                      <div className="flex items-center gap-2">
+                        <span>{t("Dashboard.tabs.dealFilters")}</span>
 
-                <AccordionContent className="flex flex-col gap-4 pb-4 pt-2">
-                  {form.groupByType === WidgetGroupByType.customColumn && (
-                    <FormSwitch
-                      id="displayOptions.useGroupColors"
-                      label={t("Common.inputs.displayOptions.useGroupColors")}
-                    />
-                  )}
+                        {widgetModalStore.activeDealFiltersCount > 0 && (
+                          <AppChip className="size-5 min-w-5 min-h-5 p-0" variant="secondary">
+                            {widgetModalStore.activeDealFiltersCount}
+                          </AppChip>
+                        )}
+                      </div>
+                    </AccordionTrigger>
 
-                  {!(
-                    form.groupByType === WidgetGroupByType.customColumn && form.displayOptions?.useGroupColors !== false
-                  ) && (
-                    <div className="space-y-1.5">
-                      <FormLabel htmlFor="displayOptions.barColors">
-                        {t("Common.inputs.displayOptions.barColors")}
-                      </FormLabel>
+                    <AccordionContent className="pt-0 pb-2">
+                      <FilterAccordion
+                        nested
+                        baseId="dealFilters"
+                        customColumns={widgetModalStore.customColumnsByEntityType[EntityType.deal]}
+                        filterableFields={widgetModalStore.dealFilterableFields}
+                        filters={widgetModalStore.form.dealFilters ?? []}
+                        value={
+                          widgetModalStore.expandedSection === "dealFilters"
+                            ? widgetModalStore.expandedFilterField
+                            : undefined
+                        }
+                        onValueChange={widgetModalStore.setExpandedFilterField}
+                      />
+                    </AccordionContent>
+                  </AccordionItem>
+                )}
 
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            aria-label={t("Common.inputs.displayOptions.barColors")}
-                            className="w-full justify-between font-normal"
-                            id="displayOptions.barColors"
-                            type="button"
-                            variant="outline"
-                          >
-                            <span className="flex flex-wrap items-center gap-1">
-                              {(form.displayOptions?.barColors ?? []).map((key) => (
-                                <span
-                                  key={key}
-                                  className="inline-flex size-4 rounded-full"
-                                  style={{ backgroundColor: chartColors[key as keyof typeof chartColors] }}
-                                />
-                              ))}
-                            </span>
+                <AccordionItem value="display">
+                  <AccordionTrigger>{t("Dashboard.tabs.display")}</AccordionTrigger>
 
-                            <ChevronsUpDownIcon className="ml-2 size-4 opacity-50" />
-                          </Button>
-                        </DropdownMenuTrigger>
-
-                        <DropdownMenuContent align="start" className="w-(--radix-dropdown-menu-trigger-width)">
-                          {Object.entries(chartColors).map(([key, color]) => {
-                            const selected = (form.displayOptions?.barColors ?? []).includes(key as ChartColor);
-                            return (
-                              <DropdownMenuCheckboxItem
-                                key={key}
-                                checked={selected}
-                                onCheckedChange={(checked) => {
-                                  const current = form.displayOptions?.barColors ?? [];
-                                  const next = checked
-                                    ? [...current, key as ChartColor]
-                                    : current.filter((k) => k !== (key as ChartColor));
-                                  if (next.length === 0) return;
-                                  widgetModalStore.onChange("displayOptions.barColors", next);
-                                }}
-                                onSelect={(e) => e.preventDefault()}
-                              >
-                                <span className="inline-flex size-4 rounded-full" style={{ backgroundColor: color }} />
-                              </DropdownMenuCheckboxItem>
-                            );
-                          })}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  )}
-
-                  <FormSelect
-                    id="displayOptions.displayType"
-                    items={Object.values(DisplayType).map((key) => ({
-                      value: key,
-                      label: t(`Dashboard.displayTypes.${key}`),
-                    }))}
-                    label={t("Common.inputs.displayOptions.displayType")}
-                  />
-
-                  {form.displayOptions?.displayType !== DisplayType.doughnutChart &&
-                    form.displayOptions?.displayType !== DisplayType.radarChart && (
-                      <>
-                        <FormSwitch
-                          id="displayOptions.reverseXAxis"
-                          label={t("Common.inputs.displayOptions.reverseXAxis")}
-                        />
-
-                        <FormSwitch
-                          id="displayOptions.reverseYAxis"
-                          label={t("Common.inputs.displayOptions.reverseYAxis")}
-                        />
-                      </>
+                  <AccordionContent className="flex flex-col gap-4 pb-4 pt-2">
+                    {form.groupByType === WidgetGroupByType.customColumn && (
+                      <FormSwitch
+                        id="displayOptions.useGroupColors"
+                        label={t("Common.inputs.displayOptions.useGroupColors")}
+                      />
                     )}
 
-                  {form.displayOptions?.displayType === DisplayType.doughnutChart && (
-                    <FormSwitch id="displayOptions.showLegend" label={t("Common.inputs.displayOptions.showLegend")} />
-                  )}
+                    {!(
+                      form.groupByType === WidgetGroupByType.customColumn &&
+                      form.displayOptions?.useGroupColors !== false
+                    ) && (
+                      <div className="space-y-1.5">
+                        <FormLabel htmlFor="displayOptions.barColors">
+                          {t("Common.inputs.displayOptions.barColors")}
+                        </FormLabel>
 
-                  <FormSwitch id="displayOptions.showFilters" label={t("Common.inputs.displayOptions.showFilters")} />
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              aria-label={t("Common.inputs.displayOptions.barColors")}
+                              className="w-full justify-between font-normal"
+                              id="displayOptions.barColors"
+                              type="button"
+                              variant="outline"
+                            >
+                              <span className="flex flex-wrap items-center gap-1">
+                                {(form.displayOptions?.barColors ?? []).map((key) => (
+                                  <span
+                                    key={key}
+                                    className="inline-flex size-4 rounded-full"
+                                    style={{ backgroundColor: chartColors[key as keyof typeof chartColors] }}
+                                  />
+                                ))}
+                              </span>
+
+                              <ChevronsUpDownIcon className="ml-2 size-4 opacity-50" />
+                            </Button>
+                          </DropdownMenuTrigger>
+
+                          <DropdownMenuContent align="start" className="w-(--radix-dropdown-menu-trigger-width)">
+                            {Object.entries(chartColors).map(([key, color]) => {
+                              const selected = (form.displayOptions?.barColors ?? []).includes(key as ChartColor);
+                              return (
+                                <DropdownMenuCheckboxItem
+                                  key={key}
+                                  checked={selected}
+                                  onCheckedChange={(checked) => {
+                                    const current = form.displayOptions?.barColors ?? [];
+                                    const next = checked
+                                      ? [...current, key as ChartColor]
+                                      : current.filter((k) => k !== (key as ChartColor));
+                                    if (next.length === 0) return;
+                                    widgetModalStore.onChange("displayOptions.barColors", next);
+                                  }}
+                                  onSelect={(e) => e.preventDefault()}
+                                >
+                                  <span
+                                    className="inline-flex size-4 rounded-full"
+                                    style={{ backgroundColor: color }}
+                                  />
+                                </DropdownMenuCheckboxItem>
+                              );
+                            })}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    )}
+
+                    <FormSelect
+                      id="displayOptions.displayType"
+                      items={Object.values(DisplayType).map((key) => ({
+                        value: key,
+                        label: t(`Dashboard.displayTypes.${key}`),
+                      }))}
+                      label={t("Common.inputs.displayOptions.displayType")}
+                    />
+
+                    {form.displayOptions?.displayType !== DisplayType.doughnutChart &&
+                      form.displayOptions?.displayType !== DisplayType.radarChart && (
+                        <>
+                          <FormSwitch
+                            id="displayOptions.reverseXAxis"
+                            label={t("Common.inputs.displayOptions.reverseXAxis")}
+                          />
+
+                          <FormSwitch
+                            id="displayOptions.reverseYAxis"
+                            label={t("Common.inputs.displayOptions.reverseYAxis")}
+                          />
+                        </>
+                      )}
+
+                    {form.displayOptions?.displayType === DisplayType.doughnutChart && (
+                      <FormSwitch id="displayOptions.showLegend" label={t("Common.inputs.displayOptions.showLegend")} />
+                    )}
+
+                    <FormSwitch id="displayOptions.showFilters" label={t("Common.inputs.displayOptions.showFilters")} />
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            )}
           </AppCardBody>
 
           <FormActions anchorScope="widget-modal" store={widgetModalStore} />


### PR DESCRIPTION
## Summary

Fixes [CUS-151](https://linear.app/customermates/issue/CUS-151/a-service-widget-using-the-deal-quantity-metric-cannot-be-edited). The chart modal no longer renders its configuration fields before the widget they describe has loaded, so a widget whose stored metric is absent from the previously-shown option list keeps that metric instead of losing it.

Two commits, both the same one-line idea applied to the two paths that load a widget into the open modal: opening one for edit, and loading one as a template.

## Context

The hypothesis in the issue was that `aggregationTypeOptions` excludes `dealQuantity` for `service`, or that a reset reaction clears the field. Both are wrong. That computed returns `[count, dealValue, dealQuantity]` for `service`, and the only reaction that writes `aggregationType` assigns `count`, which is valid.

Instrumenting the running app against the seeded database caught the real writer:

```
SelectBubbleInput.useEffect (radix)  ->  radix Select onChange
  ->  FormSelect onValueChange  ->  store.onChange("aggregationType", "")
```

Radix renders a hidden native `<select>` for form integration and deliberately feeds its change events back into the controlled value, which is how native form reset and autofill propagate. Its effect, however, assigns the value and dispatches `change` without checking the assignment took:

```js
if (prevValue !== value && setValue) {
  const event = new Event("change", { bubbles: true });
  setValue.call(select, value);
  select.dispatchEvent(event);
}
```

Per the HTML spec, assigning an unmatched value sets `selectedIndex = -1` and leaves `.value === ""`. Radix then announces that empty string through the intended feedback path, and it lands in the form.

That is a known, open upstream defect rather than intended behaviour: [radix-ui/primitives#2817](https://github.com/radix-ui/primitives/issues/2817) *"Cannot dynamically set select value to non-existent item"* is open, labelled *Resolution: Needs Investigation*, and names this exact trigger ("when options are still loading asynchronously"). [#3249](https://github.com/radix-ui/primitives/issues/3249) is the same family, closed as a duplicate of [#3135](https://github.com/radix-ui/primitives/issues/3135).

**Our half of it, which is what this fixes.** `loadById` calls `open()` before awaiting the widget, and `loadTemplate` assigns into an already-open modal. In both cases the metric options are still derived from the entity type the form held a moment earlier. On a cold dashboard that is the constructor default `entityType: deal`, whose metric list is `[count, dealValue]`. `dealQuantity` only ever appears for `service`, which is exactly why it is the one metric that never survived, and why `count` and `dealValue` widgets were unaffected. Deferring the fields until the widget has arrived removes the window, and with it the unrepresentable-value assignment that triggers the upstream bug.

The template path was not in the issue report. It was found by walking the other happy paths and reproduced identically before the fix.

An earlier revision of this pull request also guarded `FormSelect` against empty values generally. I dropped it: ablation showed the modal fix alone resolves this, and none of the other four `FormSelect` call sites hydrates asynchronously, so the guard could not fire anywhere today. If the upstream bug bites a future async form, it is three lines and can be added then with a real case to test against.

## Validation

Verified in a browser against a disposable local Postgres with the synthetic seed, running self-hosted so write paths are reachable. Every path below was exercised from a cold state with the form deliberately holding a mismatching entity type, which is the condition that triggers the bug.

| Path | Result |
| -- | -- |
| Load a `service`/`dealQuantity` template into a new widget | metric preserved |
| Create a widget from that template | saved, stored as `dealQuantity` |
| Open and re-save all 7 seeded widgets | all 7 hydrate correctly, all save |
| Open and re-save the newly created widget | hydrates, saves |
| Delete a widget | removed |
| Fields mounted while a widget is loading | no, `#aggregationType` absent from the DOM |
| Stored `aggregationType` after a name-only save | unchanged |

The seeded widgets cover every entity-and-metric combination present: `service`/`dealQuantity`, `service`/`dealValue`, `organization`/`dealValue`, `organization`/`count`, `deal`/`dealValue`, `deal`/`count`, `contact`/`count`.

Before the fix, opening "Sold Hardware" rendered a blank metric and saving produced `Aggregation Type: Invalid option: expected one of "count"|"dealValue"|"dealQuantity"`, with the modal left open and nothing written.

`yarn typecheck`, `yarn lint`, `yarn vitest run tests/conventions`, `yarn test` (115 files, 913 tests) and `yarn build` all pass.

Note for review: `widget-modal.tsx` shows a large diff because wrapping the accordion re-indents it. `git diff -w` reduces it to 16 lines, 3 of which are the change and the rest prettier re-wrapping lines pushed past 120 columns.

## Impact and rollback

Code only. No schema, data or configuration change. The only behaviour change is that the widget modal defers its configuration fields until the widget has loaded. Revert the pull request to roll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)