### PR TITLE
fix(seo): enforce landing-page shipping contracts

### DIFF
--- a/__tests__/proxy-locales.test.ts
+++ b/__tests__/proxy-locales.test.ts
@@ -191,6 +191,23 @@ describe("locale routing configuration", () => {
 });
 
 describe("proxy locale routing", () => {
+  it("normalizes page one and rejects invalid hub pagination before streaming", async () => {
+    const pageOne = await call("/en/blog?page=1&utm_source=proof");
+    expect(pageOne.status).toBe(308);
+    expect(pageOne.location).toBe("http://localhost:4000/en/blog?utm_source=proof");
+
+    for (const query of ["page=0", "page=01", "page=2junk", "page=2&page=3", "page=4"]) {
+      const invalid = await call(`/en/blog?${query}`);
+      expect(invalid.status, query).toBe(404);
+      expect(invalid.location, query).toBeNull();
+      expect(invalid.response.headers.get("x-robots-tag"), query).toBe("noindex");
+    }
+
+    const lastPage = await call("/en/blog?page=3");
+    expect(lastPage.status).toBe(200);
+    expect(lastPage.location).toBeNull();
+  });
+
   it("never emits a permanently cached redirect", async () => {
     for (const path of PATHS) {
       const { status } = await call(path);

--- a/app/[locale]/(static)/blog/page.tsx
+++ b/app/[locale]/(static)/blog/page.tsx
@@ -1,54 +1,94 @@
 import type { Metadata } from "next";
 
-import { getLocale } from "next-intl/server";
-import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+import { notFound, permanentRedirect } from "next/navigation";
 
 import { BlogPostCard } from "./blog-post-card";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { PostGridShell } from "@/components/marketing/post-grid-shell";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { blogPostsSource, blogSource } from "@/core/fumadocs/source";
-import { contentLocaleOrDefault } from "@/i18n/locale-registry";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/blog" });
+  const resolution = resolveHubPage(
+    (await searchParams)[HUB_PAGE_PARAM],
+    hubPageCount(blogPostsSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/blog", resolution.page),
+    locale,
+    route: "/blog",
+  });
 }
 
-export default async function BlogPage() {
+export default async function BlogPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = blogSource.getPage(["blog"], locale);
-  const posts = blogPostsSource.getPages(locale);
 
   if (!page) notFound();
 
-  const sortedPosts = [...posts].sort((a, b) => {
-    const dateA = new Date(a.data.blogPost.date).getTime();
-    const dateB = new Date(b.data.blogPost.date).getTime();
-    return dateB - dateA;
-  });
+  const referencePosts = blogPostsSource.getPages(DEFAULT_LOCALE);
+  const resolution = resolveHubPage((await searchParams)[HUB_PAGE_PARAM], hubPageCount(referencePosts.length));
+
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one") permanentRedirect(buildLocalePath(locale, "/blog"));
+
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
+  const paginated = paginateLocalizedHubPages(
+    referencePosts,
+    blogPostsSource.getPages(locale),
+    resolution.page,
+    (a, b) => {
+      const dateDifference =
+        new Date(b.page.data.blogPost.date).getTime() - new Date(a.page.data.blogPost.date).getTime();
+      return dateDifference || referenceCollator.compare(a.slug, b.slug);
+    },
+  );
+  const t = await getTranslations("Common.table");
 
   return (
     <div className="flex flex-col items-center justify-center">
       <PostGridShell hero={page.data.hero}>
-        {sortedPosts.map((post) => {
-          const slug = post.url?.split("/").pop() ?? "";
-          if (!slug) return null;
-
-          return (
-            <div key={post.url} className="min-w-0">
-              <BlogPostCard
-                {...post.data.blogPost}
-                description={post.data.description}
-                locale={locale}
-                title={post.data.title}
-                url={`/blog/${slug}`}
-              />
-            </div>
-          );
-        })}
+        {paginated.items.map(({ page: post, slug }) => (
+          <div key={post.url} className="min-w-0">
+            <BlogPostCard
+              {...post.data.blogPost}
+              description={post.data.description}
+              locale={locale}
+              title={post.data.title}
+              url={`/blog/${slug}`}
+            />
+          </div>
+        ))}
       </PostGridShell>
+
+      <HubPagination
+        basePath="/blog"
+        label={page.data.title}
+        nextLabel={t("nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/[locale]/(static)/compare/page.tsx
+++ b/app/[locale]/(static)/compare/page.tsx
@@ -1,22 +1,46 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { HubPostGrid, type HubPostGridItem } from "@/components/marketing/hub-post-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { comparePagesSource, compareSource } from "@/core/fumadocs/source";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { breadcrumbListSchema } from "@/core/seo/schemas";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/compare" });
+  const resolution = resolveHubPage(
+    (await searchParams)[HUB_PAGE_PARAM],
+    hubPageCount(comparePagesSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/compare", resolution.page),
+    locale,
+    route: "/compare",
+  });
 }
 
-export default async function CompareHubPage() {
+export default async function CompareHubPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = compareSource.getPage(["compare"], locale);
 
@@ -24,18 +48,27 @@ export default async function CompareHubPage() {
 
   const t = await getTranslations();
   const collator = new Intl.Collator(formattingTagFor(locale));
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
   const tagLabels = {
     alternative: t("ComparePage.tags.alternative"),
     comparison: t("ComparePage.tags.comparison"),
     review: t("ComparePage.tags.review"),
   };
 
-  const items: HubPostGridItem[] = comparePagesSource
-    .getPages(locale)
-    .map((p): HubPostGridItem | null => {
-      const slug = p.url?.split("/").pop() ?? "";
-      if (!slug) return null;
+  const referencePages = comparePagesSource.getPages(DEFAULT_LOCALE);
+  const resolution = resolveHubPage((await searchParams)[HUB_PAGE_PARAM], hubPageCount(referencePages.length));
 
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one") permanentRedirect(buildLocalePath(locale, "/compare"));
+
+  const paginated = paginateLocalizedHubPages(
+    referencePages,
+    comparePagesSource.getPages(locale),
+    resolution.page,
+    (a, b) => referenceCollator.compare(a.page.data.competitorName, b.page.data.competitorName),
+  );
+  const items: HubPostGridItem[] = paginated.items
+    .map(({ page: p, slug }): HubPostGridItem => {
       const competitor2 = p.data.comparison?.competitor2Name;
       let title = p.data.competitorName;
       if (slug.includes("-vs-") && competitor2) title = `${p.data.competitorName} vs ${competitor2}`;
@@ -57,7 +90,6 @@ export default async function CompareHubPage() {
         title,
       };
     })
-    .filter((item): item is HubPostGridItem => item !== null)
     .sort((a, b) => collator.compare(a.title, b.title));
 
   return (
@@ -73,6 +105,15 @@ export default async function CompareHubPage() {
       />
 
       <HubPostGrid hero={page.data.hero} items={items} locale={locale} />
+
+      <HubPagination
+        basePath="/compare"
+        label={page.data.title}
+        nextLabel={t("Common.table.nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("Common.table.previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/[locale]/(static)/features/all/page.tsx
+++ b/app/[locale]/(static)/features/all/page.tsx
@@ -1,22 +1,46 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { HubPostGrid, type HubPostGridItem } from "@/components/marketing/hub-post-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { featurePagesSource, featuresAllSource } from "@/core/fumadocs/source";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { breadcrumbListSchema } from "@/core/seo/schemas";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/features/all" });
+  const resolution = resolveHubPage(
+    (await searchParams)[HUB_PAGE_PARAM],
+    hubPageCount(featurePagesSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/features/all", resolution.page),
+    locale,
+    route: "/features/all",
+  });
 }
 
-export default async function FeaturesAllHubPage() {
+export default async function FeaturesAllHubPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = featuresAllSource.getPage(["all"], locale);
 
@@ -25,13 +49,22 @@ export default async function FeaturesAllHubPage() {
   const t = await getTranslations();
   const tagLabel = t("Common.tags.feature");
   const collator = new Intl.Collator(formattingTagFor(locale));
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
 
-  const items: HubPostGridItem[] = featurePagesSource
-    .getPages(locale)
-    .map((p): HubPostGridItem | null => {
-      const slug = p.url?.split("/").pop() ?? "";
-      if (!slug) return null;
+  const referencePages = featurePagesSource.getPages(DEFAULT_LOCALE);
+  const resolution = resolveHubPage((await searchParams)[HUB_PAGE_PARAM], hubPageCount(referencePages.length));
 
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one") permanentRedirect(buildLocalePath(locale, "/features/all"));
+
+  const paginated = paginateLocalizedHubPages(
+    referencePages,
+    featurePagesSource.getPages(locale),
+    resolution.page,
+    (a, b) => referenceCollator.compare(a.page.data.featureName, b.page.data.featureName),
+  );
+  const items: HubPostGridItem[] = paginated.items
+    .map(({ page: p, slug }): HubPostGridItem => {
       return {
         description: p.data.description,
         href: `/features/${slug}`,
@@ -40,7 +73,6 @@ export default async function FeaturesAllHubPage() {
         title: p.data.featureName,
       };
     })
-    .filter((item): item is HubPostGridItem => item !== null)
     .sort((a, b) => collator.compare(a.title, b.title));
 
   return (
@@ -48,12 +80,27 @@ export default async function FeaturesAllHubPage() {
       <JsonLd
         schema={breadcrumbListSchema([
           { name: t("StructuredData.breadcrumb.home"), path: `/${locale}` },
-          { name: t("StructuredData.breadcrumb.features"), path: `/${locale}/features` },
-          { name: t("StructuredData.breadcrumb.allFeatures"), path: `/${locale}/features/all` },
+          {
+            name: t("StructuredData.breadcrumb.features"),
+            path: `/${locale}/features`,
+          },
+          {
+            name: t("StructuredData.breadcrumb.allFeatures"),
+            path: `/${locale}/features/all`,
+          },
         ])}
       />
 
       <HubPostGrid hero={page.data.hero} items={items} locale={locale} />
+
+      <HubPagination
+        basePath="/features/all"
+        label={page.data.title}
+        nextLabel={t("Common.table.nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("Common.table.previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/[locale]/(static)/for/page.tsx
+++ b/app/[locale]/(static)/for/page.tsx
@@ -1,22 +1,46 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { HubPostGrid, type HubPostGridItem } from "@/components/marketing/hub-post-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { forPagesSource, forSource } from "@/core/fumadocs/source";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { breadcrumbListSchema } from "@/core/seo/schemas";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/for" });
+  const resolution = resolveHubPage(
+    (await searchParams)[HUB_PAGE_PARAM],
+    hubPageCount(forPagesSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/for", resolution.page),
+    locale,
+    route: "/for",
+  });
 }
 
-export default async function ForHubPage() {
+export default async function ForHubPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = forSource.getPage(["for"], locale);
 
@@ -25,13 +49,22 @@ export default async function ForHubPage() {
   const t = await getTranslations();
   const tagLabel = t("Common.tags.industry");
   const collator = new Intl.Collator(formattingTagFor(locale));
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
 
-  const items: HubPostGridItem[] = forPagesSource
-    .getPages(locale)
-    .map((p): HubPostGridItem | null => {
-      const slug = p.url?.split("/").pop() ?? "";
-      if (!slug) return null;
+  const referencePages = forPagesSource.getPages(DEFAULT_LOCALE);
+  const resolution = resolveHubPage((await searchParams)[HUB_PAGE_PARAM], hubPageCount(referencePages.length));
 
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one") permanentRedirect(buildLocalePath(locale, "/for"));
+
+  const paginated = paginateLocalizedHubPages(
+    referencePages,
+    forPagesSource.getPages(locale),
+    resolution.page,
+    (a, b) => referenceCollator.compare(a.page.data.industryName, b.page.data.industryName),
+  );
+  const items: HubPostGridItem[] = paginated.items
+    .map(({ page: p, slug }): HubPostGridItem => {
       return {
         description: p.data.description,
         href: `/for/${slug}`,
@@ -40,7 +73,6 @@ export default async function ForHubPage() {
         title: p.data.industryName,
       };
     })
-    .filter((item): item is HubPostGridItem => item !== null)
     .sort((a, b) => collator.compare(a.title, b.title));
 
   return (
@@ -48,11 +80,23 @@ export default async function ForHubPage() {
       <JsonLd
         schema={breadcrumbListSchema([
           { name: t("StructuredData.breadcrumb.home"), path: `/${locale}` },
-          { name: t("StructuredData.breadcrumb.industries"), path: `/${locale}/for` },
+          {
+            name: t("StructuredData.breadcrumb.industries"),
+            path: `/${locale}/for`,
+          },
         ])}
       />
 
       <HubPostGrid hero={page.data.hero} items={items} locale={locale} />
+
+      <HubPagination
+        basePath="/for"
+        label={page.data.title}
+        nextLabel={t("Common.table.nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("Common.table.previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/components/footer-selection.ts
+++ b/app/components/footer-selection.ts
@@ -1,0 +1,53 @@
+export const FOOTER_COLUMN_SIZE = 6;
+
+export const FOOTER_PREFERRED_SLUGS = {
+  "blog-posts": [
+    "customer-interaction-management",
+    "customer-retention-management",
+    "crm-examples",
+    "customer-communication-management",
+    "crm-software",
+    "agentic-ai",
+  ],
+  "compare-pages": [
+    "gohighlevel",
+    "notion-alternative",
+    "hubspot-vs-salesforce",
+    "vtiger-alternative",
+    "folk",
+    "cobra-alternative",
+  ],
+  "feature-pages": [
+    "cloud-crm",
+    "sales-tracking",
+    "lead-management",
+    "sales-automation",
+    "contact-management",
+    "reporting",
+  ],
+  "for-pages": ["healthcare", "ecommerce", "recruiting", "construction", "manufacturing", "property-management"],
+} as const;
+
+export type FooterCollection = keyof typeof FOOTER_PREFERRED_SLUGS;
+
+export function selectFooterSlugs(
+  collection: FooterCollection,
+  available: readonly string[],
+  size: number = FOOTER_COLUMN_SIZE,
+): string[] {
+  const pool = new Set(available);
+  const selected: string[] = [];
+
+  for (const slug of FOOTER_PREFERRED_SLUGS[collection]) {
+    if (selected.length >= size) break;
+    if (!pool.delete(slug)) continue;
+    selected.push(slug);
+  }
+
+  for (const slug of [...pool].sort()) {
+    if (selected.length >= size) break;
+    selected.push(slug);
+  }
+
+  return selected;
+}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,90 +1,62 @@
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { FooterContent } from "./footer-content";
+import { type FooterCollection, selectFooterSlugs } from "./footer-selection";
 
 import { blogPostsSource, comparePagesSource, featurePagesSource, forPagesSource } from "@/core/fumadocs/source";
 import { contentLocaleOrDefault } from "@/i18n/locale-registry";
 
-const FOOTER_COMPARE = new Set([
-  "gohighlevel",
-  "notion-alternative",
-  "hubspot-vs-salesforce",
-  "vtiger-alternative",
-  "folk",
-  "cobra-alternative",
-]);
+type SourcePage = {
+  url: string;
+};
 
-const FOOTER_FOR = new Set([
-  "healthcare",
-  "ecommerce",
-  "recruiting",
-  "construction",
-  "manufacturing",
-  "property-management",
-]);
+function selectPages<T extends SourcePage>(
+  collection: FooterCollection,
+  pages: readonly T[],
+): Array<{ page: T; slug: string }> {
+  const bySlug = new Map<string, T>();
 
-const FOOTER_FEATURES = new Set([
-  "cloud-crm",
-  "sales-tracking",
-  "lead-management",
-  "sales-automation",
-  "contact-management",
-  "reporting",
-]);
+  for (const page of pages) {
+    const slug = page.url.split("/").filter(Boolean).pop() ?? "";
+    if (slug) bySlug.set(slug, page);
+  }
 
-const FOOTER_BLOG_POSTS = new Set([
-  "customer-interaction-management",
-  "customer-retention-management",
-  "crm-examples",
-  "customer-communication-management",
-  "crm-software",
-  "agentic-ai",
-]);
+  return selectFooterSlugs(collection, [...bySlug.keys()]).flatMap((slug) => {
+    const page = bySlug.get(slug);
+    return page ? [{ page, slug }] : [];
+  });
+}
 
 export async function Footer() {
   const locale = contentLocaleOrDefault(await getLocale());
   const t = await getTranslations("ComparePage");
 
-  const competitors = comparePagesSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_COMPARE.has(slug)) return null;
-      const competitor2 = page.data.comparison?.competitor2Name;
-      let displayName = page.data.competitorName;
-      if (slug.includes("-vs-") && competitor2) displayName = `${page.data.competitorName} vs ${competitor2}`;
-      else if (slug.endsWith("-alternative"))
-        displayName = t("alternativeTitle", { competitor: page.data.competitorName });
-      return { slug, displayName };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const competitors = selectPages("compare-pages", comparePagesSource.getPages(locale)).map(({ page, slug }) => {
+    const competitor2 = page.data.comparison?.competitor2Name;
+    let displayName = page.data.competitorName;
+    if (slug.includes("-vs-") && competitor2) displayName = `${page.data.competitorName} vs ${competitor2}`;
+    else if (slug.endsWith("-alternative")) {
+      displayName = t("alternativeTitle", {
+        competitor: page.data.competitorName,
+      });
+    }
+    return { displayName, slug };
+  });
 
-  const industries = forPagesSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_FOR.has(slug)) return null;
-      return { slug, displayName: page.data.industryName };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const industries = selectPages("for-pages", forPagesSource.getPages(locale)).map(({ page, slug }) => ({
+    displayName: page.data.industryName,
+    slug,
+  }));
 
-  const featureLinks = featurePagesSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_FEATURES.has(slug)) return null;
-      return { slug, displayName: page.data.featureName };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const featureLinks = selectPages("feature-pages", featurePagesSource.getPages(locale)).map(({ page, slug }) => ({
+    displayName: page.data.featureName,
+    slug,
+  }));
 
-  const blogPosts = blogPostsSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_BLOG_POSTS.has(slug)) return null;
-      return { slug, displayName: page.data.hero.title };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const blogPosts = selectPages("blog-posts", blogPostsSource.getPages(locale)).map(({ page, slug }) => ({
+    displayName: page.data.hero.title,
+    slug,
+  }));
 
   return (
     <FooterContent

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -34,7 +34,7 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     rules: [
       {
         userAgent: "*",
-        crawlDelay: 10,
+        allow: "/",
       },
     ],
     sitemap: `${env.BASE_URL}/sitemap.xml`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,8 @@ import type { LocalizedRoute } from "@/core/seo/sitemap";
 
 import { env } from "@/env";
 import { assembleSitemap } from "@/core/seo/sitemap";
+import { hubPageCount, hubPageHref } from "@/core/seo/hub-pagination";
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
 import { CONTENT_LOCALES, stripLocalePrefix } from "@/i18n/locale-registry";
 import { PUBLIC_ROUTES_SEO } from "@/i18n/routing";
 import { ROUTE_SOURCE_MAP } from "@/core/fumadocs/route-source-map";
@@ -35,7 +37,23 @@ function collectLocalizedRoutes(): LocalizedRoute[] {
       const page = routeMapping.source.getPage(routeMapping.path, locale);
       if (!page) continue;
 
-      localizedRoutes.push({ locale, routePath: route, lastModified: getLastModified(page.data.lastModified) });
+      localizedRoutes.push({
+        locale,
+        routePath: route,
+        lastModified: getLastModified(page.data.lastModified),
+      });
+    }
+
+    for (const hub of LANDING_HUBS) {
+      const source = ROUTE_SOURCE_MAP[hub.detailRoute].source;
+      const pageCount = hubPageCount(source.getPages(locale).length);
+
+      for (let page = 2; page <= pageCount; page++) {
+        localizedRoutes.push({
+          locale,
+          routePath: hubPageHref(hub.hubPath, page),
+        });
+      }
     }
   }
 

--- a/components/marketing/hub-pagination.tsx
+++ b/components/marketing/hub-pagination.tsx
@@ -1,0 +1,89 @@
+import { Fragment } from "react";
+
+import { AppLink } from "@/components/shared/app-link";
+import { hubPageHref, hubPagerModel } from "@/core/seo/hub-pagination";
+import { cn } from "@/core/utils/cn";
+
+type Props = {
+  basePath: string;
+  label: string;
+  nextLabel: string;
+  page: number;
+  pageCount: number;
+  previousLabel: string;
+};
+
+const pageClassName =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2";
+
+export function HubPagination({ basePath, label, nextLabel, page, pageCount, previousLabel }: Props) {
+  if (pageCount < 2) return null;
+
+  const model = hubPagerModel(page, pageCount);
+
+  return (
+    <nav aria-label={label} className="w-full pb-16 md:pb-24">
+      <ul className="mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-2 px-4">
+        {model.previousPage ? (
+          <li>
+            <AppLink
+              appearance="unstyled"
+              className={cn(pageClassName, "border-border text-subdued")}
+              href={hubPageHref(basePath, model.previousPage)}
+              rel="prev"
+            >
+              {previousLabel}
+            </AppLink>
+          </li>
+        ) : null}
+
+        {model.pageNumbers.map((number, index) => {
+          const previousNumber = model.pageNumbers[index - 1];
+          return (
+            <Fragment key={number}>
+              {previousNumber !== undefined && number - previousNumber > 1 ? (
+                <li aria-hidden="true" className="px-1 text-subdued">
+                  …
+                </li>
+              ) : null}
+
+              <li>
+                {number === page ? (
+                  <span
+                    aria-current="page"
+                    aria-label={String(number)}
+                    className={cn(pageClassName, "border-primary font-medium text-primary")}
+                  >
+                    {number}
+                  </span>
+                ) : (
+                  <AppLink
+                    appearance="unstyled"
+                    aria-label={String(number)}
+                    className={cn(pageClassName, "border-border text-subdued")}
+                    href={hubPageHref(basePath, number)}
+                  >
+                    {number}
+                  </AppLink>
+                )}
+              </li>
+            </Fragment>
+          );
+        })}
+
+        {model.nextPage ? (
+          <li>
+            <AppLink
+              appearance="unstyled"
+              className={cn(pageClassName, "border-border text-subdued")}
+              href={hubPageHref(basePath, model.nextPage)}
+              rel="next"
+            >
+              {nextLabel}
+            </AppLink>
+          </li>
+        ) : null}
+      </ul>
+    </nav>
+  );
+}

--- a/content/blog-posts/de/salesforce-einstein.mdx
+++ b/content/blog-posts/de/salesforce-einstein.mdx
@@ -108,7 +108,7 @@ Das Preismodell von Salesforce Einstein ist der Teil, der die meisten Käufer ü
 
 Der ehrliche Einstiegspunkt für ein kleines Team, das echten Einstein-Mehrwert will (Sales Cloud + Einstein-Add-on + eine Starter-Allokation Data Cloud), liegt nach Rabatten realistisch bei 200 bis 400 USD pro Nutzer pro Monat. Das ist die Zahl, die nicht auf den Marketingseiten steht, aber bei der Budgetierung relevant ist.
 
-Eine vollständige Aufschlüsselung pro Edition finden Sie im [Salesforce Pricing Vergleich](/compare/salesforce-pricing).
+Eine vollständige Aufschlüsselung pro Edition finden Sie im [Salesforce Pricing Vergleich](/blog/salesforce-pricing).
 
 ## Salesforce Einstein vs. Agentforce
 

--- a/content/blog-posts/en/salesforce-einstein.mdx
+++ b/content/blog-posts/en/salesforce-einstein.mdx
@@ -108,7 +108,7 @@ Salesforce Einstein pricing is the part that surprises most buyers, because ther
 
 The honest floor for a small team that wants real Einstein value (Sales Cloud + Einstein add-on + a starter Data Cloud allocation) is roughly $200-400 per user per month after discounts. That is the number that does not appear on the marketing pages, but it is the one that matters when you are budgeting.
 
-For full pricing breakdowns, see the [Salesforce pricing comparison](/compare/salesforce-pricing) for the per-edition view.
+For full pricing breakdowns, see the [Salesforce pricing comparison](/blog/salesforce-pricing) for the per-edition view.
 
 ## Salesforce Einstein vs. Agentforce
 

--- a/content/feature-pages/de/contact-management.mdx
+++ b/content/feature-pages/de/contact-management.mdx
@@ -137,7 +137,7 @@ Der Wechsel von Excel oder manuellen Methoden zu einer dedizierten Kontaktmanage
 - Sie Deals mit Kontakten verknüpfen und den Vertriebsprozess nachverfolgen möchten
 - Sie [DSGVO-konform](https://dsgvo-gesetz.de/) arbeiten müssen und wissen möchten, welche Daten Sie zu wem gespeichert haben
 
-Wenn einer dieser Punkte zutrifft, ist eine [CRM-Einführung](/blog/crm-introduction) der nächste logische Schritt.
+Wenn einer dieser Punkte zutrifft, ist eine [CRM-Einführung](/blog/what-is-crm) der nächste logische Schritt.
 
 ## Kundenverwaltung vs Excel: Wann der Wechsel lohnt
 

--- a/content/for-pages/de/agencies.mdx
+++ b/content/for-pages/de/agencies.mdx
@@ -28,7 +28,7 @@ Ein CRM für Agenturen löst das zentrale operative Problem, vor dem jede Agentu
 
 Das Problem ist nicht mangelnder Einsatz. Agentur-Teams sind damit beschäftigt, Pitches zu gewinnen, Projekte umzusetzen und Kundenerwartungen zu managen. Aber ohne ein zentrales System werden Leads vergessen, Proposals nicht nachverfolgt, und wenn ein Account Manager die Agentur verlässt, gehen Jahre an Kundenkontext verloren. Laut [HubSpots Agency Growth Report](https://www.hubspot.com/agencies) berichten Agenturen, die ein CRM nutzen, von höherer Kundenbindung und planbarerer Umsatzentwicklung. Die Investition amortisiert sich beim ersten gehaltenen Kunden.
 
-Ein CRM für Agenturen bringt jede Kundenbeziehung, jeden Deal und jede Interaktion in ein strukturiertes, zugängliches System, damit Ihr Team jederzeit das vollständige Bild hat. Wenn Sie noch evaluieren, ob Ihre Agentur ein dediziertes CRM braucht, erklärt unser [CRM-Einführungsleitfaden](/blog/crm-introduction) die Grundlagen.
+Ein CRM für Agenturen bringt jede Kundenbeziehung, jeden Deal und jede Interaktion in ein strukturiertes, zugängliches System, damit Ihr Team jederzeit das vollständige Bild hat. Wenn Sie noch evaluieren, ob Ihre Agentur ein dediziertes CRM braucht, erklärt unser [CRM-Einführungsleitfaden](/blog/what-is-crm) die Grundlagen.
 
 ## Zentrale Herausforderungen für Agenturen ohne CRM
 

--- a/content/for-pages/de/manufacturing.mdx
+++ b/content/for-pages/de/manufacturing.mdx
@@ -156,7 +156,7 @@ Drei Dinge: Transparenz, Kosten und Kontrolle. Customermates ist vollständig Op
 
 ### Wie starte ich mit Customermates für die Fertigung?
 
-Der Einstieg dauert Minuten. Lesen Sie unseren [CRM-Implementierungsleitfaden](/blog/crm-implementation-guide) für eine Schritt-für-Schritt-Anleitung, oder starten Sie direkt:
+Der Einstieg dauert Minuten. Lesen Sie unseren [CRM-Implementierungsleitfaden](/blog/crm-implementation) für eine Schritt-für-Schritt-Anleitung, oder starten Sie direkt:
 
 1. **[Kostenloses Konto erstellen](/auth/signup)**, keine Kreditkarte nötig, 7 Tage zum Erkunden aller Funktionen.
 2. **Daten importieren**, bestehende Kunden, Händler und Verkaufshistorie per CSV oder API einbringen.

--- a/content/for-pages/de/personal.mdx
+++ b/content/for-pages/de/personal.mdx
@@ -62,7 +62,7 @@ Es gibt verschiedene persönliche CRM-Tools auf dem Markt, Dex, Clay, Monica, Fo
 
 ### Open Source und transparent
 
-Customermates ist vollständig Open Source. Sie können jede Zeile Code auf GitHub einsehen, Verbesserungen beitragen oder das System auf Ihrem eigenen Server [selbst hosten](/features/self-hosting). Kein Vendor Lock-in, keine Black Box.
+Customermates ist vollständig Open Source. Sie können jede Zeile Code auf GitHub einsehen, Verbesserungen beitragen oder das System auf Ihrem eigenen Server [selbst hosten](/features/self-hosted). Kein Vendor Lock-in, keine Black Box.
 
 ### In Deutschland gehostet und DSGVO-nativ
 

--- a/content/for-pages/de/property-management.mdx
+++ b/content/for-pages/de/property-management.mdx
@@ -132,7 +132,7 @@ Für ein Verwaltungsbüro mit 4 Mitarbeitenden bedeutet das €48 pro Monat in S
 
 ### Was bedeutet CRM in der Immobilienverwaltung?
 
-Ein CRM (Customer Relationship Management) für Immobilienverwaltung ist eine Software, die alle Geschäftsbeziehungen, Mieter, Eigentümer, Wartungsdienstleister und Mietinteressenten, auf einer Plattform zentralisiert. Anders als Hausverwaltungssoftware, die Buchhaltung und Mieteinzug übernimmt, konzentriert sich ein CRM auf Kommunikationsverfolgung, Pipeline-Management und Beziehungskoordination. Mehr dazu in unserem [CRM-Einführungsleitfaden](/blog/crm-introduction).
+Ein CRM (Customer Relationship Management) für Immobilienverwaltung ist eine Software, die alle Geschäftsbeziehungen, Mieter, Eigentümer, Wartungsdienstleister und Mietinteressenten, auf einer Plattform zentralisiert. Anders als Hausverwaltungssoftware, die Buchhaltung und Mieteinzug übernimmt, konzentriert sich ein CRM auf Kommunikationsverfolgung, Pipeline-Management und Beziehungskoordination. Mehr dazu in unserem [CRM-Einführungsleitfaden](/blog/what-is-crm).
 
 ### Ersetzt Customermates unsere Hausverwaltungssoftware?
 

--- a/content/for-pages/en/agencies.mdx
+++ b/content/for-pages/en/agencies.mdx
@@ -28,7 +28,7 @@ A CRM for agencies solves the core operational challenge every agency faces: cli
 
 The problem is not a lack of effort. Agency teams are busy winning pitches, delivering projects, and managing client expectations. But without a centralized system, leads get forgotten, proposals go unfollowed, and when an account manager leaves, years of client context walk out the door. According to [HubSpot's Agency Growth report](https://www.hubspot.com/agencies), agencies that use a CRM report higher client retention rates and more predictable revenue growth. The investment pays for itself in the first retained client.
 
-A CRM for agencies brings every client relationship, every deal, and every interaction into one structured, accessible system, giving your team the complete picture at all times. If you are still evaluating whether your agency needs a dedicated CRM, our [CRM introduction guide](/blog/crm-introduction) covers the fundamentals.
+A CRM for agencies brings every client relationship, every deal, and every interaction into one structured, accessible system, giving your team the complete picture at all times. If you are still evaluating whether your agency needs a dedicated CRM, our [CRM introduction guide](/blog/what-is-crm) covers the fundamentals.
 
 ## Key challenges agencies face without a CRM
 

--- a/content/for-pages/en/manufacturing.mdx
+++ b/content/for-pages/en/manufacturing.mdx
@@ -156,7 +156,7 @@ Three things: transparency, cost, and control. Customermates is fully open sourc
 
 ### How do I get started with Customermates for manufacturing?
 
-Getting started takes minutes. Read our [CRM implementation guide](/blog/crm-implementation-guide) for a step-by-step walkthrough, or jump straight in:
+Getting started takes minutes. Read our [CRM implementation guide](/blog/crm-implementation) for a step-by-step walkthrough, or jump straight in:
 
 1. **[Create your free account](/auth/signup)**, no credit card required, 7 days to explore every feature.
 2. **Import your data**, bring in existing customers, distributors, and sales history via CSV or API.

--- a/content/for-pages/en/personal.mdx
+++ b/content/for-pages/en/personal.mdx
@@ -62,7 +62,7 @@ There are several personal CRM tools on the market, Dex, Clay, Monica, Folk, and
 
 ### Open Source and Transparent
 
-Customermates is fully open source. You can inspect every line of code on GitHub, contribute improvements, or [self-host](/features/self-hosting) it on your own server. No black boxes, no vendor lock-in.
+Customermates is fully open source. You can inspect every line of code on GitHub, contribute improvements, or [self-host](/features/self-hosted) it on your own server. No black boxes, no vendor lock-in.
 
 ### EU-Hosted and GDPR-Native
 

--- a/content/for-pages/en/property-management.mdx
+++ b/content/for-pages/en/property-management.mdx
@@ -132,7 +132,7 @@ For a property management office of 4, that is €48 per month on Starter for a 
 
 ### What is a CRM in property management?
 
-A CRM (Customer Relationship Management) system for property management is software that centralizes all your business relationships, tenants, property owners, maintenance vendors, and prospective renters, in one platform. Unlike property management software that handles accounting and rent collection, a CRM focuses on communication tracking, pipeline management, and relationship coordination. Learn more in our [CRM introduction guide](/blog/crm-introduction).
+A CRM (Customer Relationship Management) system for property management is software that centralizes all your business relationships, tenants, property owners, maintenance vendors, and prospective renters, in one platform. Unlike property management software that handles accounting and rent collection, a CRM focuses on communication tracking, pipeline management, and relationship coordination. Learn more in our [CRM introduction guide](/blog/what-is-crm).
 
 ### Does Customermates replace our property management software?
 

--- a/core/fumadocs/__tests__/metadata.test.ts
+++ b/core/fumadocs/__tests__/metadata.test.ts
@@ -60,22 +60,60 @@ describe("generateMetadataFromMeta", () => {
   });
 
   it("keeps the canonical on the requested locale", () => {
-    const metadata = generateMetadataFromMeta({ locale: "de", route: "/pricing" });
+    const metadata = generateMetadataFromMeta({
+      locale: "de",
+      route: "/pricing",
+    });
 
     expect(metadata.alternates?.canonical).toBe(`${BASE_URL}/de/pricing`);
   });
 
-  it("substitutes params into dynamic routes and drops non-reciprocal alternates", () => {
-    const metadata = generateMetadataFromMeta({ locale: "en", params: { slug: "best-crm" }, route: "/blog/:slug" });
+  it("applies a paginated public path to the canonical and every alternate", () => {
+    const metadata = generateMetadataFromMeta({
+      canonicalPath: "/pricing?page=2",
+      locale: "en",
+      route: "/pricing",
+    });
 
-    expect(metadata.alternates).toEqual({ canonical: `${BASE_URL}/en/blog/best-crm` });
+    expect(metadata.alternates).toEqual({
+      canonical: `${BASE_URL}/en/pricing?page=2`,
+      languages: {
+        de: `${BASE_URL}/de/pricing?page=2`,
+        en: `${BASE_URL}/en/pricing?page=2`,
+        "x-default": `${BASE_URL}/en/pricing?page=2`,
+      },
+    });
+  });
+
+  it("substitutes params into dynamic routes and drops non-reciprocal alternates", () => {
+    const metadata = generateMetadataFromMeta({
+      locale: "en",
+      params: { slug: "best-crm" },
+      route: "/blog/:slug",
+    });
+
+    expect(metadata.alternates).toEqual({
+      canonical: `${BASE_URL}/en/blog/best-crm`,
+    });
     expect(metadata.title).toBe("Best CRM");
     expect(metadata.description).toBeUndefined();
   });
 
   it("returns empty metadata when the localized page is missing", () => {
-    expect(generateMetadataFromMeta({ locale: "de", params: { slug: "best-crm" }, route: "/blog/:slug" })).toEqual({});
-    expect(generateMetadataFromMeta({ locale: "en", params: { slug: "nope" }, route: "/blog/:slug" })).toEqual({});
+    expect(
+      generateMetadataFromMeta({
+        locale: "de",
+        params: { slug: "best-crm" },
+        route: "/blog/:slug",
+      }),
+    ).toEqual({});
+    expect(
+      generateMetadataFromMeta({
+        locale: "en",
+        params: { slug: "nope" },
+        route: "/blog/:slug",
+      }),
+    ).toEqual({});
   });
 
   it("returns empty metadata for a dynamic route invoked without its params", () => {
@@ -83,6 +121,12 @@ describe("generateMetadataFromMeta", () => {
   });
 
   it("returns empty metadata when the page title is blank", () => {
-    expect(generateMetadataFromMeta({ locale: "en", params: { slug: "untitled" }, route: "/blog/:slug" })).toEqual({});
+    expect(
+      generateMetadataFromMeta({
+        locale: "en",
+        params: { slug: "untitled" },
+        route: "/blog/:slug",
+      }),
+    ).toEqual({});
   });
 });

--- a/core/fumadocs/content-route-contract.ts
+++ b/core/fumadocs/content-route-contract.ts
@@ -1,0 +1,10 @@
+export const CONTENT_DYNAMIC_ROUTES = {
+  blogPost: { collection: "blog-posts", route: "/blog/:slug" },
+  comparison: { collection: "compare-pages", route: "/compare/:competitor" },
+  doc: { collection: "docs", route: "/docs/:slug" },
+  feature: { collection: "feature-pages", route: "/features/:slug" },
+  industry: { collection: "for-pages", route: "/for/:industry" },
+  openApiDoc: { collection: "api", route: "/docs/openapi/:slug" },
+} as const;
+
+export const UNBACKED_DYNAMIC_PUBLIC_ROUTES = ["/invitation/:token"] as const;

--- a/core/fumadocs/metadata.ts
+++ b/core/fumadocs/metadata.ts
@@ -7,12 +7,14 @@ import { buildAlternateLanguages } from "@/core/seo/alternates";
 import { CONTENT_LOCALES, buildLocalePath } from "@/i18n/locale-registry";
 
 type GenerateMetadataParams = {
+  canonicalPath?: string;
   locale: string;
   route: keyof typeof ROUTE_SOURCE_MAP;
   params?: Record<string, string>;
   type?: "article" | "website";
 };
 export function generateMetadataFromMeta({
+  canonicalPath,
   locale,
   route,
   params = {},
@@ -30,10 +32,11 @@ export function generateMetadataFromMeta({
   if (!title) return {};
 
   const routePath = buildRoutePath(route, params);
+  const publicPath = canonicalPath ?? routePath;
   const translatedLocales = CONTENT_LOCALES.filter((loc) => source.getPage(path, loc) !== undefined);
-  const alternates = buildAlternateLanguages(routePath, translatedLocales, env.BASE_URL);
+  const alternates = buildAlternateLanguages(publicPath, translatedLocales, env.BASE_URL);
 
-  const canonical = `${env.BASE_URL}${buildLocalePath(locale, routePath)}`;
+  const canonical = `${env.BASE_URL}${buildLocalePath(locale, publicPath)}`;
   const ogImageParams = new URLSearchParams({ title });
 
   if (description) ogImageParams.set("description", description);

--- a/core/fumadocs/route-source-map.ts
+++ b/core/fumadocs/route-source-map.ts
@@ -1,7 +1,11 @@
 import type { PUBLIC_ROUTES_SEO } from "@/i18n/routing";
 
+import { CONTENT_DYNAMIC_ROUTES } from "./content-route-contract";
+
 import {
   affiliateSource,
+  apiDocsSource,
+  apiOverviewSource,
   authSource,
   automationSource,
   blogPostsSource,
@@ -85,7 +89,7 @@ export const ROUTE_SOURCE_MAP = {
     source: blogSource,
     path: ["blog"],
   },
-  "/blog/:slug": {
+  [CONTENT_DYNAMIC_ROUTES.blogPost.route]: {
     source: blogPostsSource,
     path: [":slug"],
   },
@@ -93,7 +97,7 @@ export const ROUTE_SOURCE_MAP = {
     source: compareSource,
     path: ["compare"],
   },
-  "/compare/:competitor": {
+  [CONTENT_DYNAMIC_ROUTES.comparison.route]: {
     source: comparePagesSource,
     path: [":competitor"],
   },
@@ -101,11 +105,11 @@ export const ROUTE_SOURCE_MAP = {
     source: forSource,
     path: ["for"],
   },
-  "/for/:industry": {
+  [CONTENT_DYNAMIC_ROUTES.industry.route]: {
     source: forPagesSource,
     path: [":industry"],
   },
-  "/features/:slug": {
+  [CONTENT_DYNAMIC_ROUTES.feature.route]: {
     source: featurePagesSource,
     path: [":slug"],
   },
@@ -117,8 +121,24 @@ export const ROUTE_SOURCE_MAP = {
     source: docsSource,
     path: ["intro-page"],
   },
-  "/docs/:slug": {
+  [CONTENT_DYNAMIC_ROUTES.doc.route]: {
     source: docsSource,
     path: [":slug"],
   },
 } satisfies Record<(typeof PUBLIC_ROUTES_SEO)[number], { source: unknown; path: string[] }>;
+
+export const NON_SEO_CONTENT_ROUTE_SOURCE_MAP = {
+  "/docs/openapi": {
+    source: apiOverviewSource,
+    path: ["openapi"],
+  },
+  [CONTENT_DYNAMIC_ROUTES.openApiDoc.route]: {
+    source: apiDocsSource,
+    path: [":slug"],
+  },
+} as const;
+
+export const CONTENT_ROUTE_SOURCE_MAP = {
+  ...ROUTE_SOURCE_MAP,
+  ...NON_SEO_CONTENT_ROUTE_SOURCE_MAP,
+};

--- a/core/seo/__tests__/sitemap.test.ts
+++ b/core/seo/__tests__/sitemap.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { buildAlternateLanguages } from "../alternates";
 import { assembleSitemap } from "../sitemap";
 
-import { DEFAULT_LOCALE } from "@/i18n/locale-registry";
+import { CONTENT_LOCALES, DEFAULT_LOCALE } from "@/i18n/locale-registry";
 
 const BASE_URL = "https://example.test";
 const GENERATED_AT = new Date("2026-01-01T00:00:00.000Z");
@@ -134,6 +134,14 @@ describe("alternate languages", () => {
       en: `${BASE_URL}/en`,
       de: `${BASE_URL}/de`,
       "x-default": `${BASE_URL}/en`,
+    });
+  });
+
+  it("preserves a query string in localized pagination alternates", () => {
+    expect(buildAlternateLanguages("/blog?page=2", CONTENT_LOCALES, BASE_URL)).toEqual({
+      de: `${BASE_URL}/de/blog?page=2`,
+      en: `${BASE_URL}/en/blog?page=2`,
+      "x-default": `${BASE_URL}/en/blog?page=2`,
     });
   });
 });

--- a/core/seo/hub-pagination.ts
+++ b/core/seo/hub-pagination.ts
@@ -1,0 +1,122 @@
+export const HUB_PAGE_SIZE = 24;
+
+export const HUB_PAGE_PARAM = "page";
+
+export type HubPage<T> = {
+  items: T[];
+  page: number;
+  pageCount: number;
+};
+
+export type HubPageResolution =
+  | { kind: "page"; page: number }
+  | { kind: "redirect-page-one"; page: 1 }
+  | { kind: "not-found" };
+
+export type HubPagerModel = {
+  nextPage: number | null;
+  pageNumbers: number[];
+  previousPage: number | null;
+};
+
+type SourcePage = {
+  url: string;
+};
+
+export type SluggedPage<T extends SourcePage> = {
+  page: T;
+  slug: string;
+};
+
+export function hubPageCount(total: number, size: number = HUB_PAGE_SIZE): number {
+  if (!Number.isSafeInteger(total) || total < 0) throw new RangeError("Hub item total must be a non-negative integer");
+  if (!Number.isSafeInteger(size) || size < 1) throw new RangeError("Hub page size must be a positive integer");
+
+  return Math.max(1, Math.ceil(total / size));
+}
+
+export function resolveHubPage(raw: string | string[] | undefined, pageCount: number): HubPageResolution {
+  if (!Number.isSafeInteger(pageCount) || pageCount < 1) throw new RangeError("Hub page count must be positive");
+  if (raw === undefined) return { kind: "page", page: 1 };
+  if (Array.isArray(raw) || !/^[1-9]\d*$/u.test(raw)) return { kind: "not-found" };
+
+  const page = Number(raw);
+  if (!Number.isSafeInteger(page) || page > pageCount) return { kind: "not-found" };
+  if (page === 1) return { kind: "redirect-page-one", page: 1 };
+
+  return { kind: "page", page };
+}
+
+export function hubPageHref(basePath: string, page: number): string {
+  if (!Number.isSafeInteger(page) || page < 1) throw new RangeError("Hub page must be a positive integer");
+  return page === 1 ? basePath : `${basePath}?${HUB_PAGE_PARAM}=${page}`;
+}
+
+export function paginateHub<T>(items: readonly T[], page: number, size: number = HUB_PAGE_SIZE): HubPage<T> {
+  const pageCount = hubPageCount(items.length, size);
+  if (!Number.isSafeInteger(page) || page < 1 || page > pageCount)
+    throw new RangeError(`Hub page ${page} is outside 1-${pageCount}`);
+
+  const start = (page - 1) * size;
+  return { items: items.slice(start, start + size), page, pageCount };
+}
+
+export function hubPagerModel(page: number, pageCount: number): HubPagerModel {
+  if (!Number.isSafeInteger(pageCount) || pageCount < 1) throw new RangeError("Hub page count must be positive");
+  if (!Number.isSafeInteger(page) || page < 1 || page > pageCount)
+    throw new RangeError(`Hub page ${page} is outside 1-${pageCount}`);
+
+  const bucketSize = Math.ceil(Math.sqrt(pageCount));
+  const currentBucketStart = Math.floor((page - 1) / bucketSize) * bucketSize + 1;
+  const numbers = new Set<number>();
+
+  for (let bucketStart = 1; bucketStart <= pageCount; bucketStart += bucketSize) numbers.add(bucketStart);
+  for (
+    let bucketPage = currentBucketStart;
+    bucketPage <= Math.min(currentBucketStart + bucketSize - 1, pageCount);
+    bucketPage++
+  )
+    numbers.add(bucketPage);
+
+  return {
+    nextPage: page < pageCount ? page + 1 : null,
+    pageNumbers: [...numbers].sort((a, b) => a - b),
+    previousPage: page > 1 ? page - 1 : null,
+  };
+}
+
+export function paginateLocalizedHubPages<ReferencePage extends SourcePage, LocalizedPage extends SourcePage>(
+  referencePages: readonly ReferencePage[],
+  localizedPages: readonly LocalizedPage[],
+  page: number,
+  compareReference: (a: SluggedPage<ReferencePage>, b: SluggedPage<ReferencePage>) => number,
+): HubPage<SluggedPage<LocalizedPage>> {
+  const references = indexPages(referencePages, "reference").sort((a, b) => {
+    const compared = compareReference(a, b);
+    if (compared !== 0) return compared;
+    return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+  });
+  const localized = new Map(indexPages(localizedPages, "localized").map((entry) => [entry.slug, entry.page]));
+  const paginated = paginateHub(references, page);
+
+  return {
+    ...paginated,
+    items: paginated.items.map(({ slug }) => {
+      const localizedPage = localized.get(slug);
+      if (!localizedPage) throw new Error(`Localized hub content is missing slug ${slug}`);
+      return { page: localizedPage, slug };
+    }),
+  };
+}
+
+function indexPages<T extends SourcePage>(pages: readonly T[], label: string): SluggedPage<T>[] {
+  const seen = new Set<string>();
+
+  return pages.map((page) => {
+    const slug = page.url.split("/").filter(Boolean).pop() ?? "";
+    if (!slug) throw new Error(`${label} hub content has a page without a slug`);
+    if (seen.has(slug)) throw new Error(`${label} hub content repeats slug ${slug}`);
+    seen.add(slug);
+    return { page, slug };
+  });
+}

--- a/core/seo/landing-hubs.ts
+++ b/core/seo/landing-hubs.ts
@@ -1,0 +1,34 @@
+import { CONTENT_DYNAMIC_ROUTES } from "@/core/fumadocs/content-route-contract";
+
+export const LANDING_HUBS = [
+  {
+    collection: "blog-posts",
+    detailPath: "/blog",
+    detailRoute: CONTENT_DYNAMIC_ROUTES.blogPost.route,
+    hubPath: "/blog",
+    pageCount: 3,
+  },
+  {
+    collection: "compare-pages",
+    detailPath: "/compare",
+    detailRoute: CONTENT_DYNAMIC_ROUTES.comparison.route,
+    hubPath: "/compare",
+    pageCount: 2,
+  },
+  {
+    collection: "feature-pages",
+    detailPath: "/features",
+    detailRoute: CONTENT_DYNAMIC_ROUTES.feature.route,
+    hubPath: "/features/all",
+    pageCount: 1,
+  },
+  {
+    collection: "for-pages",
+    detailPath: "/for",
+    detailRoute: CONTENT_DYNAMIC_ROUTES.industry.route,
+    hubPath: "/for",
+    pageCount: 2,
+  },
+] as const;
+
+export type LandingHub = (typeof LANDING_HUBS)[number];

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@mdx-js/mdx": "^3.1.1",
     "@next/eslint-plugin-next": "15.0.4",
     "@react-email/preview-server": "4.3.2",
     "@tailwindcss/forms": "0.5.10",

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,6 +18,8 @@ import { env } from "./env";
 import { auth } from "./core/auth/better-auth";
 import { resolveRequestOrigin } from "./core/config/environment";
 import { SYNTHETIC_SEED_USER } from "./core/config/synthetic-seed-user";
+import { HUB_PAGE_PARAM, resolveHubPage } from "./core/seo/hub-pagination";
+import { LANDING_HUBS } from "./core/seo/landing-hubs";
 
 const intlAppMiddleware = createMiddleware(appRouting);
 const intlContentMiddleware = createMiddleware(contentRouting);
@@ -74,6 +76,31 @@ function appendSetCookieHeaders(response: NextResponse, authResponse: Response):
   for (const cookie of setCookies) response.headers.append("set-cookie", cookie);
 }
 
+function hubPaginationResponse(req: NextRequest, locale: string): NextResponse | null {
+  const hub = LANDING_HUBS.find(({ hubPath }) => hubPath === stripLocalePrefix(req.nextUrl.pathname));
+  if (!hub) return null;
+
+  const values = req.nextUrl.searchParams.getAll(HUB_PAGE_PARAM);
+  const raw = values.length === 0 ? undefined : values.length === 1 ? values[0] : values;
+  const resolution = resolveHubPage(raw, hub.pageCount);
+
+  if (resolution.kind === "page") return null;
+
+  if (resolution.kind === "redirect-page-one") {
+    const canonical = req.nextUrl.clone();
+    canonical.pathname = buildLocalePath(locale, hub.hubPath);
+    canonical.searchParams.delete(HUB_PAGE_PARAM);
+    return NextResponse.redirect(canonical, 308);
+  }
+
+  const notFoundTarget = req.nextUrl.clone();
+  notFoundTarget.pathname = buildLocalePath(locale, "/__invalid-hub-page");
+  notFoundTarget.search = "";
+  const response = NextResponse.rewrite(notFoundTarget, { status: 404 });
+  response.headers.set("x-robots-tag", "noindex");
+  return response;
+}
+
 export default async function proxy(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
   const base = resolveRequestOrigin(req.nextUrl.origin, env.AUTH_ALLOWED_HOSTS, env.BASE_URL);
@@ -126,6 +153,9 @@ export default async function proxy(req: NextRequest) {
     if (isUnsupportedLocalePrefix(pathname)) return NextResponse.next();
     return negotiateLocale(req, base, isAuthenticated && pathname === "/" ? "app" : "auto");
   }
+
+  const paginationResponse = hubPaginationResponse(req, currentLocale);
+  if (paginationResponse) return paginationResponse;
 
   if (env.APP_MODE === "demo") {
     const isNonDemoUser = isAuthenticated && session?.user?.email !== SYNTHETIC_SEED_USER.email;

--- a/tests/conventions/hero-asset-coverage.test.ts
+++ b/tests/conventions/hero-asset-coverage.test.ts
@@ -1,0 +1,152 @@
+import { closeSync, existsSync, openSync, readSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT } from "./walk";
+
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
+import { CONTENT_LOCALES, DEFAULT_LOCALE } from "@/i18n/locale-registry";
+
+const ENFORCED = true;
+
+const IMAGE_THEMES = ["light", "dark"] as const;
+const HERO_WIDTH = 1920;
+const HERO_HEIGHT = 1080;
+const PNG_HEADER_BYTES = 24;
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const IHDR_SIGNATURE = [0x49, 0x48, 0x44, 0x52];
+
+type Dimensions = { height: number; width: number };
+
+function startsWith(header: Uint8Array, signature: number[], offset: number): boolean {
+  return signature.every((byte, index) => header[offset + index] === byte);
+}
+
+export function pngDimensions(header: Uint8Array): Dimensions | null {
+  if (header.length < PNG_HEADER_BYTES) return null;
+  if (!startsWith(header, PNG_SIGNATURE, 0)) return null;
+  if (!startsWith(header, IHDR_SIGNATURE, 12)) return null;
+
+  const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  return { height: view.getUint32(20), width: view.getUint32(16) };
+}
+
+function readPngHeader(path: string): Uint8Array {
+  const header = new Uint8Array(PNG_HEADER_BYTES);
+  const handle = openSync(path, "r");
+
+  try {
+    const read = readSync(handle, header, 0, PNG_HEADER_BYTES, 0);
+    return header.subarray(0, read);
+  } finally {
+    closeSync(handle);
+  }
+}
+
+function collectionSlugs(collection: string): string[] {
+  const directory = join(REPO_ROOT, "content", collection, DEFAULT_LOCALE);
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+    .map((entry) => entry.name.slice(0, -".mdx".length))
+    .sort();
+}
+
+function imageSlugs(theme: string, locale: string): string[] {
+  const directory = join(REPO_ROOT, "public", "images", theme, locale);
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".png")
+    .map((entry) => entry.name.slice(0, -".png".length))
+    .sort();
+}
+
+describe("hero asset coverage", () => {
+  const slugsByCollection = new Map(LANDING_HUBS.map(({ collection }) => [collection, collectionSlugs(collection)]));
+  const expectedSlugs = new Set([...slugsByCollection.values()].flat());
+
+  it("keeps every landing slug unique in the shared image namespace", () => {
+    const owners = new Map<string, string[]>();
+
+    for (const [collection, slugs] of slugsByCollection) {
+      expect(slugs.length, `content/${collection}/${DEFAULT_LOCALE} holds no page`).toBeGreaterThan(0);
+      for (const slug of slugs) owners.set(slug, [...(owners.get(slug) ?? []), collection]);
+    }
+
+    const collisions = [...owners]
+      .filter(([, collections]) => collections.length > 1)
+      .map(([slug, collections]) => `${slug}: ${collections.join(", ")}`);
+
+    expect(collisions, `landing slugs sharing one hero filename:\n${collisions.join("\n")}`).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("gives every landing slug every localized theme asset", () => {
+    const problems: string[] = [];
+
+    for (const slug of [...expectedSlugs].sort()) {
+      for (const theme of IMAGE_THEMES) {
+        for (const locale of CONTENT_LOCALES) {
+          const relativePath = join("public", "images", theme, locale, `${slug}.png`);
+          if (!existsSync(join(REPO_ROOT, relativePath))) problems.push(`${relativePath} is missing`);
+        }
+      }
+    }
+
+    expect(problems, `landing pages without a hero asset:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("keeps every localized PNG bound to one landing page", () => {
+    const problems: string[] = [];
+
+    for (const theme of IMAGE_THEMES) {
+      for (const locale of CONTENT_LOCALES) {
+        for (const slug of imageSlugs(theme, locale)) {
+          if (!expectedSlugs.has(slug)) {
+            problems.push(`${join("public", "images", theme, locale, `${slug}.png`)} has no landing page`);
+          }
+        }
+      }
+    }
+
+    expect(problems, `hero assets without a landing page:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(`keeps every hero PNG at ${HERO_WIDTH}x${HERO_HEIGHT}`, () => {
+    const problems: string[] = [];
+
+    for (const theme of IMAGE_THEMES) {
+      for (const locale of CONTENT_LOCALES) {
+        for (const slug of imageSlugs(theme, locale)) {
+          const relativePath = join("public", "images", theme, locale, `${slug}.png`);
+          const dimensions = pngDimensions(readPngHeader(join(REPO_ROOT, relativePath)));
+
+          if (!dimensions) problems.push(`${relativePath} does not start with a PNG IHDR header`);
+          else if (dimensions.width !== HERO_WIDTH || dimensions.height !== HERO_HEIGHT) {
+            problems.push(`${relativePath} is ${dimensions.width}x${dimensions.height}`);
+          }
+        }
+      }
+    }
+
+    expect(problems, `hero assets off the required geometry:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it("reads and rejects synthetic PNG headers without decoding image bodies", () => {
+    const header = new Uint8Array(PNG_HEADER_BYTES);
+    header.set(PNG_SIGNATURE, 0);
+    header.set(IHDR_SIGNATURE, 12);
+    const view = new DataView(header.buffer);
+    view.setUint32(16, HERO_WIDTH);
+    view.setUint32(20, HERO_HEIGHT);
+
+    expect(pngDimensions(header)).toEqual({
+      height: HERO_HEIGHT,
+      width: HERO_WIDTH,
+    });
+    view.setUint32(16, 1280);
+    expect(pngDimensions(header)).toEqual({ height: HERO_HEIGHT, width: 1280 });
+    expect(pngDimensions(header.subarray(0, 20))).toBeNull();
+    expect(pngDimensions(new Uint8Array(PNG_HEADER_BYTES))).toBeNull();
+  });
+});

--- a/tests/conventions/hub-reachability.test.ts
+++ b/tests/conventions/hub-reachability.test.ts
@@ -1,0 +1,304 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { REPO_ROOT } from "./walk";
+
+vi.mock("@/components/shared/app-link", () => ({
+  AppLink: ({
+    appearance: _appearance,
+    children,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    appearance?: string;
+    children?: ReactNode;
+  }) => createElement("a", props, children),
+}));
+
+import { HubPagination } from "@/components/marketing/hub-pagination";
+import {
+  hubPageCount,
+  hubPageHref,
+  hubPagerModel,
+  paginateHub,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
+import { CONTENT_LOCALES } from "@/i18n/locale-registry";
+import { PUBLIC_ROUTES } from "@/i18n/routing";
+
+const ENFORCED = true;
+const CLICK_BOUND = 4;
+
+const HOME_PAGE_SOURCE = join(REPO_ROOT, "app", "[locale]", "(static)", "page.tsx");
+const FOOTER_SOURCE = join(REPO_ROOT, "app", "components", "footer-content.tsx");
+const HUB_ROUTE_FILES = new Map([
+  ["/blog", join(REPO_ROOT, "app", "[locale]", "(static)", "blog", "page.tsx")],
+  ["/compare", join(REPO_ROOT, "app", "[locale]", "(static)", "compare", "page.tsx")],
+  ["/features/all", join(REPO_ROOT, "app", "[locale]", "(static)", "features", "all", "page.tsx")],
+  ["/for", join(REPO_ROOT, "app", "[locale]", "(static)", "for", "page.tsx")],
+]);
+
+function collectionSlugs(collection: string, locale: string): string[] {
+  const directory = join(REPO_ROOT, "content", collection, locale);
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+    .map((entry) => entry.name.slice(0, -".mdx".length))
+    .sort();
+}
+
+function renderedPagerHrefs(basePath: string, page: number, pageCount: number): string[] {
+  const html = renderToStaticMarkup(
+    createElement(HubPagination, {
+      basePath,
+      label: `${basePath} pagination`,
+      nextLabel: "Next",
+      page,
+      pageCount,
+      previousLabel: "Previous",
+    }),
+  );
+
+  return [...html.matchAll(/\shref="([^"]+)"/gu)].map((match) => match[1].replaceAll("&amp;", "&"));
+}
+
+function buildRenderedGraph(slugsByHub: ReadonlyMap<string, readonly string[]>): Map<string, string[]> {
+  const graph = new Map<string, string[]>();
+
+  for (const { detailPath, hubPath } of LANDING_HUBS) {
+    const slugs = slugsByHub.get(hubPath) ?? [];
+    const pageCount = hubPageCount(slugs.length);
+
+    for (let page = 1; page <= pageCount; page++) {
+      const cards = paginateHub(slugs, page).items.map((slug) => `${detailPath}/${slug}`);
+      graph.set(hubPageHref(hubPath, page), [...cards, ...renderedPagerHrefs(hubPath, page, pageCount)]);
+    }
+  }
+
+  graph.set(
+    "/",
+    LANDING_HUBS.map(({ hubPath }) => hubPath),
+  );
+  return graph;
+}
+
+function landingRouteCollisions(slugsByHub: ReadonlyMap<string, readonly string[]>): string[] {
+  const reservedRoutes = new Set<string>(PUBLIC_ROUTES.filter((route) => !route.includes(":")));
+
+  return LANDING_HUBS.flatMap(({ detailPath, hubPath }) =>
+    (slugsByHub.get(hubPath) ?? [])
+      .map((slug) => `${detailPath}/${slug}`)
+      .filter((detailRoute) => reservedRoutes.has(detailRoute))
+      .map((detailRoute) => `${detailRoute} collides with a static public route`),
+  );
+}
+
+function clickDepths(graph: ReadonlyMap<string, readonly string[]>): Map<string, number> {
+  const depths = new Map<string, number>([["/", 0]]);
+  let frontier = ["/"];
+
+  while (frontier.length > 0) {
+    const next: string[] = [];
+
+    for (const node of frontier) {
+      for (const edge of graph.get(node) ?? []) {
+        if (depths.has(edge)) continue;
+        depths.set(edge, (depths.get(node) ?? 0) + 1);
+        next.push(edge);
+      }
+    }
+
+    frontier = next;
+  }
+
+  return depths;
+}
+
+describe("hub pagination and rendered reachability", () => {
+  it("strictly resolves the page query without producing duplicate 200 pages", () => {
+    expect(resolveHubPage(undefined, 3)).toEqual({ kind: "page", page: 1 });
+    expect(resolveHubPage("1", 3)).toEqual({
+      kind: "redirect-page-one",
+      page: 1,
+    });
+    expect(resolveHubPage("2", 3)).toEqual({ kind: "page", page: 2 });
+
+    const invalidValues: Array<string | string[]> = [
+      ["2"],
+      "",
+      "0",
+      "01",
+      "+2",
+      "2.0",
+      "2junk",
+      "4",
+      "9007199254740992",
+    ];
+
+    for (const invalid of invalidValues) {
+      expect(resolveHubPage(invalid, 3), String(invalid)).toEqual({
+        kind: "not-found",
+      });
+    }
+  });
+
+  it("renders crawlable previous, next, bucket, and current-page semantics", () => {
+    const html = renderToStaticMarkup(
+      createElement(HubPagination, {
+        basePath: "/blog",
+        label: "Blog",
+        nextLabel: "Next page",
+        page: 37,
+        pageCount: 94,
+        previousLabel: "Previous page",
+      }),
+    );
+    const hrefs = renderedPagerHrefs("/blog", 37, 94);
+
+    expect(html).toContain('<nav aria-label="Blog"');
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('rel="prev"');
+    expect(html).toContain('rel="next"');
+    expect(hrefs).toContain("/blog?page=36");
+    expect(hrefs).toContain("/blog?page=38");
+    expect(hrefs).toContain("/blog?page=31");
+    expect(hrefs).not.toContain("/blog?page=37");
+  });
+
+  it("keeps the square-root pager link budget sublinear at backlog scale", () => {
+    const pageCount = hubPageCount(2_256);
+    const maximumLinks = Math.max(
+      ...Array.from({ length: pageCount }, (_, index) => renderedPagerHrefs("/blog", index + 1, pageCount).length),
+    );
+
+    expect(pageCount).toBe(94);
+    expect(maximumLinks).toBeLessThanOrEqual(2 * Math.ceil(Math.sqrt(pageCount)) + 2);
+    expect(hubPagerModel(1, pageCount).pageNumbers).toContain(91);
+  });
+
+  it("uses the default sequence to keep localized page membership aligned", () => {
+    const reference = ["c", "a", "d", "b"].map((slug) => ({
+      label: slug,
+      url: `/items/${slug}`,
+    }));
+    const localized = ["b", "d", "a", "c"].map((slug) => ({
+      label: `localized-${slug}`,
+      url: `/items/${slug}`,
+    }));
+    const compare = (a: { slug: string }, b: { slug: string }) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0);
+
+    expect(paginateLocalizedHubPages(reference, reference, 1, compare).items.map(({ slug }) => slug)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+    expect(paginateLocalizedHubPages(reference, localized, 1, compare).items.map(({ slug }) => slug)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  it("partitions collections into complete, non-overlapping 24-card pages", () => {
+    const slugs = Array.from({ length: 50 }, (_, index) => `slug-${index}`);
+    const pages = Array.from({ length: hubPageCount(slugs.length) }, (_, index) => paginateHub(slugs, index + 1));
+
+    expect(pages.flatMap(({ items }) => items)).toEqual(slugs);
+    expect(pages.map(({ items }) => items.length)).toEqual([24, 24, 2]);
+    expect(() => paginateHub(slugs, 4)).toThrow(RangeError);
+  });
+
+  it("keeps the proxy's lightweight page-count registry aligned with published content", () => {
+    for (const { collection, hubPath, pageCount } of LANDING_HUBS) {
+      for (const locale of CONTENT_LOCALES) {
+        expect(pageCount, `${hubPath} page count drifted from ${collection}/${locale}`).toBe(
+          hubPageCount(collectionSlugs(collection, locale).length),
+        );
+      }
+    }
+  });
+
+  it("wires the real pager and shared resolver into all four production hubs", () => {
+    const home = readFileSync(HOME_PAGE_SOURCE, "utf8");
+    const footer = readFileSync(FOOTER_SOURCE, "utf8");
+
+    expect(home).toContain("<Footer />");
+    for (const { hubPath } of LANDING_HUBS) {
+      expect(footer, `footer does not link ${hubPath}`).toContain(`href="${hubPath}"`);
+      const routeFile = HUB_ROUTE_FILES.get(hubPath);
+      expect(routeFile, `missing route file declaration for ${hubPath}`).toBeDefined();
+      const source = readFileSync(routeFile as string, "utf8");
+      expect(source).toContain("paginateLocalizedHubPages(");
+      expect(source).toContain("resolveHubPage(");
+      expect(source).toContain("<HubPagination");
+    }
+
+    const sitemap = readFileSync(join(REPO_ROOT, "app", "sitemap.ts"), "utf8");
+    expect(sitemap).toContain("LANDING_HUBS");
+    expect(sitemap).toContain("hubPageHref(");
+  });
+
+  it("reserves every static public route from landing-page slug collisions", () => {
+    const problems: string[] = [];
+
+    for (const locale of CONTENT_LOCALES) {
+      const slugsByHub = new Map(
+        LANDING_HUBS.map(({ collection, hubPath }) => [hubPath, collectionSlugs(collection, locale)] as const),
+      );
+      problems.push(...landingRouteCollisions(slugsByHub).map((problem) => `${locale} ${problem}`));
+    }
+
+    expect(problems, `landing pages hidden behind static routes:\n${problems.join("\n")}`).toEqual([]);
+    expect(landingRouteCollisions(new Map([["/features/all", ["all"]]]))).toEqual([
+      "/features/all collides with a static public route",
+    ]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
+    `reaches every localized landing page through rendered pager hrefs within ${CLICK_BOUND} clicks`,
+    () => {
+      const problems: string[] = [];
+
+      for (const locale of CONTENT_LOCALES) {
+        const slugsByHub = new Map(
+          LANDING_HUBS.map(({ collection, hubPath }) => [hubPath, collectionSlugs(collection, locale)] as const),
+        );
+        const depths = clickDepths(buildRenderedGraph(slugsByHub));
+
+        for (const { detailPath, hubPath } of LANDING_HUBS) {
+          const slugs = slugsByHub.get(hubPath) ?? [];
+          expect(slugs.length, `${collectionSlugs.name} found no ${locale} pages for ${hubPath}`).toBeGreaterThan(0);
+
+          for (const slug of slugs) {
+            const route = `${detailPath}/${slug}`;
+            const depth = depths.get(route);
+            if (depth === undefined) problems.push(`${locale} ${route} is unreachable`);
+            else if (depth > CLICK_BOUND) problems.push(`${locale} ${route} is ${depth} clicks away`);
+          }
+        }
+      }
+
+      expect(problems, `landing pages beyond the click bound:\n${problems.join("\n")}`).toEqual([]);
+    },
+  );
+
+  it(`keeps the ${CLICK_BOUND}-click bound for a 2,256-page family`, () => {
+    const slugs = Array.from({ length: 2_256 }, (_, index) => `page-${index}`);
+    const graph = buildRenderedGraph(
+      new Map(LANDING_HUBS.map(({ hubPath }) => [hubPath, hubPath === "/blog" ? slugs : ["only-page"]])),
+    );
+    const depths = clickDepths(graph);
+    const worst = Math.max(...slugs.map((slug) => depths.get(`/blog/${slug}`) ?? Infinity));
+
+    expect(worst).toBe(CLICK_BOUND);
+  });
+});

--- a/tests/conventions/internal-link-targets.test.ts
+++ b/tests/conventions/internal-link-targets.test.ts
@@ -1,0 +1,289 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+
+import { createProcessor } from "@mdx-js/mdx";
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT, walkFiles } from "./walk";
+
+import {
+  FOOTER_COLUMN_SIZE,
+  FOOTER_PREFERRED_SLUGS,
+  type FooterCollection,
+  selectFooterSlugs,
+} from "@/app/components/footer-selection";
+import { CONTENT_DYNAMIC_ROUTES, UNBACKED_DYNAMIC_PUBLIC_ROUTES } from "@/core/fumadocs/content-route-contract";
+import {
+  CONTENT_LOCALES,
+  DEFAULT_LOCALE,
+  type ContentLocale,
+  contentLocaleOrDefault,
+  isContentLocale,
+  routingLocaleFromUrlSegment,
+} from "@/i18n/locale-registry";
+import { PUBLIC_ROUTES } from "@/i18n/routing";
+
+const ENFORCED = true;
+
+const CONTENT_ROOT = join(REPO_ROOT, "content");
+const processor = createProcessor({ format: "mdx" });
+const ROOT_LINK_CANDIDATE = /(?:\]\s*\(\s*|href\s*=\s*(?:\{\s*)?["']|^\s*\[[^\]\n]+\]:\s*)\//mu;
+
+type MdxNode = {
+  attributes?: Array<{
+    data?: { estree?: EstreeProgram };
+    name?: string;
+    type?: string;
+    value?: string | { data?: { estree?: EstreeProgram }; type?: string; value?: string } | null;
+  }>;
+  children?: MdxNode[];
+  identifier?: string;
+  position?: { start?: { line?: number } };
+  type: string;
+  url?: string;
+};
+
+type EstreeProgram = {
+  body?: Array<{ expression?: { type?: string; value?: unknown } }>;
+};
+
+type ContentLink = {
+  file: string;
+  line: number;
+  sourceLocale: ContentLocale;
+  target: string;
+};
+
+type NormalizedTarget = {
+  locale: ContentLocale | null;
+  path: string;
+};
+
+function staticExpressionValue(program: EstreeProgram | undefined): string | null {
+  const expression = program?.body?.[0]?.expression;
+  return expression?.type === "Literal" && typeof expression.value === "string" ? expression.value : null;
+}
+
+function jsxHref(node: MdxNode): string | null {
+  if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement") return null;
+  const attribute = node.attributes?.find(
+    (candidate) => candidate.type === "mdxJsxAttribute" && candidate.name === "href",
+  );
+  if (!attribute || attribute.value === null || attribute.value === undefined) return null;
+  if (typeof attribute.value === "string") return attribute.value;
+  return staticExpressionValue(attribute.value.data?.estree);
+}
+
+function rootRelative(target: string | null | undefined): target is string {
+  return typeof target === "string" && target.startsWith("/") && !target.startsWith("//");
+}
+
+function maskFrontmatter(source: string): string {
+  return source.replace(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u, (frontmatter) =>
+    frontmatter.replace(/[^\r\n]/gu, " "),
+  );
+}
+
+function linksInDocument(source: string, file: string, sourceLocale: ContentLocale): ContentLink[] {
+  let tree: MdxNode;
+
+  try {
+    tree = processor.parse(source) as unknown as MdxNode;
+  } catch (error) {
+    throw new Error(`Could not parse ${file} as MDX`, { cause: error });
+  }
+
+  const links: ContentLink[] = [];
+  const definitions = new Map<string, string>();
+  const references: Array<{ identifier: string; line: number }> = [];
+  const record = (target: string, node: MdxNode) => {
+    if (rootRelative(target)) {
+      links.push({
+        file,
+        line: node.position?.start?.line ?? 1,
+        sourceLocale,
+        target,
+      });
+    }
+  };
+  const visit = (node: MdxNode): void => {
+    if (node.type === "link" && rootRelative(node.url)) record(node.url, node);
+    if (node.type === "definition" && node.identifier && rootRelative(node.url)) {
+      definitions.set(node.identifier, node.url);
+    }
+    if (node.type === "linkReference" && node.identifier) {
+      references.push({
+        identifier: node.identifier,
+        line: node.position?.start?.line ?? 1,
+      });
+    }
+
+    const href = jsxHref(node);
+    if (href) record(href, node);
+    for (const child of node.children ?? []) visit(child);
+  };
+
+  visit(tree);
+
+  for (const reference of references) {
+    const target = definitions.get(reference.identifier);
+    if (rootRelative(target)) links.push({ file, line: reference.line, sourceLocale, target });
+  }
+
+  return links;
+}
+
+export function normalizeTarget(target: string): NormalizedTarget | null {
+  const base = "https://internal.invalid";
+  const url = new URL(target, base);
+  if (url.origin !== base) return null;
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const prefixedLocale = segments[0] ? routingLocaleFromUrlSegment(segments[0]) : null;
+  if (prefixedLocale) segments.shift();
+
+  const path = segments.length === 0 ? "/" : `/${segments.join("/")}`;
+  return {
+    locale: prefixedLocale ? contentLocaleOrDefault(prefixedLocale) : null,
+    path: path.length > 1 ? path.replace(/\/+$/u, "") : path,
+  };
+}
+
+function knownTargets(locale: ContentLocale): Set<string> {
+  const targets = new Set<string>(PUBLIC_ROUTES.filter((route) => !route.includes(":")));
+
+  for (const { collection, route } of Object.values(CONTENT_DYNAMIC_ROUTES)) {
+    const base = route.slice(0, route.lastIndexOf("/"));
+    for (const slug of collectionSlugs(collection, locale)) targets.add(`${base}/${slug}`);
+  }
+
+  return targets;
+}
+
+function contentLinks(): ContentLink[] {
+  const found: ContentLink[] = [];
+
+  for (const path of walkFiles(CONTENT_ROOT, (candidate) => extname(candidate) === ".mdx")) {
+    const source = readFileSync(path, "utf8");
+    if (!ROOT_LINK_CANDIDATE.test(source)) continue;
+
+    const file = relative(REPO_ROOT, path).split(sep).join("/");
+    const localeSegment = relative(CONTENT_ROOT, path).split(sep)[1];
+    if (!isContentLocale(localeSegment)) throw new Error(`${file} is outside a registered content locale`);
+    found.push(...linksInDocument(maskFrontmatter(source), file, localeSegment));
+  }
+
+  return found;
+}
+
+function collectionSlugs(collection: string, locale: ContentLocale): string[] {
+  const directory = join(CONTENT_ROOT, collection, locale);
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+    .map((entry) => entry.name.slice(0, -".mdx".length))
+    .sort();
+}
+
+describe("internal link targets", () => {
+  it("accounts for every dynamic public route at one canonical source map", () => {
+    const mapped = Object.values(CONTENT_DYNAMIC_ROUTES).map(({ route }) => route);
+    const declaredUnbacked = [...UNBACKED_DYNAMIC_PUBLIC_ROUTES];
+    const dynamicPublicRoutes = PUBLIC_ROUTES.filter((route) => route.includes(":"));
+
+    expect([...mapped, ...declaredUnbacked].sort()).toEqual([...dynamicPublicRoutes].sort());
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
+    "resolves every literal internal link in MDX",
+    () => {
+      const links = contentLinks();
+      const targetsByLocale = new Map(CONTENT_LOCALES.map((locale) => [locale, knownTargets(locale)]));
+      const problems: string[] = [];
+
+      expect(links.length, "expected root-relative links under content/").toBeGreaterThan(0);
+
+      for (const link of links) {
+        const normalized = normalizeTarget(link.target);
+        if (!normalized) continue;
+        const targetLocale = normalized.locale ?? link.sourceLocale;
+        if (!targetsByLocale.get(targetLocale)?.has(normalized.path)) {
+          problems.push(`${link.file}:${link.line} -> ${link.target}`);
+        }
+      }
+
+      expect(problems, `content links with no published route:\n${problems.join("\n")}`).toEqual([]);
+    },
+    30_000,
+  );
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("derives six live footer links per collection and locale", () => {
+    const selections = new Map<string, string[]>();
+    const problems: string[] = [];
+
+    for (const collection of Object.keys(FOOTER_PREFERRED_SLUGS) as FooterCollection[]) {
+      for (const locale of CONTENT_LOCALES) {
+        const published = collectionSlugs(collection, locale);
+        const selected = selectFooterSlugs(collection, published);
+        selections.set(`${collection}/${locale}`, selected);
+
+        if (selected.length !== FOOTER_COLUMN_SIZE) {
+          problems.push(`${collection}/${locale} yields ${selected.length}, expected ${FOOTER_COLUMN_SIZE}`);
+        }
+        for (const slug of selected) {
+          if (!published.includes(slug)) problems.push(`${collection}/${locale} selected absent slug ${slug}`);
+        }
+      }
+
+      const reference = selections.get(`${collection}/${DEFAULT_LOCALE}`);
+      for (const locale of CONTENT_LOCALES) {
+        expect(selections.get(`${collection}/${locale}`)).toEqual(reference);
+      }
+    }
+
+    expect(problems, `footer columns with invalid derived links:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it("tops up a footer column deterministically when a preferred page disappears", () => {
+    const preferred = FOOTER_PREFERRED_SLUGS["for-pages"];
+    const available = [...preferred.slice(1), "zzz-replacement", "aaa-replacement"];
+
+    expect(selectFooterSlugs("for-pages", available)).toEqual([...preferred.slice(1), "aaa-replacement"]);
+    expect(selectFooterSlugs("for-pages", preferred.slice(0, 2))).toEqual([...preferred.slice(0, 2)]);
+  });
+
+  it("normalizes locale prefixes, queries, fragments, and trailing slashes", () => {
+    expect(normalizeTarget("/pricing#plans")).toEqual({
+      locale: null,
+      path: "/pricing",
+    });
+    expect(normalizeTarget("/pricing?ref=footer")).toEqual({
+      locale: null,
+      path: "/pricing",
+    });
+    expect(normalizeTarget("/for/healthcare/")).toEqual({
+      locale: null,
+      path: "/for/healthcare",
+    });
+    expect(normalizeTarget("/de/for/healthcare")).toEqual({
+      locale: "de",
+      path: "/for/healthcare",
+    });
+    expect(normalizeTarget("/fr/pricing")).toEqual({
+      locale: DEFAULT_LOCALE,
+      path: "/pricing",
+    });
+    expect(normalizeTarget("/")).toEqual({ locale: null, path: "/" });
+  });
+
+  it("extracts Markdown references and static JSX href forms through the MDX AST", () => {
+    const links = linksInDocument(
+      `[inline](/pricing)\n\n[reference][plans]\n\n[plans]: /pricing#plans\n\n<Card\n  href={'/features/all'}\n/>`,
+      "synthetic.mdx",
+      DEFAULT_LOCALE,
+    );
+
+    expect(links.map(({ target }) => target)).toEqual(["/pricing", "/features/all", "/pricing#plans"]);
+  });
+});


### PR DESCRIPTION
## Summary

Reworks [CUS-196](https://linear.app/customermates/issue/CUS-196/close-the-locale-parity-orphan-page-and-hero-coverage-holes) on current `main` (`520cd53c`) and turns the landing-page publishing conventions into executable pre-merge contracts.

- Adds bidirectional hero coverage and 1920×1080 PNG-header validation for 168 landing slugs / 672 localized theme assets.
- Parses MDX with the real MDX AST and rejects root-relative links whose published route does not exist; repairs the 11 existing dead-link instances without changing surrounding CUS-164 copy.
- Replaces four footer filter Sets with one ordered preference manifest plus deterministic selection from live content.
- Paginates `/blog`, `/compare`, `/features/all`, and `/for` at 24 cards while preserving locale fallback and equivalent EN/DE page membership.
- Makes pagination URLs strict and indexable: malformed/repeated/out-of-range pages are wire-level 404s, `?page=1` is a wire-level 308 to the clean URL, and valid later pages have self-canonicals, reciprocal hreflang, and sitemap entries.
- Uses a square-root bucket pager so the 2,256-page backlog remains within four clicks without rendering 94 page-number links on every list page.
- Removes the root-host `Crawl-delay: 10` while preserving the preview/app-subdomain `Disallow: /` branch.

The old PR’s i18n-parity hunk is intentionally gone. Current `main` already has the stronger `CONTENT_LOCALES` / `DEFAULT_LOCALE` collection-wide parity implementation and explicitly disables Fumadocs language fallback. This branch keeps that authority rather than restoring stale two-locale logic.

## Context

The current catalog has 168 landing pages per content locale: 71 blog posts, 31 comparison pages, 24 feature pages, and 42 industry pages. The v5 backlog raises that toward 2,256 pages. Before this change, several failures were either silent or visible only after deployment:

1. A missing hero filename produced a broken image request because the `<slug>.png` relationship lived only in templates.
2. MDX prose was not typechecked as a route graph; 11 hrefs already targeted four absent URLs.
3. Footer entries were four independent literal Sets; removal silently shortened a column.
4. Every hub rendered its entire collection, so HTML weight grew linearly.
5. The previous pagination draft accepted values such as `2junk`, turned invalid/out-of-range URLs into duplicate page-one responses, canonicalized every page to page one, and rendered every numbered page link.
6. Next App Router streaming caused page-level `notFound()` and `permanentRedirect()` to remain HTTP 200 on the wire. The final design validates in `proxy.ts` before rendering and retains page-level checks as defense in depth. This follows Next’s documented streamed-response behavior.

### Final pagination contract

- Missing `page` means page 1.
- Exactly one canonical positive decimal is accepted. Empty, repeated, zero, signed, zero-padded, decimal, suffixed, unsafe, and out-of-range values return HTTP 404 with `X-Robots-Tag: noindex`.
- Exactly `page=1` returns HTTP 308 to the clean localized hub URL while preserving unrelated query parameters.
- Page 2+ returns HTTP 200, self-canonicalizes to that query URL, and emits EN/DE/x-default alternates for the same page.
- Page 2+ URLs are present in the sitemap. The sitemap grows from 412 to 420 URLs: eight new localized hub-page entries.
- One default-locale ordering chooses each 24-slug slice, then localized records are mapped into that slice. EN page N and DE page N therefore represent the same entities even when display sorting differs by language.
- The pager renders real server-visible anchors, localized Previous/Next labels, `aria-current`, visible focus rings, and 44px targets.

### Why the square-root pager

A three-click guarantee from home requires page 1 to link directly to every list page. At 2,256 details / 24 cards, that means 94 numbered anchors on the hub. The final model sets bucket size to `ceil(sqrt(pageCount))` and renders every bucket start plus all pages in the current bucket, with explicit Previous/Next links.

`home → hub page 1 → bucket start → target list page → detail`

This makes list-page diameter at most two and detail depth at most four. At the 94-page backlog, the largest pager measured 20 hrefs / 6,647 bytes instead of 94 numbered links. The current three-page pager is at most four hrefs / 1,585 bytes.

## Validation

All work ran in the isolated CUS-196 worktree against a disposable PostgreSQL 16 container bound only to `127.0.0.1:55432`, seeded with deterministic synthetic fixtures.

### Final repository gates

```text
yarn test (RUN_DATABASE_TESTS=true)  240 files / 1,880 tests passed
yarn lint                            passed, zero warnings
yarn typecheck                       passed
yarn i18n:audit                      passed (advisory findings only)
yarn build                           passed; optimized Next.js production build
git diff --check                     passed
```

### Rendered local preview

The final port-40196 local preview was exercised with both a browser and an HTTP crawler. Port 4000 was already owned by an unrelated CUS-68 worktree and was deliberately not stopped.

- Crawled all 16 EN/DE hub responses and all 336 localized detail routes.
- Every hub response rendered at most 24 cards; the largest observed response was about 463 KB.
- Maximum observed anchor count was 109, including global navigation and footer links.
- Every detail route was reachable from its localized home within four clicks.
- EN/DE slug membership matched for every corresponding hub page.
- Canonical and EN/DE/x-default alternate tags matched each valid page URL.
- `?page=1` returned 308; malformed, repeated, and out-of-range queries returned 404; valid pages returned 200.
- `/fr/blog?page=2` redirected to `/en/blog?page=2`, preserving the query under the app-locale/content-locale split.
- `/sitemap.xml` contained 420 URLs, including all eight localized page-2/page-3 hub URLs.
- `/robots.txt` emitted `Allow: /`, no crawl delay, and retained the separate subdomain exclusion behavior.
- Browser review covered `/en/blog`, navigation to `/en/blog?page=2`, and `/de/compare?page=2`; content rendered, pagination controls were visible and 44px high, no Next error overlay appeared, and no runtime error was logged. One pre-existing logo aspect-ratio warning remains unrelated to this diff.

### Mutation proofs

Each induced failure was restored before the final run:

| Mutation | Gate response |
| --- | --- |
| Remove `content/for-pages/de/healthcare.mdx` | Locale parity reports the exact missing file |
| Remove `public/images/dark/de/healthcare.png` | Hero coverage reports the exact missing asset |
| Add an orphan PNG | Hero coverage reports the asset with no landing page |
| Change a repaired href back to `/features/self-hosting` | AST link gate reports the exact file, line, and target |
| Synthesize a malformed/wrong-size PNG header | Header validator rejects it |
| Synthesize feature slug `all` | Reachability gate rejects collision with static `/features/all` |

### Content repairs

All repairs are href-only; no page was added or removed and all surrounding PR #51 / CUS-164 copy is preserved.

| Old target | New target | Instances |
| --- | --- | ---: |
| `/features/self-hosting` | `/features/self-hosted` | 2 |
| `/blog/crm-introduction` | `/blog/what-is-crm` | 5 |
| `/blog/crm-implementation-guide` | `/blog/crm-implementation` | 2 |
| `/compare/salesforce-pricing` | `/blog/salesforce-pricing` | 2 |

The Salesforce destination is intentionally the live pricing article because the unchanged sentence promises a full per-edition pricing breakdown. The generic Salesforce-alternative page is not semantically equivalent.

### New convention coverage

- Hero gate: 168 unique slugs × `{light,dark}` × `{en,de}` = 672 assets, both directions, PNG signature/IHDR, 1920×1080, and flat-namespace collision protection.
- Link gate: Markdown links, reference links, direct single/double-quoted JSX hrefs, and static string-literal JSX expressions, including multiline JSX. Query, fragment, trailing slash, and known locale prefixes are normalized.
- Reachability gate: renders the real pagination component, extracts its actual hrefs, builds BFS over card slices, verifies the current content graph and a synthetic 2,256-detail / 94-list-page case, and checks all four production routes remain wired to the shared helper.
- Proxy gate: keeps its lightweight page-count registry locked to the content-derived counts so content growth cannot make pre-render validation stale.

## Impact and rollback

### Impact

- No schema migration, environment-variable change, database write, external publication, or page-file creation/deletion.
- Four hubs intentionally read `searchParams`, making their pagination request-aware. They were already dynamic under the localized application shell; this is an explicit URL/metadata contract, not accidental client state.
- Current 24-link footer output is unchanged. Preferred entries are editorial preferences, not a ranking engine; if one disappears, selection deterministically tops up from live content and the convention test guarantees six valid, locale-aligned links.
- Existing five app locales and two content locales remain intact. `/fr`, `/it`, and `/es` content requests continue through `contentLocaleOrDefault` rather than trying to load nonexistent content trees.
- The public three-item navbar remains deliberately curated.
- Removing crawl delay can increase Bing’s request rate. That is accepted because the public surface is CDN-fronted static marketing content. Google ignores the directive; at the new 420-URL sitemap, the old 10-second delay would impose 4,200 seconds / 70 minutes per honoring crawler pass, and roughly 12.8 hours at backlog scale.
- CUS-202-owned `footer-content.tsx` and `tests/conventions/locale-consumer-audit.test.ts` are untouched.

### Rollback

The change can be reverted as one commit (`932e1372`) with no data reconciliation. A partial rollback must keep coupled contracts together:

- Revert hub components, metadata, sitemap entries, proxy validation, and reachability tests together.
- Revert the AST link test only together with any link repair that would otherwise become invalid.
- Revert footer selection and its selection assertions together.
- Reverting `app/robots.ts` alone restores the former crawl delay.

### Follow-up

CUS-196’s Knowledge Base companion must be refreshed after this product PR merges so its source pin can cite the actual merged product commit. Current KB `main` moved during this rework and now needs the union of the shipping gates plus the 420-URL sitemap arithmetic. That post-merge documentation update is required before CUS-196 closes, but it is not a blocker to reviewing this product PR.

Independent read-only product review found no unresolved high- or medium-severity code findings after the runtime-status, href-only content, and static-route-collision fixes.
