### PR TITLE
refactor: fold NavRouteLink into AppLink and drop two dead code paths

### DIFF
--- a/app/components/navigation/nav-main.tsx
+++ b/app/components/navigation/nav-main.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AnchorHTMLAttributes, ComponentProps, ReactNode, SVGProps } from "react";
+import type { SVGProps } from "react";
 
 import { ChevronRight } from "lucide-react";
 import { observer } from "mobx-react-lite";
@@ -19,9 +19,8 @@ import {
 } from "@/components/ui/sidebar";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { Icon } from "@/components/shared/icon";
-import { IntlLink } from "@/i18n/navigation";
 import { cn } from "@/core/utils/cn";
-import { protectedHrefFromContent } from "@/components/shared/app-link";
+import { AppLink } from "@/components/shared/app-link";
 
 import { NavLinkPendingIndicator } from "./nav-link-pending-indicator";
 
@@ -55,36 +54,6 @@ type NavMainParentProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
-
-function NavRouteLink({
-  children,
-  href,
-  pathname,
-  pendingClassName,
-  ...props
-}: Omit<ComponentProps<typeof IntlLink>, "href"> & {
-  children: ReactNode;
-  href: string;
-  pathname: string | null;
-  pendingClassName?: string;
-}) {
-  const hardNavigationHref = protectedHrefFromContent(href, pathname ?? "");
-  if (hardNavigationHref) {
-    return (
-      <a href={hardNavigationHref} {...(props as AnchorHTMLAttributes<HTMLAnchorElement>)}>
-        {children}
-      </a>
-    );
-  }
-
-  return (
-    <IntlLink href={href} {...props}>
-      {children}
-
-      <NavLinkPendingIndicator className={pendingClassName} />
-    </IntlLink>
-  );
-}
 
 function NavBadge({ count }: { count: number }) {
   if (count <= 0) return null;
@@ -128,17 +97,18 @@ function NavMainParent({ item, pathname, onNavigate, open, onOpenChange }: NavMa
                   )}
 
                   <SidebarMenuSubButton asChild isActive={subActive}>
-                    <NavRouteLink
+                    <AppLink
+                      appearance="unstyled"
                       href={sub.href}
                       id={`nav-${sub.key}`}
-                      pathname={pathname}
-                      pendingClassName={sub.badge ? "ml-0" : undefined}
                       onClick={() => onNavigate(sub.key)}
                     >
                       <span>{sub.title}</span>
 
                       <NavBadge count={sub.badge ?? 0} />
-                    </NavRouteLink>
+
+                      <NavLinkPendingIndicator className={sub.badge ? "ml-0" : undefined} />
+                    </AppLink>
                   </SidebarMenuSubButton>
                 </SidebarMenuSubItem>
               );
