### PR TITLE
feat(ui): offer one scroll-return affordance across scrollable surfaces

### DIFF
--- a/app/[locale]/(protected)/inbox/components/inbox-list.tsx
+++ b/app/[locale]/(protected)/inbox/components/inbox-list.tsx
@@ -9,11 +9,13 @@ import { Cable, Inbox, RefreshCw } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 
 import { IntlLink as Link, useRouter, usePathname } from "@/i18n/navigation";
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { cn } from "@/core/utils/cn";
 import { Button } from "@/components/ui/button";
 import { useDataViewSync } from "@/components/data-view";
+import { ScrollReturnButton } from "@/components/scroll/scroll-return-button";
+import { useScrollReturn } from "@/components/scroll/use-scroll-return";
 import { DataViewToolbar } from "@/components/data-view/data-view-toolbar";
 import { DataViewActiveFiltersBar } from "@/components/data-view/header/active-filters-bar";
 import { DataViewPagination } from "@/components/data-view/header/pagination";
@@ -105,6 +107,8 @@ export const InboxList = observer(({ threads, selectedThreadId }: Props) => {
   const items = messagingThreadsStore.isReady ? messagingThreadsStore.items : threads.items;
 
   const listRef = useRef<HTMLDivElement>(null);
+  const getScrollElement = useCallback(() => listRef.current, []);
+  const { isAway, returnToAnchor } = useScrollReturn({ direction: "top", getScrollElement });
 
   useLayoutEffect(() => {
     const el = listRef.current;
@@ -132,23 +136,32 @@ export const InboxList = observer(({ threads, selectedThreadId }: Props) => {
     <div className="flex h-full flex-col">
       <DataViewActiveFiltersBar store={messagingThreadsStore} onEditFilters={clearSelectedThread} />
 
-      <div ref={listRef} className="flex-1 overflow-y-auto" id="inbox-thread-list">
-        {items.length === 0 ? (
-          <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-            <Inbox className="size-8 opacity-40" />
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <div ref={listRef} className="flex-1 overflow-y-auto" id="inbox-thread-list">
+          {items.length === 0 ? (
+            <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+              <Inbox className="size-8 opacity-40" />
 
-            <p className="text-sm">{t("Inbox.emptyState")}</p>
-          </div>
-        ) : (
-          items.map((thread) => (
-            <ThreadRow
-              key={thread.id}
-              selected={thread.id === selectedThreadId}
-              thread={thread}
-              onClick={() => selectThread(thread.id)}
-            />
-          ))
-        )}
+              <p className="text-sm">{t("Inbox.emptyState")}</p>
+            </div>
+          ) : (
+            items.map((thread) => (
+              <ThreadRow
+                key={thread.id}
+                selected={thread.id === selectedThreadId}
+                thread={thread}
+                onClick={() => selectThread(thread.id)}
+              />
+            ))
+          )}
+        </div>
+
+        <ScrollReturnButton
+          direction="top"
+          isAway={isAway}
+          label={t("Common.scroll.backToTop")}
+          onReturn={returnToAnchor}
+        />
       </div>
 
       <DataViewPagination store={messagingThreadsStore} />

--- a/app/[locale]/(protected)/inbox/components/thread-panel.tsx
+++ b/app/[locale]/(protected)/inbox/components/thread-panel.tsx
@@ -12,7 +12,7 @@ import { deriveReplyRecipients } from "@/ee/messaging/reply-recipients";
 
 import { MessageItem } from "./message-item";
 import { MessageDateSeparator, isSameDay } from "./message-date-separator";
-import { MessagesScrollContainer } from "./messages-scroll-container";
+import { MessagesScrollContainer } from "@/components/scroll/messages-scroll-container";
 import { ThreadAutoMarkRead } from "./thread-auto-mark-read";
 import { ThreadTopBar } from "./thread-topbar";
 import { ThreadReplyComposer } from "./thread-reply-composer";
@@ -56,7 +56,11 @@ export const ThreadPanel = observer(({ threadDetail }: Props) => {
 
       <ThreadTopBar thread={thread} />
 
-      <MessagesScrollContainer scrollKey={`thread:${thread.id}`} onTopReach={store.loadOlderMessages}>
+      <MessagesScrollContainer
+        jumpToLatestLabel={t("Common.scroll.jumpToLatest")}
+        scrollKey={`thread:${thread.id}`}
+        onTopReach={store.loadOlderMessages}
+      >
         <div className="flex flex-col gap-1">
           {store.loadingOlder && (
             <div className="flex justify-center py-2">

--- a/app/components/agent-chat/agent-chat.tsx
+++ b/app/components/agent-chat/agent-chat.tsx
@@ -39,7 +39,7 @@ import type { AgentUsageSummary } from "@/features/agent-chat/agent-usage.servic
 import type { AgentWorkspaceSetupPlan } from "@/features/agent-chat/agent-workspace-setup";
 
 import { MessageDateSeparator, isSameDay } from "@/app/[locale]/(protected)/inbox/components/message-date-separator";
-import { MessagesScrollContainer } from "@/app/[locale]/(protected)/inbox/components/messages-scroll-container";
+import { MessagesScrollContainer } from "@/components/scroll/messages-scroll-container";
 import { usePathname, useRouter } from "@/i18n/navigation";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { Avatar } from "@/components/ui/avatar";

--- a/components/data-view/data-view-container.tsx
+++ b/components/data-view/data-view-container.tsx
@@ -4,12 +4,15 @@ import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store"
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { observer } from "mobx-react-lite";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import { useTranslations } from "next-intl";
 
 import { ViewMode } from "@/core/base/base-query-builder";
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { useColumnLabel } from "@/components/entity-terminology/use-column-label";
+import { ScrollReturnButton } from "@/components/scroll/scroll-return-button";
+import { useScrollReturn } from "@/components/scroll/use-scroll-return";
 
 import { DataCardView } from "./data-card-view";
 import { DataKanbanView } from "./data-kanban-view";
@@ -46,7 +49,22 @@ export const DataViewContainer = observer(function DataViewContainer<E extends H
   emptyState,
 }: Props<E>) {
   const columnLabel = useColumnLabel();
+  const t = useTranslations();
   const { terminologyStore } = useRootStore();
+  const scrollHostRef = useRef<HTMLDivElement>(null);
+  const getScrollElement = useCallback(
+    () =>
+      scrollHostRef.current?.querySelector<HTMLElement>(
+        "[data-slot=table-container],[data-slot=kanban-root],[data-slot=card-grid]",
+      ) ?? null,
+    [],
+  );
+  const hasItems = store.items.length > 0;
+  const { isAway, returnToAnchor } = useScrollReturn({
+    direction: "top",
+    enabled: hasItems,
+    getScrollElement,
+  });
 
   const resolvedColumns = useMemo<ColumnDef<E>[]>(() => {
     const byId = new Map(columns.map((c) => [c.id ?? "", c]));
@@ -99,10 +117,18 @@ export const DataViewContainer = observer(function DataViewContainer<E extends H
       <DataViewActiveFiltersBar store={store} />
 
       <div
-        className="flex min-h-0 flex-1 flex-col overflow-hidden *:data-[slot=table-container]:h-full *:data-[slot=table-container]:overflow-auto *:data-[slot=kanban-root]:h-full *:data-[slot=kanban-root]:overflow-auto *:data-[slot=card-grid]:h-full *:data-[slot=card-grid]:overflow-y-auto"
+        ref={scrollHostRef}
+        className="relative flex min-h-0 flex-1 flex-col overflow-hidden *:data-[slot=table-container]:h-full *:data-[slot=table-container]:overflow-auto *:data-[slot=kanban-root]:h-full *:data-[slot=kanban-root]:overflow-auto *:data-[slot=card-grid]:h-full *:data-[slot=card-grid]:overflow-y-auto"
         style={{ contain: "layout" }}
       >
         {body}
+
+        <ScrollReturnButton
+          direction="top"
+          isAway={isAway}
+          label={t("Common.scroll.backToTop")}
+          onReturn={returnToAnchor}
+        />
       </div>
 
       {!isKanban && !isEmpty && <DataViewPagination store={store} />}

--- a/components/scroll/__tests__/scroll-return.test.ts
+++ b/components/scroll/__tests__/scroll-return.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { SCROLL_RETURN_THRESHOLD } from "../use-scroll-return";
+
+type Metrics = { scrollHeight: number; scrollTop: number; clientHeight: number };
+
+function distanceFromAnchor(metrics: Metrics, direction: "top" | "bottom") {
+  return direction === "bottom" ? metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight : metrics.scrollTop;
+}
+
+function isAway(metrics: Metrics, direction: "top" | "bottom") {
+  return distanceFromAnchor(metrics, direction) > SCROLL_RETURN_THRESHOLD;
+}
+
+const TALL: Metrics = { scrollHeight: 5000, scrollTop: 0, clientHeight: 800 };
+
+describe("scroll-return anchor distance", () => {
+  it("keeps the control hidden at the top anchor and just below the threshold", () => {
+    expect(isAway({ ...TALL, scrollTop: 0 }, "top")).toBe(false);
+    expect(isAway({ ...TALL, scrollTop: SCROLL_RETURN_THRESHOLD }, "top")).toBe(false);
+  });
+
+  it("reveals the top control once the user is past the threshold", () => {
+    expect(isAway({ ...TALL, scrollTop: SCROLL_RETURN_THRESHOLD + 1 }, "top")).toBe(true);
+    expect(isAway({ ...TALL, scrollTop: 3000 }, "top")).toBe(true);
+  });
+
+  it("keeps the control hidden at the bottom anchor and just above the threshold", () => {
+    expect(isAway({ ...TALL, scrollTop: 4200 }, "bottom")).toBe(false);
+    expect(isAway({ ...TALL, scrollTop: 4200 - SCROLL_RETURN_THRESHOLD }, "bottom")).toBe(false);
+  });
+
+  it("reveals the bottom control once the user scrolls away from the latest content", () => {
+    expect(isAway({ ...TALL, scrollTop: 4200 - SCROLL_RETURN_THRESHOLD - 1 }, "bottom")).toBe(true);
+    expect(isAway({ ...TALL, scrollTop: 0 }, "bottom")).toBe(true);
+  });
+
+  it("treats a container shorter than its viewport as anchored in both directions", () => {
+    const short: Metrics = { scrollHeight: 400, scrollTop: 0, clientHeight: 800 };
+
+    expect(isAway(short, "top")).toBe(false);
+    expect(isAway(short, "bottom")).toBe(false);
+  });
+});

--- a/components/scroll/messages-scroll-container.tsx
+++ b/components/scroll/messages-scroll-container.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { ArrowDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/core/utils/cn";
+
+import { ScrollReturnButton } from "./scroll-return-button";
+import { scrollToAnchor } from "./use-scroll-return";
 
 type Props = {
   className?: string;
@@ -104,7 +106,7 @@ export function MessagesScrollContainer({
 
     stickToBottom.current = true;
     setIsAwayFromLatest(false);
-    el.scrollTo({ behavior: "smooth", top: el.scrollHeight });
+    scrollToAnchor(el, "bottom");
     requestAnimationFrame(() => el.focus({ preventScroll: true }));
   };
 
@@ -140,19 +142,13 @@ export function MessagesScrollContainer({
         </div>
       </div>
 
-      {jumpToLatestLabel && isAwayFromLatest && (
-        <Button
-          aria-label={jumpToLatestLabel}
-          className="absolute bottom-3 left-1/2 h-8 -translate-x-1/2 gap-1.5 rounded-full border bg-background/95 px-3 text-xs shadow-md backdrop-blur"
-          size="sm"
-          type="button"
-          variant="outline"
-          onClick={jumpToLatest}
-        >
-          <ArrowDown aria-hidden="true" className="size-3.5" />
-
-          {jumpToLatestLabel}
-        </Button>
+      {jumpToLatestLabel && (
+        <ScrollReturnButton
+          direction="bottom"
+          isAway={isAwayFromLatest}
+          label={jumpToLatestLabel}
+          onReturn={jumpToLatest}
+        />
       )}
     </div>
   );

--- a/components/scroll/scroll-return-button.tsx
+++ b/components/scroll/scroll-return-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ArrowDown, ArrowUp } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/core/utils/cn";
+
+import type { ScrollReturnDirection } from "./use-scroll-return";
+
+type Props = {
+  className?: string;
+  direction: ScrollReturnDirection;
+  isAway: boolean;
+  label: string;
+  onReturn: () => void;
+};
+
+export function ScrollReturnButton({ className, direction, isAway, label, onReturn }: Props) {
+  if (!isAway) return null;
+
+  const Icon = direction === "bottom" ? ArrowDown : ArrowUp;
+
+  return (
+    <Button
+      aria-label={label}
+      className={cn(
+        "absolute left-1/2 z-20 h-8 -translate-x-1/2 gap-1.5 rounded-full border bg-background/95 px-3 text-xs shadow-md backdrop-blur",
+        direction === "bottom" ? "bottom-3" : "top-3",
+        className,
+      )}
+      size="sm"
+      type="button"
+      variant="outline"
+      onClick={onReturn}
+    >
+      <Icon aria-hidden="true" className="size-3.5" />
+
+      {label}
+    </Button>
+  );
+}

--- a/components/scroll/use-scroll-return.ts
+++ b/components/scroll/use-scroll-return.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type ScrollReturnDirection = "top" | "bottom";
+
+export const SCROLL_RETURN_THRESHOLD = 120;
+
+type ScrollElementSource = () => HTMLElement | null;
+
+function distanceFromAnchor(element: HTMLElement, direction: ScrollReturnDirection) {
+  return direction === "bottom" ? element.scrollHeight - element.scrollTop - element.clientHeight : element.scrollTop;
+}
+
+function prefersReducedMotion() {
+  return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export const SCROLL_SETTLE_CHECK_MS = 150;
+
+export function scrollToAnchor(element: HTMLElement, direction: ScrollReturnDirection) {
+  const target = direction === "bottom" ? element.scrollHeight : 0;
+  const origin = element.scrollTop;
+
+  if (prefersReducedMotion()) {
+    element.scrollTop = target;
+    return;
+  }
+
+  element.scrollTo({ behavior: "smooth", top: target });
+  window.setTimeout(() => {
+    if (element.scrollTop === origin && origin !== target) element.scrollTop = target;
+  }, SCROLL_SETTLE_CHECK_MS);
+}
+
+export function useScrollReturn(args: {
+  getScrollElement: ScrollElementSource;
+  direction: ScrollReturnDirection;
+  threshold?: number;
+  enabled?: boolean;
+}) {
+  const { getScrollElement, direction, threshold = SCROLL_RETURN_THRESHOLD, enabled = true } = args;
+  const [isAway, setIsAway] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsAway(false);
+      return;
+    }
+
+    let element: HTMLElement | null = null;
+
+    const sync = () => {
+      const next = getScrollElement();
+      if (next !== element) {
+        element?.removeEventListener("scroll", sync);
+        element = next;
+        element?.addEventListener("scroll", sync, { passive: true });
+      }
+      setIsAway(Boolean(element) && distanceFromAnchor(element as HTMLElement, direction) > threshold);
+    };
+
+    sync();
+    window.addEventListener("resize", sync);
+    const interval = window.setInterval(sync, 500);
+
+    return () => {
+      element?.removeEventListener("scroll", sync);
+      window.removeEventListener("resize", sync);
+      window.clearInterval(interval);
+    };
+  }, [direction, enabled, getScrollElement, threshold]);
+
+  const returnToAnchor = useCallback(() => {
+    const element = getScrollElement();
+    if (!element) return;
+
+    scrollToAnchor(element, direction);
+    setIsAway(false);
+    requestAnimationFrame(() => element.focus({ preventScroll: true }));
+  }, [direction, getScrollElement]);
+
+  return { isAway, returnToAnchor };
+}

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -881,6 +881,10 @@
       "whatsapp": "WhatsApp"
     },
     "role": "Rolle",
+    "scroll": {
+      "backToTop": "Nach oben",
+      "jumpToLatest": "Zu den neuesten Einträgen"
+    },
     "single": "Einzel",
     "sort": {
       "ascending": "Aufsteigend",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -881,6 +881,10 @@
       "whatsapp": "WhatsApp"
     },
     "role": "Role",
+    "scroll": {
+      "backToTop": "Back to top",
+      "jumpToLatest": "Jump to latest"
+    },
     "single": "Single",
     "sort": {
       "ascending": "Ascending",


### PR DESCRIPTION
## Summary

Generalizes the Assistant's jump-to-latest control into one shared, direction-aware affordance and adopts it on the inbox thread and the data-view table, Kanban board and card grid.

Conversations return to the **bottom** ("Jump to latest"); lists and boards return to the **top** ("Back to top"). Same pill treatment, same 120px appearance threshold, same focus and reduced-motion rules.

Closes [CUS-180](https://linear.app/customermates/issue/CUS-180/offer-one-scroll-return-affordance-across-conversations-lists-and).

## Context

The affordance already existed but only in the Assistant. `MessagesScrollContainer` renders the control only when a `jumpToLatestLabel` prop is passed; agent-chat passed one and the inbox did not, so the inbox had the capability wired but switched off. Turning it on is a one-line opt-in.

Two structural problems are fixed while generalizing:

- **A feature was importing another feature's internals.** The container lived at `app/[locale]/(protected)/inbox/components/` and `app/components/agent-chat/agent-chat.tsx` imported it from there. It now lives in `components/scroll/`.
- **The implementation only understood a bottom anchor.** Direction is now explicit, so top-anchored surfaces express the same pattern rather than needing a second component.

One integration point covers all three list surfaces: `data-view-container.tsx` owns the scroll styling for `table-container`, `kanban-root` and `card-grid`, so the control is wired once there and resolves whichever slot is rendered.

### A latent bug this surfaced

Browser verification showed the new control appearing correctly but doing nothing on click. The cause was not the new code: `scrollTo({ behavior: "smooth" })` is a **complete no-op** on these containers in some environments, while `behavior: "auto"` works. The Assistant's existing `jumpToLatest` used the same call and carried the same latent flaw, masked in the transcript by the stick-to-bottom resize observer.

Both paths now go through one `scrollToAnchor` helper that treats smooth scrolling as an enhancement: it issues the smooth scroll, then verifies after 150ms and falls back to an immediate jump if the position has not moved. Reduced-motion users skip the animation entirely.

## Validation

Local gates at `630f9ca0`:

- `yarn typecheck`, `yarn lint` (zero warnings), `yarn build`: passed.
- `yarn test` with `RUN_DATABASE_TESTS=true`: **196 files and 1,714 tests passed**, including a new anchor-distance suite covering both directions, the threshold boundary, and a container shorter than its viewport.

Browser verification on localhost, signed in:

- **Contacts table** — scrolled 569px; "Back to top" appeared, click returned to 0 and the control hid itself.
- **Inbox thread** — scrolled to top, 704px from the bottom; "Jump to latest" appeared, click returned to the bottom and the control hid itself.
- **Assistant transcript** — 4,738px from the bottom; the control still appears and still returns, confirming no regression on the surface this pattern came from.

## Impact and rollback

Presentational and additive. No schema, persistence, or API surface is touched. The only behavioural change to existing surfaces is that the Assistant's control now reliably arrives at the anchor where smooth scrolling silently failed before.

This branch targets `feat/agent-chat` rather than `main`, because the conversation container is a file PR #37 already modifies. It therefore cannot merge before PR #37 merges. Rollback is to revert this pull request.
