### PR TITLE
refactor(i18n): collapse locale-plumbing duplication and delete dead branches

### DIFF
--- a/__tests__/proxy-locales.test.ts
+++ b/__tests__/proxy-locales.test.ts
@@ -94,6 +94,8 @@ vi.mock("@/i18n/locale-registry", () => {
       const remainder = pathname.slice(segment.length + 1);
       return remainder === "" ? "/" : remainder;
     },
+    buildLocalePath: (locale: string, routePath: string) =>
+      routePath === "/" ? `/${locale}` : `/${locale}${routePath}`,
   };
 });
 

--- a/app/[locale]/(protected)/profile/components/profile-settings-form.tsx
+++ b/app/[locale]/(protected)/profile/components/profile-settings-form.tsx
@@ -18,7 +18,7 @@ import { FormActions } from "@/components/card/form-actions";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
 import { usePathname } from "@/i18n/navigation";
-import { APP_LOCALES, FORMATTING_LOCALES } from "@/i18n/locale-registry";
+import { DISPLAY_LANGUAGE_VALUES, FORMATTING_LOCALE_VALUES } from "@/i18n/user-locale";
 import {
   appLocaleCookie,
   browserAppLocale,
@@ -99,12 +99,12 @@ export const ProfileSettingsForm = observer(({ userDetails, emailVerified }: Pro
     label: key === Theme.system ? systemThemeLabel : t(`Common.themes.${key}`),
   }));
 