@@ -185,19 +155,15 @@ export const NavMain = observer(({ groups, selectedKey, pathname, onNavigate }: 
     return (
       <SidebarMenuItem key={item.key}>
         <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
-          <NavRouteLink
-            href={item.href}
-            id={`nav-${item.key}`}
-            pathname={pathname}
-            pendingClassName={item.badge ? "ml-0" : undefined}
-            onClick={() => onNavigate(item.key)}
-          >
+          <AppLink appearance="unstyled" href={item.href} id={`nav-${item.key}`} onClick={() => onNavigate(item.key)}>
             <Icon icon={item.icon} />
 
             <span className="min-w-0 truncate">{item.title}</span>
 
             <NavBadge count={item.badge ?? 0} />
-          </NavRouteLink>
+
+            <NavLinkPendingIndicator className={item.badge ? "ml-0" : undefined} />
+          </AppLink>
         </SidebarMenuButton>
       </SidebarMenuItem>
     );

--- a/core/decorators/validate.decorator.ts
+++ b/core/decorators/validate.decorator.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { Validated } from "../validation/validation.utils";
 
 import { getZodParseContext } from "../validation/zod-error-map-server";
 
@@ -16,10 +17,7 @@ export function Validate<T>(schema: z.ZodSchema<T>) {
   };
 }
 
-async function validate<T>(
-  schema: z.ZodSchema<T>,
-  data: unknown,
-): Promise<{ ok: false; error: z.ZodError<T> } | { ok: true; data: T }> {
+async function validate<T>(schema: z.ZodSchema<T>, data: unknown): Validated<T> {
   const context = await getZodParseContext();
   const res = await schema.safeParseAsync(data, context);
 

--- a/features/mcp-tools/utils.ts
+++ b/features/mcp-tools/utils.ts
@@ -38,12 +38,6 @@ function formatDatesRecursively(value: unknown): unknown {
 
   if (value instanceof Date) return isNaN(value.getTime()) ? String(value) : value.toISOString();
 
-  if (typeof value === "string") {
-    const dateTimeResult = z.iso.datetime().safeParse(value);
-    const dateResult = z.iso.date().safeParse(value);
-    if (dateTimeResult.success || dateResult.success) return value;
-  }
-
   if (Array.isArray(value)) return value.map(formatDatesRecursively);
 
   if (typeof value === "object") {


### PR DESCRIPTION
## Summary

Applies the three actionable items from [CUS-205](https://linear.app/customermates/issue/CUS-205/land-the-second-round-simplification-residue-once-the-in-flight-prs). **−42 lines net.** The other four are corrected or deferred on the issue rather than applied, because adversarial re-verification against current `main` showed two of them are not true as written.

- **`NavRouteLink` folded into `AppLink`** (−29 lines). It duplicated AppLink's content-page hard-navigation branch: both call `protectedHrefFromContent`, AppLink getting `pathname` from `usePathname()` while the wrapper took it as a prop. PR #48 had already converted `nav-header` and `nav-secondary` to `AppLink` + `NavLinkPendingIndicator`, leaving `nav-main` the last holdout. The wrapper, its `pathname` prop, the `IntlLink` import and two now-unused type imports all go.
- **Dead ISO-string branch removed from `formatDatesRecursively`** (−6 lines). For a string it ran `z.iso.datetime()` and `z.iso.date()` and returned the string unchanged on a hit — but the fall-through returns the string unchanged too, so the parses decided nothing. This is not purely cosmetic: it was a parse pair per string field of every MCP response.
- **`validate.decorator` adopts `Validated<T>`** (−1 line) instead of re-declaring the same result shape inline.

## Context

The issue's seven items were last verified against `main` at `72d5b6de`. Main has moved a long way since (#52, #55, #57, #48, #56), so every claim was re-verified against `92fe3f69` before anything was edited: seven independent skeptics, one per claim, each tasked to falsify rather than confirm.

Two claims did not survive, and the issue is corrected accordingly:

- **`{param}` interpolation "implemented twice" — dropped.** Overstated. The MCP side is a *single line* (`message.replaceAll(...)` in a loop), not a parallel implementation; the two functions share about one line of logic and differ in everything else (sync vs async, eager vs lazy translation lookup, enum validation and throwing vs none, prefix vs none). Extracting a shared helper costs more lines than it saves.
- **Inbox rate-limits href "correctness fix" — dropped.** The premise is wrong. The claim says the hand-built `/${locale}${DOCS_PATH}` points at an unpublished locale for fr/it/es. It does, but `proxy.ts` catches exactly that and 307-redirects to the default locale, landing on the identical URL `localizedContentHref` would have produced. Verified end to end against production: `/fr|/it|/es/docs/messaging-rate-limits` all return **200** at `/en/docs/messaging-rate-limits`. The real cost is one redirect hop, not a broken link, so this is marginal dedup that also needs a null guard — not the correctness fix it was filed as.

Two more remain genuinely gated and are **not** in this PR: deleting `scripts/lib/icu.ts` (~91 lines, the biggest single win) and deriving `AUTH_SOCIAL_ERROR_KEYS` (~30 lines). Both are blocked on **#54**, which still edits `tests/conventions/i18n-parity.test.ts` and `i18n-key-resolution.test.ts`; #49 also still edits the parity test. The `#42` gate on the dead-ISO item has cleared — #42 no longer touches `features/mcp-tools/utils.ts` — which is why that item is here.

The issue also claimed the extraction of a shared parse prelude from `run-precheck`/`validate.decorator`. Measured against the repo's own prettier settings that refactor goes **48 → 52 lines**, a net loss, so only the adjacent `Validated<T>` adoption is applied. Its stated justification was false too: `z.any().superRefine()` returns the input by reference, and neither `runPrecheck` caller reads the success `data` at all, so the "success branch must stay caller-controlled" constraint it invented does not exist.

## Validation

- `yarn typecheck`; `yarn lint` zero warnings; `yarn i18n:audit`; production `yarn build` compiles successfully.
- Full suite against a disposable Postgres 16: **218 files, 1,737 tests, all pass** — identical to `main`, so no test needed updating.
- **Browser before/after comparison** for the nav change, on a local instance with a real session, on **both** page classes the issue asks for and in a non-default locale (fr):
  - App page (`/fr/dashboard`): hrefs `/fr/dashboard`, `/fr/tasks`, … identical before and after; class prefix identical (`appearance="unstyled"` reproduces the original styling); pending indicator present in both.
  - Content page (`/en/blog`, where the sidebar *does* render for a logged-in user and `protectedHrefFromContent` actually fires): hrefs are the locale-stripped hard-navigation targets `/dashboard`, `/contacts` — identical before and after.
  - Geometry measured rather than eyeballed: button 224×32 and label x=48 with identical label widths, before and after, on the content page.
  - Verified `nav-documentation` (the one content-route link in the sidebar) comes from `nav-secondary`, not `nav-main`, so every `nav-main` href is a non-content route as the issue assumed.

**One disclosed DOM delta.** On the hard-navigation branch the `NavLinkPendingIndicator` span now renders inside the anchor, where `NavRouteLink` omitted it. It is `aria-hidden`, and `useLinkStatus()` returns `pending: false` outside a `Link`, so it never animates; measured layout is unchanged. This is exactly what `nav-header` and `nav-secondary` have done since #48, so it makes `nav-main` consistent with its siblings rather than introducing a new pattern.

## Impact and rollback

No schema, migration, API, OpenAPI, environment or persisted-data change. Rendered navigation is unchanged on both page classes. Rollback is a single revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
