### PR TITLE
feat(filters): give hasSome and hasNone relationship-existence semantics

### DIFF
--- a/components/data-view/table-view.utils.ts
+++ b/components/data-view/table-view.utils.ts
@@ -9,12 +9,7 @@ import { isStandaloneOperator } from "@/core/base/base-query-builder";
 export function hasValidFilterConfiguration(filter: Filter) {
   if (isStandaloneOperator(filter.operator)) return true;
 
-  if (
-    filter.operator === FilterOperatorKey.in ||
-    filter.operator === FilterOperatorKey.notIn ||
-    filter.operator === FilterOperatorKey.hasNone ||
-    filter.operator === FilterOperatorKey.hasSome
-  )
+  if (filter.operator === FilterOperatorKey.in || filter.operator === FilterOperatorKey.notIn)
     return "value" in filter && Array.isArray(filter.value) ? filter.value.length > 0 : false;
 
   if (filter.operator === FilterOperatorKey.between)

--- a/core/base/__tests__/filter-schema.test.ts
+++ b/core/base/__tests__/filter-schema.test.ts
@@ -12,6 +12,28 @@ describe("FilterSchema relation existence operators", () => {
     expect(isStandaloneOperator(operator)).toBe(true);
   });
 
+  it.each([FilterOperatorKey.hasNone, FilterOperatorKey.hasSome])(
+    "parses %s carrying the explicit undefined value every producer emits",
+    (operator) => {
+      const fromUrl = { field: FilterFieldKey.userIds, operator, value: undefined };
+
+      expect("value" in fromUrl).toBe(true);
+      expect(FilterSchema.parse(fromUrl)).toEqual({ field: FilterFieldKey.userIds, operator });
+    },
+  );
+
+  it.each([
+    FilterOperatorKey.isNull,
+    FilterOperatorKey.isNotNull,
+    FilterOperatorKey.hasUnset,
+    FilterOperatorKey.allSet,
+  ])("keeps accepting %s with the same explicit undefined value", (operator) => {
+    expect(FilterSchema.parse({ field: FilterFieldKey.userIds, operator, value: undefined })).toEqual({
+      field: FilterFieldKey.userIds,
+      operator,
+    });
+  });
+
   it("continues to require values for relation membership operators", () => {
     expect(FilterSchema.safeParse({ field: FilterFieldKey.userIds, operator: FilterOperatorKey.in }).success).toBe(
       false,

--- a/core/base/__tests__/filter-schema.test.ts
+++ b/core/base/__tests__/filter-schema.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { FilterSchema } from "@/core/base/base-get.schema";
+import { FilterOperatorKey, isStandaloneOperator } from "@/core/base/base-query-builder";
+import { FilterFieldKey } from "@/core/types/filter-field-key";
+
+describe("FilterSchema relation existence operators", () => {
+  it.each([FilterOperatorKey.hasNone, FilterOperatorKey.hasSome])("parses %s without a value", (operator) => {
+    const filter = { field: FilterFieldKey.userIds, operator };
+
+    expect(FilterSchema.parse(filter)).toEqual(filter);
+    expect(isStandaloneOperator(operator)).toBe(true);
+  });
+
+  it("continues to require values for relation membership operators", () => {
+    expect(FilterSchema.safeParse({ field: FilterFieldKey.userIds, operator: FilterOperatorKey.in }).success).toBe(
+      false,
+    );
+    expect(FilterSchema.safeParse({ field: FilterFieldKey.userIds, operator: FilterOperatorKey.notIn }).success).toBe(
+      false,
+    );
+  });
+
+  it("normalizes legacy value-taking operators before parsing strips their values", () => {
+    expect(
+      FilterSchema.parse({
+        field: FilterFieldKey.userIds,
+        operator: FilterOperatorKey.hasNone,
+        value: ["u1"],
+      }),
+    ).toEqual({
+      field: FilterFieldKey.userIds,
+      operator: FilterOperatorKey.notIn,
+      value: ["u1"],
+    });
+
+    expect(
+      FilterSchema.parse({
+        field: FilterFieldKey.userIds,
+        operator: FilterOperatorKey.hasSome,
+        value: ["u2"],
+      }),
+    ).toEqual({
+      field: FilterFieldKey.userIds,
+      operator: FilterOperatorKey.in,
+      value: ["u2"],
+    });
+
+    expect(
+      FilterSchema.parse({
+        field: FilterFieldKey.userIds,
+        operator: FilterOperatorKey.hasSome,
+        value: [],
+      }),
+    ).toEqual({
+      field: FilterFieldKey.userIds,
+      operator: FilterOperatorKey.in,
+      value: [],
+    });
+  });
+
+  it.each([FilterOperatorKey.hasNone, FilterOperatorKey.hasSome])(
+    "rejects a malformed non-array value on %s instead of widening it to an existence filter",
+    (operator) => {
+      expect(
+        FilterSchema.safeParse({
+          field: FilterFieldKey.userIds,
+          operator,
+          value: "u1",
+        }).success,
+      ).toBe(false);
+    },
+  );
+});

--- a/core/base/__tests__/validate-filters.test.ts
+++ b/core/base/__tests__/validate-filters.test.ts
@@ -8,6 +8,29 @@ import { FilterFieldKey } from "@/core/types/filter-field-key";
 class TestQueryBuilder extends BaseQueryBuilder<Record<string, unknown>> {}
 
 const FIELDS: FilterableField[] = [{ field: FilterFieldKey.userIds, operators: [FilterOperatorKey.in] }];
+const RELATION_FIELDS: FilterableField[] = [
+  {
+    field: FilterFieldKey.userIds,
+    operators: [FilterOperatorKey.in, FilterOperatorKey.notIn, FilterOperatorKey.hasNone, FilterOperatorKey.hasSome],
+  },
+];
+
+class RelationQueryBuilder extends TestQueryBuilder {
+  override getFilterableFields(): Promise<FilterableField[]> {
+    return Promise.resolve(RELATION_FIELDS);
+  }
+}
+
+const CUSTOM_COLUMN_ID = "3f1c9a72-5d84-4a1e-9f3b-6c2d8e0a7b45";
+const CUSTOM_COLUMN_FIELDS: FilterableField[] = [
+  { field: CUSTOM_COLUMN_ID, operators: [FilterOperatorKey.hasNone, FilterOperatorKey.hasSome] },
+];
+
+class CustomColumnQueryBuilder extends TestQueryBuilder {
+  override getFilterableFields(): Promise<FilterableField[]> {
+    return Promise.resolve(CUSTOM_COLUMN_FIELDS);
+  }
+}
 
 describe("BaseQueryBuilder.validateFilters delegates to defaultValidateFilters", () => {
   const qb = new TestQueryBuilder();
@@ -38,5 +61,75 @@ describe("BaseQueryBuilder.validateFilters delegates to defaultValidateFilters",
     };
 
     expect(qb.validateFilters(args)).toEqual(defaultValidateFilters(args));
+  });
+
+  it("keeps value-less relation existence operators", () => {
+    const filters: Filter[] = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone },
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasSome },
+    ];
+
+    expect(qb.validateFilters({ filters, filterableFields: RELATION_FIELDS })).toEqual(filters);
+  });
+
+  it("normalizes legacy relation existence filters without changing their meaning", () => {
+    const filters = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone, value: ["u1"] },
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasSome, value: ["u2"] },
+    ] as unknown as Filter[];
+
+    expect(qb.validateFilters({ filters, filterableFields: RELATION_FIELDS })).toEqual([
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.notIn, value: ["u1"] },
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.in, value: ["u2"] },
+    ]);
+  });
+
+  it("keeps legacy empty relation values invalid", () => {
+    const filters = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone, value: [] },
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasSome, value: [] },
+    ] as unknown as Filter[];
+
+    expect(qb.validateFilters({ filters, filterableFields: RELATION_FIELDS })).toEqual([]);
+  });
+
+  it("drops malformed scalar relation-existence values instead of widening them", () => {
+    const filters = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone, value: "u1" },
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasSome, value: "u2" },
+    ] as unknown as Filter[];
+
+    expect(qb.validateFilters({ filters, filterableFields: RELATION_FIELDS })).toEqual([]);
+  });
+
+  it("builds relation existence queries without selected values", async () => {
+    const queryBuilder = new RelationQueryBuilder();
+    const filters: Filter[] = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone },
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasSome },
+    ];
+
+    const result = await queryBuilder.buildQueryArgs({ filters });
+
+    expect(result.where).toEqual({
+      AND: [{ users: { none: {} } }, { users: { some: {} } }],
+    });
+  });
+
+  it("scopes relation existence queries on a custom column to that column", async () => {
+    const queryBuilder = new CustomColumnQueryBuilder();
+    const filters: Filter[] = [
+      { field: CUSTOM_COLUMN_ID, operator: FilterOperatorKey.hasNone },
+      { field: CUSTOM_COLUMN_ID, operator: FilterOperatorKey.hasSome },
+    ];
+
+    const result = await queryBuilder.buildQueryArgs({ filters });
+
+    expect(result.where).toEqual({
+      AND: [
+        { customFieldValues: { none: { columnId: CUSTOM_COLUMN_ID } } },
+        { customFieldValues: { some: { columnId: CUSTOM_COLUMN_ID } } },
+      ],
+    });
   });
 });

