### PR TITLE
feat(navigation): add locale and theme actions

### DIFF
--- a/app/components/footer-content.tsx
+++ b/app/components/footer-content.tsx
@@ -5,10 +5,8 @@ import { useTranslations } from "next-intl";
 import { CompetitorLinks } from "./competitor-links";
 import { FooterBadges } from "./footer-badges";
 
-import { LanguageSelector } from "@/components/shared/language-selector";
 import { AppLink } from "@/components/shared/app-link";
 import { AppImage } from "@/components/shared/app-image";
-import { ThemeSwitcher } from "@/components/shared/theme-switcher";
 
 type LinkItem = {
   slug: string;
@@ -233,62 +231,52 @@ export function FooterContent({ blogPosts = [], competitors = [], featureLinks =
 
         <FooterBadges />
 
-        <div className="pt-8">
-          <div className="flex flex-col md:flex-row items-center justify-center md:justify-between gap-3 md:gap-4">
-            <div className="text-xs text-subdued text-center md:text-left">
-              <span>{t("Footer.copyrightText", { year: new Date().getFullYear() })}</span>
+        <div className="pt-8 text-center text-xs text-subdued">
+          <span>{t("Footer.copyrightText", { year: new Date().getFullYear() })}</span>
 
-              {" · "}
+          {" · "}
 
-              <a
-                className="hover:text-foreground transition-colors"
-                href="https://viesearch.com/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Viesearch - The Human-curated Search Engine
-              </a>
+          <a
+            className="transition-colors hover:text-foreground"
+            href="https://viesearch.com/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Viesearch - The Human-curated Search Engine
+          </a>
 
-              {" · "}
+          {" · "}
 
-              <a
-                className="hover:text-foreground transition-colors"
-                href="https://www.promotebusinessdirectory.com/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                https://www.promotebusinessdirectory.com/
-              </a>
+          <a
+            className="transition-colors hover:text-foreground"
+            href="https://www.promotebusinessdirectory.com/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://www.promotebusinessdirectory.com/
+          </a>
 
-              {" · "}
+          {" · "}
 
-              <a
-                className="hover:text-foreground transition-colors"
-                href="http://www.usawebsitesdirectory.com/computers_and_internet/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                http://www.usawebsitesdirectory.com/computers_and_internet/
-              </a>
+          <a
+            className="transition-colors hover:text-foreground"
+            href="http://www.usawebsitesdirectory.com/computers_and_internet/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            http://www.usawebsitesdirectory.com/computers_and_internet/
+          </a>
 
-              {" · "}
+          {" · "}
 
-              <a
-                className="hover:text-foreground transition-colors"
-                href="https://www.bestsitesindex.com/submit.php"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                https://www.bestsitesindex.com/submit.php
-              </a>
-            </div>
-
-            <div className="flex flex-wrap items-center justify-center md:justify-end gap-3 md:gap-4">
-              <LanguageSelector className="w-32" />
-
-              <ThemeSwitcher />
-            </div>
-          </div>
+          <a
+            className="transition-colors hover:text-foreground"
+            href="https://www.bestsitesindex.com/submit.php"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://www.bestsitesindex.com/submit.php
+          </a>
         </div>
       </div>
     </footer>

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Github, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
 
@@ -10,7 +10,9 @@ import { AppLink } from "@/components/shared/app-link";
 import { AppImage } from "@/components/shared/app-image";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/shared/icon";
+import { LanguageSelector } from "@/components/shared/language-selector";
 import { Sheet, SheetBody, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { ThemeSwitcher } from "@/components/shared/theme-switcher";
 import { cn } from "@/core/utils/cn";
 
 type Props = {
@@ -40,20 +42,22 @@ export const PublicNavbar = observer(({ isAuthenticated, onboardingComplete }: P
 
   const logoAlt = t("Common.imageAlt.logo");
   const homeLabel = t("UserAvatar.home");
-  const homeButton = (
-    <AppLink aria-label={`${logoAlt} ${homeLabel}`} href="/" onClick={closeMenu}>
-      <AppImage
-        alt={logoAlt}
-        className="object-contain select-none"
-        height={24}
-        loading="eager"
-        src="customermates.svg"
-        width={156}
-      />
+  function renderHomeButton() {
+    return (
+      <AppLink aria-label={`${logoAlt} ${homeLabel}`} href="/" onClick={closeMenu}>
+        <AppImage
+          alt={logoAlt}
+          className="object-contain select-none"
+          height={24}
+          loading="eager"
+          src="customermates.svg"
+          width={156}
+        />
 
-      <span className="sr-only">{`${logoAlt} ${homeLabel}`}</span>
-    </AppLink>
-  );
+        <span className="sr-only">{`${logoAlt} ${homeLabel}`}</span>
+      </AppLink>
+    );
+  }
 
   const ctaTarget = !isAuthenticated ? "/auth/signin" : onboardingComplete ? "/dashboard" : "/onboarding/wizard";
   const ctaLabel = !isAuthenticated
@@ -76,24 +80,22 @@ export const PublicNavbar = observer(({ isAuthenticated, onboardingComplete }: P
     </Button>
   );
 
-  const githubButton = (
-    <AppLink
-      external
-      aria-label="GitHub"
-      className="inline-flex size-8 items-center justify-center rounded-md text-subdued transition-colors hover:bg-muted hover:text-foreground"
-      href="https://github.com/customermates/customermates"
-      onClick={closeMenu}
-    >
-      <Github aria-hidden className="size-4" />
-    </AppLink>
-  );
+  function renderPreferenceButtons() {
+    return (
+      <div className="flex items-center gap-1">
+        <LanguageSelector />
+
+        <ThemeSwitcher />
+      </div>
+    );
+  }
 
   return (
     <div className="sticky top-0 z-40 bg-background/80 backdrop-blur">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
-        <div className="hidden md:flex items-center gap-3">{homeButton}</div>
+        <div className="hidden items-center gap-3 md:flex">{renderHomeButton()}</div>
 
-        <nav className="hidden md:flex items-center gap-3">
+        <nav className="hidden items-center gap-3 md:flex">
           {publicNavItems.map((item) => (
             <AppLink key={item.href} className={cn(!isNavItemActive(item.href) && "text-subdued")} href={item.href}>
               {item.title}
@@ -101,16 +103,16 @@ export const PublicNavbar = observer(({ isAuthenticated, onboardingComplete }: P
           ))}
         </nav>
 
-        <div className="hidden md:flex items-center gap-2">
-          {githubButton}
+        <div className="hidden items-center gap-2 md:flex">
+          {renderPreferenceButtons()}
 
           {contactButton}
 
           {ctaButton}
         </div>
 
-        <div className="md:hidden flex items-center w-full justify-between">
-          {homeButton}
+        <div className="flex w-full items-center justify-between md:hidden">
+          {renderHomeButton()}
 
           <Sheet open={layoutStore.isMenuOpen} onOpenChange={layoutStore.setIsMenuOpen}>
             <SheetTrigger asChild>
@@ -136,7 +138,7 @@ export const PublicNavbar = observer(({ isAuthenticated, onboardingComplete }: P
                   </AppLink>
                 ))}
 
-                {githubButton}
+                <div className="my-1 border-y py-3">{renderPreferenceButtons()}</div>
 
                 {contactButton}
 

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -138,7 +138,7 @@ export const PublicNavbar = observer(({ isAuthenticated, onboardingComplete }: P
                   </AppLink>
                 ))}
 
-                <div className="my-1 border-y py-3">{renderPreferenceButtons()}</div>
+                <div className="my-1 py-3">{renderPreferenceButtons()}</div>
 
                 {contactButton}
 

--- a/components/forms/form-autocomplete-country-item.tsx
+++ b/components/forms/form-autocomplete-country-item.tsx
@@ -18,6 +18,7 @@ export function FormAutocompleteCountryItem({ countryKey, label, size = "md" }: 
       <Avatar className={size === "sm" ? "size-3" : "size-5"}>
         <AvatarImage
           alt={t("Common.imageAlt.countryFlag", { country: label })}
+          className="rounded-[inherit] object-cover"
           src={`https://flagcdn.com/${countryKey.toLowerCase()}.svg`}
         />
       </Avatar>

--- a/components/shared/language-selector.tsx
+++ b/components/shared/language-selector.tsx
@@ -4,7 +4,7 @@ import { Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useLocale, useTranslations } from "next-intl";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { FormAutocompleteCountryItem } from "@/components/forms/form-autocomplete-country-item";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -61,16 +61,7 @@ export const LanguageSelector = observer(({ className }: Props) => {
               role="menuitemradio"
               onSelect={() => handleSelect(locale)}
             >
-              <Avatar className="size-5">
-                <AvatarImage
-                  alt={t("Common.imageAlt.countryFlag", { country: label })}
-                  src={`https://flagcdn.com/${flagCodeFor(locale).toLowerCase()}.svg`}
-                />
-
-                <AvatarFallback>{locale.toUpperCase()}</AvatarFallback>
-              </Avatar>
-
-              <span className="flex-1">{label}</span>
+              <FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />
 
               <Check aria-hidden className={cn("size-3.5", !isSelected && "opacity-0")} />
             </DropdownMenuItem>

--- a/components/shared/language-selector.tsx
+++ b/components/shared/language-selector.tsx
@@ -1,23 +1,20 @@
 "use client";
 
-import { useLocale, useTranslations } from "next-intl";
+import { Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { ChevronDownIcon } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
 
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import type { ContentLocale } from "@/i18n/locale-registry";
-
-import { usePathname } from "@/i18n/navigation";
-import { CONTENT_LOCALES, flagCodeFor } from "@/i18n/locale-registry";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { cn } from "@/core/utils/cn";
+import { CONTENT_LOCALES, type ContentLocale } from "@/i18n/locale-registry";
+import { usePathname } from "@/i18n/navigation";
 
 type Props = {
   className?: string;
@@ -41,46 +38,38 @@ export const LanguageSelector = observer(({ className }: Props) => {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          aria-label={t("Common.language")}
-          className={cn("min-w-32 h-8 justify-between gap-2", className)}
-          size="sm"
-          variant="outline"
+          aria-label={`${t("Common.language")}: ${currentLocaleLabel}`}
+          className={cn("size-8 rounded-md p-0 text-[11px] font-semibold tracking-wide text-subdued", className)}
+          size="icon-sm"
+          title={currentLocaleLabel}
+          variant="ghost"
         >
-          <span className="flex items-center gap-2">
-            <Avatar size="sm">
-              <AvatarImage
-                alt={t("Common.imageAlt.countryFlag", {
-                  country: currentLocaleLabel,
-                })}
-                loading="lazy"
-                src={`https://flagcdn.com/${flagCodeFor(currentLocale).toLowerCase()}.svg`}
-              />
-
-              <AvatarFallback>{currentLocale.toUpperCase()}</AvatarFallback>
-            </Avatar>
-
-            <span className="text-sm">{currentLocaleLabel}</span>
-          </span>
-
-          <ChevronDownIcon className="size-4 text-muted-foreground" />
+          <span aria-hidden>{currentLocale.toUpperCase()}</span>
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start" className="min-w-32">
+      <DropdownMenuContent align="start" className="min-w-40">
         {CONTENT_LOCALES.map((locale) => {
           const label = t(`Common.locales.${locale}`);
+          const isSelected = locale === currentLocale;
           return (
-            <DropdownMenuItem key={locale} onSelect={() => handleSelect(locale)}>
-              <Avatar size="sm">
-                <AvatarImage
-                  alt={t("Common.imageAlt.countryFlag", { country: label })}
-                  src={`https://flagcdn.com/${flagCodeFor(locale).toLowerCase()}.svg`}
-                />
+            <DropdownMenuItem
+              key={locale}
+              aria-checked={isSelected}
+              className="gap-2.5"
+              role="menuitemradio"
+              onSelect={() => handleSelect(locale)}
+            >
+              <span
+                aria-hidden
+                className="grid size-5 place-items-center rounded bg-foreground/10 text-[9px] font-semibold tracking-wide"
+              >
+                {locale.toUpperCase()}
+              </span>
 
-                <AvatarFallback>{locale.toUpperCase()}</AvatarFallback>
-              </Avatar>
+              <span className="flex-1">{label}</span>
 
-              <span>{label}</span>
+              <Check aria-hidden className={cn("size-3.5", !isSelected && "opacity-0")} />
             </DropdownMenuItem>
           );
         })}

--- a/components/shared/language-selector.tsx
+++ b/components/shared/language-selector.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useLocale, useTranslations } from "next-intl";
 
 import { FormAutocompleteCountryItem } from "@/components/forms/form-autocomplete-country-item";
+import { FormAutocompleteItem } from "@/components/forms/form-autocomplete-item";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -57,13 +57,15 @@ export const LanguageSelector = observer(({ className }: Props) => {
             <DropdownMenuItem
               key={locale}
               aria-checked={isSelected}
-              className="gap-2.5"
+              className={cn(isSelected && "bg-accent")}
+              data-selected={isSelected}
               role="menuitemradio"
               onSelect={() => handleSelect(locale)}
             >
-              <FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />
-
-              <Check aria-hidden className={cn("size-3.5", !isSelected && "opacity-0")} />
+              {FormAutocompleteItem({
+                textValue: label,
+                children: <FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />,
+              })}
             </DropdownMenuItem>
           );
         })}

--- a/components/shared/language-selector.tsx
+++ b/components/shared/language-selector.tsx
@@ -4,6 +4,7 @@ import { Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useLocale, useTranslations } from "next-intl";
 
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -13,7 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { cn } from "@/core/utils/cn";
-import { CONTENT_LOCALES, type ContentLocale } from "@/i18n/locale-registry";
+import { CONTENT_LOCALES, flagCodeFor, type ContentLocale } from "@/i18n/locale-registry";
 import { usePathname } from "@/i18n/navigation";
 
 type Props = {
@@ -39,7 +40,7 @@ export const LanguageSelector = observer(({ className }: Props) => {
       <DropdownMenuTrigger asChild>
         <Button
           aria-label={`${t("Common.language")}: ${currentLocaleLabel}`}
-          className={cn("size-8 rounded-md p-0 text-[11px] font-semibold tracking-wide text-subdued", className)}
+          className={cn("size-8 rounded-md p-0 text-subdued", className)}
           size="icon-sm"
           title={currentLocaleLabel}
           variant="ghost"
@@ -60,12 +61,14 @@ export const LanguageSelector = observer(({ className }: Props) => {
               role="menuitemradio"
               onSelect={() => handleSelect(locale)}
             >
-              <span
-                aria-hidden
-                className="grid size-5 place-items-center rounded bg-foreground/10 text-[9px] font-semibold tracking-wide"
-              >
-                {locale.toUpperCase()}
-              </span>
+              <Avatar className="size-5">
+                <AvatarImage
+                  alt={t("Common.imageAlt.countryFlag", { country: label })}
+                  src={`https://flagcdn.com/${flagCodeFor(locale).toLowerCase()}.svg`}
+                />
+
+                <AvatarFallback>{locale.toUpperCase()}</AvatarFallback>
+              </Avatar>
 
               <span className="flex-1">{label}</span>
 

--- a/components/shared/theme-switcher.tsx
+++ b/components/shared/theme-switcher.tsx
@@ -1,35 +1,26 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useTranslations } from "next-intl";
-import { Monitor, Moon, Sun } from "lucide-react";
 
-import { Theme } from "@/generated/prisma";
+import { Icon } from "@/components/shared/icon";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/core/utils/cn";
-
-import { Icon } from "./icon";
+import { Theme } from "@/generated/prisma";
 
 type Props = {
+  className?: string;
   onThemeChange?: (theme: Theme) => Promise<void>;
-  hideSystem?: boolean;
 };
 
-const THEMES: { key: Theme; icon: typeof Monitor }[] = [
-  { key: Theme.system, icon: Monitor },
-  { key: Theme.light, icon: Sun },
-  { key: Theme.dark, icon: Moon },
-];
-
-export function ThemeSwitcher({ onThemeChange, hideSystem = false }: Props) {
+export function ThemeSwitcher({ className, onThemeChange }: Props) {
   const t = useTranslations();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);
-
-  const availableThemes = hideSystem ? THEMES.filter((t) => t.key !== Theme.system) : THEMES;
 
   const handleThemeChange = useCallback(
     async (newTheme: Theme) => {
@@ -40,34 +31,25 @@ export function ThemeSwitcher({ onThemeChange, hideSystem = false }: Props) {
     [setTheme, onThemeChange],
   );
 
-  const defaultTheme = hideSystem ? Theme.light : Theme.system;
-  const selectedKey = mounted ? ((theme as Theme | undefined) ?? defaultTheme) : Theme.system;
+  if (!mounted) return <div aria-hidden className={cn("size-8", className)} />;
 
-  if (!mounted) return <div aria-hidden className="h-[26px] w-[52px] rounded-full bg-muted animate-pulse" />;
+  const selectedTheme = resolvedTheme === Theme.dark ? Theme.dark : Theme.light;
+  const nextTheme = selectedTheme === Theme.dark ? Theme.light : Theme.dark;
+  const SelectedIcon = selectedTheme === Theme.dark ? Moon : Sun;
+  const selectedThemeLabel = selectedTheme === Theme.dark ? t("Common.themes.dark") : t("Common.themes.light");
 
   return (
-    <div
-      aria-label={t("Common.ariaLabels.themeSwitcher")}
-      className="inline-flex items-center gap-1 rounded-full bg-muted p-0.5"
-      role="radiogroup"
+    <Button
+      aria-label={`${t("Common.ariaLabels.themeSwitcher")}: ${selectedThemeLabel}`}
+      aria-pressed={selectedTheme === Theme.dark}
+      className={cn("size-8 rounded-md p-0 text-subdued hover:text-foreground", className)}
+      data-theme={selectedTheme}
+      size="icon-sm"
+      title={selectedThemeLabel}
+      variant="ghost"
+      onClick={() => void handleThemeChange(nextTheme)}
     >
-      {availableThemes.map(({ key, icon }) => {
-        const isSelected = selectedKey === key;
-        return (
-          <Button
-            key={key}
-            aria-checked={isSelected}
-            className={cn("rounded-full size-[22px] p-0", !isSelected && "bg-transparent hover:bg-background/60")}
-            role="radio"
-            size="icon-xs"
-            type="button"
-            variant={isSelected ? "default" : "ghost"}
-            onClick={() => void handleThemeChange(key)}
-          >
-            <Icon icon={icon} size="sm" />
-          </Button>
-        );
-      })}
-    </div>
+      <Icon aria-hidden icon={SelectedIcon} size="md" />
+    </Button>
   );
 }

--- a/tests/conventions/locale-consumer-audit.test.ts
+++ b/tests/conventions/locale-consumer-audit.test.ts
@@ -71,7 +71,6 @@ const ALLOWED_VISIBLE_COPY_SITES = new Map<string, VisibleCopyException>([
     'app/components/footer-content.tsx :: jsx-text :: "LinkedIn"',
     'app/components/footer-content.tsx :: jsx-text :: "X (Twitter)"',
     'app/components/footer-content.tsx :: jsx-text :: "Viesearch - The Human-curated Search Engine"',
-    'app/components/public-navbar.tsx :: jsx-aria-label :: "GitHub"',
     'components/emails/base/email-layout.tsx :: jsx-alt :: "Customermates"',
     'components/emails/base/email-layout.tsx :: jsx-text :: "Customermates ·"',
     'components/marketing/comparison-table.tsx :: jsx-alt :: "Customermates"',

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -42,6 +42,7 @@ describe("public navigation preferences", () => {
     expect(languageSelector).not.toContain("AvatarImage");
     expect(languageSelector).not.toContain("Check");
     expect(countryItem).toContain('<Avatar className={size === "sm" ? "size-3" : "size-5"}>');
+    expect(countryItem).toContain('className="rounded-[inherit] object-cover"');
     expect(countryItem).toContain("flagcdn.com");
     expect(languageSelector).toContain('<DropdownMenuContent align="start"');
   });

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -15,13 +15,16 @@ describe("public navigation preferences", () => {
     expect(navbar.match(/\{renderPreferenceButtons\(\)\}/g)).toHaveLength(2);
     expect(navbar).toContain('className="hidden items-center gap-2 md:flex"');
     expect(navbar).toContain('className="flex w-full items-center justify-between md:hidden"');
+    expect(navbar).toContain('className="my-1 py-3"');
+    expect(navbar).not.toContain("border-y");
     expect(navbar).not.toContain("github.com/customermates/customermates");
     expect(footer).not.toContain("LanguageSelector");
     expect(footer).not.toContain("ThemeSwitcher");
   });
 
-  it("shows the locale code with navbar typography and reuses the profile country options", () => {
+  it("shows the locale code with navbar typography and reuses the complete profile country option", () => {
     const languageSelector = readFileSync(join(REPO_ROOT, "components/shared/language-selector.tsx"), "utf8");
+    const countrySelector = readFileSync(join(REPO_ROOT, "components/forms/form-autocomplete-country.tsx"), "utf8");
     const countryItem = readFileSync(
       join(REPO_ROOT, "components/forms/form-autocomplete-country-item.tsx"),
       "utf8",
@@ -30,10 +33,14 @@ describe("public navigation preferences", () => {
     expect(languageSelector).toContain("currentLocale.toUpperCase()");
     expect(languageSelector).toContain('className={cn("size-8 rounded-md p-0 text-subdued", className)}');
     expect(languageSelector).not.toContain("text-[11px]");
-    expect(languageSelector).toContain(
-      '<FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />',
-    );
+    expect(languageSelector).toContain("FormAutocompleteItem({");
+    expect(countrySelector).toContain("FormAutocompleteItem({");
+    expect(languageSelector).toContain("textValue: label");
+    expect(languageSelector).toContain('<FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />');
+    expect(languageSelector).toContain('className={cn(isSelected && "bg-accent")}');
+    expect(languageSelector).toContain("data-selected={isSelected}");
     expect(languageSelector).not.toContain("AvatarImage");
+    expect(languageSelector).not.toContain("Check");
     expect(countryItem).toContain('<Avatar className={size === "sm" ? "size-3" : "size-5"}>');
     expect(countryItem).toContain("flagcdn.com");
     expect(languageSelector).toContain('<DropdownMenuContent align="start"');

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -20,15 +20,22 @@ describe("public navigation preferences", () => {
     expect(footer).not.toContain("ThemeSwitcher");
   });
 
-  it("shows the locale code with navbar typography and country-style flags in its menu", () => {
+  it("shows the locale code with navbar typography and reuses the profile country options", () => {
     const languageSelector = readFileSync(join(REPO_ROOT, "components/shared/language-selector.tsx"), "utf8");
+    const countryItem = readFileSync(
+      join(REPO_ROOT, "components/forms/form-autocomplete-country-item.tsx"),
+      "utf8",
+    );
 
     expect(languageSelector).toContain("currentLocale.toUpperCase()");
     expect(languageSelector).toContain('className={cn("size-8 rounded-md p-0 text-subdued", className)}');
     expect(languageSelector).not.toContain("text-[11px]");
-    expect(languageSelector).toContain('<Avatar className="size-5">');
-    expect(languageSelector).toContain("flagCodeFor(locale)");
-    expect(languageSelector).toContain("flagcdn.com");
+    expect(languageSelector).toContain(
+      '<FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />',
+    );
+    expect(languageSelector).not.toContain("AvatarImage");
+    expect(countryItem).toContain('<Avatar className={size === "sm" ? "size-3" : "size-5"}>');
+    expect(countryItem).toContain("flagcdn.com");
     expect(languageSelector).toContain('<DropdownMenuContent align="start"');
   });
 

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = process.cwd();
+
+describe("public navigation preferences", () => {
+  it("renders language and theme controls in desktop and mobile navigation, but not the footer", () => {
+    const navbar = readFileSync(join(REPO_ROOT, "app/components/public-navbar.tsx"), "utf8");
+    const footer = readFileSync(join(REPO_ROOT, "app/components/footer-content.tsx"), "utf8");
+
+    expect(navbar.match(/<LanguageSelector/g)).toHaveLength(1);
+    expect(navbar.match(/<ThemeSwitcher/g)).toHaveLength(1);
+    expect(navbar.match(/\{renderPreferenceButtons\(\)\}/g)).toHaveLength(2);
+    expect(navbar).toContain('className="hidden items-center gap-2 md:flex"');
+    expect(navbar).toContain('className="flex w-full items-center justify-between md:hidden"');
+    expect(navbar).not.toContain("github.com/customermates/customermates");
+    expect(footer).not.toContain("LanguageSelector");
+    expect(footer).not.toContain("ThemeSwitcher");
+  });
+
+  it("shows the locale code and toggles directly between the resolved light and dark themes", () => {
+    const languageSelector = readFileSync(join(REPO_ROOT, "components/shared/language-selector.tsx"), "utf8");
+    const themeSwitcher = readFileSync(join(REPO_ROOT, "components/shared/theme-switcher.tsx"), "utf8");
+
+    expect(languageSelector).toContain("currentLocale.toUpperCase()");
+    expect(languageSelector).toContain('<DropdownMenuContent align="start"');
+    expect(languageSelector).not.toContain("flagcdn.com");
+    expect(themeSwitcher).toContain("resolvedTheme === Theme.dark ? Theme.dark : Theme.light");
+    expect(themeSwitcher).toContain("selectedTheme === Theme.dark ? Theme.light : Theme.dark");
+    expect(themeSwitcher).toContain('${t("Common.ariaLabels.themeSwitcher")}: ${selectedThemeLabel}');
+    expect(themeSwitcher).not.toContain("DropdownMenu");
+  });
+});

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -20,13 +20,21 @@ describe("public navigation preferences", () => {
     expect(footer).not.toContain("ThemeSwitcher");
   });
 
-  it("shows the locale code and toggles directly between the resolved light and dark themes", () => {
+  it("shows the locale code with navbar typography and country-style flags in its menu", () => {
     const languageSelector = readFileSync(join(REPO_ROOT, "components/shared/language-selector.tsx"), "utf8");
-    const themeSwitcher = readFileSync(join(REPO_ROOT, "components/shared/theme-switcher.tsx"), "utf8");
 
     expect(languageSelector).toContain("currentLocale.toUpperCase()");
+    expect(languageSelector).toContain('className={cn("size-8 rounded-md p-0 text-subdued", className)}');
+    expect(languageSelector).not.toContain("text-[11px]");
+    expect(languageSelector).toContain('<Avatar className="size-5">');
+    expect(languageSelector).toContain("flagCodeFor(locale)");
+    expect(languageSelector).toContain("flagcdn.com");
     expect(languageSelector).toContain('<DropdownMenuContent align="start"');
-    expect(languageSelector).not.toContain("flagcdn.com");
+  });
+
+  it("toggles directly between the resolved light and dark themes", () => {
+    const themeSwitcher = readFileSync(join(REPO_ROOT, "components/shared/theme-switcher.tsx"), "utf8");
+
     expect(themeSwitcher).toContain("resolvedTheme === Theme.dark ? Theme.dark : Theme.light");
     expect(themeSwitcher).toContain("selectedTheme === Theme.dark ? Theme.light : Theme.dark");
     expect(themeSwitcher).toContain('${t("Common.ariaLabels.themeSwitcher")}: ${selectedThemeLabel}');


### PR DESCRIPTION
## Summary

- Replace the public-navbar GitHub action with compact locale and theme actions on desktop and in the mobile sheet.
- Show the current locale as `EN`/`DE`; its menu reuses the complete `/profile/settings` country-option structure.
- Render the shared FlagCDN artwork as a true rounded avatar with `object-fit: cover` and the inherited radius, so the visible flags—not only their wrappers—match the profile country selector.
- Toggle directly between the resolved Light and Dark themes; System is intentionally not offered in this view.
- Keep Contact and Login unchanged, remove duplicate footer preferences, and remove the mobile preference row's horizontal dividers.

## Context

[CUS-202](https://linear.app/customermates/issue/CUS-202/move-language-and-theme-controls-into-the-public-navigation) records the browser-reviewed design and its refinements. Previously, these preferences were only available in the footer while the navbar used the action slot for GitHub. The implementation reuses the locale registry, guarded locale navigation, theme persistence, the same country-option component used by the profile country selector, and design-system primitives.

The follow-up visual mismatch came from the flag image itself: its wide SVG artwork was not covering the square avatar and had no inherited image radius. The shared country item now applies the crop/radius to the image in both profile and navbar contexts.

## Validation

- Branch update commit `71263fa4` merges current `origin/main` (`72d5b6de`) without conflicts; the branch is 0 commits behind main
- Focused locale/navbar integration suite: 6 files and 53 tests passed
- `yarn typecheck`
- `yarn lint` with zero warnings
- Full Vitest suite: 199 files and 1,523 tests passed
- `yarn build` (60 static pages generated)
- Deployed commit `71263fa4`: https://feat-public-navbar-preferences.customermates.com/de/pricing
- Real seeded browser E2E compared the German option in `/en/profile/settings` with the German public locale option
- Both contexts: 32 px row, 4 px row radius, 8 px gap, 8×6 px padding, 14/20 px text, 20×20 px avatar and image, 6 px radius, hidden overflow, and `object-fit: cover`
- Mobile at 390×844: 160 px menu remains contained in the 320 px sheet, with no horizontal overflow and no preference-row dividers
- Keyboard/ARIA: `menuitemradio` plus `aria-checked`; accessibility tree unchanged
- Updated hosted page exposes the current `DE` trigger and `Sprache: Deutsch`
- GitHub CI, CodeQL, repository policy, and Vercel deployment checks passed on the updated branch
- Independent read-only merge review: no findings

## Impact and rollback

This is a public-navigation UI change plus a shared country-flag presentation correction. It adds no migration, environment variable, API change, external-system write, or persisted-data migration. Revert the commits in this PR to restore the previous presentation.

## Screenshots

Desktop:

![Deployed desktop locale options](https://uploads.linear.app/3958cb56-baac-41c4-9856-3e520ba73b75/cdd6505a-bd22-4f91-af24-65ea715c4b1c/760fad4a-fc1b-4a66-ab75-2b99255ac508)

Mobile sheet:

![Deployed mobile locale options](https://uploads.linear.app/3958cb56-baac-41c4-9856-3e520ba73b75/012620bf-8f06-4fdd-bca6-b8239878efa0/1592216c-f5f3-4ce0-9118-1df7c709bd99)