-  const displayLanguageItems = [...APP_LOCALES, Locale.system].map((key) => ({
+  const displayLanguageItems = DISPLAY_LANGUAGE_VALUES.map((key) => ({
     value: key,
     label: key === Locale.system ? systemDisplayLanguageLabel : t(`Common.locales.${key}`),
   }));
 
-  const formattingLocaleItems = [...FORMATTING_LOCALES, Locale.system].map((key) => ({
+  const formattingLocaleItems = FORMATTING_LOCALE_VALUES.map((key) => ({
     value: key,
     label: key === Locale.system ? systemFormattingLocaleLabel : t(`Common.locales.${key}`),
   }));

--- a/app/[locale]/(static)/docs/docs.utils.ts
+++ b/app/[locale]/(static)/docs/docs.utils.ts
@@ -1,5 +1,3 @@
-import { stripLocalePrefix } from "@/i18n/locale-registry";
-
 type DocWithOpenApi = {
   data: {
     _openapi?: unknown;
@@ -38,8 +36,4 @@ export function getDocMethodColor(method: string | undefined) {
     default:
       return "secondary";
   }
-}
-
-export function toLocaleRelativeHref(url: string) {
-  return stripLocalePrefix(url);
 }

--- a/app/[locale]/(static)/docs/openapi/[slug]/page.tsx
+++ b/app/[locale]/(static)/docs/openapi/[slug]/page.tsx
@@ -2,13 +2,13 @@ import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { cn } from "@/core/utils/cn";
 
-import { getDocMethod, getDocMethodColor, toLocaleRelativeHref } from "../../docs.utils";
+import { getDocMethod, getDocMethodColor } from "../../docs.utils";
 import { apiDocsSource } from "@/core/fumadocs/source";
 import { getMDXComponents } from "@/core/fumadocs/mdx-components";
 import { PageContainer } from "@/components/shared/page-container";
 import { AppLink } from "@/components/shared/app-link";
 import { AppChip } from "@/components/chip/app-chip";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { contentLocaleOrDefault, formattingTagFor, stripLocalePrefix } from "@/i18n/locale-registry";
 
 export default async function OpenApiDocPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
@@ -50,7 +50,7 @@ export default async function OpenApiDocPage({ params }: { params: Promise<{ slu
                       ? "bg-primary/10 text-primary font-medium"
                       : "text-subdued hover:text-foreground hover:bg-muted",
                   )}
-                  href={toLocaleRelativeHref(doc.url)}
+                  href={stripLocalePrefix(doc.url)}
                 >
                   <span className="flex items-center justify-between gap-2 min-w-0">
                     <span className="truncate text-sm">{doc.data.title}</span>

--- a/app/[locale]/(static)/docs/openapi/page.tsx
+++ b/app/[locale]/(static)/docs/openapi/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { DocsPageHeader } from "../components/docs-page-header";
-import { getDocMethod, getDocMethodColor, toLocaleRelativeHref } from "../docs.utils";
+import { getDocMethod, getDocMethodColor } from "../docs.utils";
 import { env } from "@/env";
 import { apiDocsSource, apiOverviewSource } from "@/core/fumadocs/source";
 import { PageContainer } from "@/components/shared/page-container";
@@ -11,7 +11,7 @@ import { AppLink } from "@/components/shared/app-link";
 import { AppCard } from "@/components/card/app-card";
 import { AppCardBody } from "@/components/card/app-card-body";
 import { AppChip } from "@/components/chip/app-chip";
-import { DEFAULT_LOCALE } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, stripLocalePrefix } from "@/i18n/locale-registry";
 
 const GROUPS_ORDER = ["contact", "organization", "deal", "service", "task", "user"] as const;
 
@@ -53,7 +53,7 @@ export default async function OpenApiOverviewPage() {
       description: doc.data.description ?? "",
       method,
       title: doc.data.title ?? "",
-      url: toLocaleRelativeHref(doc.url),
+      url: stripLocalePrefix(doc.url),
     });
     return acc;
   }, {});

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,4 @@
 import type { MetadataRoute } from "next";
-import type { ContentLocale } from "@/i18n/locale-registry";
 import type { LocalizedRoute } from "@/core/seo/sitemap";
 
 import { env } from "@/env";
@@ -14,13 +13,12 @@ function getLastModified(lastModified: Date | number | undefined) {
   return isNaN(date.getTime()) ? undefined : date;
 }
 
-export function collectLocalizedRoutes(locales: readonly ContentLocale[] = CONTENT_LOCALES): LocalizedRoute[] {
+function collectLocalizedRoutes(): LocalizedRoute[] {
   const localizedRoutes: LocalizedRoute[] = [];
 
-  for (const locale of locales) {
+  for (const locale of CONTENT_LOCALES) {
     for (const route of PUBLIC_ROUTES_SEO) {
       const routeMapping = ROUTE_SOURCE_MAP[route];
-      if (!routeMapping) continue;
 
       if (route.includes(":")) {
         for (const page of routeMapping.source.getPages(locale)) {

--- a/components/shared/app-link.tsx
+++ b/components/shared/app-link.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "next-intl";
 
 import { IntlLink, usePathname } from "@/i18n/navigation";
 import {
+  buildLocalePath,
   contentLocaleOrDefault,
   isContentLocale,
   routingLocaleFromPathname,
@@ -33,9 +34,8 @@ export function localizedContentHref(href: string, locale: unknown): string | nu
   const targetLocale = routingLocaleFromPathname(target.pathname);
   const contentLocale = isContentLocale(targetLocale) ? targetLocale : contentLocaleOrDefault(locale);
   const pathname = stripLocalePrefix(target.pathname);
-  const localizedPathname = pathname === "/" ? `/${contentLocale}` : `/${contentLocale}${pathname}`;
 
-  return `${localizedPathname}${target.search}${target.hash}`;
+  return `${buildLocalePath(contentLocale, pathname)}${target.search}${target.hash}`;
 }
 
 export function contentHrefForLocale(href: string, locale: unknown): string | null {

--- a/core/fumadocs/__tests__/metadata.test.ts
+++ b/core/fumadocs/__tests__/metadata.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../route-source-map", () => {
+  const pages = new Map([
+    ["pricing|en", { data: { description: "Plans and pricing", title: "Pricing" } }],
+    ["pricing|de", { data: { description: "Pläne und Preise", title: "Preise" } }],
+    ["best-crm|en", { data: { description: "", title: "Best CRM" } }],
+    ["untitled|en", { data: { description: "Body without a title", title: "   " } }],
+  ]);
+  const source = {
+    getPage: (path: string[], locale: string) => pages.get(`${path.join("/")}|${locale}`),
+    getPages: () => [],
+  };
+
+  return {
+    ROUTE_SOURCE_MAP: {
+      "/blog/:slug": { path: [":slug"], source },
+      "/pricing": { path: ["pricing"], source },
+    },
+  };
+});
+
+import { generateMetadataFromMeta } from "../metadata";
+
+const BASE_URL = "http://localhost:4000";
+
+describe("generateMetadataFromMeta", () => {
+  it("emits the canonical, reciprocal alternates, and social cards for a translated static route", () => {
+    const image = {
+      alt: "Pricing",
+      height: 630,
+      url: "/og/image.png?title=Pricing&description=Plans+and+pricing",
+      width: 1200,
+    };
+
+    expect(generateMetadataFromMeta({ locale: "en", route: "/pricing" })).toEqual({
+      alternates: {
+        canonical: `${BASE_URL}/en/pricing`,
+        languages: {
+          de: `${BASE_URL}/de/pricing`,
+          en: `${BASE_URL}/en/pricing`,
+          "x-default": `${BASE_URL}/en/pricing`,
+        },
+      },
+      description: "Plans and pricing",
+      openGraph: {
+        description: "Plans and pricing",
+        images: [image],
+        title: "Pricing",
+        type: "website",
+      },
+      title: "Pricing",
+      twitter: {
+        card: "summary_large_image",
+        description: "Plans and pricing",
+        images: [image],
+        title: "Pricing",
+      },
+    });
+  });
+
+  it("keeps the canonical on the requested locale", () => {
+    const metadata = generateMetadataFromMeta({ locale: "de", route: "/pricing" });
+
+    expect(metadata.alternates?.canonical).toBe(`${BASE_URL}/de/pricing`);
+  });
+
+  it("substitutes params into dynamic routes and drops non-reciprocal alternates", () => {
+    const metadata = generateMetadataFromMeta({ locale: "en", params: { slug: "best-crm" }, route: "/blog/:slug" });
+
+    expect(metadata.alternates).toEqual({ canonical: `${BASE_URL}/en/blog/best-crm` });
+    expect(metadata.title).toBe("Best CRM");
+    expect(metadata.description).toBeUndefined();
+  });
+
+  it("returns empty metadata when the localized page is missing", () => {
+    expect(generateMetadataFromMeta({ locale: "de", params: { slug: "best-crm" }, route: "/blog/:slug" })).toEqual({});
+    expect(generateMetadataFromMeta({ locale: "en", params: { slug: "nope" }, route: "/blog/:slug" })).toEqual({});
+  });
+
+  it("returns empty metadata for a dynamic route invoked without its params", () => {
+    expect(generateMetadataFromMeta({ locale: "en", route: "/blog/:slug" })).toEqual({});
+  });
+
+  it("returns empty metadata when the page title is blank", () => {
+    expect(generateMetadataFromMeta({ locale: "en", params: { slug: "untitled" }, route: "/blog/:slug" })).toEqual({});
+  });
+});

--- a/core/fumadocs/metadata.ts
+++ b/core/fumadocs/metadata.ts
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
-import type { ROUTE_SOURCE_MAP } from "./route-source-map";
 
-import { getSourceFromRoute } from "./route-source-map";
+import { ROUTE_SOURCE_MAP } from "./route-source-map";
 
 import { env } from "@/env";
-import { buildAlternateLanguages, buildLocalePath } from "@/core/seo/alternates";
-import { CONTENT_LOCALES } from "@/i18n/locale-registry";
+import { buildAlternateLanguages } from "@/core/seo/alternates";
+import { CONTENT_LOCALES, buildLocalePath } from "@/i18n/locale-registry";
 
 type GenerateMetadataParams = {
   locale: string;
@@ -19,11 +18,8 @@ export function generateMetadataFromMeta({
   params = {},
   type = "website",
 }: GenerateMetadataParams): Metadata {
-  const routeMapping = getSourceFromRoute(route, params);
-
-  if (!routeMapping) return {};
-
-  const { source, path } = routeMapping;
+  const { source, path: mappedPath } = ROUTE_SOURCE_MAP[route];
+  const path = mappedPath.map((part) => (part.startsWith(":") ? (params[part.slice(1)] ?? part) : part));
   const page = source.getPage(path, locale);
 
   if (!page) return {};

--- a/core/fumadocs/route-source-map.ts
+++ b/core/fumadocs/route-source-map.ts
@@ -1,5 +1,4 @@
 import type { PUBLIC_ROUTES_SEO } from "@/i18n/routing";
-import type { apiOverviewSource } from "./source";
 
 import {
   affiliateSource,
@@ -23,7 +22,6 @@ import {
 
 type Loader =
   | typeof affiliateSource
-  | typeof apiOverviewSource
   | typeof authSource
   | typeof automationSource
   | typeof blogPostsSource
@@ -149,18 +147,3 @@ export const ROUTE_SOURCE_MAP: Record<
     path: [":slug"],
   },
 };
-
-export function getSourceFromRoute(
-  route: keyof typeof ROUTE_SOURCE_MAP,
-  params: Record<string, string> = {},
-): { source: Loader; path: string[] } | null {
-  const mapping = ROUTE_SOURCE_MAP[route];
-  if (!mapping) return null;
-
-  if (Object.keys(params).length > 0) {
-    const path = mapping.path.map((part) => (part.startsWith(":") ? params[part.slice(1)] : part));
-    return { source: mapping.source, path };
-  }
-
-  return mapping;
-}

--- a/core/fumadocs/route-source-map.ts
+++ b/core/fumadocs/route-source-map.ts
@@ -20,32 +20,7 @@ import {
   pricingSource,
 } from "./source";
 
-type Loader =
-  | typeof affiliateSource
-  | typeof authSource
-  | typeof automationSource
-  | typeof blogPostsSource
-  | typeof blogSource
-  | typeof comparePagesSource
-  | typeof compareSource
-  | typeof docsSource
-  | typeof featurePagesSource
-  | typeof featuresAllSource
-  | typeof featuresSource
-  | typeof forPagesSource
-  | typeof forSource
-  | typeof helpAndFeedbackSource
-  | typeof homepageSource
-  | typeof legalSource
-  | typeof pricingSource;
-
-export const ROUTE_SOURCE_MAP: Record<
-  (typeof PUBLIC_ROUTES_SEO)[number],
-  {
-    source: Loader;
-    path: string[];
-  }
-> = {
+export const ROUTE_SOURCE_MAP = {
   "/": {
     source: homepageSource,
     path: ["homepage"],
@@ -146,4 +121,4 @@ export const ROUTE_SOURCE_MAP: Record<
     source: docsSource,
     path: [":slug"],
   },
-};
+} satisfies Record<(typeof PUBLIC_ROUTES_SEO)[number], { source: unknown; path: string[] }>;

--- a/core/seo/alternates.ts
+++ b/core/seo/alternates.ts
@@ -1,10 +1,6 @@
 import type { ContentLocale } from "@/i18n/locale-registry";
 
-import { DEFAULT_LOCALE } from "@/i18n/locale-registry";
-
-export function buildLocalePath(locale: string, routePath: string): string {
-  return routePath === "/" ? `/${locale}` : `/${locale}${routePath}`;
-}
+import { DEFAULT_LOCALE, buildLocalePath } from "@/i18n/locale-registry";
 
 const RECIPROCAL_ALTERNATE_MINIMUM = 2;
 

--- a/core/seo/homepage-metadata.ts
+++ b/core/seo/homepage-metadata.ts
@@ -3,7 +3,8 @@ import type { HomepageRootMetadata } from "@/core/fumadocs/schemas/homepage";
 import type { ContentLocale } from "@/i18n/locale-registry";
 
 import { env } from "@/env";
-import { buildAlternateLanguages, buildLocalePath } from "@/core/seo/alternates";
+import { buildAlternateLanguages } from "@/core/seo/alternates";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export const GLOBAL_METADATA: Metadata = {
   metadataBase: new URL(env.BASE_URL),

--- a/core/seo/sitemap.ts
+++ b/core/seo/sitemap.ts
@@ -1,7 +1,9 @@
 import type { MetadataRoute } from "next";
 import type { ContentLocale } from "@/i18n/locale-registry";
 
-import { buildAlternateLanguages, buildLocalePath } from "./alternates";
+import { buildLocalePath } from "@/i18n/locale-registry";
+
+import { buildAlternateLanguages } from "./alternates";
 
 export type LocalizedRoute = {
   locale: ContentLocale;

--- a/features/auth/next/require.ts
+++ b/features/auth/next/require.ts
@@ -4,26 +4,23 @@ import { redirect } from "next/navigation";
 import { getLocale } from "next-intl/server";
 
 import { getAuthService, getRouteGuardService } from "@/core/di";
+import { buildLocalePath } from "@/i18n/locale-registry";
 import { isRedirect } from "../auth-outcome";
 
 import type { AccessOptions } from "../route-guard.service";
 
-function localePath(locale: string, path: string): string {
-  return path === "/" ? `/${locale}` : `/${locale}${path}`;
-}
-
 export async function requireAccess(options?: AccessOptions): Promise<void> {
   const result = await getRouteGuardService().resolveAccess(options);
-  if (result) redirect(localePath(await getLocale(), result.redirect));
+  if (result) redirect(buildLocalePath(await getLocale(), result.redirect));
 }
 
 export async function requireUnauthenticated(): Promise<void> {
   const result = await getRouteGuardService().resolveUnauthenticated();
-  if (result) redirect(localePath(await getLocale(), result.redirect));
+  if (result) redirect(buildLocalePath(await getLocale(), result.redirect));
 }
 
 export async function requireSession() {
   const result = await getAuthService().resolveSession();
-  if (isRedirect(result)) redirect(localePath(await getLocale(), result.redirect));
+  if (isRedirect(result)) redirect(buildLocalePath(await getLocale(), result.redirect));
   return result.session;
 }

--- a/features/user/get/get-user-details.interactor.ts
+++ b/features/user/get/get-user-details.interactor.ts
@@ -7,14 +7,11 @@ import { ValidateOutput } from "@/core/decorators/validate-output.decorator";
 import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { getTenantUser } from "@/core/decorators/tenant-context";
 import {
-  DISPLAY_LANGUAGE_VALUES,
-  FORMATTING_LOCALE_VALUES,
+  StoredDisplayLanguageSchema,
+  StoredFormattingLocaleSchema,
   normalizeStoredDisplayLanguage,
   normalizeStoredFormattingLocale,
 } from "@/i18n/user-locale";
-
-const [firstDisplayLanguage, ...otherDisplayLanguages] = DISPLAY_LANGUAGE_VALUES;
-const [firstFormattingLocale, ...otherFormattingLocales] = FORMATTING_LOCALE_VALUES;
 
 export const UserDetailsDtoSchema = z.object({
   id: z.string(),
@@ -25,8 +22,8 @@ export const UserDetailsDtoSchema = z.object({
   country: z.enum(CountryCodeEnum),
   avatarUrl: z.string().nullable(),
   theme: z.enum(Theme),
-  displayLanguage: z.enum([firstDisplayLanguage, ...otherDisplayLanguages]),
-  formattingLocale: z.enum([firstFormattingLocale, ...otherFormattingLocales]),
+  displayLanguage: StoredDisplayLanguageSchema,
+  formattingLocale: StoredFormattingLocaleSchema,
   roleId: z.string().nullable(),
   roleName: z.string().nullable(),
   roleIsSystemRole: z.boolean(),

--- a/features/user/upsert/update-user-details.interactor.ts
+++ b/features/user/upsert/update-user-details.interactor.ts
@@ -14,14 +14,11 @@ import { DomainEvent } from "@/features/event/domain-events";
 import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { getTenantUser } from "@/core/decorators/tenant-context";
 import {
-  DISPLAY_LANGUAGE_VALUES,
-  FORMATTING_LOCALE_VALUES,
+  StoredDisplayLanguageSchema,
+  StoredFormattingLocaleSchema,
   normalizeStoredDisplayLanguage,
   normalizeStoredFormattingLocale,
 } from "@/i18n/user-locale";
-
-const [firstDisplayLanguage, ...otherDisplayLanguages] = DISPLAY_LANGUAGE_VALUES;
-const [firstFormattingLocale, ...otherFormattingLocales] = FORMATTING_LOCALE_VALUES;
 
 export const UpdateUserDetailsSchema = z.object({
   firstName: z.string().min(1).max(255).optional(),
@@ -29,8 +26,8 @@ export const UpdateUserDetailsSchema = z.object({
   country: z.enum(CountryCode).optional(),
   avatarUrl: zx.secureUrl().or(z.literal("")).nullable().optional(),
   theme: z.enum(Theme).optional(),
-  displayLanguage: z.enum([firstDisplayLanguage, ...otherDisplayLanguages]).optional(),
-  formattingLocale: z.enum([firstFormattingLocale, ...otherFormattingLocales]).optional(),
+  displayLanguage: StoredDisplayLanguageSchema.optional(),
+  formattingLocale: StoredFormattingLocaleSchema.optional(),
 });
 export type UpdateUserDetailsData = Data<typeof UpdateUserDetailsSchema>;
 
@@ -40,8 +37,8 @@ const OutputSchema = z.object({
   country: z.enum(CountryCode),
   avatarUrl: z.string().nullable(),
   theme: z.enum(Theme),
-  displayLanguage: z.enum([firstDisplayLanguage, ...otherDisplayLanguages]),
-  formattingLocale: z.enum([firstFormattingLocale, ...otherFormattingLocales]),
+  displayLanguage: StoredDisplayLanguageSchema,
+  formattingLocale: StoredFormattingLocaleSchema,
 });
 export type UserProfileData = Data<typeof OutputSchema>;
 

--- a/i18n/__tests__/global-error-copy.test.ts
+++ b/i18n/__tests__/global-error-copy.test.ts
@@ -1,11 +1,10 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
-import deMessages from "@/i18n/locales/de.json";
-import enMessages from "@/i18n/locales/en.json";
-import esMessages from "@/i18n/locales/es.json";
-import frMessages from "@/i18n/locales/fr.json";
-import itMessages from "@/i18n/locales/it.json";
 import { APP_LOCALES } from "@/i18n/locale-registry";
+import { REPO_ROOT } from "@/tests/conventions/walk";
 
 import {
   GLOBAL_ERROR_COPY,
@@ -14,19 +13,26 @@ import {
   resolveGlobalErrorLocale,
 } from "../global-error-copy";
 
-const CATALOGS = { de: deMessages, en: enMessages, es: esMessages, fr: frMessages, it: itMessages } as const;
+type ErrorCardCatalog = { ErrorCard: Record<string, string> };
+
+function errorCardCopy(locale: string): Record<string, string> {
+  const raw = readFileSync(join(REPO_ROOT, "i18n", "locales", `${locale}.json`), "utf8");
+  return (JSON.parse(raw) as ErrorCardCatalog).ErrorCard;
+}
 
 describe("global error fallback", () => {
   it("stays aligned with the catalog copy for every application locale", () => {
     expect(assertGlobalErrorCopyCoverage()).toBe(true);
 
-    for (const [locale, messages] of Object.entries(CATALOGS)) {
-      expect(GLOBAL_ERROR_COPY[locale as keyof typeof CATALOGS]).toEqual({
-        backLabel: messages.ErrorCard.ctaLabel,
-        body: messages.ErrorCard.contactSupport,
-        retryLabel: messages.ErrorCard.retry,
-        subtitle: messages.ErrorCard.subtitle,
-        title: messages.ErrorCard.title,
+    for (const locale of APP_LOCALES) {
+      const errorCard = errorCardCopy(locale);
+
+      expect(GLOBAL_ERROR_COPY[locale]).toEqual({
+        backLabel: errorCard.ctaLabel,
+        body: errorCard.contactSupport,
+        retryLabel: errorCard.retry,
+        subtitle: errorCard.subtitle,
+        title: errorCard.title,
       });
     }
   });

--- a/i18n/locale-preference.ts
+++ b/i18n/locale-preference.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_LOCALE,
   appLocaleFromLanguageTag,
   appLocaleOrDefault,
+  buildLocalePath,
   isAppLocale,
   stripLocalePrefix,
 } from "./locale-registry";
@@ -29,9 +30,7 @@ export function displayLanguageNavigationTarget(locale: unknown, pathname: strin
   const unprefixedPath = stripLocalePrefix(path);
   if (locale === "system") return `${unprefixedPath}${suffix}`;
 
-  const localizedPath =
-    unprefixedPath === "/" ? `/${appLocaleOrDefault(locale)}` : `/${appLocaleOrDefault(locale)}${unprefixedPath}`;
-  return `${localizedPath}${suffix}`;
+  return `${buildLocalePath(appLocaleOrDefault(locale), unprefixedPath)}${suffix}`;
 }
 
 export function appLocaleReconciliationTarget(

--- a/i18n/locale-registry.ts
+++ b/i18n/locale-registry.ts
@@ -163,3 +163,7 @@ export function stripLocalePrefix(pathname: string): string {
   const remainder = pathname.slice(locale.length + 1);
   return remainder === "" ? "/" : remainder;
 }
+
+export function buildLocalePath(locale: string, routePath: string): string {
+  return routePath === "/" ? `/${locale}` : `/${locale}${routePath}`;
+}

--- a/i18n/user-locale.ts
+++ b/i18n/user-locale.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { Locale } from "@/generated/prisma";
 import type { AppLocale, FormattingLocale } from "@/i18n/locale-registry";
 
@@ -15,6 +16,12 @@ export type StoredFormattingLocale = FormattingLocale | "system";
 
 export const DISPLAY_LANGUAGE_VALUES = [...APP_LOCALES, "system"] as const;
 export const FORMATTING_LOCALE_VALUES = [...FORMATTING_LOCALES, "system"] as const;
+
+const [firstDisplayLanguage, ...otherDisplayLanguages] = DISPLAY_LANGUAGE_VALUES;
+const [firstFormattingLocale, ...otherFormattingLocales] = FORMATTING_LOCALE_VALUES;
+
+export const StoredDisplayLanguageSchema = z.enum([firstDisplayLanguage, ...otherDisplayLanguages]);
+export const StoredFormattingLocaleSchema = z.enum([firstFormattingLocale, ...otherFormattingLocales]);
 
 export function resolveUserLocale(user: { displayLanguage: Locale | null }): AppLocale {
   return appLocaleOrDefault(user.displayLanguage);

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,6 +5,7 @@ import createMiddleware from "next-intl/middleware";
 
 import {
   DEFAULT_LOCALE,
+  buildLocalePath,
   isAppLocale,
   isContentLocale,
   routingLocaleFromPathname,
@@ -23,18 +24,24 @@ const intlContentMiddleware = createMiddleware(contentRouting);
 
 const LOCALE_SHAPED_SEGMENT = /^[a-z]{2}(?:-[a-z0-9]{2,8})*$/i;
 
+function preferredAppLocale(req: NextRequest) {
+  const value = req.cookies.get(APP_LOCALE_COOKIE_NAME)?.value;
+  return isAppLocale(value) ? value : null;
+}
+
+function localeRedirect(locale: string, unprefixedPath: string, base: string | URL, search: string) {
+  const target = new URL(buildLocalePath(locale, unprefixedPath), base);
+  target.search = search;
+  return NextResponse.redirect(target);
+}
+
 function negotiateLocale(req: NextRequest, base: string | URL, domain: "app" | "auto" = "auto") {
   const useContentLocale = domain === "auto" && isContentPage(req);
 
   if (!useContentLocale) {
-    const preferredLocale = req.cookies.get(APP_LOCALE_COOKIE_NAME)?.value;
-    if (isAppLocale(preferredLocale)) {
-      const target = new URL(
-        req.nextUrl.pathname === "/" ? `/${preferredLocale}` : `/${preferredLocale}${req.nextUrl.pathname}`,
-        base,
-      );
-      target.search = req.nextUrl.search;
-      const response = NextResponse.redirect(target);
+    const preferredLocale = preferredAppLocale(req);
+    if (preferredLocale) {
+      const response = localeRedirect(preferredLocale, req.nextUrl.pathname, base, req.nextUrl.search);
       response.headers.set("vary", "accept-language, cookie");
       return response;
     }
@@ -149,47 +156,32 @@ export default async function proxy(req: NextRequest) {
   const isLocaleRootPage = pathname === `/${currentLocale}`;
 
   if (isAuthenticated && isLocaleRootPage) {
-    const preferredLocale = req.cookies.get(APP_LOCALE_COOKIE_NAME)?.value;
-    const target = isAppLocale(preferredLocale)
-      ? new URL(`/${preferredLocale}/dashboard`, base)
-      : new URL("/dashboard", base);
+    const preferredLocale = preferredAppLocale(req);
+    const target = preferredLocale ? new URL(`/${preferredLocale}/dashboard`, base) : new URL("/dashboard", base);
     target.search = req.nextUrl.search;
     return NextResponse.redirect(target);
   }
 
   if (isContentPage(req)) {
-    if (!isContentLocale(currentLocale)) {
-      const unprefixed = stripLocalePrefix(pathname);
-      const target = new URL(unprefixed === "/" ? `/${DEFAULT_LOCALE}` : `/${DEFAULT_LOCALE}${unprefixed}`, base);
-      target.search = req.nextUrl.search;
-      return NextResponse.redirect(target);
-    }
+    if (!isContentLocale(currentLocale))
+      return localeRedirect(DEFAULT_LOCALE, stripLocalePrefix(pathname), base, req.nextUrl.search);
 
     return intlContentMiddleware(req);
   }
 
   if (!isAppLocale(currentLocale)) {
-    const unprefixed = stripLocalePrefix(pathname);
-    const preferredLocale = req.cookies.get(APP_LOCALE_COOKIE_NAME)?.value;
-    const appLocale = isAppLocale(preferredLocale) ? preferredLocale : DEFAULT_LOCALE;
-    const target = new URL(unprefixed === "/" ? `/${appLocale}` : `/${appLocale}${unprefixed}`, base);
-    target.search = req.nextUrl.search;
-    return NextResponse.redirect(target);
+    const appLocale = preferredAppLocale(req) ?? DEFAULT_LOCALE;
+    return localeRedirect(appLocale, stripLocalePrefix(pathname), base, req.nextUrl.search);
   }
 
   if (isPublicPage(req)) return intlAppMiddleware(req);
 
-  const preferredLocale = req.cookies.get(APP_LOCALE_COOKIE_NAME)?.value;
-  if (isAuthenticated && isAppLocale(preferredLocale) && preferredLocale !== currentLocale) {
-    const unprefixed = stripLocalePrefix(pathname);
-    const target = new URL(unprefixed === "/" ? `/${preferredLocale}` : `/${preferredLocale}${unprefixed}`, base);
-    target.search = req.nextUrl.search;
-    return NextResponse.redirect(target);
-  }
+  const preferredLocale = preferredAppLocale(req);
+  if (isAuthenticated && preferredLocale && preferredLocale !== currentLocale)
+    return localeRedirect(preferredLocale, stripLocalePrefix(pathname), base, req.nextUrl.search);
 
   if (!isAuthenticated) {
-    const redirectLocale = currentLocale ?? DEFAULT_LOCALE;
-    const signInPath = `/${redirectLocale}/auth/signin`;
+    const signInPath = `/${currentLocale}/auth/signin`;
     const signInUrl = new URL(signInPath, base);
     signInUrl.searchParams.set("callbackURL", new URL(req.nextUrl.pathname + req.nextUrl.search, base).toString());
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -153,11 +153,13 @@ export default async function proxy(req: NextRequest) {
     }
   }
 
-  const isLocaleRootPage = pathname === `/${currentLocale}`;
+  const isLocaleRootPage = pathname === buildLocalePath(currentLocale, "/");
 
   if (isAuthenticated && isLocaleRootPage) {
     const preferredLocale = preferredAppLocale(req);
-    const target = preferredLocale ? new URL(`/${preferredLocale}/dashboard`, base) : new URL("/dashboard", base);
+    const target = preferredLocale
+      ? new URL(buildLocalePath(preferredLocale, "/dashboard"), base)
+      : new URL("/dashboard", base);
     target.search = req.nextUrl.search;
     return NextResponse.redirect(target);
   }
@@ -181,7 +183,7 @@ export default async function proxy(req: NextRequest) {
     return localeRedirect(preferredLocale, stripLocalePrefix(pathname), base, req.nextUrl.search);
 
   if (!isAuthenticated) {
-    const signInPath = `/${currentLocale}/auth/signin`;
+    const signInPath = buildLocalePath(currentLocale, "/auth/signin");
     const signInUrl = new URL(signInPath, base);
     signInUrl.searchParams.set("callbackURL", new URL(req.nextUrl.pathname + req.nextUrl.search, base).toString());
 

--- a/scripts/audit-i18n.ts
+++ b/scripts/audit-i18n.ts
@@ -1,8 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { icuArgumentNames, richTextTagNames } from "./lib/icu";
-
 import { APP_LOCALES, DEFAULT_LOCALE } from "@/i18n/locale-registry";
 
 type Leaves = Map<string, string>;
@@ -13,8 +11,6 @@ const STRICT = process.argv.includes("--strict");
 const SHARED_VALUE_PREFIXES = [
   "Common.providers.",
   "Common.filters.operators.",
-  "Common.seedData.contact.",
-  "Common.seedData.organization.",
   "DocsSidebar.mcp",
   "DocsSidebar.n8n",
   "DocsSidebar.openapi",
@@ -86,7 +82,6 @@ function loadLeavesCached(locale: string): Leaves {
 const reference = loadLeaves(DEFAULT_LOCALE);
 const others = APP_LOCALES.filter((locale) => locale !== DEFAULT_LOCALE);
 
-const blocking: string[] = [];
 const advisory: string[] = [];
 
 console.log(`reference locale: ${DEFAULT_LOCALE} (${reference.size} keys)\n`);
@@ -94,27 +89,6 @@ console.log(`reference locale: ${DEFAULT_LOCALE} (${reference.size} keys)\n`);
 for (const locale of others) {
   const leaves = loadLeaves(locale);
   const report: string[] = [];
-
-  const missing = [...reference.keys()].filter((key) => !leaves.has(key));
-  const extra = [...leaves.keys()].filter((key) => !reference.has(key));
-  if (leaves.size !== reference.size || missing.length || extra.length) {
-    blocking.push(
-      `${locale}: ${leaves.size} keys against ${reference.size}; ${missing.length} missing, ${extra.length} unknown` +
-        (missing.length ? `\n    missing: ${missing.slice(0, 10).join(", ")}` : "") +
-        (extra.length ? `\n    unknown: ${extra.slice(0, 10).join(", ")}` : ""),
-    );
-  }
-
-  const icu: string[] = [];
-  const tags: string[] = [];
-  for (const [key, source] of reference) {
-    const value = leaves.get(key);
-    if (value === undefined) continue;
-    if (icuArgumentNames(source) !== icuArgumentNames(value)) icu.push(key);
-    if (richTextTagNames(source) !== richTextTagNames(value)) tags.push(key);
-  }
-  if (icu.length) blocking.push(`${locale}: ICU arguments differ on ${icu.length} key(s): ${icu.join(", ")}`);
-  if (tags.length) blocking.push(`${locale}: rich-text tags differ on ${tags.length} key(s): ${tags.join(", ")}`);
 
   const bySource = new Map<string, Map<string, string[]>>();
   for (const [key, source] of reference) {
@@ -209,14 +183,9 @@ for (const locale of others) {
   console.log("");
 }
 
-if (blocking.length) {
-  console.error(`BLOCKING:\n  ${blocking.join("\n  ")}`);
-  process.exit(1);
-}
-
 if (advisory.length && STRICT) {
   console.error(`advisory findings present and --strict was passed`);
   process.exit(1);
 }
 
-console.log(blocking.length === 0 && advisory.length === 0 ? "catalogs are consistent" : "no blocking findings");
+console.log(advisory.length === 0 ? "catalogs are consistent" : "advisory findings only; parity is enforced by yarn test");

--- a/tests/conventions/locale-consumer-audit.test.ts
+++ b/tests/conventions/locale-consumer-audit.test.ts
@@ -35,10 +35,12 @@ const DOMAIN_EXPECTATIONS: Array<{ file: string; imports: string }> = [
   { file: "core/fumadocs/metadata.ts", imports: "CONTENT_LOCALES" },
   { file: "components/shared/language-selector.tsx", imports: "CONTENT_LOCALES" },
   { file: "scripts/generate-raw-docs-manifest.ts", imports: "CONTENT_LOCALES" },
-  { file: "app/[locale]/(protected)/profile/components/profile-settings-form.tsx", imports: "APP_LOCALES" },
-  { file: "app/[locale]/(protected)/profile/components/profile-settings-form.tsx", imports: "FORMATTING_LOCALES" },
-  { file: "features/user/upsert/update-user-details.interactor.ts", imports: "DISPLAY_LANGUAGE_VALUES" },
-  { file: "features/user/upsert/update-user-details.interactor.ts", imports: "FORMATTING_LOCALE_VALUES" },
+  { file: "app/[locale]/(protected)/profile/components/profile-settings-form.tsx", imports: "DISPLAY_LANGUAGE_VALUES" },
+  { file: "app/[locale]/(protected)/profile/components/profile-settings-form.tsx", imports: "FORMATTING_LOCALE_VALUES" },
+  { file: "features/user/upsert/update-user-details.interactor.ts", imports: "StoredDisplayLanguageSchema" },
+  { file: "features/user/upsert/update-user-details.interactor.ts", imports: "StoredFormattingLocaleSchema" },
+  { file: "features/user/get/get-user-details.interactor.ts", imports: "StoredDisplayLanguageSchema" },
+  { file: "features/user/get/get-user-details.interactor.ts", imports: "StoredFormattingLocaleSchema" },
   { file: "core/stores/intl.store.ts", imports: "isFormattingLocale" },
 ];
 

--- a/tests/conventions/locale-registry.test.ts
+++ b/tests/conventions/locale-registry.test.ts
@@ -13,11 +13,13 @@ import {
   LOCALE_REGISTRY,
   ROUTING_LOCALES,
   appLocaleFromLanguageTag,
+  buildLocalePath,
   isAppLocale,
   isContentLocale,
   isFormattingLocale,
   isRoutingLocale,
   routingLocaleFromUrlSegment,
+  stripLocalePrefix,
   validationTagFor,
 } from "@/i18n/locale-registry";
 
@@ -109,6 +111,17 @@ describe("locale registry", () => {
 
     expect(routingLocaleFromUrlSegment("en-US")).toBeNull();
     expect(routingLocaleFromUrlSegment("EN")).toBe("en");
+  });
+
+  it.skipIf(!ENFORCED)("round-trips locale-prefixed paths through buildLocalePath and stripLocalePrefix", () => {
+    const paths = ["/", "/pricing", "/blog/best-crm-software", "/docs/openapi/create-contact", "/auth/signin"];
+
+    for (const locale of ROUTING_LOCALES) {
+      for (const path of paths) {
+        expect(stripLocalePrefix(buildLocalePath(locale, path)), `${locale} ${path}`).toBe(path);
+      }
+      expect(buildLocalePath(locale, "/")).toBe(`/${locale}`);
+    }
   });
 
   it.skipIf(!ENFORCED)("keeps route segments distinguishable from locale prefixes", () => {


### PR DESCRIPTION
## Summary

Implements [CUS-203](https://linear.app/customermates/issue/CUS-203/collapse-residual-locale-plumbing-duplication-and-dead-branches-left): the cohesive subset of a post-merge simplification audit of merged PR #36 (CUS-49). Every piece of locale-URL and locale-value domain knowledge the merge left stated more than once is now stated exactly once, and provably dead branches are deleted. Zero observable behavior change: **−68 net lines** across the touched files, plus one new 88-line contract test for a boundary nothing pinned before.

- `buildLocalePath` moves into `i18n/locale-registry.ts` beside its inverse `stripLocalePrefix`; the private `localePath` duplicate in `features/auth/next/require.ts` and six inline ternaries (`proxy.ts` ×4, `app-link.tsx`, `locale-preference.ts`) are replaced with calls. Eight statements of one URL rule collapse to one.
- `proxy.ts` validates the `APP_LOCALE` cookie in one `preferredAppLocale` helper (four sites collapsed), builds search-preserving redirects in one `localeRedirect` helper (three homogeneous branches), and drops the unreachable `?? DEFAULT_LOCALE` fallback (`currentLocale` is proven non-null and an app locale before that line).
- The stored display/formatting-locale value space is built once: `StoredDisplayLanguageSchema`/`StoredFormattingLocaleSchema` in `i18n/user-locale.ts` replace four identical tuple-destructure `z.enum` constructions across both user interactors, and the profile form derives its option lists from `DISPLAY_LANGUAGE_VALUES`/`FORMATTING_LOCALE_VALUES` (same members, same order) instead of hand-building them.
- `getSourceFromRoute` (single consumer) is inlined into `core/fumadocs/metadata.ts` with a single `:param` substitution pass (`params[key] ?? part` preserves the missing-params miss); the three unreachable route-map guards go away (the map is a total `Record` over `PUBLIC_ROUTES_SEO`); the stale `apiOverviewSource` member leaves the `Loader` union.
- `toLocaleRelativeHref` (a pass-through alias of `stripLocalePrefix`) is deleted; the two openapi pages call the registry helper the sibling docs-sidebar already uses.
- `collectLocalizedRoutes` is un-exported and loses its never-passed `locales` parameter.
- `scripts/audit-i18n.ts` drops its BLOCKING section (missing/extra keys, ICU arguments, rich-text tags), which duplicated `tests/conventions/i18n-parity.test.ts` using the same `scripts/lib/icu.ts` helpers, plus two dead `Common.seedData.*` allowlist prefixes matching zero catalog keys. The script stays the advisory heuristics tool with `--strict`.

Second commit, from a follow-up sweep of the branch itself:

- `proxy.ts` routes its last three hand-written locale prefixes (the locale-root comparison, the authenticated `/dashboard` target, and the sign-in path) through `buildLocalePath`. A grep for a hand-written `/${locale}` construction in `proxy.ts` now returns nothing. This is a file-scoped invariant: other hand-written prefixes remain elsewhere in the tree and no convention test enforces the helper yet.
- `core/fumadocs/route-source-map.ts` derives its loader union from the map via `satisfies` instead of a hand-listed 17-member `type Loader`, which the first commit had already had to correct once by deleting a stale `apiOverviewSource` member. Totality over `PUBLIC_ROUTES_SEO` is still compile-enforced, and consumers get more precise per-route types than the old union.
- `i18n/__tests__/global-error-copy.test.ts` drives its fixtures from `APP_LOCALES` plus a `REPO_ROOT` disk read (the pattern `core/seo/__tests__/schemas.test.ts` already uses) instead of five hard-coded catalog imports, so a sixth application locale is covered without editing the test.

## Context

Production PR #36 (squash `2aedc86b`, deployed as `dpl_PPnVWiF6sMExFHDng7md6ezYMeBX`) decoupled app locales from public content locales. A read-only eight-domain audit of the full merged diff with two adversarial verification lenses per candidate confirmed the architecture is sound and found this residue of duplicated statements and dead code. CUS-49 stays Done and PR #36 stays closed; this is a new issue, branch, and PR from current `origin/main`. Verified-file overlap against the changed-file lists of all nine open PRs (#37/#42/#48/#49/#50/#51/#53/#54) and the CUS-185/CUS-202/CUS-179/CUS-152 surfaces: none. One sequencing note, not a conflict: PR #53 also lists `tests/conventions/locale-consumer-audit.test.ts`, so whichever merges second resolves a small edit there. The synthetic registry mock in `__tests__/proxy-locales.test.ts` gains a one-line `buildLocalePath` mirror because it stubs the whole registry module; no scenario or expectation changed.

CI-ordering note: `yarn i18n:audit` no longer exits 1 on parity breaks. The CI gate for parity/ICU/tags is `yarn test` (`tests/conventions/i18n-parity.test.ts`), which runs before `yarn i18n:audit` in the same job. Negative proof below.

## Validation

- `yarn typecheck` pass; `yarn lint` pass with zero warnings; `yarn openapi:generate`/`yarn raw-docs:generate` reproduce tracked artifacts with no diff.
- Full suite against the CI-parity database (`customermates_test`, Postgres 16, migrate deploy + double seed): **198 files, 1,520 tests, all pass**, including the real-database registration suite and the two new tests (buildLocalePath/stripLocalePrefix round-trip over registry routing locales; `generateMetadataFromMeta` contract: canonical, reciprocal alternates, param substitution, missing-page/missing-title/missing-params empties). Re-run green after the second commit.
- Negative proofs that the remaining guards still bite: deleting one `ROUTE_SOURCE_MAP` entry fails typecheck at three sites (`TS1360` on the `satisfies` clause plus two consumers); corrupting one locale's `ErrorCard.title` fails the derived global-error fixture; deleting a catalog key fails `i18n-parity`; `yarn i18n:audit --strict` still exits 1.
- Negative tripwire proof: deleting one key from `de.json` fails `tests/conventions/i18n-parity.test.ts` (2 tests); catalog restored. `yarn i18n:audit` exits 0, advisory-only.
- **Byte-identity proof** against a pristine `2aedc86b` worktree, both trees served via `next dev` against one seeded local Postgres 16 container, repeated after the second commit: a 35-probe matrix comparing status line, `location`, `vary` and `set-cookie` (cookie present/absent/empty/stale `nl`/invalid `zz`, content fallback `/it/pricing`→`/en/pricing`, unsupported prefixes `/xx` and `/nl-NL`, sign-in and `mcp-consent` redirects incl. `callbackURL`, query preservation); 31 metadata heads (canonical, hreflang set, x-default, og/twitter, robots, description, JSON-LD size); the 412-URL sitemap (410 content-derived lastmod compared verbatim); and **full rendered-DOM equality on 28 pages** spanning every content collection and all five locales, with differences confined to dev-only turbopack script scaffolding. All identical after normalizing only the server port.
- **Authenticated redirect parity**, which anonymous probes cannot reach, compared across both trees with a minted seed-user session: signed-in locale roots for en/de/it/es/fr with and without a preference cookie, including the deliberate unprefixed `/dashboard` target when the cookie is absent, and query-string preservation. Identical.
- Browser verification (self-hosted mode, minted seed-user session): explicit EN→DE→IT→System→FR→ES display-language switches through the profile form, each producing the right hard navigation, `APP_LOCALE` cookie write/expiry, and fully translated UI; signed-in root `/`→`/de/dashboard` under the preference cookie; stale-cookie reconciliation (cookie `fr` vs persisted System: proxy honors cookie, sync expires it and returns to negotiated `/en/dashboard`); soft navigation keeps the locale (`/it/deals` from the Italian shell); the AppLink content boundary localizes the docs link to `/en/docs` from Italian/French/Spanish app UI (no Italian content exists); production `yarn build` pass (136 routes), re-run green after the second commit.
- React best-practices review of the four touched TSX files: PASS (option-list identity semantics unchanged; server/client boundaries valid; one pre-existing a11y note recorded on the issue, out of scope).

## Impact and rollback

No schema, migration, API, OpenAPI, environment, or persisted-data change. Runtime behavior, redirects, cookies, SEO output, and validation accept/reject sets are byte-identical (proofs above). Developer-facing change only: `yarn i18n:audit` is advisory-only; parity enforcement lives in the convention suite that CI runs first. Rollback is a single revert of this PR; the registry keeps its pre-change exports plus one addition, so a revert restores the prior tree exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