--- a/core/base/base-get.schema.ts
+++ b/core/base/base-get.schema.ts
@@ -4,66 +4,78 @@ import { z } from "zod";
 import { Prisma } from "@/generated/prisma";
 
 import { FilterOperatorKey } from "./base-query-builder";
+import { normalizeLegacyRelationFilterInput } from "./filter-compat";
 
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { CustomColumnDtoSchema } from "@/features/custom-column/custom-column.schema";
 
-export const FilterSchema = z.discriminatedUnion("operator", [
-  z
-    .object({
-      field: z.string(),
-      operator: z.union([
-        z.literal(FilterOperatorKey.equals).meta({ title: "equals" }),
-        z.literal(FilterOperatorKey.contains).meta({ title: "contains" }),
-        z.literal(FilterOperatorKey.gt).meta({ title: "gt" }),
-        z.literal(FilterOperatorKey.gte).meta({ title: "gte" }),
-        z.literal(FilterOperatorKey.lt).meta({ title: "lt" }),
-        z.literal(FilterOperatorKey.lte).meta({ title: "lte" }),
-      ]),
-      value: z.string(),
-    })
-    .meta({ title: "Single value filter" }),
-  z
-    .object({
-      field: z.string(),
-      operator: z.union([
-        z.literal(FilterOperatorKey.in).meta({ title: "in" }),
-        z.literal(FilterOperatorKey.notIn).meta({ title: "notIn" }),
-        z.literal(FilterOperatorKey.between).meta({ title: "between" }),
-        z.literal(FilterOperatorKey.hasNone).meta({ title: "hasNone" }),
-        z.literal(FilterOperatorKey.hasSome).meta({ title: "hasSome" }),
-      ]),
-      value: z.array(z.string()),
-    })
-    .superRefine((data, ctx) => {
-      if (data.operator === FilterOperatorKey.between && data.value.length !== 2) {
-        ctx.addIssue({
-          code: "custom",
-          params: { error: CustomErrorCode.filterBetweenInvalidArrayLength },
-          path: ["value"],
-        });
-      }
-    })
-    .meta({ title: "Multi value filter" }),
-  z
-    .object({
-      field: z.string(),
-      operator: z.union([
-        z.literal(FilterOperatorKey.isNull).meta({ title: "isNull" }),
-        z.literal(FilterOperatorKey.isNotNull).meta({ title: "isNotNull" }),
-        z.literal(FilterOperatorKey.hasUnset).meta({ title: "hasUnset" }),
-        z.literal(FilterOperatorKey.allSet).meta({ title: "allSet" }),
-      ]),
-    })
-    .meta({ title: "Standalone filter" }),
-  z
-    .object({
-      field: z.string(),
-      operator: z.literal(FilterOperatorKey.inLastDays).meta({ title: "inLastDays" }),
-      value: z.coerce.number().int().positive(),
-    })
-    .meta({ title: "Relative window filter" }),
-]);
+export const FilterSchema = z.preprocess(
+  normalizeLegacyRelationFilterInput,
+  z.discriminatedUnion("operator", [
+    z
+      .object({
+        field: z.string(),
+        operator: z.union([
+          z.literal(FilterOperatorKey.equals).meta({ title: "equals" }),
+          z.literal(FilterOperatorKey.contains).meta({ title: "contains" }),
+          z.literal(FilterOperatorKey.gt).meta({ title: "gt" }),
+          z.literal(FilterOperatorKey.gte).meta({ title: "gte" }),
+          z.literal(FilterOperatorKey.lt).meta({ title: "lt" }),
+          z.literal(FilterOperatorKey.lte).meta({ title: "lte" }),
+        ]),
+        value: z.string(),
+      })
+      .meta({ title: "Single value filter" }),
+    z
+      .object({
+        field: z.string(),
+        operator: z.union([
+          z.literal(FilterOperatorKey.in).meta({ title: "in" }),
+          z.literal(FilterOperatorKey.notIn).meta({ title: "notIn" }),
+          z.literal(FilterOperatorKey.between).meta({ title: "between" }),
+        ]),
+        value: z.array(z.string()),
+      })
+      .superRefine((data, ctx) => {
+        if (data.operator === FilterOperatorKey.between && data.value.length !== 2) {
+          ctx.addIssue({
+            code: "custom",
+            params: { error: CustomErrorCode.filterBetweenInvalidArrayLength },
+            path: ["value"],
+          });
+        }
+      })
+      .meta({ title: "Multi value filter" }),
+    z
+      .object({
+        field: z.string(),
+        operator: z.union([
+          z.literal(FilterOperatorKey.isNull).meta({ title: "isNull" }),
+          z.literal(FilterOperatorKey.isNotNull).meta({ title: "isNotNull" }),
+          z.literal(FilterOperatorKey.hasUnset).meta({ title: "hasUnset" }),
+          z.literal(FilterOperatorKey.allSet).meta({ title: "allSet" }),
+        ]),
+      })
+      .meta({ title: "Standalone filter" }),
+    z
+      .object({
+        field: z.string(),
+        operator: z.union([
+          z.literal(FilterOperatorKey.hasNone).meta({ title: "hasNone" }),
+          z.literal(FilterOperatorKey.hasSome).meta({ title: "hasSome" }),
+        ]),
+      })
+      .strict()
+      .meta({ title: "Relationship existence filter" }),
+    z
+      .object({
+        field: z.string(),
+        operator: z.literal(FilterOperatorKey.inLastDays).meta({ title: "inLastDays" }),
+        value: z.coerce.number().int().positive(),
+      })
+      .meta({ title: "Relative window filter" }),
+  ]),
+);
 export type Filter = Data<typeof FilterSchema>;
 
 export const SortDescriptorSchema = z.object({

--- a/core/base/base-query-builder.ts
+++ b/core/base/base-query-builder.ts
@@ -12,6 +12,7 @@ import { CustomColumnType } from "@/generated/prisma";
 
 import { FilterFieldKey } from "@/core/types/filter-field-key";
 import { isCustomField } from "@/core/utils/custom-field";
+import { normalizeLegacyRelationFilter } from "@/core/base/filter-compat";
 
 export interface SortableField {
   field: string;
@@ -426,21 +427,9 @@ export abstract class BaseQueryBuilder<TWhereInput extends Record<string, unknow
           : { none: { [relationField]: { in: filter.value } } };
       }
       case FilterOperatorKey.hasNone:
-        return isCustom
-          ? {
-              none: {
-                AND: [{ columnId: filter.field }, { [relationField]: { in: filter.value } }],
-              },
-            }
-          : { none: { [relationField]: { in: filter.value } } };
+        return isCustom ? { none: { columnId: filter.field } } : { none: {} };
       case FilterOperatorKey.hasSome:
-        return isCustom
-          ? {
-              some: {
-                AND: [{ columnId: filter.field }, { [relationField]: { in: filter.value } }],
-              },
-            }
-          : { some: { [relationField]: { in: filter.value } } };
+        return isCustom ? { some: { columnId: filter.field } } : { some: {} };
       case FilterOperatorKey.isNull:
         return isCustom
           ? {
@@ -547,17 +536,18 @@ export function defaultValidateFilters(args: {
 
   const result: Filter[] = [];
 
-  for (const filter of filters) {
+  for (const candidate of filters) {
     const hasValidStructure =
-      filter &&
-      typeof filter === "object" &&
-      filter.field &&
-      typeof filter.field === "string" &&
-      filter.operator &&
-      typeof filter.operator === "string";
+      candidate &&
+      typeof candidate === "object" &&
+      candidate.field &&
+      typeof candidate.field === "string" &&
+      candidate.operator &&
+      typeof candidate.operator === "string";
 
     if (!hasValidStructure) continue;
 
+    const filter = normalizeLegacyRelationFilter(candidate);
     const fieldConfig = filterableFields.find((f) => f.field === filter.field);
     if (!fieldConfig || !fieldConfig.operators.includes(filter.operator)) continue;
 
@@ -575,13 +565,19 @@ export function isStandaloneOperator(operator?: FilterOperatorKey) {
   return [
     FilterOperatorKey.isNull,
     FilterOperatorKey.isNotNull,
+    FilterOperatorKey.hasNone,
+    FilterOperatorKey.hasSome,
     FilterOperatorKey.hasUnset,
     FilterOperatorKey.allSet,
   ].includes(operator);
 }
 
 function isFilterValueWellFormed(filter: Filter, fieldOperators: FilterOperatorKey[]): boolean {
-  if (isStandaloneOperator(filter.operator)) return true;
+  if (isStandaloneOperator(filter.operator)) {
+    const isRelationshipExistence =
+      filter.operator === FilterOperatorKey.hasNone || filter.operator === FilterOperatorKey.hasSome;
+    return !isRelationshipExistence || !("value" in filter) || filter.value === undefined;
+  }
 
   const rawValue: unknown = "value" in filter ? filter.value : undefined;
 

--- a/core/base/filter-compat.ts
+++ b/core/base/filter-compat.ts
@@ -1,0 +1,21 @@
+import type { Filter } from "./base-get.schema";
+
+export function normalizeLegacyRelationFilterInput(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+
+  const filter = input as Record<string, unknown>;
+  if (!Array.isArray(filter.value)) return input;
+
+  if (filter.operator === "hasNone") return { ...filter, operator: "notIn" };
+  if (filter.operator === "hasSome") return { ...filter, operator: "in" };
+
+  return input;
+}
+
+export function normalizeLegacyRelationFilter(filter: Filter): Filter {
+  return normalizeLegacyRelationFilterInput(filter) as Filter;
+}
+
+export function normalizeLegacyRelationFilters(filters: Filter[]): Filter[] {
+  return filters.map(normalizeLegacyRelationFilter);
+}

--- a/core/base/filter-compat.ts
+++ b/core/base/filter-compat.ts
@@ -1,10 +1,21 @@
 import type { Filter } from "./base-get.schema";
 
+const RELATION_EXISTENCE_OPERATORS = new Set(["hasNone", "hasSome"]);
+
 export function normalizeLegacyRelationFilterInput(input: unknown): unknown {
   if (!input || typeof input !== "object" || Array.isArray(input)) return input;
 
   const filter = input as Record<string, unknown>;
-  if (!Array.isArray(filter.value)) return input;
+
+  if (!Array.isArray(filter.value)) {
+    if (!RELATION_EXISTENCE_OPERATORS.has(filter.operator as string)) return input;
+    if (!("value" in filter) || filter.value !== undefined) return input;
+
+    const withoutValue: Record<string, unknown> = { ...filter };
+    delete withoutValue.value;
+
+    return withoutValue;
+  }
 
   if (filter.operator === "hasNone") return { ...filter, operator: "notIn" };
   if (filter.operator === "hasSome") return { ...filter, operator: "in" };

--- a/core/utils/__tests__/get-params.test.ts
+++ b/core/utils/__tests__/get-params.test.ts
@@ -1,0 +1,41 @@
+import type { Filter } from "@/core/base/base-get.schema";
+
+import { describe, expect, it } from "vitest";
+
+import { FilterOperatorKey } from "@/core/base/base-query-builder";
+import { FilterFieldKey } from "@/core/types/filter-field-key";
+import { decodeGetParams, encodeGetParams } from "@/core/utils/get-params";
+
+describe("filter URL parameters", () => {
+  it("round trips relation existence filters without a value token", () => {
+    const filters: Filter[] = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone },
+      { field: FilterFieldKey.contactIds, operator: FilterOperatorKey.hasSome },
+    ];
+
+    const encoded = encodeGetParams({ filters });
+
+    expect(encoded.getAll("filters")).toEqual(["userIds:hasNone", "contactIds:hasSome"]);
+    expect(decodeGetParams(encoded).filters).toEqual(filters);
+  });
+
+  it("preserves legacy value-taking tokens as membership filters", () => {
+    const encoded = new URLSearchParams();
+    encoded.append("filters", "userIds:hasNone:u1,u2");
+    encoded.append("filters", "contactIds:hasSome:c1");
+
+    expect(decodeGetParams(encoded).filters).toEqual([
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.notIn, value: ["u1", "u2"] },
+      { field: FilterFieldKey.contactIds, operator: FilterOperatorKey.in, value: ["c1"] },
+    ]);
+  });
+
+  it("normalizes legacy filter objects before encoding", () => {
+    const filters = [
+      { field: FilterFieldKey.userIds, operator: FilterOperatorKey.hasNone, value: ["u1"] },
+      { field: FilterFieldKey.contactIds, operator: FilterOperatorKey.hasSome, value: ["c1"] },
+    ] as unknown as Filter[];
+
+    expect(encodeGetParams({ filters }).getAll("filters")).toEqual(["userIds:notIn:u1", "contactIds:in:c1"]);
+  });
+});

--- a/core/utils/get-params.ts
+++ b/core/utils/get-params.ts
@@ -1,6 +1,7 @@
 import type { Filter, GetQueryParams, PaginationRequest, SortDescriptor } from "@/core/base/base-get.schema";
 
 import { FilterOperatorKey } from "../base/base-query-builder";
+import { normalizeLegacyRelationFilter } from "../base/filter-compat";
 
 export function encodeGetParams(params: GetQueryParams = {}): URLSearchParams {
   const sp = new URLSearchParams();
@@ -24,7 +25,8 @@ export function encodeGetParams(params: GetQueryParams = {}): URLSearchParams {
   }
 
   if (params.filters && params.filters.length > 0) {
-    for (const f of params.filters) {
+    for (const candidate of params.filters) {
+      const f = normalizeLegacyRelationFilter(candidate);
       const valuePart = serializeFilterValue(f.operator, "value" in f ? f.value : undefined);
       const token =
         valuePart !== undefined && valuePart !== null && valuePart !== ""
@@ -133,15 +135,15 @@ function serializeFilterValue(op: FilterOperatorKey, value: unknown): string | u
   switch (op) {
     case FilterOperatorKey.in:
     case FilterOperatorKey.notIn:
-    case FilterOperatorKey.between:
-    case FilterOperatorKey.hasNone:
-    case FilterOperatorKey.hasSome: {
+    case FilterOperatorKey.between: {
       const arr = Array.isArray(value) ? value : value !== undefined && value !== null ? [value] : [];
 
       return arr.map((x) => String(x)).join(",");
     }
     case FilterOperatorKey.isNull:
     case FilterOperatorKey.isNotNull:
+    case FilterOperatorKey.hasNone:
+    case FilterOperatorKey.hasSome:
     case FilterOperatorKey.hasUnset:
     case FilterOperatorKey.allSet:
       return undefined;
@@ -169,14 +171,20 @@ function decodeFilterToken(token: string): Filter | undefined {
       case FilterOperatorKey.in:
       case FilterOperatorKey.notIn:
       case FilterOperatorKey.between:
-      case FilterOperatorKey.hasNone:
-      case FilterOperatorKey.hasSome:
         value = rest ? rest.split(",") : [];
         break;
       case FilterOperatorKey.isNull:
       case FilterOperatorKey.isNotNull:
       case FilterOperatorKey.hasUnset:
       case FilterOperatorKey.allSet:
+        value = undefined;
+        break;
+      case FilterOperatorKey.hasNone:
+        if (rest) return { field, operator: FilterOperatorKey.notIn, value: rest.split(",") };
+        value = undefined;
+        break;
+      case FilterOperatorKey.hasSome:
+        if (rest) return { field, operator: FilterOperatorKey.in, value: rest.split(",") };
         value = undefined;
         break;
       case FilterOperatorKey.inLastDays:

--- a/features/mcp-tools/utils.ts
+++ b/features/mcp-tools/utils.ts
@@ -71,9 +71,9 @@ export function formatDatesInResponse<T>(data: T): SerializedDates<T> {
 export const FILTER_SYNTAX = {
   operators: {
     string: ["equals", "contains", "gt", "gte", "lt", "lte"],
-    array: ["in", "notIn", "hasNone", "hasSome"],
+    array: ["in", "notIn"],
     range: ["between"],
-    noValue: ["isNull", "isNotNull"],
+    noValue: ["isNull", "isNotNull", "hasNone", "hasSome", "hasUnset", "allSet"],
   },
   examples: [
     { field: "status", operator: "equals", value: "active" },

--- a/features/p13n/__tests__/prisma-p13n.repository.test.ts
+++ b/features/p13n/__tests__/prisma-p13n.repository.test.ts
@@ -88,4 +88,27 @@ describe("PrismaP13nRepo legacy filter normalization", () => {
       },
     ]);
   });
+
+  it("reads personalization holding a malformed preset entry without throwing", async () => {
+    p13nFindUnique.mockResolvedValue({
+      companyId: mockUser.companyId,
+      userId: mockUser.id,
+      p13nId: "organizations",
+      filters: null,
+      savedFilterPresets: [null, { id: "p1", name: "Mine", filters: [] }],
+      searchTerm: null,
+      sortDescriptor: null,
+      pagination: null,
+      columnOrder: [],
+      columnWidths: null,
+      hiddenColumns: [],
+      viewMode: null,
+      groupingColumnId: null,
+    });
+
+    const result = await runWithTenant(mockUser, () => new PrismaP13nRepo().getP13n("organizations"));
+
+    expect(result?.savedFilterPresets).toHaveLength(2);
+    expect(result?.savedFilterPresets?.[1].id).toBe("p1");
+  });
 });

--- a/features/p13n/__tests__/prisma-p13n.repository.test.ts
+++ b/features/p13n/__tests__/prisma-p13n.repository.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockUser } from "@/tests/helpers/mock-user";
+import {
+  createMockDiModule,
+  MOCK_ENV_MODULE,
+  MOCK_PRISMA_DB_MODULE,
+  MOCK_ZOD_MODULE,
+} from "@/tests/helpers/interactor-test-setup";
+
+const mockUser = createMockUser();
+const { p13nFindUnique } = vi.hoisted(() => ({
+  p13nFindUnique: vi.fn(),
+}));
+
+vi.mock("@/env", () => MOCK_ENV_MODULE);
+vi.mock("@/core/di", () => createMockDiModule(() => mockUser));
+vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
+vi.mock("@/prisma/db", () => ({
+  ...MOCK_PRISMA_DB_MODULE,
+  prisma: {
+    ...MOCK_PRISMA_DB_MODULE.prisma,
+    p13n: {
+      findUnique: p13nFindUnique,
+    },
+  },
+}));
+
+import { PrismaP13nRepo } from "../prisma-p13n.repository";
+import { FilterOperatorKey } from "@/core/base/base-query-builder";
+import { runWithTenant } from "@/core/decorators/tenant-context";
+import { FilterFieldKey } from "@/core/types/filter-field-key";
+
+describe("PrismaP13nRepo legacy filter normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves active and preset relation filter behavior on read", async () => {
+    p13nFindUnique.mockResolvedValue({
+      companyId: mockUser.companyId,
+      userId: mockUser.id,
+      p13nId: "organizations",
+      filters: [
+        {
+          field: FilterFieldKey.dealIds,
+          operator: FilterOperatorKey.hasNone,
+          value: ["d1"],
+        },
+      ],
+      savedFilterPresets: [
+        {
+          id: "preset-1",
+          name: "Linked deals",
+          filters: [
+            {
+              field: FilterFieldKey.dealIds,
+              operator: FilterOperatorKey.hasSome,
+              value: ["d2"],
+            },
+          ],
+        },
+      ],
+      searchTerm: null,
+      sortDescriptor: null,
+      pagination: null,
+      columnOrder: [],
+      columnWidths: null,
+      hiddenColumns: [],
+      viewMode: null,
+      groupingColumnId: null,
+    });
+
+    const result = await runWithTenant(mockUser, () => new PrismaP13nRepo().getP13n("organizations"));
+
+    expect(result?.filters).toEqual([
+      {
+        field: FilterFieldKey.dealIds,
+        operator: FilterOperatorKey.notIn,
+        value: ["d1"],
+      },
+    ]);
+    expect(result?.savedFilterPresets?.[0].filters).toEqual([
+      {
+        field: FilterFieldKey.dealIds,
+        operator: FilterOperatorKey.in,
+        value: ["d2"],
+      },
+    ]);
+  });
+});

--- a/features/p13n/prisma-p13n.repository.ts
+++ b/features/p13n/prisma-p13n.repository.ts
@@ -38,10 +38,11 @@ function normalizeStoredFilters(value: unknown): Filter[] | undefined {
 function normalizeStoredFilterPresets(value: unknown): SavedFilterPreset[] | undefined {
   if (!Array.isArray(value)) return undefined;
 
-  return (value as unknown as SavedFilterPreset[]).map((preset) => ({
-    ...preset,
-    filters: normalizeStoredFilters(preset.filters) ?? preset.filters,
-  }));
+  return (value as unknown as SavedFilterPreset[]).map((preset) => {
+    if (!preset || typeof preset !== "object") return preset;
+
+    return { ...preset, filters: normalizeStoredFilters(preset.filters) ?? preset.filters };
+  });
 }
 
 export class PrismaP13nRepo

--- a/features/p13n/prisma-p13n.repository.ts
+++ b/features/p13n/prisma-p13n.repository.ts
@@ -9,6 +9,7 @@ import type { P13nRepo } from "@/core/base/base-get.interactor";
 import { Prisma } from "@/generated/prisma";
 
 import { BaseRepository } from "@/core/base/base-repository";
+import { normalizeLegacyRelationFilters } from "@/core/base/filter-compat";
 
 export type SavedFilterPreset = {
   id: string;
@@ -28,6 +29,19 @@ export interface P13nEntry {
   hiddenColumns?: string[];
   viewMode?: ViewMode;
   groupingColumnId?: string;
+}
+
+function normalizeStoredFilters(value: unknown): Filter[] | undefined {
+  return Array.isArray(value) ? normalizeLegacyRelationFilters(value as unknown as Filter[]) : undefined;
+}
+
+function normalizeStoredFilterPresets(value: unknown): SavedFilterPreset[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  return (value as unknown as SavedFilterPreset[]).map((preset) => ({
+    ...preset,
+    filters: normalizeStoredFilters(preset.filters) ?? preset.filters,
+  }));
 }
 
 export class PrismaP13nRepo
@@ -58,10 +72,8 @@ export class PrismaP13nRepo
 
     return {
       p13nId,
-      filters: (filters as Filter[] | null) ?? undefined,
-      savedFilterPresets: Array.isArray(savedFilterPresets)
-        ? (savedFilterPresets as unknown as SavedFilterPreset[])
-        : undefined,
+      filters: normalizeStoredFilters(filters),
+      savedFilterPresets: normalizeStoredFilterPresets(savedFilterPresets),
       searchTerm: searchTerm ?? undefined,
       sortDescriptor: (sortDescriptor as SortDescriptor | null) ?? undefined,
       pagination: (pagination as PaginationRequest | null) ?? undefined,
@@ -118,10 +130,8 @@ export class PrismaP13nRepo
 
     return {
       p13nId,
-      filters: (row.filters as Filter[] | null) ?? undefined,
-      savedFilterPresets: Array.isArray(row.savedFilterPresets)
-        ? (row.savedFilterPresets as unknown as SavedFilterPreset[])
-        : undefined,
+      filters: normalizeStoredFilters(row.filters),
+      savedFilterPresets: normalizeStoredFilterPresets(row.savedFilterPresets),
       searchTerm: row.searchTerm ?? undefined,
       sortDescriptor: (row.sortDescriptor as SortDescriptor | null) ?? undefined,
       pagination: (row.pagination as PaginationRequest | null) ?? undefined,

--- a/public/v1/openapi.json
+++ b/public/v1/openapi.json
@@ -1206,16 +1206,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -1269,6 +1259,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -2233,16 +2251,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -2298,6 +2306,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -2532,16 +2568,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -2597,6 +2623,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -6540,16 +6594,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -6603,6 +6647,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -7567,16 +7639,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -7632,6 +7694,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -7866,16 +7956,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -7931,6 +8011,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -11729,16 +11837,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -11792,6 +11890,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -12756,16 +12882,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -12821,6 +12937,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -13055,16 +13199,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -13120,6 +13254,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -16847,16 +17009,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -16910,6 +17062,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -17874,16 +18054,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -17939,6 +18109,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -18173,16 +18371,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -18238,6 +18426,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -21890,16 +22106,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -21953,6 +22159,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -22917,16 +23151,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -22982,6 +23206,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -23216,16 +23468,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -23281,6 +23523,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -26166,16 +26436,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -26229,6 +26489,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -27489,16 +27777,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -27552,6 +27830,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -28947,16 +29253,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -29010,6 +29306,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -29974,16 +30298,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -30039,6 +30353,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -30273,16 +30615,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -30338,6 +30670,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -30752,16 +31112,6 @@
                                   "type": "string",
                                   "const": "between",
                                   "title": "between"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasNone",
-                                  "title": "hasNone"
-                                },
-                                {
-                                  "type": "string",
-                                  "const": "hasSome",
-                                  "title": "hasSome"
                                 }
                               ]
                             },
@@ -30815,6 +31165,34 @@
                             "operator"
                           ],
                           "title": "Standalone filter"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "hasNone",
+                                  "title": "hasNone"
+                                },
+                                {
+                                  "type": "string",
+                                  "const": "hasSome",
+                                  "title": "hasSome"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator"
+                          ],
+                          "additionalProperties": false,
+                          "title": "Relationship existence filter"
                         },
                         {
                           "type": "object",
@@ -31779,16 +32157,6 @@
                                     "type": "string",
                                     "const": "between",
                                     "title": "between"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasNone",
-                                    "title": "hasNone"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "const": "hasSome",
-                                    "title": "hasSome"
                                   }
                                 ]
                               },
@@ -31844,6 +32212,34 @@
                             ],
                             "additionalProperties": false,
                             "title": "Standalone filter"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "hasNone",
+                                    "title": "hasNone"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "hasSome",
+                                    "title": "hasSome"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "field",
+                              "operator"
+                            ],
+                            "additionalProperties": false,
+                            "title": "Relationship existence filter"
                           },
                           {
                             "type": "object",
@@ -32078,16 +32474,6 @@
                                           "type": "string",
                                           "const": "between",
                                           "title": "between"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasNone",
-                                          "title": "hasNone"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "const": "hasSome",
-                                          "title": "hasSome"
                                         }
                                       ]
                                     },
