### PR TITLE
refactor(forms): share date preset values and drop inert number-input props

### DIFF
--- a/app/[locale]/(protected)/deals/components/deal-services-selection.tsx
+++ b/app/[locale]/(protected)/deals/components/deal-services-selection.tsx
@@ -119,13 +119,11 @@ export const DealServicesSelection = observer(() => {
                 </FormAutocomplete>
 
                 <FormNumberInput
-                  hideStepper
                   required
                   className="rounded-l-none border-l-0 text-right font-mono tabular-nums"
                   containerClassName="w-20 shrink-0"
                   id={`services[${index}].quantity`}
                   label={null}
-                  size="sm"
                 />
               </div>
 

--- a/components/data-view/custom-columns/custom-field-editor.tsx
+++ b/components/data-view/custom-columns/custom-field-editor.tsx
@@ -113,7 +113,6 @@ export const CustomFieldEditor = observer(({ column, value, onChange, id, label,
     case CustomColumnType.currency:
       return (
         <FormNumberInput
-          hideStepper
           endContent={
             column.options?.currency && (
               <span className="mr-1.5">

--- a/components/data-view/filter-modal/inputs/filter-input-iso-date-range.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-iso-date-range.tsx
@@ -5,12 +5,20 @@ import type { DateRange } from "react-day-picker";
 import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { CalendarIcon } from "lucide-react";
-import { addDays, addMonths, addWeeks, endOfMonth, startOfMonth } from "date-fns";
+import { startOfMonth } from "date-fns";
 import { useTranslations } from "next-intl";
 
 import { useAppForm } from "@/components/forms/form-context";
 import { FormLabel } from "@/components/forms/form-label";
 import { InputClearButton } from "@/components/forms/input-clear-button";
+import {
+  RANGE_PRESET_KEYS,
+  localTimeValue,
+  parseIsoDate,
+  rangeForPreset,
+  toLocalIso,
+} from "@/components/forms/iso-date-values";
+import type { RangePresetKey } from "@/components/forms/iso-date-values";
 import { TimeInput } from "@/components/forms/time-input";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -26,34 +34,6 @@ type Props = {
   granularity?: "day" | "minute";
 };
 
-type PresetKey = "today" | "inAWeek" | "thisMonth" | "nextMonth" | "next7Days" | "next30Days";
-
-const PRESET_KEYS: ReadonlyArray<PresetKey> = ["today", "inAWeek", "thisMonth", "nextMonth", "next7Days", "next30Days"];
-
-function rangeForPreset(key: PresetKey): { from: Date; to: Date } {
-  const today = new Date();
-  const start = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const baseToday = start(today);
-  switch (key) {
-    case "today":
-      return { from: baseToday, to: baseToday };
-    case "inAWeek": {
-      const d = addWeeks(baseToday, 1);
-      return { from: d, to: d };
-    }
-    case "thisMonth":
-      return { from: startOfMonth(today), to: endOfMonth(today) };
-    case "nextMonth": {
-      const next = addMonths(today, 1);
-      return { from: startOfMonth(next), to: endOfMonth(next) };
-    }
-    case "next7Days":
-      return { from: baseToday, to: addDays(baseToday, 6) };
-    case "next30Days":
-      return { from: baseToday, to: addDays(baseToday, 29) };
-  }
-}
-
 export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularity = "day" }: Props) => {
   const store = useAppForm();
   const t = useTranslations();
@@ -62,8 +42,8 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
   const tuple = Array.isArray(raw) ? (raw as Array<string | undefined>) : undefined;
   const dateOnly = granularity === "day";
 
-  const startDate = parseIso(tuple?.[0]);
-  const endDate = parseIso(tuple?.[1]);
+  const startDate = parseIsoDate(tuple?.[0]);
+  const endDate = parseIsoDate(tuple?.[1]);
 
   const selected: DateRange | undefined = startDate ? { from: startDate, to: endDate } : undefined;
 
@@ -82,7 +62,7 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
       }
       return;
     }
-    store?.onChange(id, [toIso(range.from, granularity), toIso(range.to, granularity)]);
+    store?.onChange(id, [toLocalIso(range.from, dateOnly), toLocalIso(range.to, dateOnly)]);
     setCurrentMonth(startOfMonth(range.from));
   }
 
@@ -109,7 +89,7 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
     commit(next);
   }
 
-  function handlePreset(key: PresetKey) {
+  function handlePreset(key: RangePresetKey) {
     const range = rangeForPreset(key);
     const next = { from: range.from, to: range.to };
     if (!dateOnly) {
@@ -121,12 +101,8 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
 
   const formatter = dateOnly ? intlStore.dateFormatMap.descriptiveLong : intlStore.dateTimeFormatMap.descriptiveLong;
   const hasBoth = startDate && endDate;
-  const fromTimeValue = startDate
-    ? `${String(startDate.getHours()).padStart(2, "0")}:${String(startDate.getMinutes()).padStart(2, "0")}:${String(startDate.getSeconds()).padStart(2, "0")}`
-    : "";
-  const toTimeValue = endDate
-    ? `${String(endDate.getHours()).padStart(2, "0")}:${String(endDate.getMinutes()).padStart(2, "0")}:${String(endDate.getSeconds()).padStart(2, "0")}`
-    : "";
+  const fromTimeValue = startDate ? localTimeValue(startDate) : "";
+  const toTimeValue = endDate ? localTimeValue(endDate) : "";
 
   return (
     <Popover>
@@ -204,7 +180,7 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
         <Separator />
 
         <div className="grid grid-cols-2 gap-2 p-3 sm:grid-cols-3">
-          {PRESET_KEYS.map((key) => (
+          {RANGE_PRESET_KEYS.map((key) => (
             <Button
               key={key}
               disabled={store?.isDisabled}
@@ -221,19 +197,3 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
     </Popover>
   );
 });
-
-function parseIso(value: string | undefined): Date | undefined {
-  if (!value) return undefined;
-  const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-}
-
-function toIso(date: Date, granularity: "day" | "minute"): string {
-  if (granularity === "day") {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    return `${y}-${m}-${d}`;
-  }
-  return date.toISOString();
-}

--- a/components/data-view/filter-modal/inputs/filter-input-iso-date.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-iso-date.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { CalendarIcon } from "lucide-react";
-import { addMonths, addWeeks, addYears, startOfMonth } from "date-fns";
+import { startOfMonth } from "date-fns";
 import { useTranslations } from "next-intl";
 
 import { useAppForm } from "@/components/forms/form-context";
 import { FormLabel } from "@/components/forms/form-label";
 import { InputClearButton } from "@/components/forms/input-clear-button";
+import { DATE_PRESETS, localTimeValue, parseIsoDate, toLocalIso } from "@/components/forms/iso-date-values";
 import { TimeInput } from "@/components/forms/time-input";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -23,20 +24,13 @@ type Props = {
   granularity?: "day" | "minute";
 };
 
-const PRESETS: ReadonlyArray<{ key: string; compute: (today: Date) => Date }> = [
-  { key: "today", compute: (d) => d },
-  { key: "inAWeek", compute: (d) => addWeeks(d, 1) },
-  { key: "inAMonth", compute: (d) => addMonths(d, 1) },
-  { key: "inAYear", compute: (d) => addYears(d, 1) },
-];
-
 export const FilterInputIsoDate = observer(({ id, isValidFilter, granularity = "day" }: Props) => {
   const store = useAppForm();
   const t = useTranslations();
   const { intlStore } = useRootStore();
   const raw = store?.getValue(id);
   const isoValue = typeof raw === "string" ? raw : undefined;
-  const parsed = parseIso(isoValue);
+  const parsed = parseIsoDate(isoValue);
   const dateOnly = granularity === "day";
 
   const [currentMonth, setCurrentMonth] = useState<Date>(() => startOfMonth(parsed ?? new Date()));
@@ -50,7 +44,7 @@ export const FilterInputIsoDate = observer(({ id, isValidFilter, granularity = "
       store?.onChange(id, undefined);
       return;
     }
-    store?.onChange(id, toIso(date, granularity));
+    store?.onChange(id, toLocalIso(date, dateOnly));
     setCurrentMonth(startOfMonth(date));
   }
 
@@ -82,9 +76,7 @@ export const FilterInputIsoDate = observer(({ id, isValidFilter, granularity = "
   }
 
   const formatter = dateOnly ? intlStore.dateFormatMap.descriptiveLong : intlStore.dateTimeFormatMap.descriptiveLong;
-  const timeValue = parsed
-    ? `${String(parsed.getHours()).padStart(2, "0")}:${String(parsed.getMinutes()).padStart(2, "0")}:${String(parsed.getSeconds()).padStart(2, "0")}`
-    : "";
+  const timeValue = parsed ? localTimeValue(parsed) : "";
 
   return (
     <Popover>
@@ -145,7 +137,7 @@ export const FilterInputIsoDate = observer(({ id, isValidFilter, granularity = "
         <Separator />
 
         <div className="grid grid-cols-2 gap-2 p-3">
-          {PRESETS.map((preset) => (
+          {DATE_PRESETS.map((preset) => (
             <Button
               key={preset.key}
               disabled={store?.isDisabled}
@@ -162,19 +154,3 @@ export const FilterInputIsoDate = observer(({ id, isValidFilter, granularity = "
     </Popover>
   );
 });
-
-function parseIso(value: string | undefined): Date | undefined {
-  if (!value) return undefined;
-  const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-}
-
-function toIso(date: Date, granularity: "day" | "minute"): string {
-  if (granularity === "day") {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    return `${y}-${m}-${d}`;
-  }
-  return date.toISOString();
-}

--- a/components/forms/__tests__/iso-date-values.test.ts
+++ b/components/forms/__tests__/iso-date-values.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DATE_PRESETS,
+  RANGE_PRESET_KEYS,
+  localTimeValue,
+  parseIsoDate,
+  rangeForPreset,
+  toLocalIso,
+} from "../iso-date-values";
+
+const NOW = new Date(2026, 2, 9, 14, 30, 45);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function ymd(date: Date): string {
+  return toLocalIso(date, true);
+}
+
+describe("single-date presets", () => {
+  it("offers today, one week, one month, and one year from the given day", () => {
+    expect(DATE_PRESETS.map((preset) => preset.key)).toEqual(["today", "inAWeek", "inAMonth", "inAYear"]);
+
+    const baseToday = new Date(2026, 2, 9);
+    const computed = DATE_PRESETS.map((preset) => ymd(preset.compute(baseToday)));
+
+    expect(computed).toEqual(["2026-03-09", "2026-03-16", "2026-04-09", "2027-03-09"]);
+  });
+});
+
+describe("range presets", () => {
+  it("exposes the six range keys in display order", () => {
+    expect(RANGE_PRESET_KEYS).toEqual(["today", "inAWeek", "thisMonth", "nextMonth", "next7Days", "next30Days"]);
+  });
+
+  it("resolves each key to a local-midnight range", () => {
+    const ranges = Object.fromEntries(
+      RANGE_PRESET_KEYS.map((key) => {
+        const range = rangeForPreset(key);
+        return [key, [ymd(range.from), ymd(range.to)]];
+      }),
+    );
+
+    expect(ranges).toEqual({
+      today: ["2026-03-09", "2026-03-09"],
+      inAWeek: ["2026-03-16", "2026-03-16"],
+      thisMonth: ["2026-03-01", "2026-03-31"],
+      nextMonth: ["2026-04-01", "2026-04-30"],
+      next7Days: ["2026-03-09", "2026-03-15"],
+      next30Days: ["2026-03-09", "2026-04-07"],
+    });
+  });
+
+  it("starts single-day presets at midnight rather than the current time", () => {
+    const { from } = rangeForPreset("today");
+
+    expect([from.getHours(), from.getMinutes(), from.getSeconds()]).toEqual([0, 0, 0]);
+  });
+});
+
+describe("parseIsoDate", () => {
+  it("parses a stored value and rejects anything unusable", () => {
+    expect(parseIsoDate("2026-03-09")?.getTime()).toBe(new Date("2026-03-09").getTime());
+    expect(parseIsoDate(undefined)).toBeUndefined();
+    expect(parseIsoDate("")).toBeUndefined();
+    expect(parseIsoDate("not-a-date")).toBeUndefined();
+  });
+});
+
+describe("toLocalIso", () => {
+  it("serializes a date-only value from local calendar fields", () => {
+    expect(toLocalIso(new Date(2026, 2, 9, 23, 59, 59), true)).toBe("2026-03-09");
+    expect(toLocalIso(new Date(2026, 0, 1, 0, 0, 0), true)).toBe("2026-01-01");
+  });
+
+  it("keeps the full instant when the value carries a time", () => {
+    const withTime = new Date(2026, 2, 9, 14, 30, 45);
+
+    expect(toLocalIso(withTime, false)).toBe(withTime.toISOString());
+  });
+});
+
+describe("localTimeValue", () => {
+  it("renders zero-padded hours, minutes, and seconds", () => {
+    expect(localTimeValue(new Date(2026, 2, 9, 14, 30, 45))).toBe("14:30:45");
+    expect(localTimeValue(new Date(2026, 2, 9, 0, 5, 9))).toBe("00:05:09");
+  });
+});

--- a/components/forms/form-iso-date-picker.tsx
+++ b/components/forms/form-iso-date-picker.tsx
@@ -6,12 +6,13 @@ import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { CalendarIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { addMonths, addWeeks, addYears, startOfMonth } from "date-fns";
+import { startOfMonth } from "date-fns";
 
 import { Calendar } from "@/components/ui/calendar";
 import { Button } from "@/components/ui/button";
 import { FormLabel } from "./form-label";
 import { InputClearButton } from "./input-clear-button";
+import { DATE_PRESETS, localTimeValue, parseIsoDate, toLocalIso } from "./iso-date-values";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { TimeInput } from "./time-input";
@@ -32,13 +33,6 @@ type Props = {
   containerClassName?: string;
 };
 
-const PRESETS: ReadonlyArray<{ key: string; compute: (today: Date) => Date }> = [
-  { key: "today", compute: (d) => d },
-  { key: "inAWeek", compute: (d) => addWeeks(d, 1) },
-  { key: "inAMonth", compute: (d) => addMonths(d, 1) },
-  { key: "inAYear", compute: (d) => addYears(d, 1) },
-];
-
 export const FormIsoDatePicker = observer(
   ({
     id,
@@ -57,7 +51,7 @@ export const FormIsoDatePicker = observer(
 
     const raw = store?.getValue(id);
     const isoValue = typeof raw === "string" ? raw : undefined;
-    const parsed = parseIso(isoValue);
+    const parsed = parseIsoDate(isoValue);
     const { hasError } = useFormFieldErrors(id);
 
     const resolvedLabel = label ?? undefined;
@@ -75,7 +69,7 @@ export const FormIsoDatePicker = observer(
         store?.onChange(id, undefined);
         return;
       }
-      store?.onChange(id, toIso(date, dateOnly));
+      store?.onChange(id, toLocalIso(date, dateOnly));
       setCurrentMonth(startOfMonth(date));
     }
 
@@ -108,9 +102,7 @@ export const FormIsoDatePicker = observer(
       commit(next);
     }
 
-    const timeValue = parsed
-      ? `${String(parsed.getHours()).padStart(2, "0")}:${String(parsed.getMinutes()).padStart(2, "0")}:${String(parsed.getSeconds()).padStart(2, "0")}`
-      : "";
+    const timeValue = parsed ? localTimeValue(parsed) : "";
 
     return (
       <div className={cn("flex flex-col gap-1.5", containerClassName)}>
@@ -181,7 +173,7 @@ export const FormIsoDatePicker = observer(
             <Separator />
 
             <div className="grid grid-cols-2 gap-2 p-3">
-              {PRESETS.map((preset) => (
+              {DATE_PRESETS.map((preset) => (
                 <Button
                   key={preset.key}
                   disabled={store?.isDisabled}
@@ -200,19 +192,3 @@ export const FormIsoDatePicker = observer(
     );
   },
 );
-
-function parseIso(value: string | undefined): Date | undefined {
-  if (!value) return undefined;
-  const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-}
-
-function toIso(date: Date, dateOnly: boolean): string {
-  if (dateOnly) {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    return `${y}-${m}-${d}`;
-  }
-  return date.toISOString();
-}

--- a/components/forms/form-iso-date-range-picker.tsx
+++ b/components/forms/form-iso-date-range-picker.tsx
@@ -7,12 +7,14 @@ import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { CalendarIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { addDays, addMonths, addWeeks, endOfMonth, startOfMonth } from "date-fns";
+import { startOfMonth } from "date-fns";
 
 import { Calendar } from "@/components/ui/calendar";
 import { Button } from "@/components/ui/button";
 import { FormLabel } from "./form-label";
 import { InputClearButton } from "./input-clear-button";
+import { RANGE_PRESET_KEYS, localTimeValue, rangeForPreset, toLocalIso } from "./iso-date-values";
+import type { RangePresetKey } from "./iso-date-values";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { TimeInput } from "./time-input";
@@ -33,34 +35,6 @@ type Props = {
   className?: string;
   containerClassName?: string;
 };
-
-type PresetKey = "today" | "inAWeek" | "thisMonth" | "nextMonth" | "next7Days" | "next30Days";
-
-function rangeForPreset(key: PresetKey): { from: Date; to: Date } {
-  const today = new Date();
-  const start = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const baseToday = start(today);
-  switch (key) {
-    case "today":
-      return { from: baseToday, to: baseToday };
-    case "inAWeek": {
-      const d = addWeeks(baseToday, 1);
-      return { from: d, to: d };
-    }
-    case "thisMonth":
-      return { from: startOfMonth(today), to: endOfMonth(today) };
-    case "nextMonth": {
-      const next = addMonths(today, 1);
-      return { from: startOfMonth(next), to: endOfMonth(next) };
-    }
-    case "next7Days":
-      return { from: baseToday, to: addDays(baseToday, 6) };
-    case "next30Days":
-      return { from: baseToday, to: addDays(baseToday, 29) };
-  }
-}
-
-const PRESET_KEYS: ReadonlyArray<PresetKey> = ["today", "inAWeek", "thisMonth", "nextMonth", "next7Days", "next30Days"];
 
 export const FormIsoDateRangePicker = observer(
   ({
@@ -99,7 +73,7 @@ export const FormIsoDateRangePicker = observer(
         store?.onChange(id, undefined);
         return;
       }
-      store?.onChange(id, `${toIso(range.from, dateOnly)},${toIso(range.to, dateOnly)}`);
+      store?.onChange(id, `${toLocalIso(range.from, dateOnly)},${toLocalIso(range.to, dateOnly)}`);
       setCurrentMonth(startOfMonth(range.from));
     }
 
@@ -133,7 +107,7 @@ export const FormIsoDateRangePicker = observer(
       commit(next);
     }
 
-    function handlePreset(key: PresetKey) {
+    function handlePreset(key: RangePresetKey) {
       const range = rangeForPreset(key);
       const next = { from: range.from, to: range.to };
       if (!dateOnly && parsedRange) {
@@ -148,8 +122,8 @@ export const FormIsoDateRangePicker = observer(
       commit(next);
     }
 
-    const fromTimeValue = parsedRange ? formatTime(parsedRange.from) : "";
-    const toTimeValue = parsedRange ? formatTime(parsedRange.to) : "";
+    const fromTimeValue = parsedRange ? localTimeValue(parsedRange.from) : "";
+    const toTimeValue = parsedRange ? localTimeValue(parsedRange.to) : "";
 
     const triggerLabel = parsedRange
       ? `${formatter(parsedRange.from)} – ${formatter(parsedRange.to)}`
@@ -245,7 +219,7 @@ export const FormIsoDateRangePicker = observer(
             <Separator />
 
             <div className="grid grid-cols-2 gap-2 p-3 sm:grid-cols-3">
-              {PRESET_KEYS.map((key) => (
+              {RANGE_PRESET_KEYS.map((key) => (
                 <Button
                   key={key}
                   disabled={store?.isDisabled}
@@ -273,18 +247,4 @@ function parseRange(value: string | undefined): { from: Date; to: Date } | undef
   const to = new Date(toStr);
   if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return undefined;
   return { from, to };
-}
-
-function toIso(date: Date, dateOnly: boolean): string {
-  if (dateOnly) {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    return `${y}-${m}-${d}`;
-  }
-  return date.toISOString();
-}
-
-function formatTime(date: Date): string {
-  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}`;
 }

--- a/components/forms/form-number-input.tsx
+++ b/components/forms/form-number-input.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentProps, ReactNode } from "react";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 
 import { Input } from "@/components/ui/input";
@@ -20,15 +20,11 @@ type Props = Omit<
   id: string;
   label?: string | null;
   required?: boolean;
-  locale?: string;
-  formatOptions?: Intl.NumberFormatOptions;
   value?: number;
   onValueChange?: (value: number | undefined) => void;
   className?: string;
   containerClassName?: string;
   endContent?: ReactNode;
-  hideStepper?: boolean;
-  size?: "sm" | "md" | "lg";
 };
 
 export const FormNumberInput = observer(
@@ -36,8 +32,6 @@ export const FormNumberInput = observer(
     id,
     label,
     required,
-    locale,
-    formatOptions,
     value: controlledValue,
     onValueChange,
     className,
@@ -45,8 +39,6 @@ export const FormNumberInput = observer(
     onBlur,
     onFocus,
     endContent,
-    hideStepper: _hideStepper,
-    size: _size,
     ...props
   }: Props) => {
     const isReq = required;
@@ -59,29 +51,16 @@ export const FormNumberInput = observer(
     const isDisabled = store?.isLoading;
     const isReadOnly = store?.isReadOnly;
 
-    const effectiveLocale = locale ?? intlStore.formattingLocale;
-
-    const fmt = useCallback(
-      (n: number | undefined) =>
-        n == null
-          ? ""
-          : new Intl.NumberFormat(effectiveLocale, {
-              maximumFractionDigits: 2,
-              useGrouping: true,
-              ...formatOptions,
-            }).format(n),
-      [effectiveLocale, formatOptions],
-    );
-
     const storeNumber = store?.getValue(id) as number | undefined;
     const activeNumber = controlled ? controlledValue : storeNumber;
+    const formattedValue = activeNumber == null ? "" : intlStore.formatNumber(activeNumber);
 
     const [focused, setFocused] = useState(false);
-    const [text, setText] = useState<string>(() => fmt(activeNumber));
+    const [text, setText] = useState<string>(formattedValue);
 
     useEffect(() => {
-      if (!focused) setText(fmt(activeNumber));
-    }, [activeNumber, focused, fmt]);
+      if (!focused) setText(formattedValue);
+    }, [formattedValue, focused]);
 
     function commit(n: number | undefined) {
       if (controlled) onValueChange?.(n);
@@ -112,18 +91,18 @@ export const FormNumberInput = observer(
             {...props}
             onBlur={(e) => {
               setFocused(false);
-              const parsed = intlStore.parseNumber(text, effectiveLocale);
-              setText(fmt(parsed));
+              const parsed = intlStore.parseNumber(text);
+              setText(parsed == null ? "" : intlStore.formatNumber(parsed));
               commit(parsed);
               onBlur?.(e);
             }}
             onChange={(e) => {
               const next = e.target.value;
               setText(next);
-              commit(intlStore.parseNumber(next, effectiveLocale));
+              commit(intlStore.parseNumber(next));
             }}
             onFocus={(e) => {
-              setText(intlStore.formatNumberForEditing(activeNumber, effectiveLocale));
+              setText(intlStore.formatNumberForEditing(activeNumber));
               setFocused(true);
               onFocus?.(e);
             }}

--- a/components/forms/iso-date-values.ts
+++ b/components/forms/iso-date-values.ts
@@ -1,0 +1,66 @@
+import { addDays, addMonths, addWeeks, addYears, endOfMonth, startOfMonth } from "date-fns";
+
+export type RangePresetKey = "today" | "inAWeek" | "thisMonth" | "nextMonth" | "next7Days" | "next30Days";
+
+export const DATE_PRESETS: ReadonlyArray<{ key: string; compute: (today: Date) => Date }> = [
+  { key: "today", compute: (d) => d },
+  { key: "inAWeek", compute: (d) => addWeeks(d, 1) },
+  { key: "inAMonth", compute: (d) => addMonths(d, 1) },
+  { key: "inAYear", compute: (d) => addYears(d, 1) },
+];
+
+export const RANGE_PRESET_KEYS: ReadonlyArray<RangePresetKey> = [
+  "today",
+  "inAWeek",
+  "thisMonth",
+  "nextMonth",
+  "next7Days",
+  "next30Days",
+];
+
+export function rangeForPreset(key: RangePresetKey): { from: Date; to: Date } {
+  const today = new Date();
+  const start = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const baseToday = start(today);
+  switch (key) {
+    case "today":
+      return { from: baseToday, to: baseToday };
+    case "inAWeek": {
+      const d = addWeeks(baseToday, 1);
+      return { from: d, to: d };
+    }
+    case "thisMonth":
+      return { from: startOfMonth(today), to: endOfMonth(today) };
+    case "nextMonth": {
+      const next = addMonths(today, 1);
+      return { from: startOfMonth(next), to: endOfMonth(next) };
+    }
+    case "next7Days":
+      return { from: baseToday, to: addDays(baseToday, 6) };
+    case "next30Days":
+      return { from: baseToday, to: addDays(baseToday, 29) };
+  }
+}
+
+export function parseIsoDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+export function toLocalIso(date: Date, dateOnly: boolean): string {
+  if (dateOnly) {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }
+  return date.toISOString();
+}
+
+export function localTimeValue(date: Date): string {
+  const h = String(date.getHours()).padStart(2, "0");
+  const m = String(date.getMinutes()).padStart(2, "0");
+  const s = String(date.getSeconds()).padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}

--- a/core/stores/intl.store.ts
+++ b/core/stores/intl.store.ts
@@ -87,22 +87,12 @@ export class IntlStore {
   }
 
   formatNumber(value: number | undefined, options?: { useGrouping?: boolean; maximumFractionDigits?: number }): string {
-    if (value === undefined) return "";
-
-    const numberFormatOptions: Intl.NumberFormatOptions = {
-      style: "decimal" as const,
+    return formatLocalizedNumber(value, this.formattingLocale, {
+      style: "decimal",
       minimumFractionDigits: 0,
-      maximumFractionDigits: 2,
-      useGrouping: true,
-    };
-
-    const formatOptions = {
-      ...numberFormatOptions,
-      useGrouping: options?.useGrouping ?? numberFormatOptions.useGrouping,
-      maximumFractionDigits: options?.maximumFractionDigits ?? numberFormatOptions.maximumFractionDigits,
-    };
-
-    return formatLocalizedNumber(value, this.formattingLocale, formatOptions);
+      maximumFractionDigits: options?.maximumFractionDigits ?? 2,
+      useGrouping: options?.useGrouping ?? true,
+    });
   }
 
   formatNumberForEditing(value: number | undefined, locale = this.formattingLocale): string {


### PR DESCRIPTION
## Summary

Implements [CUS-204](https://linear.app/customermates/issue/CUS-204/extract-the-shared-date-picker-value-module-and-drop-formnumberinputs), the form-layer half of the PR #36 post-merge simplification audit. Behavior-preserving: **−162 lines** across the eight touched files, plus one new 66-line module and its 88-line test.

- **One module for ISO date values.** `components/forms/iso-date-values.ts` now owns `DATE_PRESETS`, `RANGE_PRESET_KEYS`, `rangeForPreset`, `parseIsoDate`, `toLocalIso`, and `localTimeValue`, moved character-for-character from the four pickers that each carried a copy: the single-date preset table existed twice, the range preset block twice, `toIso` four times, `parseIso` three times, and the HH:MM:SS expression five times. The four components (`form-iso-date-picker`, `form-iso-date-range-picker`, `filter-input-iso-date`, `filter-input-iso-date-range`) import it and keep their own `t()` label calls, so the `Common.datePresets.${key}` dynamic-key contract the convention suite checks is untouched.
- **`toIso`'s two spellings unify.** The form pickers took `dateOnly: boolean`, the filter inputs `granularity: "day" | "minute"`. The shared `toLocalIso(date, dateOnly)` takes the boolean, and each filter passes its already-computed `dateOnly`.
- **FormNumberInput sheds four inert props.** `locale` and `formatOptions` were passed by no consumer; `hideStepper` and `size` were destructured into `_hideStepper`/`_size` and discarded while three call sites still set them, so they read as functional and did nothing. All four are gone, along with the now-invalid attributes at `deal-services-selection.tsx` and `custom-field-editor.tsx`. `size` stays in the component's `Omit<>`, so passing it is now a type error rather than a silent no-op.
- **Formatting delegates to the store.** The component's inline `Intl.NumberFormat` restated the display defaults (2 fraction digits, grouping) that `IntlStore.formatNumber` already owns; it now calls the store. `IntlStore.formatNumber` in turn states those defaults once instead of building an options literal and then re-merging it, keeping the `?? 2` / `?? true` override semantics exactly (a plain spread would have let an explicitly-undefined `maximumFractionDigits` drift to Intl's default of 3).

Deliberately out of scope: `calendarDayKey` in `components/ui/calendar-locales.ts` is left alone because it pads the year to four digits while `toLocalIso` does not, so unifying them would change output for years below 1000.

## Context

The audit that produced this ran over merged PR #36 and confirmed both findings under two independent adversarial verification lenses; a later pass re-verified every file path and line span against merged `main` at `72d5b6de`. The sibling locale-plumbing half shipped as PR #52. Overlap was re-checked at claim time by enumerating all 900 changed files across the eight open PRs (#37, #42, #48, #49, #50, #51, #53, #54): zero overlap with any of the ten paths in this change.

## Validation

- `yarn typecheck`; `yarn lint` with zero warnings; `yarn openapi:generate` and `yarn raw-docs:generate` reproduce tracked artifacts with no drift; production `yarn build` passes with 136 routes.
- Full suite against a CI-parity database (Postgres 16, `migrate deploy` + double seed): **199 files, 1,528 tests, all pass** — the 1,520 on `main` plus the 8 new ones. Every pre-existing picker and number-input test passes unchanged.
- New `components/forms/__tests__/iso-date-values.test.ts` pins the extracted contract on a frozen clock: the four single-date presets, all six range presets resolved to explicit dates, midnight starts, `parseIsoDate` accepting a stored value and rejecting empty/invalid/undefined, `toLocalIso` serializing from **local** calendar fields (a 23:59 local time must not roll to the next UTC day) versus the full instant when a time is carried, and zero-padded `localTimeValue`.
- **Browser verification** on a disposable local Postgres, self-hosted mode, seeded data. Every consumer of every touched component was exercised, and each write was confirmed by querying the database directly rather than reading the rendered label:
  - `FormIsoDatePicker` (date) — a `date` custom column, day picked from the calendar grid: stored **`2026-08-27`**. Local-CEST midnight, so a naive UTC serialization would have stored `2026-08-26`; this is the local-calendar guarantee the new unit test pins, proven live.
  - `FormIsoDatePicker` (dateTime) — a `dateTime` column, day picked and the time edited to `02:45:30 PM`: stored **`2026-08-18T12:45:30.000Z`**, the correct UTC instant for 14:45:30 CEST, seconds preserved. This is the `toLocalIso(date, false)` branch plus `localTimeValue` round-tripping through `TimeInput`.
  - `FormIsoDateRangePicker` — the seeded Project Period column, both by day selection (stored **`2026-05-01,2026-05-17`**) and by preset ("Next 7 days" → `10.08.26 – 16.08.26`).
  - `FilterInputIsoDateRange` and `FilterInputIsoDate` — tasks Created-at, *between* → "This month" gave `1. August 2026 um 00:00 – 31. August 2026 um 23:59`; `>` → "In a month" gave `10. September 2026 um 00:00`.
  - Clear affordance — clearing Kickoff Date and saving removed the stored row entirely, confirming `commit(undefined)`.
  - `FormNumberInput`, all three production consumers: deal service quantity (`12345.678` → `12,345.68` in English, `12345,678` → `12.345,68` in German, `9876543.219` → `9,876,543.22`); the custom-column currency editor, the call site whose `hideStepper` attribute this PR removes (typed `1234567.891`, displayed `1,234,567.89`, stored **`1234567.891`** at full precision — display rounding only, exactly as before); and the service detail Amount (typed `8250.5`, stored **`8250.5`**).
  - Locale switching EN↔DE was exercised throughout, including the German calendar, and English formatting was confirmed restored afterwards.
- React best-practices review: **PASS**, no regressions. It flagged one hazard in my first implementation — a `useCallback` whose `formattingLocale` dependency was load-bearing but referenced nowhere in the body, which `react-hooks/exhaustive-deps` (disabled here) would not protect and the no-comments rule could not document. Rewritten to derive the formatted string during render, which removes the `useCallback` entirely and makes the dependency a real value dependency. Re-verified in the browser after the change.

## Impact and rollback

No schema, migration, API, OpenAPI, environment, or persisted-data change. Rendered output, stored ISO values, preset semantics, and number formatting are unchanged in every locale; the only externally visible difference is that `hideStepper` and `size` are now compile errors on `FormNumberInput` instead of silently ignored. Rollback is a single revert of this PR.

One pre-existing defect was found during review and deliberately **not** fixed here, because this PR's contract is behavior preservation: `rangeForPreset("today")` and `rangeForPreset("inAWeek")` return the same `Date` instance as both `from` and `to`, so on the `minute` granularity path the two `setHours` calls in the range components write to one object and the committed range's start time ends up equal to its end time. Both deleted copies had the identical aliasing, so this change carries it over verbatim — but the extraction gives it a single fix site. Tracked separately as [CUS-208](https://linear.app/customermates/issue/CUS-208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
