### PR TITLE
fix(table): keep column resizing continuous and discoverable

### DIFF
--- a/components/data-view/__tests__/data-table-resize.test.ts
+++ b/components/data-view/__tests__/data-table-resize.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  beginColumnResize,
+  COLUMN_RESIZE_KEYBOARD_LARGE_STEP,
+  COLUMN_RESIZE_KEYBOARD_STEP,
+  columnResizeLabel,
+  isTouchResetDoubleTap,
+  keyboardColumnWidth,
+  MIN_COLUMN_WIDTH,
+  shouldCommitColumnResize,
+  TOUCH_RESET_DOUBLE_TAP_MS,
+  updateColumnResize,
+  withoutColumnWidth,
+} from "../data-table-resize";
+
+function start(renderedWidth = 237.5) {
+  return beginColumnResize({
+    columnId: "name",
+    pointerId: 1,
+    pointerType: "mouse",
+    clientX: 500,
+    renderedWidth,
+  });
+}
+
+describe("data-table column resizing", () => {
+  it("uses the rendered column width instead of TanStack's unsized 150px default", () => {
+    const session = start();
+
+    expect(session.startWidth).toBe(237.5);
+    expect(session.currentWidth).toBe(237.5);
+  });
+
+  it.each([1, 3, 5])("turns an initial %ipx pointer move into the same visible delta", (delta) => {
+    const session = updateColumnResize(start(), 500 + delta);
+
+    expect(session.currentWidth).toBe(237.5 + delta);
+    expect(shouldCommitColumnResize(session)).toBe(true);
+  });
+
+  it("keeps zero-movement taps measurement-only", () => {
+    const session = updateColumnResize(start(), 500);
+
+    expect(session.currentWidth).toBe(session.startWidth);
+    expect(shouldCommitColumnResize(session)).toBe(false);
+  });
+
+  it("starts subsequent and persisted-width drags from the newly rendered width", () => {
+    const first = updateColumnResize(start(220), 512);
+    const second = updateColumnResize(start(first.currentWidth), 496);
+
+    expect(first.currentWidth).toBe(232);
+    expect(second.startWidth).toBe(232);
+    expect(second.currentWidth).toBe(228);
+  });
+
+  it("clamps only when the pointer crosses the 80px minimum", () => {
+    expect(updateColumnResize(start(120), 461).currentWidth).toBe(81);
+    expect(updateColumnResize(start(120), 460).currentWidth).toBe(MIN_COLUMN_WIDTH);
+    expect(updateColumnResize(start(120), 430).currentWidth).toBe(MIN_COLUMN_WIDTH);
+  });
+
+  it("supports small and accelerated keyboard resizing plus the minimum shortcut", () => {
+    expect(keyboardColumnWidth(200, "ArrowLeft")).toBe(200 - COLUMN_RESIZE_KEYBOARD_STEP);
+    expect(keyboardColumnWidth(200, "ArrowRight", true)).toBe(200 + COLUMN_RESIZE_KEYBOARD_LARGE_STEP);
+    expect(keyboardColumnWidth(82, "ArrowLeft")).toBe(MIN_COLUMN_WIDTH);
+    expect(keyboardColumnWidth(200, "Home")).toBe(MIN_COLUMN_WIDTH);
+    expect(keyboardColumnWidth(200, "Enter")).toBeUndefined();
+  });
+
+  it("removes only the reset column's persisted width", () => {
+    expect(withoutColumnWidth({ name: 240, email: 320 }, "name")).toEqual({
+      email: 320,
+    });
+  });
+
+  it("recognizes only a timely second touch tap as reset", () => {
+    expect(isTouchResetDoubleTap(undefined, 1000)).toBe(false);
+    expect(isTouchResetDoubleTap(1000, 1000 + TOUCH_RESET_DOUBLE_TAP_MS)).toBe(true);
+    expect(isTouchResetDoubleTap(1000, 1001 + TOUCH_RESET_DOUBLE_TAP_MS)).toBe(false);
+    expect(isTouchResetDoubleTap(1000, 999)).toBe(false);
+  });
+
+  it("uses the visible or configured label instead of exposing custom-column IDs", () => {
+    const customColumnId = "16000000-0000-4000-8000-000000000009";
+
+    expect(columnResizeLabel(customColumnId, "Sales Pipeline")).toBe("Sales Pipeline");
+    expect(columnResizeLabel(customColumnId, () => null, "Sales Pipeline")).toBe("Sales Pipeline");
+    expect(columnResizeLabel("name", undefined)).toBe("name");
+  });
+});

--- a/components/data-view/__tests__/data-table-resize.test.ts
+++ b/components/data-view/__tests__/data-table-resize.test.ts
@@ -2,14 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   beginColumnResize,
-  COLUMN_RESIZE_KEYBOARD_LARGE_STEP,
-  COLUMN_RESIZE_KEYBOARD_STEP,
   columnResizeLabel,
   isTouchResetDoubleTap,
   keyboardColumnWidth,
   MIN_COLUMN_WIDTH,
   shouldCommitColumnResize,
-  TOUCH_RESET_DOUBLE_TAP_MS,
   updateColumnResize,
   withoutColumnWidth,
 } from "../data-table-resize";