@@ -32143,6 +32529,34 @@
                                   ],
                                   "additionalProperties": false,
                                   "title": "Standalone filter"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "field": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "const": "hasNone",
+                                          "title": "hasNone"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "const": "hasSome",
+                                          "title": "hasSome"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "field",
+                                    "operator"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "Relationship existence filter"
                                 },
                                 {
                                   "type": "object",
@@ -50177,16 +50591,6 @@
                           "type": "string",
                           "const": "between",
                           "title": "between"
-                        },
-                        {
-                          "type": "string",
-                          "const": "hasNone",
-                          "title": "hasNone"
-                        },
-                        {
-                          "type": "string",
-                          "const": "hasSome",
-                          "title": "hasSome"
                         }
                       ]
                     },
@@ -50240,6 +50644,34 @@
                     "operator"
                   ],
                   "title": "Standalone filter"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    },
+                    "operator": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "hasNone",
+                          "title": "hasNone"
+                        },
+                        {
+                          "type": "string",
+                          "const": "hasSome",
+                          "title": "hasSome"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "field",
+                    "operator"
+                  ],
+                  "additionalProperties": false,
+                  "title": "Relationship existence filter"
                 },
                 {
                   "type": "object",


### PR DESCRIPTION
## Summary

`hasSome` and `hasNone` emitted byte-identical Prisma `where` clauses to `in` and `notIn` (`base-query-builder.ts:428-443` on main), so they were redundant aliases that still demanded a value. The shipped filter-syntax docs have always described them as taking **no value** and answering "does this record have any related row at all" — `content/docs/en/filter-syntax.mdx:41-42` lists them as `no value`, and the example at line 84 is `{ "field": "organizationIds", "operator": "hasNone" }`. This makes the implementation match the contract we already document.

- `hasSome` compiles to `{ some: {} }`, `hasNone` to `{ none: {} }`, both scoped to the requested column via `{ columnId }` when the field is a custom column.
- Both become standalone operators, so the shared filter modal stops rendering a value picker for them and chips stop showing a value suffix.
- Legacy stored filters, saved presets and shareable filter URLs that still carry a value are normalized to `in` / `notIn` on read (`core/base/filter-compat.ts`). The rewrite is exactly meaning-preserving, because on main those operators *were* `in` / `notIn`.

## Context

Extracted from #42 (CUS-68, activity timeline widget). That branch needed value-less relationship-existence filters for the activity feed and changed the shared filter framework to get them. The framework change is not CUS-68 work, so it lands here on its own instead of riding along in a feature PR. #42 will rebase on top of this.

The custom-column scoping is a fix, not a port: the version on #42 returned a bare `{ some: {} }`, which dropped the `columnId` predicate main had and made `hasSome` on custom column *X* match records holding a value for *any* custom column. `validate-filters.test.ts` now covers it, and the test fails without the fix.

## Validation

### End-to-end UI testing found a defect in the first version of this PR

The first push shipped a regression that every unit test missed. It is fixed in `4c88c5ff`.

The new relationship-existence arm is `.strict()`, and Zod treats a key that is **present with the value `undefined`** as an unrecognized key. Every producer in the app emits exactly that shape: `decodeFilterToken` returns `{ field, operator, value }` with `value` undefined for a value-less operator (`core/utils/get-params.ts:196`), and the filter modal seeds and re-assigns the same key rather than deleting it. The captured wire payload from the modal is literally `{"field":"userIds","operator":"hasNone","value":"$undefined"}`.

Result: a `hasSome` or `hasNone` filter failed validation on the page-load path and **the table rendered empty, with HTTP 200 and no error toast**, on all four relationship fields.

The unit tests passed because they build the filter object without a `value` key at all, which is a shape the application never produces. `core/base/__tests__/filter-schema.test.ts` now asserts the shape producers actually emit, and fails without the fix.

`isNull`, `isNotNull`, `hasUnset` and `allSet` were never affected: their arm is not strict.

### Filter matrix, real database, real page-load path

One custom column per `CustomColumnType` was created on contacts (10 types) with values spread so every operator has matching, non-matching and unset rows, and the four relationship fields were given gaps (22/8, 20/10, 12/18, 3/27 coverage). Then **83 filter combinations** were driven through the real `/en/contacts` page and the rendered result set compared against an **independent SQL expectation** that never touches the app's query builder.

| group | cases | result |
|---|---|---|
| relationship fields x `in` / `notIn` / `hasSome` / `hasNone` | 16 | pass |
| `createdAt` / `updatedAt` x `gt` `gte` `lt` `lte` `between` `inLastDays` | 12 | pass |
| custom columns x `isNull` / `isNotNull` (all 10 types) | 20 | pass |
| custom `plain` / `email` / `link` / `phone` x `equals` / `contains` | 8 | pass |
| custom `currency` x `equals` `gt` `gte` `lt` `lte` | 5 | pass |
| custom `date` / `dateTime` x `gt` `gte` `lt` `lte` `between` | 10 | pass |
| custom `dateRange` / `dateTimeRange` x `contains` `gt` `gte` `lt` `lte` `between` | 12 | pass |
| **total** | **83** | **83 pass** |

**Control run with the fix reverted: 75 of 83 pass**, and the 8 failures are exactly the relationship-existence rows, each returning 0 rows. That asymmetry is the evidence that this change breaks nothing else: every other operator, every custom column type, and the other four standalone operators behave identically with and without it.

### Generalization: the other four entity list pages

Because the change is in the shared filter framework, the relationship operators were also driven on `/en/organizations`, `/en/deals`, `/en/tasks` and `/en/services`, against coverage gaps created for each so **no case is degenerate** (no row expects 0 or all).

| page | fields | cases | result |
|---|---|---|---|
| organizations | `contactIds`, `dealIds` | 8 | pass |
| deals | `contactIds`, `organizationIds` | 8 | pass |
| tasks | `contactIds`, `organizationIds` | 8 | pass |
| services | `dealIds`, `taskIds` | 8 | pass |
| **total** | | **32** | **32 pass** |

**Control with the fix reverted: 16 of 32**, failing exactly the 16 `hasSome` / `hasNone` rows, each returning 0 with a 200. Combined with contacts, the defect reproduced on **24 relationship-existence combinations across five pages**, and every one of the other 91 combinations was unaffected.

### Participant filters on the inbox

`participants` (`hasUnset` / `allSet`) and `participantContactId` are the standalone and membership operators contacts cannot reach. They are handled by a dedicated override in `prisma-messaging.repository.ts:203-236` rather than the generic query builder, so they were verified separately on `/en/inbox`, again against independent SQL that replicates the channel-class linking rule (`email` = mail|google|outlook, `phone` = whatsapp, otherwise the provider).

| case | expected | actual |
|---|---|---|
| `participants:hasUnset` | 4 | 4 |
| `participants:allSet` | 21 | 21 |
| `participantContactId:in:<contact>` | 6 | 6 |
| `participantContactId:notIn:<contact>` | 19 | 19 |
| `provider:in:google` | 10 | 10 |
| `provider:notIn:google` | 15 | 15 |
| `state:in:unread` | 10 | 10 |
| `state:notIn:unread` | 15 | 15 |
| `participants:allSet` AND `provider:in:google` | 8 | 8 |

9 of 9, no degenerate rows, including the two-filter AND case (21 ∩ 10 = 8).

**These are the control group.** `hasUnset` and `allSet` are value-less operators on the *non-strict* "Standalone filter" arm, so they should be indifferent to this change, and they are: **9 of 9 pass with the fix reverted as well**. That is what localises the defect to the `.strict()` arm specifically rather than to standalone operators in general.

In the browser, the Participants field offers exactly "not fully linked" and "fully linked", neither renders a value control, and applying the first yields 4 threads with the chip "Participants not fully linked".

Also hardened in `da8380d7`: normalizing stored filter presets dereferenced every array element, so a `null` entry in the `savedFilterPresets` JSON threw a `TypeError`. `getP13n` runs on the critical path of every list view, so that would have taken the whole page down rather than one filter. Main was immune because it cast the array through untouched.

Spot-checked in the browser: the operator dropdown offers `in` / `not in` / `has none` / `has some`; selecting `has some` renders **no value control**; Apply produces the two-segment URL token `userIds:hasSome` and 22 rows. Custom `currency gt 1200` returns 10 rows, which also proves the comparison is numeric rather than lexicographic (a string compare would have included `900`).



- `yarn typecheck` clean.
- `yarn lint --max-warnings=0` clean.
- `yarn test`: 1541 passed. The 5 failures in `features/user/__tests__/registration-real-db.test.ts` are pre-existing and environmental — they fail identically on a pristine `origin/main` checkout in the same worktree, because the shared local database is migrated to a different schema. CI provisions its own database.
- New coverage: `core/base/__tests__/filter-schema.test.ts` (value-less parsing, legacy normalization, malformed-value rejection), the relationship-existence and custom-column cases in `core/base/__tests__/validate-filters.test.ts`, and URL round-tripping in `core/utils/__tests__/get-params.test.ts`.
- `public/v1/openapi.json` regenerated. Verified main's committed spec was already up to date, so the whole diff is produced by this change.

## Impact and rollback

Contract change. `hasSome` / `hasNone` move from the "Multi value filter" arm to a new value-less "Relationship existence filter" arm on the 9 `POST /v1/*/search` endpoints that expose relationship fields, and `FILTER_SYNTAX` moves them from `operators.array` to `operators.noValue` for `get_record_schema` / `search_records`. Requests that still send a value keep working — they are normalized to `in` / `notIn` rather than rejected.

No migration. Rollback is a straight revert of this commit; stored filters are untouched on disk, since normalization happens on read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