@@ -26,10 +23,7 @@ function start(renderedWidth = 237.5) {
 
 describe("data-table column resizing", () => {
   it("uses the rendered column width instead of TanStack's unsized 150px default", () => {
-    const session = start();
-
-    expect(session.startWidth).toBe(237.5);
-    expect(session.currentWidth).toBe(237.5);
+    expect(start()).toMatchObject({ startWidth: 237.5, currentWidth: 237.5 });
   });
 
   it.each([1, 3, 5])("turns an initial %ipx pointer move into the same visible delta", (delta) => {
@@ -43,6 +37,13 @@ describe("data-table column resizing", () => {
     const session = updateColumnResize(start(), 500);
 
     expect(session.currentWidth).toBe(session.startWidth);
+    expect(shouldCommitColumnResize(session)).toBe(false);
+  });
+
+  it("does not commit a drag that returns to its starting coordinate", () => {
+    const session = updateColumnResize(updateColumnResize(start(), 510), 500);
+
+    expect(session.hasMoved).toBe(true);
     expect(shouldCommitColumnResize(session)).toBe(false);
   });
 
@@ -62,8 +63,8 @@ describe("data-table column resizing", () => {
   });
 
   it("supports small and accelerated keyboard resizing plus the minimum shortcut", () => {
-    expect(keyboardColumnWidth(200, "ArrowLeft")).toBe(200 - COLUMN_RESIZE_KEYBOARD_STEP);
-    expect(keyboardColumnWidth(200, "ArrowRight", true)).toBe(200 + COLUMN_RESIZE_KEYBOARD_LARGE_STEP);
+    expect(keyboardColumnWidth(200, "ArrowLeft")).toBe(190);
+    expect(keyboardColumnWidth(200, "ArrowRight", true)).toBe(230);
     expect(keyboardColumnWidth(82, "ArrowLeft")).toBe(MIN_COLUMN_WIDTH);
     expect(keyboardColumnWidth(200, "Home")).toBe(MIN_COLUMN_WIDTH);
     expect(keyboardColumnWidth(200, "Enter")).toBeUndefined();
@@ -77,8 +78,8 @@ describe("data-table column resizing", () => {
 
   it("recognizes only a timely second touch tap as reset", () => {
     expect(isTouchResetDoubleTap(undefined, 1000)).toBe(false);
-    expect(isTouchResetDoubleTap(1000, 1000 + TOUCH_RESET_DOUBLE_TAP_MS)).toBe(true);
-    expect(isTouchResetDoubleTap(1000, 1001 + TOUCH_RESET_DOUBLE_TAP_MS)).toBe(false);
+    expect(isTouchResetDoubleTap(1000, 1400)).toBe(true);
+    expect(isTouchResetDoubleTap(1000, 1401)).toBe(false);
     expect(isTouchResetDoubleTap(1000, 999)).toBe(false);
   });
 

--- a/components/data-view/data-table-resize.ts
+++ b/components/data-view/data-table-resize.ts
@@ -1,0 +1,78 @@
+export const MIN_COLUMN_WIDTH = 80;
+export const COLUMN_RESIZE_KEYBOARD_STEP = 10;
+export const COLUMN_RESIZE_KEYBOARD_LARGE_STEP = 30;
+export const TOUCH_RESET_DOUBLE_TAP_MS = 400;
+
+export type ColumnResizeSession = {
+  columnId: string;
+  pointerId: number;
+  pointerType: string;
+  startClientX: number;
+  startWidth: number;
+  currentWidth: number;
+  hasMoved: boolean;
+};
+
+function roundWidth(width: number): number {
+  return Math.round(width * 100) / 100;
+}
+
+export function beginColumnResize(args: {
+  columnId: string;
+  pointerId: number;
+  pointerType: string;
+  clientX: number;
+  renderedWidth: number;
+}): ColumnResizeSession {
+  const renderedWidth = roundWidth(args.renderedWidth);
+
+  return {
+    columnId: args.columnId,
+    pointerId: args.pointerId,
+    pointerType: args.pointerType,
+    startClientX: args.clientX,
+    startWidth: renderedWidth,
+    currentWidth: renderedWidth,
+    hasMoved: false,
+  };
+}
+
+export function updateColumnResize(session: ColumnResizeSession, clientX: number): ColumnResizeSession {
+  const delta = clientX - session.startClientX;
+  const currentWidth = roundWidth(Math.max(MIN_COLUMN_WIDTH, session.startWidth + delta));
+
+  return {
+    ...session,
+    currentWidth,
+    hasMoved: session.hasMoved || delta !== 0,
+  };
+}
+
+export function shouldCommitColumnResize(session: ColumnResizeSession): boolean {
+  return session.hasMoved && session.currentWidth !== session.startWidth;
+}
+
+export function keyboardColumnWidth(renderedWidth: number, key: string, largeStep = false): number | undefined {
+  const step = largeStep ? COLUMN_RESIZE_KEYBOARD_LARGE_STEP : COLUMN_RESIZE_KEYBOARD_STEP;
+
+  if (key === "ArrowLeft") return roundWidth(Math.max(MIN_COLUMN_WIDTH, renderedWidth - step));
+  if (key === "ArrowRight") return roundWidth(renderedWidth + step);
+  if (key === "Home") return MIN_COLUMN_WIDTH;
+  return undefined;
+}
+
+export function withoutColumnWidth(widths: Record<string, number>, columnId: string): Record<string, number> {
+  return Object.fromEntries(Object.entries(widths).filter(([uid]) => uid !== columnId));
+}
+
+export function isTouchResetDoubleTap(previousTapAt: number | undefined, currentTapAt: number): boolean {
+  if (previousTapAt === undefined) return false;
+  const elapsed = currentTapAt - previousTapAt;
+  return elapsed > 0 && elapsed <= TOUCH_RESET_DOUBLE_TAP_MS;
+}
+
+export function columnResizeLabel(columnId: string, header: unknown, configuredLabel?: string): string {
+  if (typeof header === "string" && header.trim()) return header;
+  if (configuredLabel?.trim()) return configuredLabel;
+  return columnId;
+}

--- a/components/data-view/data-table-resize.ts
+++ b/components/data-view/data-table-resize.ts
@@ -1,43 +1,39 @@
 export const MIN_COLUMN_WIDTH = 80;
-export const COLUMN_RESIZE_KEYBOARD_STEP = 10;
-export const COLUMN_RESIZE_KEYBOARD_LARGE_STEP = 30;
-export const TOUCH_RESET_DOUBLE_TAP_MS = 400;
+const COLUMN_RESIZE_KEYBOARD_STEP = 10;
+const COLUMN_RESIZE_KEYBOARD_LARGE_STEP = 30;
+const TOUCH_RESET_DOUBLE_TAP_MS = 400;
 
-export type ColumnResizeSession = {
-  columnId: string;
-  pointerId: number;
-  pointerType: string;
-  startClientX: number;
-  startWidth: number;
-  currentWidth: number;
-  hasMoved: boolean;
-};
+const roundWidth = (width: number) => Math.round(width * 100) / 100;
 
-function roundWidth(width: number): number {
-  return Math.round(width * 100) / 100;
-}
-
-export function beginColumnResize(args: {
+export function beginColumnResize({
+  columnId,
+  pointerId,
+  pointerType,
+  clientX,
+  renderedWidth,
+}: {
   columnId: string;
   pointerId: number;
   pointerType: string;
   clientX: number;
   renderedWidth: number;
-}): ColumnResizeSession {
-  const renderedWidth = roundWidth(args.renderedWidth);
+}) {
+  const width = roundWidth(renderedWidth);
 
   return {
-    columnId: args.columnId,
-    pointerId: args.pointerId,
-    pointerType: args.pointerType,
-    startClientX: args.clientX,
-    startWidth: renderedWidth,
-    currentWidth: renderedWidth,
+    columnId,
+    pointerId,
+    pointerType,
+    startClientX: clientX,
+    startWidth: width,
+    currentWidth: width,
     hasMoved: false,
   };
 }
 
-export function updateColumnResize(session: ColumnResizeSession, clientX: number): ColumnResizeSession {
+export type ColumnResizeSession = ReturnType<typeof beginColumnResize>;
+
+export function updateColumnResize(session: ColumnResizeSession, clientX: number) {
   const delta = clientX - session.startClientX;
   const currentWidth = roundWidth(Math.max(MIN_COLUMN_WIDTH, session.startWidth + delta));
 
@@ -48,11 +44,11 @@ export function updateColumnResize(session: ColumnResizeSession, clientX: number
   };
 }
 
-export function shouldCommitColumnResize(session: ColumnResizeSession): boolean {
+export function shouldCommitColumnResize(session: ColumnResizeSession) {
   return session.hasMoved && session.currentWidth !== session.startWidth;
 }
 
-export function keyboardColumnWidth(renderedWidth: number, key: string, largeStep = false): number | undefined {
+export function keyboardColumnWidth(renderedWidth: number, key: string, largeStep = false) {
   const step = largeStep ? COLUMN_RESIZE_KEYBOARD_LARGE_STEP : COLUMN_RESIZE_KEYBOARD_STEP;
 
   if (key === "ArrowLeft") return roundWidth(Math.max(MIN_COLUMN_WIDTH, renderedWidth - step));
@@ -61,17 +57,17 @@ export function keyboardColumnWidth(renderedWidth: number, key: string, largeSte
   return undefined;
 }
 
-export function withoutColumnWidth(widths: Record<string, number>, columnId: string): Record<string, number> {
+export function withoutColumnWidth(widths: Record<string, number>, columnId: string) {
   return Object.fromEntries(Object.entries(widths).filter(([uid]) => uid !== columnId));
 }
 
-export function isTouchResetDoubleTap(previousTapAt: number | undefined, currentTapAt: number): boolean {
+export function isTouchResetDoubleTap(previousTapAt: number | undefined, currentTapAt: number) {
   if (previousTapAt === undefined) return false;
   const elapsed = currentTapAt - previousTapAt;
   return elapsed > 0 && elapsed <= TOUCH_RESET_DOUBLE_TAP_MS;
 }
 
-export function columnResizeLabel(columnId: string, header: unknown, configuredLabel?: string): string {
+export function columnResizeLabel(columnId: string, header: unknown, configuredLabel?: string) {
   if (typeof header === "string" && header.trim()) return header;
   if (configuredLabel?.trim()) return configuredLabel;
   return columnId;

--- a/components/data-view/data-table.tsx
+++ b/components/data-view/data-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store";
-import type { ColumnDef, ColumnSizingState, SortingState, VisibilityState } from "@tanstack/react-table";
+import type { ColumnDef, SortingState, VisibilityState } from "@tanstack/react-table";
 import type { KeyboardEvent, PointerEvent } from "react";
 
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
@@ -36,20 +36,7 @@ type Props<E extends HasId> = {
   onRowHref?: (item: E) => string | undefined;
 };
 
-type ResizeDraft = {
-  columnId: string;
-  width: number;
-};
-
-type ActiveResize = {
-  handle: HTMLButtonElement;
-  session: ColumnResizeSession;
-};
-
-type LastTouchTap = {
-  columnId: string;
-  at: number;
-};
+const fixedWidthStyle = (width: number) => ({ width, minWidth: width, maxWidth: width });
 
 export const DataTable = observer(function DataTable<E extends HasId>({
   store,
@@ -58,25 +45,23 @@ export const DataTable = observer(function DataTable<E extends HasId>({
   onRowHref,
 }: Props<E>) {
   const navigateToHref = useNavigateToHref();
-  const [resizeDraft, setResizeDraft] = useState<ResizeDraft>();
-  const activeResizeRef = useRef<ActiveResize | undefined>(undefined);
-  const lastTouchTapRef = useRef<LastTouchTap | undefined>(undefined);
+  const [resizeSession, setResizeSession] = useState<ColumnResizeSession>();
+  const activeResizeRef = useRef<{ handle: HTMLButtonElement; session: ColumnResizeSession }>();
+  const lastTouchTapRef = useRef<{ columnId: string; at: number }>();
 
-  const resetColumnWidth = useCallback(
-    (columnId: string) => {
-      store.setViewOptions({
-        columnWidths: withoutColumnWidth(store.columnWidths, columnId),
-      });
-    },
-    [store],
-  );
+  function resetColumnWidth(columnId: string) {
+    store.setViewOptions({ columnWidths: withoutColumnWidth(store.columnWidths, columnId) });
+  }
+
+  const getColumnWidth = (columnId: string) =>
+    resizeSession?.columnId === columnId ? resizeSession.currentWidth : store.columnWidths[columnId];
 
   const cancelActiveResize = useCallback(() => {
     const active = activeResizeRef.current;
     if (!active) return;
 
     activeResizeRef.current = undefined;
-    setResizeDraft(undefined);
+    setResizeSession(undefined);
     if (active.handle.hasPointerCapture(active.session.pointerId))
       active.handle.releasePointerCapture(active.session.pointerId);
   }, []);
@@ -101,7 +86,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
     };
   }, [cancelActiveResize]);
 
-  const onResizePointerDown = useCallback((event: PointerEvent<HTMLButtonElement>, columnId: string) => {
+  function onResizePointerDown(event: PointerEvent<HTMLButtonElement>, columnId: string) {
     if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
 
     const headerCell = event.currentTarget.closest("th");
@@ -117,77 +102,63 @@ export const DataTable = observer(function DataTable<E extends HasId>({
     });
 
     activeResizeRef.current = { handle: event.currentTarget, session };
-    setResizeDraft({ columnId, width: session.currentWidth });
+    setResizeSession(session);
     event.currentTarget.focus({ preventScroll: true });
     event.currentTarget.setPointerCapture(event.pointerId);
-  }, []);
+  }
 
-  const onResizePointerMove = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+  function onResizePointerMove(event: PointerEvent<HTMLButtonElement>) {
     const active = activeResizeRef.current;
     if (!active || active.session.pointerId !== event.pointerId) return;
 
     event.preventDefault();
     const session = updateColumnResize(active.session, event.clientX);
-    activeResizeRef.current = { ...active, session };
-    setResizeDraft({
-      columnId: session.columnId,
-      width: session.currentWidth,
-    });
-  }, []);
+    active.session = session;
+    setResizeSession(session);
+  }
 
-  const onResizePointerUp = useCallback(
-    (event: PointerEvent<HTMLButtonElement>) => {
-      const active = activeResizeRef.current;
-      if (!active || active.session.pointerId !== event.pointerId) return;
+  function onResizePointerUp(event: PointerEvent<HTMLButtonElement>) {
+    const active = activeResizeRef.current;
+    if (!active || active.session.pointerId !== event.pointerId) return;
 
-      event.stopPropagation();
-      const session = updateColumnResize(active.session, event.clientX);
-      activeResizeRef.current = undefined;
-      setResizeDraft(undefined);
-      if (event.currentTarget.hasPointerCapture(event.pointerId))
-        event.currentTarget.releasePointerCapture(event.pointerId);
+    event.stopPropagation();
+    const session = updateColumnResize(active.session, event.clientX);
+    cancelActiveResize();
 
-      if (shouldCommitColumnResize(session)) {
-        lastTouchTapRef.current = undefined;
-        store.setViewOptions({
-          columnWidth: { uid: session.columnId, width: session.currentWidth },
-        });
-        return;
-      }
+    if (shouldCommitColumnResize(session)) {
+      lastTouchTapRef.current = undefined;
+      store.setViewOptions({
+        columnWidth: { uid: session.columnId, width: session.currentWidth },
+      });
+      return;
+    }
 
-      if (session.pointerType !== "touch") return;
-      const previousTap = lastTouchTapRef.current;
-      if (previousTap?.columnId === session.columnId && isTouchResetDoubleTap(previousTap.at, event.timeStamp)) {
-        lastTouchTapRef.current = undefined;
-        resetColumnWidth(session.columnId);
-      } else {
-        lastTouchTapRef.current = {
-          columnId: session.columnId,
-          at: event.timeStamp,
-        };
-      }
-    },
-    [resetColumnWidth, store],
-  );
+    if (session.pointerType !== "touch" || session.hasMoved) return;
+    const previousTap = lastTouchTapRef.current;
+    if (previousTap?.columnId === session.columnId && isTouchResetDoubleTap(previousTap.at, event.timeStamp)) {
+      lastTouchTapRef.current = undefined;
+      resetColumnWidth(session.columnId);
+      return;
+    }
 
-  const onResizeKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLButtonElement>, columnId: string) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        resetColumnWidth(columnId);
-        return;
-      }
+    lastTouchTapRef.current = { columnId: session.columnId, at: event.timeStamp };
+  }
 
-      const headerCell = event.currentTarget.closest("th");
-      if (!headerCell) return;
-      const width = keyboardColumnWidth(headerCell.getBoundingClientRect().width, event.key, event.shiftKey);
-      if (width === undefined) return;
-
+  function onResizeKeyDown(event: KeyboardEvent<HTMLButtonElement>, columnId: string) {
+    if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      store.setViewOptions({ columnWidth: { uid: columnId, width } });
-    },
-    [resetColumnWidth, store],
-  );
+      resetColumnWidth(columnId);
+      return;
+    }
+
+    const headerCell = event.currentTarget.closest("th");
+    if (!headerCell) return;
+    const width = keyboardColumnWidth(headerCell.getBoundingClientRect().width, event.key, event.shiftKey);
+    if (width === undefined) return;
+
+    event.preventDefault();
+    store.setViewOptions({ columnWidth: { uid: columnId, width } });
+  }
   const sorting: SortingState = useMemo(
     () =>
       store.sortDescriptor
@@ -206,8 +177,6 @@ export const DataTable = observer(function DataTable<E extends HasId>({
     for (const uid of store.hiddenColumns) visibility[uid] = false;
     return visibility;
   }, [store.hiddenColumns]);
-
-  const columnSizing: ColumnSizingState = useMemo(() => ({ ...store.columnWidths }), [store.columnWidths]);
 
   const selectionColumn: ColumnDef<E> = useMemo(
     () => ({
@@ -257,7 +226,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
   const table = useReactTable<E>({
     data: store.items,
     columns: allColumns,
-    state: { sorting, columnVisibility, columnSizing },
+    state: { sorting, columnVisibility },
     getCoreRowModel: getCoreRowModel(),
     manualSorting: true,
     manualPagination: true,
@@ -281,16 +250,17 @@ export const DataTable = observer(function DataTable<E extends HasId>({
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>
             {headerGroup.headers.map((header) => {
-              const isSelectionCol = header.column.id === "__select";
+              const columnId = header.column.id;
+              const isSelectionCol = columnId === "__select";
               const canSort = header.column.getCanSort() && !isSelectionCol;
               const canResize = header.column.getCanResize() && !isSelectionCol;
               const sorted = header.column.getIsSorted();
-              const persistedWidth = store.columnWidths[header.column.id];
-              const liveWidth = resizeDraft?.columnId === header.column.id ? resizeDraft.width : persistedWidth;
+              const isResizing = resizeSession?.columnId === columnId;
+              const liveWidth = getColumnWidth(columnId);
               const accessibleColumnLabel = columnResizeLabel(
-                header.column.id,
+                columnId,
                 header.column.columnDef.header,
-                store.columnsDefinition.find((column) => column.uid === header.column.id)?.label,
+                store.columnsDefinition.find((column) => column.uid === columnId)?.label,
               );
               return (
                 <TableHead
@@ -303,11 +273,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                   )}
                   style={
                     liveWidth != null
-                      ? {
-                          width: liveWidth,
-                          minWidth: liveWidth,
-                          maxWidth: liveWidth,
-                        }
+                      ? fixedWidthStyle(liveWidth)
                       : canResize
                         ? { minWidth: MIN_COLUMN_WIDTH }
                         : undefined
@@ -323,12 +289,11 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                           onClick={() => {
                             const currentField = store.sortDescriptor?.field;
                             const currentDir = store.sortDescriptor?.direction;
-                            const fieldId = header.column.id;
                             const nextDirection: Prisma.SortOrder =
-                              currentField === fieldId && currentDir === "asc" ? "desc" : "asc";
+                              currentField === columnId && currentDir === "asc" ? "desc" : "asc";
                             store.setQueryOptions({
                               sortDescriptor: {
-                                field: fieldId,
+                                field: columnId,
                                 direction: nextDirection,
                               },
                             });
@@ -358,40 +323,30 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                     <button
                       aria-keyshortcuts="ArrowLeft ArrowRight Home Enter Space"
                       aria-label={`Resize ${accessibleColumnLabel} column. Drag or use arrow keys to resize; double-tap or press Enter to reset.`}
-                      className={cn(
-                        "group/resize-handle absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize touch-none select-none items-stretch justify-center border-0 bg-transparent p-0 opacity-0 outline-none",
-                        "group-hover/resize-header:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-                        resizeDraft?.columnId === header.column.id && "opacity-100",
-                        "[@media(any-pointer:coarse)]:w-6 [@media(any-pointer:coarse)]:opacity-100",
-                      )}
+                      className="group/resize-handle absolute inset-y-0 right-0 z-10 flex w-3 translate-x-1/2 cursor-col-resize touch-none select-none justify-center border-0 bg-transparent p-0 opacity-0 outline-none group-hover/resize-header:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-foreground/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background data-[state=resizing]:opacity-100 any-pointer-coarse:w-6 any-pointer-coarse:opacity-100"
                       data-slot="column-resize-handle"
-                      data-state={resizeDraft?.columnId === header.column.id ? "resizing" : undefined}
+                      data-state={isResizing ? "resizing" : undefined}
                       title="Drag to resize. Double-click, double-tap, or press Enter to reset."
                       type="button"
                       onClick={(event) => {
                         event.stopPropagation();
-                        if (event.detail === 0) resetColumnWidth(header.column.id);
+                        if (event.detail === 0) resetColumnWidth(columnId);
                       }}
                       onDoubleClick={(event) => {
                         event.preventDefault();
                         event.stopPropagation();
-                        resetColumnWidth(header.column.id);
+                        resetColumnWidth(columnId);
                       }}
-                      onKeyDown={(event) => onResizeKeyDown(event, header.column.id)}
+                      onKeyDown={(event) => onResizeKeyDown(event, columnId)}
                       onLostPointerCapture={cancelActiveResize}
                       onPointerCancel={cancelActiveResize}
-                      onPointerDown={(event) => onResizePointerDown(event, header.column.id)}
+                      onPointerDown={(event) => onResizePointerDown(event, columnId)}
                       onPointerMove={onResizePointerMove}
                       onPointerUp={onResizePointerUp}
                     >
                       <span
                         aria-hidden="true"
-                        className={cn(
-                          "w-px bg-border transition-colors",
-                          "group-hover/resize-header:bg-primary/60 group-focus-visible/resize-handle:bg-primary",
-                          resizeDraft?.columnId === header.column.id && "w-0.5 bg-primary",
-                          "[@media(any-pointer:coarse)]:bg-primary/60",
-                        )}
+                        className="w-0.5 rounded-full bg-foreground/45 transition-colors group-hover/resize-handle:bg-foreground/70 group-focus-visible/resize-handle:bg-foreground/70 group-data-[state=resizing]/resize-handle:bg-foreground/70"
                         data-slot="column-resize-indicator"
                       />
                     </button>
@@ -427,10 +382,10 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                 }}
               >
                 {row.getVisibleCells().map((cell) => {
-                  const isSelectionCell = cell.column.id === "__select";
-                  const isNameCell = cell.column.id === "name";
-                  const persistedWidth = store.columnWidths[cell.column.id];
-                  const liveWidth = resizeDraft?.columnId === cell.column.id ? resizeDraft.width : persistedWidth;
+                  const columnId = cell.column.id;
+                  const isSelectionCell = columnId === "__select";
+                  const isNameCell = columnId === "name";
+                  const liveWidth = getColumnWidth(columnId);
                   const content = flexRender(cell.column.columnDef.cell, cell.getContext());
                   const rowHref = onRowHref?.(row.original);
                   const wrapped =
@@ -458,15 +413,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                     <TableCell
                       key={cell.id}
                       className={isSelectionCell ? "w-10" : undefined}
-                      style={
-                        liveWidth != null && !isSelectionCell
-                          ? {
-                              width: liveWidth,
-                              minWidth: liveWidth,
-                              maxWidth: liveWidth,
-                            }
-                          : undefined
-                      }
+                      style={liveWidth != null && !isSelectionCell ? fixedWidthStyle(liveWidth) : undefined}
                     >
                       {liveWidth != null && !isSelectionCell ? (
                         <div className="truncate" style={{ width: Math.max(0, liveWidth - 24) }}>

--- a/components/data-view/data-table.tsx
+++ b/components/data-view/data-table.tsx
@@ -2,11 +2,12 @@
 
 import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store";
 import type { ColumnDef, ColumnSizingState, SortingState, VisibilityState } from "@tanstack/react-table";
+import type { KeyboardEvent, PointerEvent } from "react";
 
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
 import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { observer } from "mobx-react-lite";
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
@@ -16,12 +17,38 @@ import type { Prisma } from "@/generated/prisma";
 import { cn } from "@/core/utils/cn";
 
 import { isInteractiveClick } from "./is-interactive-click";
+import {
+  beginColumnResize,
+  columnResizeLabel,
+  isTouchResetDoubleTap,
+  keyboardColumnWidth,
+  MIN_COLUMN_WIDTH,
+  shouldCommitColumnResize,
+  updateColumnResize,
+  withoutColumnWidth,
+  type ColumnResizeSession,
+} from "./data-table-resize";
 
 type Props<E extends HasId> = {
   store: BaseDataViewStore<E>;
   columns: ColumnDef<E>[];
   onRowClick?: (item: E) => void;
   onRowHref?: (item: E) => string | undefined;
+};
+
+type ResizeDraft = {
+  columnId: string;
+  width: number;
+};
+
+type ActiveResize = {
+  handle: HTMLButtonElement;
+  session: ColumnResizeSession;
+};
+
+type LastTouchTap = {
+  columnId: string;
+  at: number;
 };
 
 export const DataTable = observer(function DataTable<E extends HasId>({
@@ -31,6 +58,136 @@ export const DataTable = observer(function DataTable<E extends HasId>({
   onRowHref,
 }: Props<E>) {
   const navigateToHref = useNavigateToHref();
+  const [resizeDraft, setResizeDraft] = useState<ResizeDraft>();
+  const activeResizeRef = useRef<ActiveResize | undefined>(undefined);
+  const lastTouchTapRef = useRef<LastTouchTap | undefined>(undefined);
+
+  const resetColumnWidth = useCallback(
+    (columnId: string) => {
+      store.setViewOptions({
+        columnWidths: withoutColumnWidth(store.columnWidths, columnId),
+      });
+    },
+    [store],
+  );
+
+  const cancelActiveResize = useCallback(() => {
+    const active = activeResizeRef.current;
+    if (!active) return;
+
+    activeResizeRef.current = undefined;
+    setResizeDraft(undefined);
+    if (active.handle.hasPointerCapture(active.session.pointerId))
+      active.handle.releasePointerCapture(active.session.pointerId);
+  }, []);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") cancelActiveResize();
+    };
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") cancelActiveResize();
+    };
+
+    window.addEventListener("blur", cancelActiveResize);
+    window.addEventListener("resize", cancelActiveResize);
+    window.addEventListener("keydown", onKeyDown);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("blur", cancelActiveResize);
+      window.removeEventListener("resize", cancelActiveResize);
+      window.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [cancelActiveResize]);
+
+  const onResizePointerDown = useCallback((event: PointerEvent<HTMLButtonElement>, columnId: string) => {
+    if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+
+    const headerCell = event.currentTarget.closest("th");
+    if (!headerCell) return;
+
+    event.stopPropagation();
+    const session = beginColumnResize({
+      columnId,
+      pointerId: event.pointerId,
+      pointerType: event.pointerType,
+      clientX: event.clientX,
+      renderedWidth: headerCell.getBoundingClientRect().width,
+    });
+
+    activeResizeRef.current = { handle: event.currentTarget, session };
+    setResizeDraft({ columnId, width: session.currentWidth });
+    event.currentTarget.focus({ preventScroll: true });
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
+
+  const onResizePointerMove = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+    const active = activeResizeRef.current;
+    if (!active || active.session.pointerId !== event.pointerId) return;
+
+    event.preventDefault();
+    const session = updateColumnResize(active.session, event.clientX);
+    activeResizeRef.current = { ...active, session };
+    setResizeDraft({
+      columnId: session.columnId,
+      width: session.currentWidth,
+    });
+  }, []);
+
+  const onResizePointerUp = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      const active = activeResizeRef.current;
+      if (!active || active.session.pointerId !== event.pointerId) return;
+
+      event.stopPropagation();
+      const session = updateColumnResize(active.session, event.clientX);
+      activeResizeRef.current = undefined;
+      setResizeDraft(undefined);
+      if (event.currentTarget.hasPointerCapture(event.pointerId))
+        event.currentTarget.releasePointerCapture(event.pointerId);
+
+      if (shouldCommitColumnResize(session)) {
+        lastTouchTapRef.current = undefined;
+        store.setViewOptions({
+          columnWidth: { uid: session.columnId, width: session.currentWidth },
+        });
+        return;
+      }
+
+      if (session.pointerType !== "touch") return;
+      const previousTap = lastTouchTapRef.current;
+      if (previousTap?.columnId === session.columnId && isTouchResetDoubleTap(previousTap.at, event.timeStamp)) {
+        lastTouchTapRef.current = undefined;
+        resetColumnWidth(session.columnId);
+      } else {
+        lastTouchTapRef.current = {
+          columnId: session.columnId,
+          at: event.timeStamp,
+        };
+      }
+    },
+    [resetColumnWidth, store],
+  );
+
+  const onResizeKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, columnId: string) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        resetColumnWidth(columnId);
+        return;
+      }
+
+      const headerCell = event.currentTarget.closest("th");
+      if (!headerCell) return;
+      const width = keyboardColumnWidth(headerCell.getBoundingClientRect().width, event.key, event.shiftKey);
+      if (width === undefined) return;
+
+      event.preventDefault();
+      store.setViewOptions({ columnWidth: { uid: columnId, width } });
+    },
+    [resetColumnWidth, store],
+  );
   const sorting: SortingState = useMemo(
     () =>
       store.sortDescriptor
@@ -104,15 +261,6 @@ export const DataTable = observer(function DataTable<E extends HasId>({
     getCoreRowModel: getCoreRowModel(),
     manualSorting: true,
     manualPagination: true,
-    columnResizeMode: "onEnd",
-    onColumnSizingChange: (updater) => {
-      const next = typeof updater === "function" ? updater(columnSizing) : updater;
-      const changed = Object.entries(next).find(([uid, width]) => store.columnWidths[uid] !== width);
-      if (changed) {
-        const [uid, width] = changed;
-        store.setViewOptions({ columnWidth: { uid, width } });
-      }
-    },
     onSortingChange: (updater) => {
       const next = typeof updater === "function" ? updater(sorting) : updater;
       const first = next[0];
@@ -138,26 +286,31 @@ export const DataTable = observer(function DataTable<E extends HasId>({
               const canResize = header.column.getCanResize() && !isSelectionCol;
               const sorted = header.column.getIsSorted();
               const persistedWidth = store.columnWidths[header.column.id];
-              const isResizing = header.column.getIsResizing();
-              const deltaOffset = table.getState().columnSizingInfo.deltaOffset ?? 0;
-              const liveWidth =
-                isResizing && persistedWidth
-                  ? Math.max(80, persistedWidth + deltaOffset)
-                  : isResizing
-                    ? Math.max(80, header.getSize() + deltaOffset)
-                    : persistedWidth;
+              const liveWidth = resizeDraft?.columnId === header.column.id ? resizeDraft.width : persistedWidth;
+              const accessibleColumnLabel = columnResizeLabel(
+                header.column.id,
+                header.column.columnDef.header,
+                store.columnsDefinition.find((column) => column.uid === header.column.id)?.label,
+              );
               return (
                 <TableHead
                   key={header.id}
-                  className={cn("relative", canSort && "cursor-pointer select-none", isSelectionCol && "w-10")}
+                  className={cn(
+                    "relative",
+                    canResize && "group/resize-header",
+                    canSort && "cursor-pointer select-none",
+                    isSelectionCol && "w-10",
+                  )}
                   style={
-                    liveWidth
+                    liveWidth != null
                       ? {
                           width: liveWidth,
                           minWidth: liveWidth,
                           maxWidth: liveWidth,
                         }
-                      : undefined
+                      : canResize
+                        ? { minWidth: MIN_COLUMN_WIDTH }
+                        : undefined
                   }
                 >
                   {header.isPlaceholder ? null : (
@@ -202,17 +355,46 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                   )}
 
                   {canResize && (
-                    <span
-                      aria-hidden="true"
+                    <button
+                      aria-keyshortcuts="ArrowLeft ArrowRight Home Enter Space"
+                      aria-label={`Resize ${accessibleColumnLabel} column. Drag or use arrow keys to resize; double-tap or press Enter to reset.`}
                       className={cn(
-                        "absolute right-0 top-0 h-full w-1.5 cursor-col-resize touch-none select-none",
-                        "hover:bg-primary/40 active:bg-primary",
-                        header.column.getIsResizing() && "bg-primary",
+                        "group/resize-handle absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize touch-none select-none items-stretch justify-center border-0 bg-transparent p-0 opacity-0 outline-none",
+                        "group-hover/resize-header:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                        resizeDraft?.columnId === header.column.id && "opacity-100",
+                        "[@media(any-pointer:coarse)]:w-6 [@media(any-pointer:coarse)]:opacity-100",
                       )}
-                      onDoubleClick={() => header.column.resetSize()}
-                      onMouseDown={header.getResizeHandler()}
-                      onTouchStart={header.getResizeHandler()}
-                    />
+                      data-slot="column-resize-handle"
+                      data-state={resizeDraft?.columnId === header.column.id ? "resizing" : undefined}
+                      title="Drag to resize. Double-click, double-tap, or press Enter to reset."
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (event.detail === 0) resetColumnWidth(header.column.id);
+                      }}
+                      onDoubleClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        resetColumnWidth(header.column.id);
+                      }}
+                      onKeyDown={(event) => onResizeKeyDown(event, header.column.id)}
+                      onLostPointerCapture={cancelActiveResize}
+                      onPointerCancel={cancelActiveResize}
+                      onPointerDown={(event) => onResizePointerDown(event, header.column.id)}
+                      onPointerMove={onResizePointerMove}
+                      onPointerUp={onResizePointerUp}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          "w-px bg-border transition-colors",
+                          "group-hover/resize-header:bg-primary/60 group-focus-visible/resize-handle:bg-primary",
+                          resizeDraft?.columnId === header.column.id && "w-0.5 bg-primary",
+                          "[@media(any-pointer:coarse)]:bg-primary/60",
+                        )}
+                        data-slot="column-resize-indicator"
+                      />
+                    </button>
                   )}
                 </TableHead>
               );
@@ -248,6 +430,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                   const isSelectionCell = cell.column.id === "__select";
                   const isNameCell = cell.column.id === "name";
                   const persistedWidth = store.columnWidths[cell.column.id];
+                  const liveWidth = resizeDraft?.columnId === cell.column.id ? resizeDraft.width : persistedWidth;
                   const content = flexRender(cell.column.columnDef.cell, cell.getContext());
                   const rowHref = onRowHref?.(row.original);
                   const wrapped =
@@ -272,9 +455,21 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                       content
                     );
                   return (
-                    <TableCell key={cell.id} className={isSelectionCell ? "w-10" : undefined}>
-                      {persistedWidth != null && !isSelectionCell ? (
-                        <div className="truncate" style={{ width: persistedWidth - 24 }}>
+                    <TableCell
+                      key={cell.id}
+                      className={isSelectionCell ? "w-10" : undefined}
+                      style={
+                        liveWidth != null && !isSelectionCell
+                          ? {
+                              width: liveWidth,
+                              minWidth: liveWidth,
+                              maxWidth: liveWidth,
+                            }
+                          : undefined
+                      }
+                    >
+                      {liveWidth != null && !isSelectionCell ? (
+                        <div className="truncate" style={{ width: Math.max(0, liveWidth - 24) }}>
                           {wrapped}
                         </div>
                       ) : (

--- a/tests/conventions/data-table-resize.test.ts
+++ b/tests/conventions/data-table-resize.test.ts
@@ -16,19 +16,22 @@ describe("shared data-table resize contract", () => {
     expect(dataTableSource).toContain('data-slot="column-resize-handle"');
     expect(dataTableSource).toContain('data-slot="column-resize-indicator"');
     expect(dataTableSource).toContain("group-hover/resize-header:opacity-100");
-    expect(dataTableSource).toContain(
-      'data-state={resizeDraft?.columnId === header.column.id ? "resizing" : undefined}',
-    );
-    expect(dataTableSource).toContain("group-focus-visible/resize-handle:bg-primary");
+    expect(dataTableSource).toContain("w-0.5 rounded-full bg-foreground/45");
+    expect(dataTableSource).toContain("group-focus-visible/resize-handle:bg-foreground/70");
+    expect(dataTableSource).toContain("focus-visible:ring-foreground/50");
+    expect(dataTableSource).toContain("any-pointer-coarse:w-6 any-pointer-coarse:opacity-100");
+    expect(dataTableSource).not.toContain("resize-handle:bg-primary");
+    expect(dataTableSource).not.toContain("ring-primary");
     expect(dataTableSource).toContain('aria-keyshortcuts="ArrowLeft ArrowRight Home Enter Space"');
-    expect(dataTableSource).toContain("accessibleColumnLabel");
     expect(dataTableSource).toContain("event.detail === 0");
-    expect(dataTableSource).toContain("onResizeKeyDown(event, header.column.id)");
+    expect(dataTableSource).toContain("onResizeKeyDown(event, columnId)");
+    expect(dataTableSource).toContain('const canResize = header.column.getCanResize() && !isSelectionCol;');
   });
 
   it("applies the same draft width to header and body cells before persisting", () => {
-    expect(dataTableSource.match(/resizeDraft\?\.columnId ===/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(dataTableSource.match(/fixedWidthStyle\(liveWidth\)/g)).toHaveLength(2);
     expect(dataTableSource).toContain("shouldCommitColumnResize(session)");
     expect(dataTableSource).toContain("withoutColumnWidth(store.columnWidths, columnId)");
+    expect(dataTableSource).toContain('if (session.pointerType !== "touch" || session.hasMoved) return;');
   });
 });

--- a/tests/conventions/data-table-resize.test.ts
+++ b/tests/conventions/data-table-resize.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const dataTableSource = readFileSync(new URL("../../components/data-view/data-table.tsx", import.meta.url), "utf8");
+
+describe("shared data-table resize contract", () => {
+  it("starts custom pointer resizing from the rendered header width", () => {
+    expect(dataTableSource).toContain("headerCell.getBoundingClientRect().width");
+    expect(dataTableSource).toContain("setPointerCapture(event.pointerId)");
+    expect(dataTableSource).toContain("onPointerCancel={cancelActiveResize}");
+    expect(dataTableSource).not.toContain("getResizeHandler()");
+  });
+
+  it("exposes a whole-header hover affordance and keyboard-operable handle", () => {
+    expect(dataTableSource).toContain('data-slot="column-resize-handle"');
+    expect(dataTableSource).toContain('data-slot="column-resize-indicator"');
+    expect(dataTableSource).toContain("group-hover/resize-header:opacity-100");
+    expect(dataTableSource).toContain(
+      'data-state={resizeDraft?.columnId === header.column.id ? "resizing" : undefined}',
+    );
+    expect(dataTableSource).toContain("group-focus-visible/resize-handle:bg-primary");
+    expect(dataTableSource).toContain('aria-keyshortcuts="ArrowLeft ArrowRight Home Enter Space"');
+    expect(dataTableSource).toContain("accessibleColumnLabel");
+    expect(dataTableSource).toContain("event.detail === 0");
+    expect(dataTableSource).toContain("onResizeKeyDown(event, header.column.id)");
+  });
+
+  it("applies the same draft width to header and body cells before persisting", () => {
+    expect(dataTableSource.match(/resizeDraft\?\.columnId ===/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(dataTableSource).toContain("shouldCommitColumnResize(session)");
+    expect(dataTableSource).toContain("withoutColumnWidth(store.columnWidths, columnId)");
+  });
+});


### PR DESCRIPTION
## Summary

- Replace TanStack's 150 px resize baseline with a pointer-captured resize session that starts from the rendered header width.
- Reveal a 2 px neutral divider from whole-header hover, keyboard focus, active drag, and coarse-pointer media without using the primary color.
- Keep header and body widths aligned during the draft, persist once on release, and make reset work for mouse, touch, keyboard, and assistive activation.
- Simplify the implementation by sharing one resize-session shape, removing unused TanStack sizing state and duplicate cleanup, and inferring straightforward return types.

## Context

Fixes [CUS-62](https://linear.app/customermates/issue/CUS-62/fix-table-resize-handle-discoverability-and-the-first-drag-width-jump).

Previously, an unsized column began its first drag from TanStack's 150 px default even when the browser rendered a different width, causing an immediate snap. The 6 px transparent handle was also only discoverable when the pointer was already directly over it.

Task key: `product:data-table-column-resize-affordance-continuity`

## Validation

- `yarn lint`
- `yarn typecheck`
- `yarn vitest run tests/conventions` - 86/86
- `yarn test` with the isolated local PostgreSQL URL - 1,025/1,025
- `yarn build`
- Focused resize suite - 15/15
- Independent read-only review - no actionable findings
- Local browser acceptance on `/en/contacts` with seeded user Sofia Rossi:
  - whole-header hover changed handle opacity from 0 to 1 and rendered a 2 px neutral-foreground divider with no primary-color class;
  - pointer-down stayed at the rendered 171.77 px baseline, then a 3 px move produced 174.77 px for both header and body;
  - reload retained the persisted width and Enter restored the automatic width;
  - keyboard focus produced a visible neutral ring and readable divider;
  - coarse-pointer emulation produced a persistent 24 px target at opacity 1;
  - touch emulation moved exactly 4 px and returned to baseline on cancellation.

## Impact and rollback

No database migration, environment-variable change, API change, or production-data access. The change is limited to the shared data-table resize behavior and its tests.

Rollback by reverting commits `95cc1dcc` and `7ddcf5b1`; existing persisted column-width records remain compatible.

## Screenshots

Hover and keyboard-focus screenshots are attached to CUS-62 with the browser measurements above.
