### PR TITLE
fix(seo): enforce landing page shipping contracts

### DIFF
--- a/.github/workflows/page-shipping-e2e.yml
+++ b/.github/workflows/page-shipping-e2e.yml
@@ -1,0 +1,62 @@
+name: Page shipping E2E
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  rendered-hubs:
+    name: rendered-hubs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      APP_MODE: self-hosted
+      BASE_URL: http://localhost:40196
+      BETTER_AUTH_SECRET: synthetic-page-shipping-e2e-secret
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/customermates_page_shipping_e2e
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - name: Build the production application
+        run: yarn build
+      - name: Crawl rendered landing hubs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          server_log="$RUNNER_TEMP/page-shipping-server.log"
+          yarn next start --hostname 127.0.0.1 -p 40196 >"$server_log" 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true' EXIT
+
+          ready=0
+          for _attempt in {1..60}; do
+            if curl --silent --show-error --fail http://localhost:40196/en/blog >/dev/null; then
+              ready=1
+              break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              cat "$server_log"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          if [[ "$ready" -ne 1 ]]; then
+            cat "$server_log"
+            exit 1
+          fi
+
+          if ! HUB_E2E_BASE_URL=http://localhost:40196 yarn vitest run tests/conventions/hub-reachability.test.ts; then
+            cat "$server_log"
+            exit 1
+          fi

--- a/__tests__/proxy-locales.test.ts
+++ b/__tests__/proxy-locales.test.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { describe, expect, it, vi } from "vitest";
-import { NextRequest as NextRequestValue } from "next/server";
 
 const mockEnv = vi.hoisted(() => ({
   APP_MODE: "self-hosted" as const,
@@ -102,7 +102,9 @@ vi.mock("@/i18n/locale-registry", () => {
 vi.mock("@/env", () => ({ env: mockEnv }));
 
 vi.mock("@/core/auth/better-auth", () => ({
-  auth: { api: { getSession: vi.fn(), signInEmail: vi.fn(), signOut: vi.fn() } },
+  auth: {
+    api: { getSession: vi.fn(), signInEmail: vi.fn(), signOut: vi.fn() },
+  },
 }));
 
 vi.mock("next-intl/middleware", async () => {
@@ -132,8 +134,17 @@ vi.mock("next-intl/middleware", async () => {
   };
 });
 
-import proxy from "@/proxy";
 import { appRouting, contentRouting, routing } from "@/i18n/routing";
+
+(
+  globalThis as typeof globalThis & {
+    AsyncLocalStorage: typeof AsyncLocalStorage;
+  }
+).AsyncLocalStorage = AsyncLocalStorage;
+const [{ NextRequest: NextRequestValue }, { config, default: proxy }] = await Promise.all([
+  import("next/server"),
+  import("@/proxy"),
+]);
 
 function request(pathname: string, acceptLanguage?: string): NextRequest {
   return new NextRequestValue(`http://localhost:4000${pathname}`, {
@@ -143,7 +154,11 @@ function request(pathname: string, acceptLanguage?: string): NextRequest {
 
 async function call(pathname: string, acceptLanguage?: string) {
   const response = await proxy(request(pathname, acceptLanguage));
-  return { status: response.status, location: response.headers.get("location"), response };
+  return {
+    status: response.status,
+    location: response.headers.get("location"),
+    response,
+  };
 }
 
 const PATHS = [
@@ -191,6 +206,105 @@ describe("locale routing configuration", () => {
 });
 
 describe("proxy locale routing", () => {
+  it("keeps hub URL validation active for both prefetch header variants", async () => {
+    const { unstable_doesMiddlewareMatch } = await import("next/experimental/testing/server");
+    const headerSets = [
+      { purpose: "prefetch" },
+      { "next-router-prefetch": "1" },
+      { purpose: "prefetch", "next-router-prefetch": "1" },
+    ];
+
+    for (const headers of headerSets) {
+      for (const prefix of ["", "/en", "/de", "/fr", "/it", "/es"]) {
+        for (const hub of ["/blog", "/compare", "/for", "/features/all"]) {
+          expect(
+            unstable_doesMiddlewareMatch({
+              config,
+              headers,
+              nextConfig: {},
+              url: `http://localhost:4000${prefix}${hub}?page=99`,
+            }),
+            `${prefix}${hub}`,
+          ).toBe(true);
+        }
+      }
+
+      for (const path of ["/en/pricing", "/en/blog/post", "/en/features/all/child"]) {
+        expect(
+          unstable_doesMiddlewareMatch({
+            config,
+            headers,
+            nextConfig: {},
+            url: `http://localhost:4000${path}`,
+          }),
+          path,
+        ).toBe(false);
+      }
+    }
+
+    for (const prefix of ["/EN", "/pt-BR", "/nl"]) {
+      for (const hub of ["/blog", "/compare", "/for", "/features/all"]) {
+        expect(
+          unstable_doesMiddlewareMatch({
+            config,
+            headers: { "next-router-prefetch": "1" },
+            nextConfig: {},
+            url: `http://localhost:4000${prefix}${hub}?page=99`,
+          }),
+          `${prefix}${hub}`,
+        ).toBe(true);
+      }
+    }
+
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "http://localhost:4000/en/pricing",
+      }),
+    ).toBe(true);
+  });
+
+  it("normalizes page one and rejects invalid hub pagination before streaming", async () => {
+    const pageOne = await call("/en/blog?page=1&utm_source=proof");
+    expect(pageOne.status).toBe(308);
+    expect(pageOne.location).toBe("http://localhost:4000/en/blog?utm_source=proof");
+
+    for (const query of ["page=0", "page=01", "page=2junk", "page=2&page=3", "page=4"]) {
+      const invalid = await call(`/en/blog?${query}`);
+      expect(invalid.status, query).toBe(404);
+      expect(invalid.location, query).toBeNull();
+      expect(invalid.response.headers.get("x-robots-tag"), query).toBe("noindex");
+    }
+
+    const lastPage = await call("/en/blog?page=3");
+    expect(lastPage.status).toBe(200);
+    expect(lastPage.location).toBeNull();
+  });
+
+  it("normalizes an app-only locale before applying the hub page contract", async () => {
+    const localeFallback = await call("/fr/blog?page=1&utm_source=proof");
+    expect(localeFallback.status).toBe(307);
+    expect(localeFallback.location).toBe("http://localhost:4000/en/blog?page=1&utm_source=proof");
+
+    const pageOne = await call("/en/blog?page=1&utm_source=proof");
+    expect(pageOne.status).toBe(308);
+    expect(pageOne.location).toBe("http://localhost:4000/en/blog?utm_source=proof");
+
+    const invalidLocaleFallback = await call("/fr/blog?page=4");
+    expect(invalidLocaleFallback.status).toBe(307);
+    expect(invalidLocaleFallback.location).toBe("http://localhost:4000/en/blog?page=4");
+
+    const invalid = await call("/en/blog?page=4");
+    expect(invalid.status).toBe(404);
+    expect(invalid.location).toBeNull();
+    expect(invalid.response.headers.get("x-robots-tag")).toBe("noindex");
+
+    const valid = await call("/fr/blog?page=2");
+    expect(valid.status).toBe(307);
+    expect(valid.location).toBe("http://localhost:4000/en/blog?page=2");
+  });
+
   it("never emits a permanently cached redirect", async () => {
     for (const path of PATHS) {
       const { status } = await call(path);

--- a/__tests__/proxy-locales.test.ts
+++ b/__tests__/proxy-locales.test.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import { describe, expect, it, vi } from "vitest";
+import { NextRequest as NextRequestValue } from "next/server";
 
 const mockEnv = vi.hoisted(() => ({
   APP_MODE: "self-hosted" as const,
@@ -134,17 +134,8 @@ vi.mock("next-intl/middleware", async () => {
   };
 });
 
+import proxy from "@/proxy";
 import { appRouting, contentRouting, routing } from "@/i18n/routing";
-
-(
-  globalThis as typeof globalThis & {
-    AsyncLocalStorage: typeof AsyncLocalStorage;
-  }
-).AsyncLocalStorage = AsyncLocalStorage;
-const [{ NextRequest: NextRequestValue }, { config, default: proxy }] = await Promise.all([
-  import("next/server"),
-  import("@/proxy"),
-]);
 
 function request(pathname: string, acceptLanguage?: string): NextRequest {
   return new NextRequestValue(`http://localhost:4000${pathname}`, {
@@ -206,103 +197,12 @@ describe("locale routing configuration", () => {
 });
 
 describe("proxy locale routing", () => {
-  it("keeps hub URL validation active for both prefetch header variants", async () => {
-    const { unstable_doesMiddlewareMatch } = await import("next/experimental/testing/server");
-    const headerSets = [
-      { purpose: "prefetch" },
-      { "next-router-prefetch": "1" },
-      { purpose: "prefetch", "next-router-prefetch": "1" },
-    ];
-
-    for (const headers of headerSets) {
-      for (const prefix of ["", "/en", "/de", "/fr", "/it", "/es"]) {
-        for (const hub of ["/blog", "/compare", "/for", "/features/all"]) {
-          expect(
-            unstable_doesMiddlewareMatch({
-              config,
-              headers,
-              nextConfig: {},
-              url: `http://localhost:4000${prefix}${hub}?page=99`,
-            }),
-            `${prefix}${hub}`,
-          ).toBe(true);
-        }
-      }
-
-      for (const path of ["/en/pricing", "/en/blog/post", "/en/features/all/child"]) {
-        expect(
-          unstable_doesMiddlewareMatch({
-            config,
-            headers,
-            nextConfig: {},
-            url: `http://localhost:4000${path}`,
-          }),
-          path,
-        ).toBe(false);
-      }
+  it("preserves hub queries while falling back to a published content locale", async () => {
+    for (const query of ["page=1&utm_source=proof", "page=4", "page=2"]) {
+      const fallback = await call(`/fr/blog?${query}`);
+      expect(fallback.status, query).toBe(307);
+      expect(fallback.location, query).toBe(`http://localhost:4000/en/blog?${query}`);
     }
-
-    for (const prefix of ["/EN", "/pt-BR", "/nl"]) {
-      for (const hub of ["/blog", "/compare", "/for", "/features/all"]) {
-        expect(
-          unstable_doesMiddlewareMatch({
-            config,
-            headers: { "next-router-prefetch": "1" },
-            nextConfig: {},
-            url: `http://localhost:4000${prefix}${hub}?page=99`,
-          }),
-          `${prefix}${hub}`,
-        ).toBe(true);
-      }
-    }
-
-    expect(
-      unstable_doesMiddlewareMatch({
-        config,
-        nextConfig: {},
-        url: "http://localhost:4000/en/pricing",
-      }),
-    ).toBe(true);
-  });
-
-  it("normalizes page one and rejects invalid hub pagination before streaming", async () => {
-    const pageOne = await call("/en/blog?page=1&utm_source=proof");
-    expect(pageOne.status).toBe(308);
-    expect(pageOne.location).toBe("http://localhost:4000/en/blog?utm_source=proof");
-
-    for (const query of ["page=0", "page=01", "page=2junk", "page=2&page=3", "page=4"]) {
-      const invalid = await call(`/en/blog?${query}`);
-      expect(invalid.status, query).toBe(404);
-      expect(invalid.location, query).toBeNull();
-      expect(invalid.response.headers.get("x-robots-tag"), query).toBe("noindex");
-    }
-
-    const lastPage = await call("/en/blog?page=3");
-    expect(lastPage.status).toBe(200);
-    expect(lastPage.location).toBeNull();
-  });
-
-  it("normalizes an app-only locale before applying the hub page contract", async () => {
-    const localeFallback = await call("/fr/blog?page=1&utm_source=proof");
-    expect(localeFallback.status).toBe(307);
-    expect(localeFallback.location).toBe("http://localhost:4000/en/blog?page=1&utm_source=proof");
-
-    const pageOne = await call("/en/blog?page=1&utm_source=proof");
-    expect(pageOne.status).toBe(308);
-    expect(pageOne.location).toBe("http://localhost:4000/en/blog?utm_source=proof");
-
-    const invalidLocaleFallback = await call("/fr/blog?page=4");
-    expect(invalidLocaleFallback.status).toBe(307);
-    expect(invalidLocaleFallback.location).toBe("http://localhost:4000/en/blog?page=4");
-
-    const invalid = await call("/en/blog?page=4");
-    expect(invalid.status).toBe(404);
-    expect(invalid.location).toBeNull();
-    expect(invalid.response.headers.get("x-robots-tag")).toBe("noindex");
-
-    const valid = await call("/fr/blog?page=2");
-    expect(valid.status).toBe(307);
-    expect(valid.location).toBe("http://localhost:4000/en/blog?page=2");
   });
 
   it("never emits a permanently cached redirect", async () => {

--- a/app/[locale]/(static)/blog/page.tsx
+++ b/app/[locale]/(static)/blog/page.tsx
@@ -1,54 +1,98 @@
 import type { Metadata } from "next";
 
-import { getLocale } from "next-intl/server";
-import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+import { notFound, permanentRedirect } from "next/navigation";
 
 import { BlogPostCard } from "./blog-post-card";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { PostGridShell } from "@/components/marketing/post-grid-shell";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { blogPostsSource, blogSource } from "@/core/fumadocs/source";
-import { contentLocaleOrDefault } from "@/i18n/locale-registry";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  hubPageOneRedirectHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/blog" });
+  const query = await searchParams;
+  const resolution = resolveHubPage(
+    query[HUB_PAGE_PARAM],
+    hubPageCount(blogPostsSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/blog", resolution.page),
+    locale,
+    route: "/blog",
+  });
 }
 
-export default async function BlogPage() {
+export default async function BlogPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = blogSource.getPage(["blog"], locale);
-  const posts = blogPostsSource.getPages(locale);
 
   if (!page) notFound();
 
-  const sortedPosts = [...posts].sort((a, b) => {
-    const dateA = new Date(a.data.blogPost.date).getTime();
-    const dateB = new Date(b.data.blogPost.date).getTime();
-    return dateB - dateA;
-  });
+  const referencePosts = blogPostsSource.getPages(DEFAULT_LOCALE);
+  const query = await searchParams;
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCount(referencePosts.length));
+
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one")
+    permanentRedirect(buildLocalePath(locale, hubPageOneRedirectHref("/blog", query)));
+
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
+  const paginated = paginateLocalizedHubPages(
+    referencePosts,
+    blogPostsSource.getPages(locale),
+    resolution.page,
+    (a, b) => {
+      const dateDifference =
+        new Date(b.page.data.blogPost.date).getTime() - new Date(a.page.data.blogPost.date).getTime();
+      return dateDifference || referenceCollator.compare(a.slug, b.slug);
+    },
+  );
+  const t = await getTranslations("Common.table");
 
   return (
     <div className="flex flex-col items-center justify-center">
       <PostGridShell hero={page.data.hero}>
-        {sortedPosts.map((post) => {
-          const slug = post.url?.split("/").pop() ?? "";
-          if (!slug) return null;
-
-          return (
-            <div key={post.url} className="min-w-0">
-              <BlogPostCard
-                {...post.data.blogPost}
-                description={post.data.description}
-                locale={locale}
-                title={post.data.title}
-                url={`/blog/${slug}`}
-              />
-            </div>
-          );
-        })}
+        {paginated.items.map(({ page: post, slug }) => (
+          <div key={post.url} className="min-w-0">
+            <BlogPostCard
+              {...post.data.blogPost}
+              description={post.data.description}
+              locale={locale}
+              title={post.data.title}
+              url={`/blog/${slug}`}
+            />
+          </div>
+        ))}
       </PostGridShell>
+
+      <HubPagination
+        basePath="/blog"
+        label={page.data.title}
+        nextLabel={t("nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/[locale]/(static)/compare/page.tsx
+++ b/app/[locale]/(static)/compare/page.tsx
@@ -1,22 +1,48 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { HubPostGrid, type HubPostGridItem } from "@/components/marketing/hub-post-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { comparePagesSource, compareSource } from "@/core/fumadocs/source";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  hubPageOneRedirectHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { breadcrumbListSchema } from "@/core/seo/schemas";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/compare" });
+  const query = await searchParams;
+  const resolution = resolveHubPage(
+    query[HUB_PAGE_PARAM],
+    hubPageCount(comparePagesSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/compare", resolution.page),
+    locale,
+    route: "/compare",
+  });
 }
 
-export default async function CompareHubPage() {
+export default async function CompareHubPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = compareSource.getPage(["compare"], locale);
 
@@ -24,18 +50,29 @@ export default async function CompareHubPage() {
 
   const t = await getTranslations();
   const collator = new Intl.Collator(formattingTagFor(locale));
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
   const tagLabels = {
     alternative: t("ComparePage.tags.alternative"),
     comparison: t("ComparePage.tags.comparison"),
     review: t("ComparePage.tags.review"),
   };
 
-  const items: HubPostGridItem[] = comparePagesSource
-    .getPages(locale)
-    .map((p): HubPostGridItem | null => {
-      const slug = p.url?.split("/").pop() ?? "";
-      if (!slug) return null;
+  const referencePages = comparePagesSource.getPages(DEFAULT_LOCALE);
+  const query = await searchParams;
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCount(referencePages.length));
 
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one")
+    permanentRedirect(buildLocalePath(locale, hubPageOneRedirectHref("/compare", query)));
+
+  const paginated = paginateLocalizedHubPages(
+    referencePages,
+    comparePagesSource.getPages(locale),
+    resolution.page,
+    (a, b) => referenceCollator.compare(a.page.data.competitorName, b.page.data.competitorName),
+  );
+  const items: HubPostGridItem[] = paginated.items
+    .map(({ page: p, slug }): HubPostGridItem => {
       const competitor2 = p.data.comparison?.competitor2Name;
       let title = p.data.competitorName;
       if (slug.includes("-vs-") && competitor2) title = `${p.data.competitorName} vs ${competitor2}`;
@@ -57,7 +94,6 @@ export default async function CompareHubPage() {
         title,
       };
     })
-    .filter((item): item is HubPostGridItem => item !== null)
     .sort((a, b) => collator.compare(a.title, b.title));
 
   return (
@@ -73,6 +109,15 @@ export default async function CompareHubPage() {
       />
 
       <HubPostGrid hero={page.data.hero} items={items} locale={locale} />
+
+      <HubPagination
+        basePath="/compare"
+        label={page.data.title}
+        nextLabel={t("Common.table.nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("Common.table.previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/[locale]/(static)/features/all/page.tsx
+++ b/app/[locale]/(static)/features/all/page.tsx
@@ -1,22 +1,48 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { HubPostGrid, type HubPostGridItem } from "@/components/marketing/hub-post-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { featurePagesSource, featuresAllSource } from "@/core/fumadocs/source";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  hubPageOneRedirectHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { breadcrumbListSchema } from "@/core/seo/schemas";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/features/all" });
+  const query = await searchParams;
+  const resolution = resolveHubPage(
+    query[HUB_PAGE_PARAM],
+    hubPageCount(featurePagesSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/features/all", resolution.page),
+    locale,
+    route: "/features/all",
+  });
 }
 
-export default async function FeaturesAllHubPage() {
+export default async function FeaturesAllHubPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = featuresAllSource.getPage(["all"], locale);
 
@@ -25,13 +51,24 @@ export default async function FeaturesAllHubPage() {
   const t = await getTranslations();
   const tagLabel = t("Common.tags.feature");
   const collator = new Intl.Collator(formattingTagFor(locale));
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
 
-  const items: HubPostGridItem[] = featurePagesSource
-    .getPages(locale)
-    .map((p): HubPostGridItem | null => {
-      const slug = p.url?.split("/").pop() ?? "";
-      if (!slug) return null;
+  const referencePages = featurePagesSource.getPages(DEFAULT_LOCALE);
+  const query = await searchParams;
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCount(referencePages.length));
 
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one")
+    permanentRedirect(buildLocalePath(locale, hubPageOneRedirectHref("/features/all", query)));
+
+  const paginated = paginateLocalizedHubPages(
+    referencePages,
+    featurePagesSource.getPages(locale),
+    resolution.page,
+    (a, b) => referenceCollator.compare(a.page.data.featureName, b.page.data.featureName),
+  );
+  const items: HubPostGridItem[] = paginated.items
+    .map(({ page: p, slug }): HubPostGridItem => {
       return {
         description: p.data.description,
         href: `/features/${slug}`,
@@ -40,7 +77,6 @@ export default async function FeaturesAllHubPage() {
         title: p.data.featureName,
       };
     })
-    .filter((item): item is HubPostGridItem => item !== null)
     .sort((a, b) => collator.compare(a.title, b.title));
 
   return (
@@ -48,12 +84,27 @@ export default async function FeaturesAllHubPage() {
       <JsonLd
         schema={breadcrumbListSchema([
           { name: t("StructuredData.breadcrumb.home"), path: `/${locale}` },
-          { name: t("StructuredData.breadcrumb.features"), path: `/${locale}/features` },
-          { name: t("StructuredData.breadcrumb.allFeatures"), path: `/${locale}/features/all` },
+          {
+            name: t("StructuredData.breadcrumb.features"),
+            path: `/${locale}/features`,
+          },
+          {
+            name: t("StructuredData.breadcrumb.allFeatures"),
+            path: `/${locale}/features/all`,
+          },
         ])}
       />
 
       <HubPostGrid hero={page.data.hero} items={items} locale={locale} />
+
+      <HubPagination
+        basePath="/features/all"
+        label={page.data.title}
+        nextLabel={t("Common.table.nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("Common.table.previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/[locale]/(static)/for/page.tsx
+++ b/app/[locale]/(static)/for/page.tsx
@@ -1,22 +1,48 @@
 import type { Metadata } from "next";
 
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { Footer } from "@/app/components/footer";
+import { HubPagination } from "@/components/marketing/hub-pagination";
 import { HubPostGrid, type HubPostGridItem } from "@/components/marketing/hub-post-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { forPagesSource, forSource } from "@/core/fumadocs/source";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  hubPageOneRedirectHref,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { breadcrumbListSchema } from "@/core/seo/schemas";
-import { contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
+import { DEFAULT_LOCALE, buildLocalePath, contentLocaleOrDefault, formattingTagFor } from "@/i18n/locale-registry";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+type Props = {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
-  return generateMetadataFromMeta({ locale, route: "/for" });
+  const query = await searchParams;
+  const resolution = resolveHubPage(
+    query[HUB_PAGE_PARAM],
+    hubPageCount(forPagesSource.getPages(DEFAULT_LOCALE).length),
+  );
+
+  if (resolution.kind === "not-found") notFound();
+
+  return generateMetadataFromMeta({
+    canonicalPath: hubPageHref("/for", resolution.page),
+    locale,
+    route: "/for",
+  });
 }
 
-export default async function ForHubPage() {
+export default async function ForHubPage({ searchParams }: Props) {
   const locale = contentLocaleOrDefault(await getLocale());
   const page = forSource.getPage(["for"], locale);
 
@@ -25,13 +51,24 @@ export default async function ForHubPage() {
   const t = await getTranslations();
   const tagLabel = t("Common.tags.industry");
   const collator = new Intl.Collator(formattingTagFor(locale));
+  const referenceCollator = new Intl.Collator(formattingTagFor(DEFAULT_LOCALE));
 
-  const items: HubPostGridItem[] = forPagesSource
-    .getPages(locale)
-    .map((p): HubPostGridItem | null => {
-      const slug = p.url?.split("/").pop() ?? "";
-      if (!slug) return null;
+  const referencePages = forPagesSource.getPages(DEFAULT_LOCALE);
+  const query = await searchParams;
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCount(referencePages.length));
 
+  if (resolution.kind === "not-found") notFound();
+  if (resolution.kind === "redirect-page-one")
+    permanentRedirect(buildLocalePath(locale, hubPageOneRedirectHref("/for", query)));
+
+  const paginated = paginateLocalizedHubPages(
+    referencePages,
+    forPagesSource.getPages(locale),
+    resolution.page,
+    (a, b) => referenceCollator.compare(a.page.data.industryName, b.page.data.industryName),
+  );
+  const items: HubPostGridItem[] = paginated.items
+    .map(({ page: p, slug }): HubPostGridItem => {
       return {
         description: p.data.description,
         href: `/for/${slug}`,
@@ -40,7 +77,6 @@ export default async function ForHubPage() {
         title: p.data.industryName,
       };
     })
-    .filter((item): item is HubPostGridItem => item !== null)
     .sort((a, b) => collator.compare(a.title, b.title));
 
   return (
@@ -48,11 +84,23 @@ export default async function ForHubPage() {
       <JsonLd
         schema={breadcrumbListSchema([
           { name: t("StructuredData.breadcrumb.home"), path: `/${locale}` },
-          { name: t("StructuredData.breadcrumb.industries"), path: `/${locale}/for` },
+          {
+            name: t("StructuredData.breadcrumb.industries"),
+            path: `/${locale}/for`,
+          },
         ])}
       />
 
       <HubPostGrid hero={page.data.hero} items={items} locale={locale} />
+
+      <HubPagination
+        basePath="/for"
+        label={page.data.title}
+        nextLabel={t("Common.table.nextPage")}
+        page={paginated.page}
+        pageCount={paginated.pageCount}
+        previousLabel={t("Common.table.previousPage")}
+      />
 
       <Footer />
     </div>

--- a/app/components/footer-selection.ts
+++ b/app/components/footer-selection.ts
@@ -1,0 +1,53 @@
+export const FOOTER_COLUMN_SIZE = 6;
+
+export const FOOTER_PREFERRED_SLUGS = {
+  "blog-posts": [
+    "customer-interaction-management",
+    "customer-retention-management",
+    "crm-examples",
+    "customer-communication-management",
+    "crm-software",
+    "agentic-ai",
+  ],
+  "compare-pages": [
+    "gohighlevel",
+    "notion-alternative",
+    "hubspot-vs-salesforce",
+    "vtiger-alternative",
+    "folk",
+    "cobra-alternative",
+  ],
+  "feature-pages": [
+    "cloud-crm",
+    "sales-tracking",
+    "lead-management",
+    "sales-automation",
+    "contact-management",
+    "reporting",
+  ],
+  "for-pages": ["healthcare", "ecommerce", "recruiting", "construction", "manufacturing", "property-management"],
+} as const;
+
+export type FooterCollection = keyof typeof FOOTER_PREFERRED_SLUGS;
+
+export function selectFooterSlugs(
+  collection: FooterCollection,
+  available: readonly string[],
+  size: number = FOOTER_COLUMN_SIZE,
+): string[] {
+  const pool = new Set(available);
+  const selected: string[] = [];
+
+  for (const slug of FOOTER_PREFERRED_SLUGS[collection]) {
+    if (selected.length >= size) break;
+    if (!pool.delete(slug)) continue;
+    selected.push(slug);
+  }
+
+  for (const slug of [...pool].sort()) {
+    if (selected.length >= size) break;
+    selected.push(slug);
+  }
+
+  return selected;
+}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,90 +1,62 @@
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { FooterContent } from "./footer-content";
+import { type FooterCollection, selectFooterSlugs } from "./footer-selection";
 
 import { blogPostsSource, comparePagesSource, featurePagesSource, forPagesSource } from "@/core/fumadocs/source";
 import { contentLocaleOrDefault } from "@/i18n/locale-registry";
 
-const FOOTER_COMPARE = new Set([
-  "gohighlevel",
-  "notion-alternative",
-  "hubspot-vs-salesforce",
-  "vtiger-alternative",
-  "folk",
-  "cobra-alternative",
-]);
+type SourcePage = {
+  url: string;
+};
 
-const FOOTER_FOR = new Set([
-  "healthcare",
-  "ecommerce",
-  "recruiting",
-  "construction",
-  "manufacturing",
-  "property-management",
-]);
+function selectPages<T extends SourcePage>(
+  collection: FooterCollection,
+  pages: readonly T[],
+): Array<{ page: T; slug: string }> {
+  const bySlug = new Map<string, T>();
 
-const FOOTER_FEATURES = new Set([
-  "cloud-crm",
-  "sales-tracking",
-  "lead-management",
-  "sales-automation",
-  "contact-management",
-  "reporting",
-]);
+  for (const page of pages) {
+    const slug = page.url.split("/").filter(Boolean).pop() ?? "";
+    if (slug) bySlug.set(slug, page);
+  }
 
-const FOOTER_BLOG_POSTS = new Set([
-  "customer-interaction-management",
-  "customer-retention-management",
-  "crm-examples",
-  "customer-communication-management",
-  "crm-software",
-  "agentic-ai",
-]);
+  return selectFooterSlugs(collection, [...bySlug.keys()]).flatMap((slug) => {
+    const page = bySlug.get(slug);
+    return page ? [{ page, slug }] : [];
+  });
+}
 
 export async function Footer() {
   const locale = contentLocaleOrDefault(await getLocale());
   const t = await getTranslations("ComparePage");
 
-  const competitors = comparePagesSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_COMPARE.has(slug)) return null;
-      const competitor2 = page.data.comparison?.competitor2Name;
-      let displayName = page.data.competitorName;
-      if (slug.includes("-vs-") && competitor2) displayName = `${page.data.competitorName} vs ${competitor2}`;
-      else if (slug.endsWith("-alternative"))
-        displayName = t("alternativeTitle", { competitor: page.data.competitorName });
-      return { slug, displayName };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const competitors = selectPages("compare-pages", comparePagesSource.getPages(locale)).map(({ page, slug }) => {
+    const competitor2 = page.data.comparison?.competitor2Name;
+    let displayName = page.data.competitorName;
+    if (slug.includes("-vs-") && competitor2) displayName = `${page.data.competitorName} vs ${competitor2}`;
+    else if (slug.endsWith("-alternative")) {
+      displayName = t("alternativeTitle", {
+        competitor: page.data.competitorName,
+      });
+    }
+    return { displayName, slug };
+  });
 
-  const industries = forPagesSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_FOR.has(slug)) return null;
-      return { slug, displayName: page.data.industryName };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const industries = selectPages("for-pages", forPagesSource.getPages(locale)).map(({ page, slug }) => ({
+    displayName: page.data.industryName,
+    slug,
+  }));
 
-  const featureLinks = featurePagesSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_FEATURES.has(slug)) return null;
-      return { slug, displayName: page.data.featureName };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const featureLinks = selectPages("feature-pages", featurePagesSource.getPages(locale)).map(({ page, slug }) => ({
+    displayName: page.data.featureName,
+    slug,
+  }));
 
-  const blogPosts = blogPostsSource
-    .getPages(locale)
-    .map((page) => {
-      const slug = page.url?.split("/").pop() || "";
-      if (!FOOTER_BLOG_POSTS.has(slug)) return null;
-      return { slug, displayName: page.data.hero.title };
-    })
-    .filter((item): item is { slug: string; displayName: string } => item !== null);
+  const blogPosts = selectPages("blog-posts", blogPostsSource.getPages(locale)).map(({ page, slug }) => ({
+    displayName: page.data.hero.title,
+    slug,
+  }));
 
   return (
     <FooterContent

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -34,7 +34,7 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     rules: [
       {
         userAgent: "*",
-        crawlDelay: 10,
+        allow: "/",
       },
     ],
     sitemap: `${env.BASE_URL}/sitemap.xml`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,8 @@ import type { LocalizedRoute } from "@/core/seo/sitemap";
 
 import { env } from "@/env";
 import { assembleSitemap } from "@/core/seo/sitemap";
+import { hubPageCount, hubPageHref } from "@/core/seo/hub-pagination";
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
 import { CONTENT_LOCALES, stripLocalePrefix } from "@/i18n/locale-registry";
 import { PUBLIC_ROUTES_SEO } from "@/i18n/routing";
 import { ROUTE_SOURCE_MAP } from "@/core/fumadocs/route-source-map";
@@ -35,7 +37,23 @@ function collectLocalizedRoutes(): LocalizedRoute[] {
       const page = routeMapping.source.getPage(routeMapping.path, locale);
       if (!page) continue;
 
-      localizedRoutes.push({ locale, routePath: route, lastModified: getLastModified(page.data.lastModified) });
+      localizedRoutes.push({
+        locale,
+        routePath: route,
+        lastModified: getLastModified(page.data.lastModified),
+      });
+    }
+
+    for (const hub of LANDING_HUBS) {
+      const source = ROUTE_SOURCE_MAP[hub.detailRoute].source;
+      const pageCount = hubPageCount(source.getPages(locale).length);
+
+      for (let page = 2; page <= pageCount; page++) {
+        localizedRoutes.push({
+          locale,
+          routePath: hubPageHref(hub.hubPath, page),
+        });
+      }
     }
   }
 

--- a/components/marketing/hub-pagination.tsx
+++ b/components/marketing/hub-pagination.tsx
@@ -1,0 +1,89 @@
+import { Fragment } from "react";
+
+import { AppLink } from "@/components/shared/app-link";
+import { hubPageHref, hubPagerModel } from "@/core/seo/hub-pagination";
+import { cn } from "@/core/utils/cn";
+
+type Props = {
+  basePath: string;
+  label: string;
+  nextLabel: string;
+  page: number;
+  pageCount: number;
+  previousLabel: string;
+};
+
+const pageClassName =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2";
+
+export function HubPagination({ basePath, label, nextLabel, page, pageCount, previousLabel }: Props) {
+  if (pageCount < 2) return null;
+
+  const model = hubPagerModel(page, pageCount);
+
+  return (
+    <nav aria-label={label} className="w-full pb-16 md:pb-24">
+      <ul className="mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-2 px-4">
+        {model.previousPage ? (
+          <li>
+            <AppLink
+              appearance="unstyled"
+              className={cn(pageClassName, "border-border text-subdued")}
+              href={hubPageHref(basePath, model.previousPage)}
+              rel="prev"
+            >
+              {previousLabel}
+            </AppLink>
+          </li>
+        ) : null}
+
+        {model.pageNumbers.map((number, index) => {
+          const previousNumber = model.pageNumbers[index - 1];
+          return (
+            <Fragment key={number}>
+              {previousNumber !== undefined && number - previousNumber > 1 ? (
+                <li aria-hidden="true" className="px-1 text-subdued">
+                  …
+                </li>
+              ) : null}
+
+              <li>
+                {number === page ? (
+                  <span
+                    aria-current="page"
+                    aria-label={String(number)}
+                    className={cn(pageClassName, "border-primary font-medium text-primary")}
+                  >
+                    {number}
+                  </span>
+                ) : (
+                  <AppLink
+                    appearance="unstyled"
+                    aria-label={String(number)}
+                    className={cn(pageClassName, "border-border text-subdued")}
+                    href={hubPageHref(basePath, number)}
+                  >
+                    {number}
+                  </AppLink>
+                )}
+              </li>
+            </Fragment>
+          );
+        })}
+
+        {model.nextPage ? (
+          <li>
+            <AppLink
+              appearance="unstyled"
+              className={cn(pageClassName, "border-border text-subdued")}
+              href={hubPageHref(basePath, model.nextPage)}
+              rel="next"
+            >
+              {nextLabel}
+            </AppLink>
+          </li>
+        ) : null}
+      </ul>
+    </nav>
+  );
+}

--- a/components/marketing/post-grid-shell.tsx
+++ b/components/marketing/post-grid-shell.tsx
@@ -14,7 +14,7 @@ export function PostGridShell({ children, hero }: Props) {
     <div className="flex w-full flex-col items-center pt-16 md:pt-24">
       <PageHero {...hero} />
 
-      <section className="relative w-full pb-16 md:pb-24">
+      <section className="relative w-full pb-16 md:pb-24" data-hub-results="">
         <div className="mx-auto max-w-7xl px-4">
           <div className="grid auto-rows-fr grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8 lg:grid-cols-3">{children}</div>
         </div>

--- a/core/fumadocs/__tests__/metadata.test.ts
+++ b/core/fumadocs/__tests__/metadata.test.ts
@@ -60,22 +60,60 @@ describe("generateMetadataFromMeta", () => {
   });
 
   it("keeps the canonical on the requested locale", () => {
-    const metadata = generateMetadataFromMeta({ locale: "de", route: "/pricing" });
+    const metadata = generateMetadataFromMeta({
+      locale: "de",
+      route: "/pricing",
+    });
 
     expect(metadata.alternates?.canonical).toBe(`${BASE_URL}/de/pricing`);
   });
 
-  it("substitutes params into dynamic routes and drops non-reciprocal alternates", () => {
-    const metadata = generateMetadataFromMeta({ locale: "en", params: { slug: "best-crm" }, route: "/blog/:slug" });
+  it("applies a paginated public path to the canonical and every alternate", () => {
+    const metadata = generateMetadataFromMeta({
+      canonicalPath: "/pricing?page=2",
+      locale: "en",
+      route: "/pricing",
+    });
 
-    expect(metadata.alternates).toEqual({ canonical: `${BASE_URL}/en/blog/best-crm` });
+    expect(metadata.alternates).toEqual({
+      canonical: `${BASE_URL}/en/pricing?page=2`,
+      languages: {
+        de: `${BASE_URL}/de/pricing?page=2`,
+        en: `${BASE_URL}/en/pricing?page=2`,
+        "x-default": `${BASE_URL}/en/pricing?page=2`,
+      },
+    });
+  });
+
+  it("substitutes params into dynamic routes and drops non-reciprocal alternates", () => {
+    const metadata = generateMetadataFromMeta({
+      locale: "en",
+      params: { slug: "best-crm" },
+      route: "/blog/:slug",
+    });
+
+    expect(metadata.alternates).toEqual({
+      canonical: `${BASE_URL}/en/blog/best-crm`,
+    });
     expect(metadata.title).toBe("Best CRM");
     expect(metadata.description).toBeUndefined();
   });
 
   it("returns empty metadata when the localized page is missing", () => {
-    expect(generateMetadataFromMeta({ locale: "de", params: { slug: "best-crm" }, route: "/blog/:slug" })).toEqual({});
-    expect(generateMetadataFromMeta({ locale: "en", params: { slug: "nope" }, route: "/blog/:slug" })).toEqual({});
+    expect(
+      generateMetadataFromMeta({
+        locale: "de",
+        params: { slug: "best-crm" },
+        route: "/blog/:slug",
+      }),
+    ).toEqual({});
+    expect(
+      generateMetadataFromMeta({
+        locale: "en",
+        params: { slug: "nope" },
+        route: "/blog/:slug",
+      }),
+    ).toEqual({});
   });
 
   it("returns empty metadata for a dynamic route invoked without its params", () => {
@@ -83,6 +121,12 @@ describe("generateMetadataFromMeta", () => {
   });
 
   it("returns empty metadata when the page title is blank", () => {
-    expect(generateMetadataFromMeta({ locale: "en", params: { slug: "untitled" }, route: "/blog/:slug" })).toEqual({});
+    expect(
+      generateMetadataFromMeta({
+        locale: "en",
+        params: { slug: "untitled" },
+        route: "/blog/:slug",
+      }),
+    ).toEqual({});
   });
 });

--- a/core/fumadocs/metadata.ts
+++ b/core/fumadocs/metadata.ts
@@ -7,12 +7,14 @@ import { buildAlternateLanguages } from "@/core/seo/alternates";
 import { CONTENT_LOCALES, buildLocalePath } from "@/i18n/locale-registry";
 
 type GenerateMetadataParams = {
+  canonicalPath?: string;
   locale: string;
   route: keyof typeof ROUTE_SOURCE_MAP;
   params?: Record<string, string>;
   type?: "article" | "website";
 };
 export function generateMetadataFromMeta({
+  canonicalPath,
   locale,
   route,
   params = {},
@@ -30,10 +32,11 @@ export function generateMetadataFromMeta({
   if (!title) return {};
 
   const routePath = buildRoutePath(route, params);
+  const publicPath = canonicalPath ?? routePath;
   const translatedLocales = CONTENT_LOCALES.filter((loc) => source.getPage(path, loc) !== undefined);
-  const alternates = buildAlternateLanguages(routePath, translatedLocales, env.BASE_URL);
+  const alternates = buildAlternateLanguages(publicPath, translatedLocales, env.BASE_URL);
 
-  const canonical = `${env.BASE_URL}${buildLocalePath(locale, routePath)}`;
+  const canonical = `${env.BASE_URL}${buildLocalePath(locale, publicPath)}`;
   const ogImageParams = new URLSearchParams({ title });
 
   if (description) ogImageParams.set("description", description);

--- a/core/fumadocs/route-source-map.ts
+++ b/core/fumadocs/route-source-map.ts
@@ -2,6 +2,8 @@ import type { PUBLIC_ROUTES_SEO } from "@/i18n/routing";
 
 import {
   affiliateSource,
+  apiDocsSource,
+  apiOverviewSource,
   authSource,
   automationSource,
   blogPostsSource,
@@ -121,4 +123,15 @@ export const ROUTE_SOURCE_MAP = {
     source: docsSource,
     path: [":slug"],
   },
-} satisfies Record<(typeof PUBLIC_ROUTES_SEO)[number], { source: unknown; path: string[] }>;
+  "/docs/openapi": {
+    source: apiOverviewSource,
+    path: ["openapi"],
+  },
+  "/docs/openapi/:slug": {
+    source: apiDocsSource,
+    path: [":slug"],
+  },
+} satisfies Record<
+  (typeof PUBLIC_ROUTES_SEO)[number] | "/docs/openapi" | "/docs/openapi/:slug",
+  { source: unknown; path: string[] }
+>;

--- a/core/seo/__tests__/sitemap.test.ts
+++ b/core/seo/__tests__/sitemap.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { buildAlternateLanguages } from "../alternates";
 import { assembleSitemap } from "../sitemap";
 
-import { DEFAULT_LOCALE } from "@/i18n/locale-registry";
+import { CONTENT_LOCALES, DEFAULT_LOCALE } from "@/i18n/locale-registry";
 
 const BASE_URL = "https://example.test";
 const GENERATED_AT = new Date("2026-01-01T00:00:00.000Z");
@@ -134,6 +134,14 @@ describe("alternate languages", () => {
       en: `${BASE_URL}/en`,
       de: `${BASE_URL}/de`,
       "x-default": `${BASE_URL}/en`,
+    });
+  });
+
+  it("preserves a query string in localized pagination alternates", () => {
+    expect(buildAlternateLanguages("/blog?page=2", CONTENT_LOCALES, BASE_URL)).toEqual({
+      de: `${BASE_URL}/de/blog?page=2`,
+      en: `${BASE_URL}/en/blog?page=2`,
+      "x-default": `${BASE_URL}/en/blog?page=2`,
     });
   });
 });

--- a/core/seo/hub-pagination.ts
+++ b/core/seo/hub-pagination.ts
@@ -1,0 +1,137 @@
+export const HUB_PAGE_SIZE = 24;
+
+export const HUB_PAGE_PARAM = "page";
+
+export type HubSearchParams = Record<string, string | string[] | undefined>;
+
+export type HubPage<T> = {
+  items: T[];
+  page: number;
+  pageCount: number;
+};
+
+export type HubPageResolution =
+  | { kind: "page"; page: number }
+  | { kind: "redirect-page-one"; page: 1 }
+  | { kind: "not-found" };
+
+export type HubPagerModel = {
+  nextPage: number | null;
+  pageNumbers: number[];
+  previousPage: number | null;
+};
+
+type SourcePage = {
+  url: string;
+};
+
+export type SluggedPage<T extends SourcePage> = {
+  page: T;
+  slug: string;
+};
+
+export function hubPageCount(total: number, size: number = HUB_PAGE_SIZE): number {
+  if (!Number.isSafeInteger(total) || total < 0) throw new RangeError("Hub item total must be a non-negative integer");
+  if (!Number.isSafeInteger(size) || size < 1) throw new RangeError("Hub page size must be a positive integer");
+
+  return Math.max(1, Math.ceil(total / size));
+}
+
+export function resolveHubPage(raw: string | string[] | undefined, pageCount: number): HubPageResolution {
+  if (!Number.isSafeInteger(pageCount) || pageCount < 1) throw new RangeError("Hub page count must be positive");
+  if (raw === undefined) return { kind: "page", page: 1 };
+  if (Array.isArray(raw) || !/^[1-9]\d*$/u.test(raw)) return { kind: "not-found" };
+
+  const page = Number(raw);
+  if (!Number.isSafeInteger(page) || page > pageCount) return { kind: "not-found" };
+  if (page === 1) return { kind: "redirect-page-one", page: 1 };
+
+  return { kind: "page", page };
+}
+
+export function hubPageHref(basePath: string, page: number): string {
+  if (!Number.isSafeInteger(page) || page < 1) throw new RangeError("Hub page must be a positive integer");
+  return page === 1 ? basePath : `${basePath}?${HUB_PAGE_PARAM}=${page}`;
+}
+
+export function hubPageOneRedirectHref(basePath: string, searchParams: HubSearchParams): string {
+  const preserved = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (key === HUB_PAGE_PARAM || value === undefined) continue;
+    if (Array.isArray(value)) for (const entry of value) preserved.append(key, entry);
+    else preserved.append(key, value);
+  }
+
+  const query = preserved.toString();
+  return query ? `${basePath}?${query}` : basePath;
+}
+
+export function paginateHub<T>(items: readonly T[], page: number, size: number = HUB_PAGE_SIZE): HubPage<T> {
+  const pageCount = hubPageCount(items.length, size);
+  if (!Number.isSafeInteger(page) || page < 1 || page > pageCount)
+    throw new RangeError(`Hub page ${page} is outside 1-${pageCount}`);
+
+  const start = (page - 1) * size;
+  return { items: items.slice(start, start + size), page, pageCount };
+}
+
+export function hubPagerModel(page: number, pageCount: number): HubPagerModel {
+  if (!Number.isSafeInteger(pageCount) || pageCount < 1) throw new RangeError("Hub page count must be positive");
+  if (!Number.isSafeInteger(page) || page < 1 || page > pageCount)
+    throw new RangeError(`Hub page ${page} is outside 1-${pageCount}`);
+
+  const bucketSize = Math.ceil(Math.sqrt(pageCount));
+  const currentBucketStart = Math.floor((page - 1) / bucketSize) * bucketSize + 1;
+  const numbers = new Set<number>();
+
+  for (let bucketStart = 1; bucketStart <= pageCount; bucketStart += bucketSize) numbers.add(bucketStart);
+  for (
+    let bucketPage = currentBucketStart;
+    bucketPage <= Math.min(currentBucketStart + bucketSize - 1, pageCount);
+    bucketPage++
+  )
+    numbers.add(bucketPage);
+
+  return {
+    nextPage: page < pageCount ? page + 1 : null,
+    pageNumbers: [...numbers].sort((a, b) => a - b),
+    previousPage: page > 1 ? page - 1 : null,
+  };
+}
+
+export function paginateLocalizedHubPages<ReferencePage extends SourcePage, LocalizedPage extends SourcePage>(
+  referencePages: readonly ReferencePage[],
+  localizedPages: readonly LocalizedPage[],
+  page: number,
+  compareReference: (a: SluggedPage<ReferencePage>, b: SluggedPage<ReferencePage>) => number,
+): HubPage<SluggedPage<LocalizedPage>> {
+  const references = indexPages(referencePages, "reference").sort((a, b) => {
+    const compared = compareReference(a, b);
+    if (compared !== 0) return compared;
+    return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+  });
+  const localized = new Map(indexPages(localizedPages, "localized").map((entry) => [entry.slug, entry.page]));
+  const paginated = paginateHub(references, page);
+
+  return {
+    ...paginated,
+    items: paginated.items.map(({ slug }) => {
+      const localizedPage = localized.get(slug);
+      if (!localizedPage) throw new Error(`Localized hub content is missing slug ${slug}`);
+      return { page: localizedPage, slug };
+    }),
+  };
+}
+
+function indexPages<T extends SourcePage>(pages: readonly T[], label: string): SluggedPage<T>[] {
+  const seen = new Set<string>();
+
+  return pages.map((page) => {
+    const slug = page.url.split("/").filter(Boolean).pop() ?? "";
+    if (!slug) throw new Error(`${label} hub content has a page without a slug`);
+    if (seen.has(slug)) throw new Error(`${label} hub content repeats slug ${slug}`);
+    seen.add(slug);
+    return { page, slug };
+  });
+}

--- a/core/seo/landing-hubs.ts
+++ b/core/seo/landing-hubs.ts
@@ -1,0 +1,44 @@
+import type { PUBLIC_ROUTES } from "@/i18n/routing";
+
+type PublicRoute = (typeof PUBLIC_ROUTES)[number];
+type DynamicPublicRoute = Extract<PublicRoute, `${string}/:${string}`>;
+
+function landingHub<
+  const Collection extends string,
+  const DetailRoute extends DynamicPublicRoute,
+  const HubPath extends string,
+>(config: { collection: Collection; detailRoute: DetailRoute; hubPath: HubPath; pageCount: number }) {
+  return {
+    ...config,
+    detailPath: config.detailRoute.slice(0, config.detailRoute.lastIndexOf("/")),
+  };
+}
+
+export const LANDING_HUBS = [
+  landingHub({
+    collection: "blog-posts",
+    detailRoute: "/blog/:slug",
+    hubPath: "/blog",
+    pageCount: 3,
+  }),
+  landingHub({
+    collection: "compare-pages",
+    detailRoute: "/compare/:competitor",
+    hubPath: "/compare",
+    pageCount: 2,
+  }),
+  landingHub({
+    collection: "feature-pages",
+    detailRoute: "/features/:slug",
+    hubPath: "/features/all",
+    pageCount: 1,
+  }),
+  landingHub({
+    collection: "for-pages",
+    detailRoute: "/for/:industry",
+    hubPath: "/for",
+    pageCount: 2,
+  }),
+] as const;
+
+export type LandingHub = (typeof LANDING_HUBS)[number];

--- a/core/seo/landing-hubs.ts
+++ b/core/seo/landing-hubs.ts
@@ -7,7 +7,7 @@ function landingHub<
   const Collection extends string,
   const DetailRoute extends DynamicPublicRoute,
   const HubPath extends string,
->(config: { collection: Collection; detailRoute: DetailRoute; hubPath: HubPath; pageCount: number }) {
+>(config: { collection: Collection; detailRoute: DetailRoute; hubPath: HubPath }) {
   return {
     ...config,
     detailPath: config.detailRoute.slice(0, config.detailRoute.lastIndexOf("/")),
@@ -19,25 +19,21 @@ export const LANDING_HUBS = [
     collection: "blog-posts",
     detailRoute: "/blog/:slug",
     hubPath: "/blog",
-    pageCount: 3,
   }),
   landingHub({
     collection: "compare-pages",
     detailRoute: "/compare/:competitor",
     hubPath: "/compare",
-    pageCount: 2,
   }),
   landingHub({
     collection: "feature-pages",
     detailRoute: "/features/:slug",
     hubPath: "/features/all",
-    pageCount: 1,
   }),
   landingHub({
     collection: "for-pages",
     detailRoute: "/for/:industry",
     hubPath: "/for",
-    pageCount: 2,
   }),
 ] as const;
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import type { ContentLocale } from "./i18n/locale-registry";
 
 import { NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
@@ -18,6 +19,8 @@ import { env } from "./env";
 import { auth } from "./core/auth/better-auth";
 import { resolveRequestOrigin } from "./core/config/environment";
 import { SYNTHETIC_SEED_USER } from "./core/config/synthetic-seed-user";
+import { HUB_PAGE_PARAM, resolveHubPage } from "./core/seo/hub-pagination";
+import { LANDING_HUBS } from "./core/seo/landing-hubs";
 
 const intlAppMiddleware = createMiddleware(appRouting);
 const intlContentMiddleware = createMiddleware(contentRouting);
@@ -74,6 +77,39 @@ function appendSetCookieHeaders(response: NextResponse, authResponse: Response):
   for (const cookie of setCookies) response.headers.append("set-cookie", cookie);
 }
 
+function hubPaginationResponse(req: NextRequest, locale: ContentLocale): NextResponse | null {
+  const hub = LANDING_HUBS.find(({ hubPath }) => hubPath === stripLocalePrefix(req.nextUrl.pathname));
+  if (!hub) return null;
+
+  const values = req.nextUrl.searchParams.getAll(HUB_PAGE_PARAM);
+  const raw = values.length === 0 ? undefined : values.length === 1 ? values[0] : values;
+  const resolution = resolveHubPage(raw, hub.pageCount);
+
+  if (resolution.kind === "page") return null;
+
+  if (resolution.kind === "redirect-page-one") {
+    const canonical = req.nextUrl.clone();
+    canonical.pathname = buildLocalePath(locale, hub.hubPath);
+    canonical.searchParams.delete(HUB_PAGE_PARAM);
+    return NextResponse.redirect(canonical, 308);
+  }
+
+  // Next strips its router-prefetch header before constructing the proxy
+  // request and restores it for rendering. A rewrite can therefore become an
+  // RSC-level 500 even though the matcher ran. Terminate every invalid URL in
+  // the proxy with a small semantic document instead of entering rendering.
+  return new NextResponse(
+    `<!doctype html><html lang="${locale}"><head><meta charset="utf-8"><meta name="robots" content="noindex"><title>404</title></head><body><main><h1>404</h1></main></body></html>`,
+    {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "x-robots-tag": "noindex",
+      },
+      status: 404,
+    },
+  );
+}
+
 export default async function proxy(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
   const base = resolveRequestOrigin(req.nextUrl.origin, env.AUTH_ALLOWED_HOSTS, env.BASE_URL);
@@ -126,6 +162,12 @@ export default async function proxy(req: NextRequest) {
     if (isUnsupportedLocalePrefix(pathname)) return NextResponse.next();
     return negotiateLocale(req, base, isAuthenticated && pathname === "/" ? "app" : "auto");
   }
+
+  // A cross-locale fallback is temporary: an app-only locale can gain content
+  // later, so it remains a 307. Apply the permanent page-one normalization
+  // only after the request is already in a locale that publishes content.
+  const paginationResponse = isContentLocale(currentLocale) ? hubPaginationResponse(req, currentLocale) : null;
+  if (paginationResponse) return paginationResponse;
 
   if (env.APP_MODE === "demo") {
     const isNonDemoUser = isAuthenticated && session?.user?.email !== SYNTHETIC_SEED_USER.email;
@@ -195,6 +237,12 @@ export default async function proxy(req: NextRequest) {
 
 export const config = {
   matcher: [
+    // Hub pagination is a public URL contract, so it must also run for Next's
+    // prefetch requests. These narrow matchers intentionally have no `missing`
+    // header exclusions; the broad matcher below keeps the existing shortcut
+    // for every other route.
+    { source: "/:locale([a-zA-Z]{2}(?:-[a-zA-Z0-9]{2,8})*)?/:hub(blog|compare|for)" },
+    { source: "/:locale([a-zA-Z]{2}(?:-[a-zA-Z0-9]{2,8})*)?/features/all" },
     {
       /*
        * Exclude paths:

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server";
-import type { ContentLocale } from "./i18n/locale-registry";
 
 import { NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
@@ -19,8 +18,6 @@ import { env } from "./env";
 import { auth } from "./core/auth/better-auth";
 import { resolveRequestOrigin } from "./core/config/environment";
 import { SYNTHETIC_SEED_USER } from "./core/config/synthetic-seed-user";
-import { HUB_PAGE_PARAM, resolveHubPage } from "./core/seo/hub-pagination";
-import { LANDING_HUBS } from "./core/seo/landing-hubs";
 
 const intlAppMiddleware = createMiddleware(appRouting);
 const intlContentMiddleware = createMiddleware(contentRouting);
@@ -77,39 +74,6 @@ function appendSetCookieHeaders(response: NextResponse, authResponse: Response):
   for (const cookie of setCookies) response.headers.append("set-cookie", cookie);
 }
 
-function hubPaginationResponse(req: NextRequest, locale: ContentLocale): NextResponse | null {
-  const hub = LANDING_HUBS.find(({ hubPath }) => hubPath === stripLocalePrefix(req.nextUrl.pathname));
-  if (!hub) return null;
-
-  const values = req.nextUrl.searchParams.getAll(HUB_PAGE_PARAM);
-  const raw = values.length === 0 ? undefined : values.length === 1 ? values[0] : values;
-  const resolution = resolveHubPage(raw, hub.pageCount);
-
-  if (resolution.kind === "page") return null;
-
-  if (resolution.kind === "redirect-page-one") {
-    const canonical = req.nextUrl.clone();
-    canonical.pathname = buildLocalePath(locale, hub.hubPath);
-    canonical.searchParams.delete(HUB_PAGE_PARAM);
-    return NextResponse.redirect(canonical, 308);
-  }
-
-  // Next strips its router-prefetch header before constructing the proxy
-  // request and restores it for rendering. A rewrite can therefore become an
-  // RSC-level 500 even though the matcher ran. Terminate every invalid URL in
-  // the proxy with a small semantic document instead of entering rendering.
-  return new NextResponse(
-    `<!doctype html><html lang="${locale}"><head><meta charset="utf-8"><meta name="robots" content="noindex"><title>404</title></head><body><main><h1>404</h1></main></body></html>`,
-    {
-      headers: {
-        "content-type": "text/html; charset=utf-8",
-        "x-robots-tag": "noindex",
-      },
-      status: 404,
-    },
-  );
-}
-
 export default async function proxy(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
   const base = resolveRequestOrigin(req.nextUrl.origin, env.AUTH_ALLOWED_HOSTS, env.BASE_URL);
@@ -162,12 +126,6 @@ export default async function proxy(req: NextRequest) {
     if (isUnsupportedLocalePrefix(pathname)) return NextResponse.next();
     return negotiateLocale(req, base, isAuthenticated && pathname === "/" ? "app" : "auto");
   }
-
-  // A cross-locale fallback is temporary: an app-only locale can gain content
-  // later, so it remains a 307. Apply the permanent page-one normalization
-  // only after the request is already in a locale that publishes content.
-  const paginationResponse = isContentLocale(currentLocale) ? hubPaginationResponse(req, currentLocale) : null;
-  if (paginationResponse) return paginationResponse;
 
   if (env.APP_MODE === "demo") {
     const isNonDemoUser = isAuthenticated && session?.user?.email !== SYNTHETIC_SEED_USER.email;
@@ -237,12 +195,6 @@ export default async function proxy(req: NextRequest) {
 
 export const config = {
   matcher: [
-    // Hub pagination is a public URL contract, so it must also run for Next's
-    // prefetch requests. These narrow matchers intentionally have no `missing`
-    // header exclusions; the broad matcher below keeps the existing shortcut
-    // for every other route.
-    { source: "/:locale([a-zA-Z]{2}(?:-[a-zA-Z0-9]{2,8})*)?/:hub(blog|compare|for)" },
-    { source: "/:locale([a-zA-Z]{2}(?:-[a-zA-Z0-9]{2,8})*)?/features/all" },
     {
       /*
        * Exclude paths:

--- a/tests/conventions/hero-asset-coverage.test.ts
+++ b/tests/conventions/hero-asset-coverage.test.ts
@@ -1,4 +1,10 @@
-import { closeSync, existsSync, openSync, readSync, readdirSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readSync,
+  readdirSync,
+} from "node:fs";
 import { extname, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -7,8 +13,6 @@ import { REPO_ROOT } from "./walk";
 
 import { LANDING_HUBS } from "@/core/seo/landing-hubs";
 import { CONTENT_LOCALES, DEFAULT_LOCALE } from "@/i18n/locale-registry";
-
-const ENFORCED = true;
 
 const IMAGE_THEMES = ["light", "dark"] as const;
 const HERO_WIDTH = 1920;
@@ -19,7 +23,11 @@ const IHDR_SIGNATURE = [0x49, 0x48, 0x44, 0x52];
 
 type Dimensions = { height: number; width: number };
 
-function startsWith(header: Uint8Array, signature: number[], offset: number): boolean {
+function startsWith(
+  header: Uint8Array,
+  signature: number[],
+  offset: number,
+): boolean {
   return signature.every((byte, index) => header[offset + index] === byte);
 }
 
@@ -28,7 +36,11 @@ export function pngDimensions(header: Uint8Array): Dimensions | null {
   if (!startsWith(header, PNG_SIGNATURE, 0)) return null;
   if (!startsWith(header, IHDR_SIGNATURE, 12)) return null;
 
-  const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  const view = new DataView(
+    header.buffer,
+    header.byteOffset,
+    header.byteLength,
+  );
   return { height: view.getUint32(20), width: view.getUint32(16) };
 }
 
@@ -63,73 +75,119 @@ function imageSlugs(theme: string, locale: string): string[] {
 }
 
 describe("hero asset coverage", () => {
-  const slugsByCollection = new Map(LANDING_HUBS.map(({ collection }) => [collection, collectionSlugs(collection)]));
+  const slugsByCollection = new Map(
+    LANDING_HUBS.map(({ collection }) => [
+      collection,
+      collectionSlugs(collection),
+    ]),
+  );
   const expectedSlugs = new Set([...slugsByCollection.values()].flat());
 
   it("keeps every landing slug unique in the shared image namespace", () => {
     const owners = new Map<string, string[]>();
 
     for (const [collection, slugs] of slugsByCollection) {
-      expect(slugs.length, `content/${collection}/${DEFAULT_LOCALE} holds no page`).toBeGreaterThan(0);
-      for (const slug of slugs) owners.set(slug, [...(owners.get(slug) ?? []), collection]);
+      expect(
+        slugs.length,
+        `content/${collection}/${DEFAULT_LOCALE} holds no page`,
+      ).toBeGreaterThan(0);
+      for (const slug of slugs)
+        owners.set(slug, [...(owners.get(slug) ?? []), collection]);
     }
 
     const collisions = [...owners]
       .filter(([, collections]) => collections.length > 1)
       .map(([slug, collections]) => `${slug}: ${collections.join(", ")}`);
 
-    expect(collisions, `landing slugs sharing one hero filename:\n${collisions.join("\n")}`).toEqual([]);
+    expect(
+      collisions,
+      `landing slugs sharing one hero filename:\n${collisions.join("\n")}`,
+    ).toEqual([]);
   });
 
-  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("gives every landing slug every localized theme asset", () => {
+  it("gives every landing slug every localized theme asset", () => {
     const problems: string[] = [];
 
     for (const slug of [...expectedSlugs].sort()) {
       for (const theme of IMAGE_THEMES) {
         for (const locale of CONTENT_LOCALES) {
-          const relativePath = join("public", "images", theme, locale, `${slug}.png`);
-          if (!existsSync(join(REPO_ROOT, relativePath))) problems.push(`${relativePath} is missing`);
+          const relativePath = join(
+            "public",
+            "images",
+            theme,
+            locale,
+            `${slug}.png`,
+          );
+          if (!existsSync(join(REPO_ROOT, relativePath)))
+            problems.push(`${relativePath} is missing`);
         }
       }
     }
 
-    expect(problems, `landing pages without a hero asset:\n${problems.join("\n")}`).toEqual([]);
+    expect(
+      problems,
+      `landing pages without a hero asset:\n${problems.join("\n")}`,
+    ).toEqual([]);
   });
 
-  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("keeps every localized PNG bound to one landing page", () => {
+  it("keeps every localized PNG bound to one landing page", () => {
     const problems: string[] = [];
 
     for (const theme of IMAGE_THEMES) {
       for (const locale of CONTENT_LOCALES) {
         for (const slug of imageSlugs(theme, locale)) {
           if (!expectedSlugs.has(slug)) {
-            problems.push(`${join("public", "images", theme, locale, `${slug}.png`)} has no landing page`);
+            problems.push(
+              `${join("public", "images", theme, locale, `${slug}.png`)} has no landing page`,
+            );
           }
         }
       }
     }
 
-    expect(problems, `hero assets without a landing page:\n${problems.join("\n")}`).toEqual([]);
+    expect(
+      problems,
+      `hero assets without a landing page:\n${problems.join("\n")}`,
+    ).toEqual([]);
   });
 
-  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(`keeps every hero PNG at ${HERO_WIDTH}x${HERO_HEIGHT}`, () => {
+  it(`keeps every hero PNG at ${HERO_WIDTH}x${HERO_HEIGHT}`, () => {
     const problems: string[] = [];
 
     for (const theme of IMAGE_THEMES) {
       for (const locale of CONTENT_LOCALES) {
         for (const slug of imageSlugs(theme, locale)) {
-          const relativePath = join("public", "images", theme, locale, `${slug}.png`);
-          const dimensions = pngDimensions(readPngHeader(join(REPO_ROOT, relativePath)));
+          const relativePath = join(
+            "public",
+            "images",
+            theme,
+            locale,
+            `${slug}.png`,
+          );
+          const dimensions = pngDimensions(
+            readPngHeader(join(REPO_ROOT, relativePath)),
+          );
 
-          if (!dimensions) problems.push(`${relativePath} does not start with a PNG IHDR header`);
-          else if (dimensions.width !== HERO_WIDTH || dimensions.height !== HERO_HEIGHT) {
-            problems.push(`${relativePath} is ${dimensions.width}x${dimensions.height}`);
+          if (!dimensions)
+            problems.push(
+              `${relativePath} does not start with a PNG IHDR header`,
+            );
+          else if (
+            dimensions.width !== HERO_WIDTH ||
+            dimensions.height !== HERO_HEIGHT
+          ) {
+            problems.push(
+              `${relativePath} is ${dimensions.width}x${dimensions.height}`,
+            );
           }
         }
       }
     }
 
-    expect(problems, `hero assets off the required geometry:\n${problems.join("\n")}`).toEqual([]);
+    expect(
+      problems,
+      `hero assets off the required geometry:\n${problems.join("\n")}`,
+    ).toEqual([]);
   });
 
   it("reads and rejects synthetic PNG headers without decoding image bodies", () => {

--- a/tests/conventions/hero-asset-coverage.test.ts
+++ b/tests/conventions/hero-asset-coverage.test.ts
@@ -1,0 +1,152 @@
+import { closeSync, existsSync, openSync, readSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT } from "./walk";
+
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
+import { CONTENT_LOCALES, DEFAULT_LOCALE } from "@/i18n/locale-registry";
+
+const ENFORCED = true;
+
+const IMAGE_THEMES = ["light", "dark"] as const;
+const HERO_WIDTH = 1920;
+const HERO_HEIGHT = 1080;
+const PNG_HEADER_BYTES = 24;
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const IHDR_SIGNATURE = [0x49, 0x48, 0x44, 0x52];
+
+type Dimensions = { height: number; width: number };
+
+function startsWith(header: Uint8Array, signature: number[], offset: number): boolean {
+  return signature.every((byte, index) => header[offset + index] === byte);
+}
+
+export function pngDimensions(header: Uint8Array): Dimensions | null {
+  if (header.length < PNG_HEADER_BYTES) return null;
+  if (!startsWith(header, PNG_SIGNATURE, 0)) return null;
+  if (!startsWith(header, IHDR_SIGNATURE, 12)) return null;
+
+  const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  return { height: view.getUint32(20), width: view.getUint32(16) };
+}
+
+function readPngHeader(path: string): Uint8Array {
+  const header = new Uint8Array(PNG_HEADER_BYTES);
+  const handle = openSync(path, "r");
+
+  try {
+    const read = readSync(handle, header, 0, PNG_HEADER_BYTES, 0);
+    return header.subarray(0, read);
+  } finally {
+    closeSync(handle);
+  }
+}
+
+function collectionSlugs(collection: string): string[] {
+  const directory = join(REPO_ROOT, "content", collection, DEFAULT_LOCALE);
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+    .map((entry) => entry.name.slice(0, -".mdx".length))
+    .sort();
+}
+
+function imageSlugs(theme: string, locale: string): string[] {
+  const directory = join(REPO_ROOT, "public", "images", theme, locale);
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".png")
+    .map((entry) => entry.name.slice(0, -".png".length))
+    .sort();
+}
+
+describe("hero asset coverage", () => {
+  const slugsByCollection = new Map(LANDING_HUBS.map(({ collection }) => [collection, collectionSlugs(collection)]));
+  const expectedSlugs = new Set([...slugsByCollection.values()].flat());
+
+  it("keeps every landing slug unique in the shared image namespace", () => {
+    const owners = new Map<string, string[]>();
+
+    for (const [collection, slugs] of slugsByCollection) {
+      expect(slugs.length, `content/${collection}/${DEFAULT_LOCALE} holds no page`).toBeGreaterThan(0);
+      for (const slug of slugs) owners.set(slug, [...(owners.get(slug) ?? []), collection]);
+    }
+
+    const collisions = [...owners]
+      .filter(([, collections]) => collections.length > 1)
+      .map(([slug, collections]) => `${slug}: ${collections.join(", ")}`);
+
+    expect(collisions, `landing slugs sharing one hero filename:\n${collisions.join("\n")}`).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("gives every landing slug every localized theme asset", () => {
+    const problems: string[] = [];
+
+    for (const slug of [...expectedSlugs].sort()) {
+      for (const theme of IMAGE_THEMES) {
+        for (const locale of CONTENT_LOCALES) {
+          const relativePath = join("public", "images", theme, locale, `${slug}.png`);
+          if (!existsSync(join(REPO_ROOT, relativePath))) problems.push(`${relativePath} is missing`);
+        }
+      }
+    }
+
+    expect(problems, `landing pages without a hero asset:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("keeps every localized PNG bound to one landing page", () => {
+    const problems: string[] = [];
+
+    for (const theme of IMAGE_THEMES) {
+      for (const locale of CONTENT_LOCALES) {
+        for (const slug of imageSlugs(theme, locale)) {
+          if (!expectedSlugs.has(slug)) {
+            problems.push(`${join("public", "images", theme, locale, `${slug}.png`)} has no landing page`);
+          }
+        }
+      }
+    }
+
+    expect(problems, `hero assets without a landing page:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(`keeps every hero PNG at ${HERO_WIDTH}x${HERO_HEIGHT}`, () => {
+    const problems: string[] = [];
+
+    for (const theme of IMAGE_THEMES) {
+      for (const locale of CONTENT_LOCALES) {
+        for (const slug of imageSlugs(theme, locale)) {
+          const relativePath = join("public", "images", theme, locale, `${slug}.png`);
+          const dimensions = pngDimensions(readPngHeader(join(REPO_ROOT, relativePath)));
+
+          if (!dimensions) problems.push(`${relativePath} does not start with a PNG IHDR header`);
+          else if (dimensions.width !== HERO_WIDTH || dimensions.height !== HERO_HEIGHT) {
+            problems.push(`${relativePath} is ${dimensions.width}x${dimensions.height}`);
+          }
+        }
+      }
+    }
+
+    expect(problems, `hero assets off the required geometry:\n${problems.join("\n")}`).toEqual([]);
+  });
+
+  it("reads and rejects synthetic PNG headers without decoding image bodies", () => {
+    const header = new Uint8Array(PNG_HEADER_BYTES);
+    header.set(PNG_SIGNATURE, 0);
+    header.set(IHDR_SIGNATURE, 12);
+    const view = new DataView(header.buffer);
+    view.setUint32(16, HERO_WIDTH);
+    view.setUint32(20, HERO_HEIGHT);
+
+    expect(pngDimensions(header)).toEqual({
+      height: HERO_HEIGHT,
+      width: HERO_WIDTH,
+    });
+    view.setUint32(16, 1280);
+    expect(pngDimensions(header)).toEqual({ height: HERO_HEIGHT, width: 1280 });
+    expect(pngDimensions(header.subarray(0, 20))).toBeNull();
+    expect(pngDimensions(new Uint8Array(PNG_HEADER_BYTES))).toBeNull();
+  });
+});

--- a/tests/conventions/hub-reachability.test.ts
+++ b/tests/conventions/hub-reachability.test.ts
@@ -1,0 +1,794 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+import { existsSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { extname, join } from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { REPO_ROOT } from "./walk";
+
+const { JSDOM } = createRequire(import.meta.url)("jsdom") as {
+  JSDOM: new (
+    html: string,
+    options?: { contentType?: string },
+  ) => { window: { document: Document } };
+};
+
+vi.mock("@/components/shared/app-link", () => ({
+  AppLink: ({
+    appearance: _appearance,
+    children,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    appearance?: string;
+    children?: ReactNode;
+  }) => createElement("a", props, children),
+}));
+
+const routeFixtures = vi.hoisted(() => {
+  const pages = (
+    basePath: string,
+    count: number,
+    data: (slug: string) => Record<string, unknown>,
+  ) =>
+    Array.from({ length: count }, (_, index) => {
+      const slug = `page-${String(index + 1).padStart(3, "0")}`;
+      return { data: data(slug), url: `${basePath}/${slug}` };
+    });
+
+  return {
+    blog: pages("/blog", 71, (slug) => ({
+      blogPost: { date: "2026-01-01" },
+      description: slug,
+      hero: { title: slug },
+      title: slug,
+    })),
+    compare: pages("/compare", 31, (slug) => ({
+      competitorName: slug,
+      description: slug,
+    })),
+    features: pages("/features", 24, (slug) => ({
+      description: slug,
+      featureName: slug,
+    })),
+    forPages: pages("/for", 42, (slug) => ({
+      description: slug,
+      industryName: slug,
+    })),
+  };
+});
+
+vi.mock("@/core/fumadocs/source", () => {
+  const collection = (pages: readonly unknown[]) => ({ getPages: () => pages });
+  const hub = (title: string) => ({
+    getPage: () => ({ data: { hero: {}, title } }),
+  });
+
+  return {
+    blogPostsSource: collection(routeFixtures.blog),
+    blogSource: hub("Blog"),
+    comparePagesSource: collection(routeFixtures.compare),
+    compareSource: hub("Compare"),
+    featurePagesSource: collection(routeFixtures.features),
+    featuresAllSource: hub("Features"),
+    forPagesSource: collection(routeFixtures.forPages),
+    forSource: hub("Industries"),
+  };
+});
+
+vi.mock("@/core/fumadocs/metadata", () => ({
+  generateMetadataFromMeta: vi.fn(),
+}));
+vi.mock("next-intl/server", () => ({
+  getLocale: async () => "en",
+  getTranslations: async () => (key: string) => key,
+}));
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("unexpected notFound");
+  },
+  permanentRedirect: (href: string) => {
+    throw new Error(`unexpected permanentRedirect to ${href}`);
+  },
+}));
+vi.mock("@/app/components/footer", () => ({ Footer: () => null }));
+vi.mock("@/components/marketing/page-hero", () => ({ PageHero: () => null }));
+vi.mock("@/components/seo/json-ld", () => ({ JsonLd: () => null }));
+vi.mock("@/components/marketing/hub-post-card", async () => {
+  const { createElement } = await import("react");
+  return {
+    HubPostCard: ({ href }: { href: string }) =>
+      createElement("a", { href }, href),
+  };
+});
+vi.mock("@/app/[locale]/(static)/blog/blog-post-card", async () => {
+  const { createElement } = await import("react");
+  return {
+    BlogPostCard: ({ url }: { url: string }) =>
+      createElement("a", { href: url }, url),
+  };
+});
+
+import { HubPagination } from "@/components/marketing/hub-pagination";
+import { selectFooterSlugs } from "@/app/components/footer-selection";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  hubPageHref,
+  hubPageOneRedirectHref,
+  hubPagerModel,
+  paginateHub,
+  paginateLocalizedHubPages,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
+import { CONTENT_LOCALES, buildLocalePath } from "@/i18n/locale-registry";
+import { PUBLIC_ROUTES } from "@/i18n/routing";
+
+const ENFORCED = true;
+const CLICK_BOUND = 4;
+const E2E_BASE_URL = process.env.HUB_E2E_BASE_URL?.replace(/\/+$/u, "");
+
+function collectionSlugs(collection: string, locale: string): string[] {
+  const directory = join(REPO_ROOT, "content", collection, locale);
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+    .map((entry) => entry.name.slice(0, -".mdx".length))
+    .sort();
+}
+
+function renderedPagerHrefs(
+  basePath: string,
+  page: number,
+  pageCount: number,
+): string[] {
+  const html = renderToStaticMarkup(
+    createElement(HubPagination, {
+      basePath,
+      label: `${basePath} pagination`,
+      nextLabel: "Next",
+      page,
+      pageCount,
+      previousLabel: "Previous",
+    }),
+  );
+
+  return [...html.matchAll(/\shref="([^"]+)"/gu)].map((match) =>
+    match[1].replaceAll("&amp;", "&"),
+  );
+}
+
+type HubPageComponent = (props: {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) => Promise<ReactNode>;
+
+type LandingHubPath = (typeof LANDING_HUBS)[number]["hubPath"];
+type HubPageModule = { default: HubPageComponent };
+
+const HUB_PAGE_LOADERS = {
+  "/blog": () => import("@/app/[locale]/(static)/blog/page"),
+  "/compare": () => import("@/app/[locale]/(static)/compare/page"),
+  "/features/all": () => import("@/app/[locale]/(static)/features/all/page"),
+  "/for": () => import("@/app/[locale]/(static)/for/page"),
+} satisfies Record<LandingHubPath, () => Promise<HubPageModule>>;
+
+async function renderProductionHub(
+  hubPath: LandingHubPath,
+  page: number,
+): Promise<string> {
+  const component = (await HUB_PAGE_LOADERS[hubPath]()).default;
+
+  const node = await component({
+    params: Promise.resolve({ locale: "en" }),
+    searchParams: Promise.resolve(page === 1 ? {} : { page: String(page) }),
+  });
+  return renderToStaticMarkup(node);
+}
+
+function hrefsIn(document: Document, selector: string): string[] {
+  return [...document.querySelectorAll<HTMLAnchorElement>(selector)].map(
+    (anchor) => anchor.getAttribute("href") ?? "",
+  );
+}
+
+function buildPagerGraph(
+  basePath: string,
+  pageCount: number,
+): Map<string, string[]> {
+  const graph = new Map<string, string[]>();
+
+  for (let page = 1; page <= pageCount; page++) {
+    graph.set(
+      hubPageHref(basePath, page),
+      renderedPagerHrefs(basePath, page, pageCount),
+    );
+  }
+  return graph;
+}
+
+function landingRouteCollisions(
+  slugsByHub: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  const reservedRoutes = new Set<string>(
+    PUBLIC_ROUTES.filter((route) => !route.includes(":")),
+  );
+
+  return LANDING_HUBS.flatMap(({ detailPath, hubPath }) =>
+    (slugsByHub.get(hubPath) ?? [])
+      .map((slug) => `${detailPath}/${slug}`)
+      .filter((detailRoute) => reservedRoutes.has(detailRoute))
+      .map(
+        (detailRoute) => `${detailRoute} collides with a static public route`,
+      ),
+  );
+}
+
+function clickDepths(
+  graph: ReadonlyMap<string, readonly string[]>,
+  start: string = "/",
+): Map<string, number> {
+  const depths = new Map<string, number>([[start, 0]]);
+  let frontier = [start];
+
+  while (frontier.length > 0) {
+    const next: string[] = [];
+
+    for (const node of frontier) {
+      for (const edge of graph.get(node) ?? []) {
+        if (depths.has(edge)) continue;
+        depths.set(edge, (depths.get(node) ?? 0) + 1);
+        next.push(edge);
+      }
+    }
+
+    frontier = next;
+  }
+
+  return depths;
+}
+
+function sameOriginPath(href: string, baseUrl: string): string | null {
+  const url = new URL(href, baseUrl);
+  const base = new URL(baseUrl);
+  return url.origin === base.origin ? `${url.pathname}${url.search}` : null;
+}
+
+async function e2eResponse(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  if (!E2E_BASE_URL) throw new Error("HUB_E2E_BASE_URL is required");
+  return fetch(new URL(path, E2E_BASE_URL), {
+    redirect: "manual",
+    signal: AbortSignal.timeout(20_000),
+    ...init,
+  });
+}
+
+describe("hub pagination and rendered reachability", () => {
+  it("strictly resolves the page query without producing duplicate 200 pages", () => {
+    expect(resolveHubPage(undefined, 3)).toEqual({ kind: "page", page: 1 });
+    expect(resolveHubPage("1", 3)).toEqual({
+      kind: "redirect-page-one",
+      page: 1,
+    });
+    expect(resolveHubPage("2", 3)).toEqual({ kind: "page", page: 2 });
+
+    const invalidValues: Array<string | string[]> = [
+      ["2"],
+      "",
+      "0",
+      "01",
+      "+2",
+      "2.0",
+      "2junk",
+      "4",
+      "9007199254740992",
+    ];
+
+    for (const invalid of invalidValues) {
+      expect(resolveHubPage(invalid, 3), String(invalid)).toEqual({
+        kind: "not-found",
+      });
+    }
+  });
+
+  it("preserves unrelated and repeated query values while removing page one", () => {
+    expect(
+      hubPageOneRedirectHref("/blog", {
+        page: "1",
+        tag: ["sales", "crm"],
+        utm_source: "proof",
+      }),
+    ).toBe("/blog?tag=sales&tag=crm&utm_source=proof");
+  });
+
+  it("renders crawlable previous, next, bucket, and current-page semantics", () => {
+    const html = renderToStaticMarkup(
+      createElement(HubPagination, {
+        basePath: "/blog",
+        label: "Blog",
+        nextLabel: "Next page",
+        page: 37,
+        pageCount: 94,
+        previousLabel: "Previous page",
+      }),
+    );
+    const hrefs = renderedPagerHrefs("/blog", 37, 94);
+
+    expect(html).toContain('<nav aria-label="Blog"');
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('rel="prev"');
+    expect(html).toContain('rel="next"');
+    expect(hrefs).toContain("/blog?page=36");
+    expect(hrefs).toContain("/blog?page=38");
+    expect(hrefs).toContain("/blog?page=31");
+    expect(hrefs).not.toContain("/blog?page=37");
+  });
+
+  it("keeps the square-root pager link budget sublinear at backlog scale", () => {
+    const pageCount = hubPageCount(2_256);
+    const maximumLinks = Math.max(
+      ...Array.from(
+        { length: pageCount },
+        (_, index) => renderedPagerHrefs("/blog", index + 1, pageCount).length,
+      ),
+    );
+
+    expect(pageCount).toBe(94);
+    expect(maximumLinks).toBeLessThanOrEqual(
+      2 * Math.ceil(Math.sqrt(pageCount)) + 2,
+    );
+    expect(hubPagerModel(1, pageCount).pageNumbers).toContain(91);
+  });
+
+  it("uses the default sequence to keep localized page membership aligned", () => {
+    const reference = ["c", "a", "d", "b"].map((slug) => ({
+      label: slug,
+      url: `/items/${slug}`,
+    }));
+    const localized = ["b", "d", "a", "c"].map((slug) => ({
+      label: `localized-${slug}`,
+      url: `/items/${slug}`,
+    }));
+    const compare = (a: { slug: string }, b: { slug: string }) =>
+      a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+
+    expect(
+      paginateLocalizedHubPages(reference, reference, 1, compare).items.map(
+        ({ slug }) => slug,
+      ),
+    ).toEqual(["a", "b", "c", "d"]);
+    expect(
+      paginateLocalizedHubPages(reference, localized, 1, compare).items.map(
+        ({ slug }) => slug,
+      ),
+    ).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("partitions collections into complete, non-overlapping 24-card pages", () => {
+    const slugs = Array.from({ length: 50 }, (_, index) => `slug-${index}`);
+    const pages = Array.from(
+      { length: hubPageCount(slugs.length) },
+      (_, index) => paginateHub(slugs, index + 1),
+    );
+
+    expect(pages.flatMap(({ items }) => items)).toEqual(slugs);
+    expect(pages.map(({ items }) => items.length)).toEqual([24, 24, 2]);
+    expect(() => paginateHub(slugs, 4)).toThrow(RangeError);
+  });
+
+  it("keeps the proxy's lightweight page-count registry aligned with published content", () => {
+    for (const { collection, hubPath, pageCount } of LANDING_HUBS) {
+      for (const locale of CONTENT_LOCALES) {
+        expect(
+          pageCount,
+          `${hubPath} page count drifted from ${collection}/${locale}`,
+        ).toBe(hubPageCount(collectionSlugs(collection, locale).length));
+      }
+    }
+  });
+
+  it("renders the real four hub page modules into complete 24-card slices and pager edges", async () => {
+    const fixturePages = new Map<string, readonly { url: string }[]>([
+      ["/blog", routeFixtures.blog],
+      ["/compare", routeFixtures.compare],
+      ["/features/all", routeFixtures.features],
+      ["/for", routeFixtures.forPages],
+    ]);
+
+    for (const { detailPath, hubPath, pageCount } of LANDING_HUBS) {
+      const expected = new Set(
+        (fixturePages.get(hubPath) ?? []).map(({ url }) => url),
+      );
+      const renderedCards = new Set<string>();
+      const graph = new Map<string, string[]>();
+
+      for (let page = 1; page <= pageCount; page++) {
+        const html = await renderProductionHub(hubPath, page);
+        const document = new JSDOM(html).window.document;
+        const cards = hrefsIn(document, "[data-hub-results] a[href]").filter(
+          (href) => href.startsWith(`${detailPath}/`),
+        );
+        const pager = hrefsIn(document, "nav a[href]").filter(
+          (href) => href === hubPath || href.startsWith(`${hubPath}?`),
+        );
+
+        expect(
+          cards.length,
+          `${hubPath} page ${page} card count`,
+        ).toBeLessThanOrEqual(24);
+        expect(
+          new Set(cards).size,
+          `${hubPath} page ${page} repeats a card`,
+        ).toBe(cards.length);
+        for (const href of cards) {
+          expect(
+            renderedCards.has(href),
+            `${hubPath} repeats ${href} across pages`,
+          ).toBe(false);
+          renderedCards.add(href);
+        }
+        graph.set(hubPageHref(hubPath, page), [...cards, ...pager]);
+      }
+
+      expect(
+        renderedCards,
+        `${hubPath} did not render its complete collection`,
+      ).toEqual(expected);
+      const depths = clickDepths(graph, hubPath);
+      for (const href of expected) {
+        expect(
+          depths.get(href),
+          `${href} is not reachable through the production pager`,
+        ).toBeLessThanOrEqual(3);
+      }
+    }
+  });
+
+  it("reserves every static public route from landing-page slug collisions", () => {
+    const problems: string[] = [];
+
+    for (const locale of CONTENT_LOCALES) {
+      const slugsByHub = new Map(
+        LANDING_HUBS.map(
+          ({ collection, hubPath }) =>
+            [hubPath, collectionSlugs(collection, locale)] as const,
+        ),
+      );
+      problems.push(
+        ...landingRouteCollisions(slugsByHub).map(
+          (problem) => `${locale} ${problem}`,
+        ),
+      );
+    }
+
+    expect(
+      problems,
+      `landing pages hidden behind static routes:\n${problems.join("\n")}`,
+    ).toEqual([]);
+    expect(
+      landingRouteCollisions(new Map([["/features/all", ["all"]]])),
+    ).toEqual(["/features/all collides with a static public route"]);
+  });
+
+  it(`models the pager topology needed for a ${CLICK_BOUND}-click bound at 2,256 items`, () => {
+    const pageCount = hubPageCount(2_256);
+    const graph = buildPagerGraph("/blog", pageCount);
+    const depths = clickDepths(graph, "/blog");
+    const worstListPage = Math.max(
+      ...Array.from(
+        { length: pageCount },
+        (_, index) => depths.get(hubPageHref("/blog", index + 1)) ?? Infinity,
+      ),
+    );
+
+    expect(pageCount).toBe(94);
+    expect(worstListPage).toBe(2);
+    // Home -> hub (1), at most two actual pager hops, then detail card (1).
+    expect(1 + worstListPage + 1).toBe(CLICK_BOUND);
+  });
+
+  it.skipIf(!E2E_BASE_URL)(
+    "crawls the production server output, metadata, statuses, sitemap, and every localized detail route",
+    async () => {
+      const graph = new Map<string, string[]>();
+      const details: string[] = [];
+      const memberships = new Map<string, string[]>();
+      let maxCards = 0;
+      let maxHtmlBytes = 0;
+
+      for (const locale of CONTENT_LOCALES) {
+        const homePath = buildLocalePath(locale, "/");
+        const home = await e2eResponse(homePath);
+        expect(home.status, homePath).toBe(200);
+        const homeHtml = await home.text();
+        maxHtmlBytes = Math.max(maxHtmlBytes, Buffer.byteLength(homeHtml));
+        const homeDocument = new JSDOM(homeHtml).window.document;
+        const localizedHubs = new Set(
+          LANDING_HUBS.map(({ hubPath }) => buildLocalePath(locale, hubPath)),
+        );
+        graph.set(
+          homePath,
+          hrefsIn(homeDocument, "a[href]")
+            .map((href) => sameOriginPath(href, E2E_BASE_URL as string))
+            .filter((href): href is string =>
+              Boolean(href && localizedHubs.has(href)),
+            ),
+        );
+
+        const publishedFooterDetails = new Set<string>();
+        const expectedFooterDetails = new Set<string>();
+        for (const { collection, detailPath } of LANDING_HUBS) {
+          const slugs = collectionSlugs(collection, locale);
+          for (const slug of slugs) {
+            publishedFooterDetails.add(
+              buildLocalePath(locale, `${detailPath}/${slug}`),
+            );
+          }
+          for (const slug of selectFooterSlugs(collection, slugs)) {
+            expectedFooterDetails.add(
+              buildLocalePath(locale, `${detailPath}/${slug}`),
+            );
+          }
+        }
+        const renderedFooterDetails = hrefsIn(homeDocument, "footer a[href]")
+          .map((href) => sameOriginPath(href, E2E_BASE_URL as string))
+          .filter((href): href is string =>
+            Boolean(href && publishedFooterDetails.has(href)),
+          )
+          .sort();
+        expect(
+          renderedFooterDetails,
+          `${locale} rendered footer landing links`,
+        ).toEqual([...expectedFooterDetails].sort());
+        expect(
+          new Set(renderedFooterDetails).size,
+          `${locale} duplicate footer landing links`,
+        ).toBe(renderedFooterDetails.length);
+
+        for (const {
+          collection,
+          detailPath,
+          hubPath,
+          pageCount,
+        } of LANDING_HUBS) {
+          const expected = new Set(
+            collectionSlugs(collection, locale).map((slug) =>
+              buildLocalePath(locale, `${detailPath}/${slug}`),
+            ),
+          );
+          const rendered = new Set<string>();
+
+          for (let page = 1; page <= pageCount; page++) {
+            const route = buildLocalePath(locale, hubPageHref(hubPath, page));
+            const response = await e2eResponse(route);
+            expect(response.status, route).toBe(200);
+            const html = await response.text();
+            maxHtmlBytes = Math.max(maxHtmlBytes, Buffer.byteLength(html));
+            const document = new JSDOM(html).window.document;
+            const detailPrefix = buildLocalePath(locale, `${detailPath}/`);
+            const cards = hrefsIn(document, "[data-hub-results] a[href]")
+              .map((href) => sameOriginPath(href, E2E_BASE_URL as string))
+              .filter((href): href is string =>
+                Boolean(href?.startsWith(detailPrefix)),
+              );
+            const pager = hrefsIn(document, "nav a[href]")
+              .map((href) => sameOriginPath(href, E2E_BASE_URL as string))
+              .filter((href): href is string => {
+                const cleanHub = buildLocalePath(locale, hubPath);
+                return (
+                  href === cleanHub || Boolean(href?.startsWith(`${cleanHub}?`))
+                );
+              });
+
+            expect(cards.length, `${route} card count`).toBeGreaterThan(0);
+            expect(cards.length, `${route} card count`).toBeLessThanOrEqual(24);
+            expect(new Set(cards).size, `${route} duplicate cards`).toBe(
+              cards.length,
+            );
+            maxCards = Math.max(maxCards, cards.length);
+            for (const card of cards) {
+              expect(
+                rendered.has(card),
+                `${card} appears on multiple ${hubPath} pages`,
+              ).toBe(false);
+              rendered.add(card);
+              details.push(card);
+            }
+            graph.set(route, [...cards, ...pager]);
+
+            const canonical = document.querySelector<HTMLLinkElement>(
+              'link[rel="canonical"]',
+            )?.href;
+            expect(canonical, `${route} canonical`).toBeDefined();
+            expect(
+              sameOriginPath(canonical as string, E2E_BASE_URL as string),
+              `${route} canonical`,
+            ).toBe(route);
+
+            const alternates = new Map(
+              [
+                ...document.querySelectorAll<HTMLLinkElement>(
+                  'link[rel="alternate"][hreflang]',
+                ),
+              ].map((link) => [
+                link.getAttribute("hreflang"),
+                sameOriginPath(link.href, E2E_BASE_URL as string),
+              ]),
+            );
+            for (const alternateLocale of CONTENT_LOCALES) {
+              expect(
+                alternates.get(alternateLocale),
+                `${route} ${alternateLocale} alternate`,
+              ).toBe(
+                buildLocalePath(alternateLocale, hubPageHref(hubPath, page)),
+              );
+            }
+            expect(
+              alternates.get("x-default"),
+              `${route} x-default alternate`,
+            ).toBe(buildLocalePath("en", hubPageHref(hubPath, page)));
+
+            memberships.set(
+              `${locale}:${hubPath}:${page}`,
+              cards.map((href) => href.split("/").at(-1) as string).sort(),
+            );
+          }
+
+          expect(rendered, `${locale} ${hubPath} rendered membership`).toEqual(
+            expected,
+          );
+
+          const pageOne = await e2eResponse(
+            `${buildLocalePath(locale, hubPath)}?page=1&utm_source=e2e&tag=a&tag=b`,
+          );
+          expect(pageOne.status, `${locale} ${hubPath} page one`).toBe(308);
+          const pageOneLocation = sameOriginPath(
+            pageOne.headers.get("location") ?? "",
+            E2E_BASE_URL as string,
+          );
+          expect(pageOneLocation).toBe(
+            `${buildLocalePath(locale, hubPath)}?utm_source=e2e&tag=a&tag=b`,
+          );
+
+          const invalidPage = await e2eResponse(
+            `${buildLocalePath(locale, hubPath)}?page=${pageCount + 1}`,
+          );
+          expect(invalidPage.status, `${locale} ${hubPath} invalid page`).toBe(
+            404,
+          );
+          expect(invalidPage.headers.get("x-robots-tag")).toBe("noindex");
+          expect(invalidPage.headers.get("content-type")).toContain(
+            "text/html",
+          );
+          const invalidDocument = new JSDOM(await invalidPage.text()).window
+            .document;
+          expect(
+            invalidDocument.querySelector("h1")?.textContent?.trim(),
+            `${locale} ${hubPath} visible 404`,
+          ).toBe("404");
+
+          const prefetchHeaders: Array<Record<string, string>> = [
+            { purpose: "prefetch" },
+            { "next-router-prefetch": "1" },
+          ];
+          for (const headers of prefetchHeaders) {
+            const invalid = await e2eResponse(
+              `${buildLocalePath(locale, hubPath)}?page=${pageCount + 1}`,
+              { headers },
+            );
+            expect(
+              invalid.status,
+              `${locale} ${hubPath} ${JSON.stringify(headers)}`,
+            ).toBe(404);
+            expect(invalid.headers.get("x-robots-tag")).toBe("noindex");
+          }
+        }
+
+        const depths = clickDepths(graph, homePath);
+        for (const detail of details.filter((path) =>
+          path.startsWith(`/${locale}/`),
+        )) {
+          expect(
+            depths.get(detail),
+            `${detail} rendered click depth`,
+          ).toBeLessThanOrEqual(CLICK_BOUND);
+        }
+      }
+
+      for (const { hubPath, pageCount } of LANDING_HUBS) {
+        for (let page = 1; page <= pageCount; page++) {
+          const reference = memberships.get(`en:${hubPath}:${page}`);
+          for (const locale of CONTENT_LOCALES) {
+            expect(
+              memberships.get(`${locale}:${hubPath}:${page}`),
+              `${locale} ${hubPath} page ${page}`,
+            ).toEqual(reference);
+          }
+        }
+      }
+
+      const malformed = await e2eResponse("/en/blog?page=2junk");
+      expect(malformed.status).toBe(404);
+      const repeated = await e2eResponse("/en/blog?page=2&page=3");
+      expect(repeated.status).toBe(404);
+
+      const appOnly = await e2eResponse("/fr/blog?page=1&utm_source=e2e");
+      expect(appOnly.status).toBe(307);
+      expect(
+        sameOriginPath(
+          appOnly.headers.get("location") ?? "",
+          E2E_BASE_URL as string,
+        ),
+      ).toBe("/en/blog?page=1&utm_source=e2e");
+
+      for (let offset = 0; offset < details.length; offset += 16) {
+        await Promise.all(
+          details.slice(offset, offset + 16).map(async (detail) => {
+            const response = await e2eResponse(detail);
+            expect(response.status, detail).toBe(200);
+          }),
+        );
+      }
+
+      const sitemapResponse = await e2eResponse("/sitemap.xml");
+      expect(sitemapResponse.status).toBe(200);
+      const sitemap = await sitemapResponse.text();
+      const sitemapDocument = new JSDOM(sitemap, {
+        contentType: "application/xml",
+      }).window.document;
+      const sitemapPaths = [...sitemapDocument.querySelectorAll("loc")].map(
+        (loc) => {
+          const url = new URL(loc.textContent ?? "");
+          return `${url.pathname}${url.search}`;
+        },
+      );
+      const actualPaginatedPaths = sitemapPaths.filter((path) =>
+        new URL(path, "https://sitemap.invalid").searchParams.has(
+          HUB_PAGE_PARAM,
+        ),
+      );
+      const expectedPaginatedPaths = CONTENT_LOCALES.flatMap((locale) =>
+        LANDING_HUBS.flatMap(({ collection, hubPath }) => {
+          const pageCount = hubPageCount(
+            collectionSlugs(collection, locale).length,
+          );
+          return Array.from({ length: pageCount - 1 }, (_, index) =>
+            buildLocalePath(locale, hubPageHref(hubPath, index + 2)),
+          );
+        }),
+      ).sort();
+
+      expect(actualPaginatedPaths.sort()).toEqual(expectedPaginatedPaths);
+      expect(new Set(actualPaginatedPaths).size).toBe(
+        actualPaginatedPaths.length,
+      );
+      expect(
+        actualPaginatedPaths.some(
+          (path) =>
+            new URL(path, "https://sitemap.invalid").searchParams.get(
+              HUB_PAGE_PARAM,
+            ) === "1",
+        ),
+      ).toBe(false);
+
+      const robotsResponse = await e2eResponse("/robots.txt");
+      expect(robotsResponse.status).toBe(200);
+      const robots = await robotsResponse.text();
+      expect(robots).not.toContain("Crawl-delay");
+      const hostname = new URL(E2E_BASE_URL as string).hostname;
+      if (hostname === "localhost" || /^127(?:\.\d{1,3}){3}$/u.test(hostname))
+        expect(robots).toContain("Allow: /");
+      else expect(robots).toContain("Disallow: /");
+      expect(maxCards).toBe(24);
+      expect(maxHtmlBytes).toBeGreaterThan(0);
+    },
+    180_000,
+  );
+});

--- a/tests/conventions/hub-reachability.test.ts
+++ b/tests/conventions/hub-reachability.test.ts
@@ -251,10 +251,15 @@ function clickDepths(
   return depths;
 }
 
+function pathWithQuery(href: string, baseUrl: string): string {
+  const url = new URL(href, baseUrl);
+  return `${url.pathname}${url.search}`;
+}
+
 function sameOriginPath(href: string, baseUrl: string): string | null {
   const url = new URL(href, baseUrl);
   const base = new URL(baseUrl);
-  return url.origin === base.origin ? `${url.pathname}${url.search}` : null;
+  return url.origin === base.origin ? pathWithQuery(url.href, baseUrl) : null;
 }
 
 async function e2eResponse(
@@ -606,21 +611,32 @@ describe("hub pagination and rendered reachability", () => {
               'link[rel="canonical"]',
             )?.href;
             expect(canonical, `${route} canonical`).toBeDefined();
+            const canonicalUrl = new URL(
+              canonical as string,
+              E2E_BASE_URL as string,
+            );
             expect(
-              sameOriginPath(canonical as string, E2E_BASE_URL as string),
+              pathWithQuery(canonicalUrl.href, E2E_BASE_URL as string),
               `${route} canonical`,
             ).toBe(route);
 
+            const alternateLinks = [
+              ...document.querySelectorAll<HTMLLinkElement>(
+                'link[rel="alternate"][hreflang]',
+              ),
+            ];
             const alternates = new Map(
-              [
-                ...document.querySelectorAll<HTMLLinkElement>(
-                  'link[rel="alternate"][hreflang]',
-                ),
-              ].map((link) => [
+              alternateLinks.map((link) => [
                 link.getAttribute("hreflang"),
-                sameOriginPath(link.href, E2E_BASE_URL as string),
+                pathWithQuery(link.href, E2E_BASE_URL as string),
               ]),
             );
+            for (const link of alternateLinks) {
+              expect(
+                new URL(link.href, E2E_BASE_URL as string).origin,
+                `${route} alternate canonical origin`,
+              ).toBe(canonicalUrl.origin);
+            }
             for (const alternateLocale of CONTENT_LOCALES) {
               expect(
                 alternates.get(alternateLocale),

--- a/tests/conventions/hub-reachability.test.ts
+++ b/tests/conventions/hub-reachability.test.ts
@@ -124,7 +124,12 @@ import {
   resolveHubPage,
 } from "@/core/seo/hub-pagination";
 import { LANDING_HUBS } from "@/core/seo/landing-hubs";
-import { CONTENT_LOCALES, buildLocalePath } from "@/i18n/locale-registry";
+import {
+  CONTENT_LOCALES,
+  DEFAULT_LOCALE,
+  type ContentLocale,
+  buildLocalePath,
+} from "@/i18n/locale-registry";
 import { PUBLIC_ROUTES } from "@/i18n/routing";
 
 const CLICK_BOUND = 4;
@@ -138,6 +143,10 @@ function collectionSlugs(collection: string, locale: string): string[] {
     .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
     .map((entry) => entry.name.slice(0, -".mdx".length))
     .sort();
+}
+
+function publishedHubPageCount(collection: string): number {
+  return hubPageCount(collectionSlugs(collection, DEFAULT_LOCALE).length);
 }
 
 function renderedPagerHrefs(
@@ -274,8 +283,99 @@ async function e2eResponse(
   });
 }
 
+async function semanticRedirectPath(
+  response: Response,
+  label: string,
+): Promise<string> {
+  expect([200, 308], `${label} redirect transport`).toContain(response.status);
+  const location = response.headers.get("location");
+  if (response.status === 308) {
+    expect(location, `${label} location`).not.toBeNull();
+    if (!location) throw new Error(`${label} did not include a location`);
+    const path = sameOriginPath(location, E2E_BASE_URL as string);
+    expect(path, `${label} same-origin location`).not.toBeNull();
+    if (!path) throw new Error(`${label} redirected outside the application`);
+    return path;
+  }
+
+  expect(location, `${label} streamed location`).toBeNull();
+
+  const document = new JSDOM(await response.text()).window.document;
+  const refresh = document
+    .querySelector('meta[http-equiv="refresh"]')
+    ?.getAttribute("content");
+  const target = /(?:^|;)\s*url=(.+)$/iu
+    .exec(refresh ?? "")?.[1]
+    ?.trim()
+    .replace(/^['"]|['"]$/gu, "");
+
+  expect(target, `${label} redirect metadata`).toBeDefined();
+  if (!target) throw new Error(`${label} did not include redirect metadata`);
+
+  const path = sameOriginPath(target, E2E_BASE_URL as string);
+  expect(path, `${label} same-origin redirect metadata`).not.toBeNull();
+  if (!path) throw new Error(`${label} redirected outside the application`);
+  return path;
+}
+
+async function expectSemanticNotFound(
+  response: Response,
+  label: string,
+  locale: ContentLocale,
+): Promise<void> {
+  expect([200, 404], `${label} streamed status`).toContain(response.status);
+  expect(
+    response.headers.get("content-type"),
+    `${label} content type`,
+  ).toContain("text/html");
+
+  const document = new JSDOM(await response.text()).window.document;
+  expect(document.documentElement.lang, `${label} document locale`).toBe(
+    locale,
+  );
+  expect(
+    document.querySelector('meta[name="robots"]')?.getAttribute("content"),
+    `${label} robots metadata`,
+  ).toContain("noindex");
+  expect(
+    document.querySelector('link[rel="canonical"]'),
+    `${label} canonical`,
+  ).toBeNull();
+}
+
+async function expectCanonicalResponse(
+  response: Response,
+  expectedPath: string,
+  label: string,
+): Promise<void> {
+  expect(response.status, `${label} final status`).toBe(200);
+  expect(
+    response.headers.get("content-type"),
+    `${label} content type`,
+  ).toContain("text/html");
+
+  const document = new JSDOM(await response.text()).window.document;
+  const canonical = document.querySelector<HTMLLinkElement>(
+    'link[rel="canonical"]',
+  )?.href;
+  expect(canonical, `${label} canonical`).toBeDefined();
+  const canonicalUrl = new URL(canonical as string, E2E_BASE_URL as string);
+  expect(canonicalUrl.origin, `${label} canonical origin`).toBe(
+    new URL(E2E_BASE_URL as string).origin,
+  );
+  expect(
+    pathWithQuery(canonicalUrl.href, E2E_BASE_URL as string),
+    `${label} canonical`,
+  ).toBe(expectedPath);
+  expect(
+    document.querySelector('meta[name="robots"]')?.getAttribute("content") ??
+      "",
+    `${label} robots metadata`,
+  ).not.toContain("noindex");
+}
+
 describe("hub pagination and rendered reachability", () => {
-  it("strictly resolves the page query without producing duplicate 200 pages", () => {
+  it("strictly resolves the page query", () => {
     expect(resolveHubPage(undefined, 3)).toEqual({ kind: "page", page: 1 });
     expect(resolveHubPage("1", 3)).toEqual({
       kind: "redirect-page-one",
@@ -299,6 +399,40 @@ describe("hub pagination and rendered reachability", () => {
       expect(resolveHubPage(invalid, 3), String(invalid)).toEqual({
         kind: "not-found",
       });
+    }
+  });
+
+  it("lets every real hub page own invalid and page-one query handling", async () => {
+    for (const { collection, hubPath } of LANDING_HUBS) {
+      const pageCount = publishedHubPageCount(collection);
+      const component = (await HUB_PAGE_LOADERS[hubPath]()).default;
+      const props = (
+        searchParams: Record<string, string | string[] | undefined>,
+      ) => ({
+        params: Promise.resolve({ locale: "en" }),
+        searchParams: Promise.resolve(searchParams),
+      });
+
+      await expect(
+        component(props({ page: String(pageCount + 1) })),
+        `${hubPath} invalid page`,
+      ).rejects.toThrow("unexpected notFound");
+      await expect(
+        component(props({ page: ["2", "3"] })),
+        `${hubPath} repeated page`,
+      ).rejects.toThrow("unexpected notFound");
+
+      const query = {
+        page: "1",
+        tag: ["sales", "crm"],
+        utm_source: "proof",
+      };
+      await expect(
+        component(props(query)),
+        `${hubPath} page one`,
+      ).rejects.toThrow(
+        `unexpected permanentRedirect to /en${hubPath}?tag=sales&tag=crm&utm_source=proof`,
+      );
     }
   });
 
@@ -387,17 +521,6 @@ describe("hub pagination and rendered reachability", () => {
     expect(() => paginateHub(slugs, 4)).toThrow(RangeError);
   });
 
-  it("keeps the proxy's lightweight page-count registry aligned with published content", () => {
-    for (const { collection, hubPath, pageCount } of LANDING_HUBS) {
-      for (const locale of CONTENT_LOCALES) {
-        expect(
-          pageCount,
-          `${hubPath} page count drifted from ${collection}/${locale}`,
-        ).toBe(hubPageCount(collectionSlugs(collection, locale).length));
-      }
-    }
-  });
-
   it("renders the real four hub page modules into complete 24-card slices and pager edges", async () => {
     const fixturePages = new Map<string, readonly { url: string }[]>([
       ["/blog", routeFixtures.blog],
@@ -406,7 +529,8 @@ describe("hub pagination and rendered reachability", () => {
       ["/for", routeFixtures.forPages],
     ]);
 
-    for (const { detailPath, hubPath, pageCount } of LANDING_HUBS) {
+    for (const { detailPath, hubPath } of LANDING_HUBS) {
+      const pageCount = hubPageCount((fixturePages.get(hubPath) ?? []).length);
       const expected = new Set(
         (fixturePages.get(hubPath) ?? []).map(({ url }) => url),
       );
@@ -499,7 +623,7 @@ describe("hub pagination and rendered reachability", () => {
   });
 
   it.skipIf(!E2E_BASE_URL)(
-    "crawls the production server output, metadata, statuses, sitemap, and every localized detail route",
+    "crawls the production server output, metadata, semantic pagination outcomes, sitemap, and every localized detail route",
     async () => {
       const graph = new Map<string, string[]>();
       const details: string[] = [];
@@ -556,12 +680,8 @@ describe("hub pagination and rendered reachability", () => {
           `${locale} duplicate footer landing links`,
         ).toBe(renderedFooterDetails.length);
 
-        for (const {
-          collection,
-          detailPath,
-          hubPath,
-          pageCount,
-        } of LANDING_HUBS) {
+        for (const { collection, detailPath, hubPath } of LANDING_HUBS) {
+          const pageCount = publishedHubPageCount(collection);
           const expected = new Set(
             collectionSlugs(collection, locale).map((slug) =>
               buildLocalePath(locale, `${detailPath}/${slug}`),
@@ -616,6 +736,10 @@ describe("hub pagination and rendered reachability", () => {
               E2E_BASE_URL as string,
             );
             expect(
+              canonicalUrl.origin,
+              `${route} canonical origin`,
+            ).toBe(new URL(E2E_BASE_URL as string).origin);
+            expect(
               pathWithQuery(canonicalUrl.href, E2E_BASE_URL as string),
               `${route} canonical`,
             ).toBe(route);
@@ -663,47 +787,31 @@ describe("hub pagination and rendered reachability", () => {
           const pageOne = await e2eResponse(
             `${buildLocalePath(locale, hubPath)}?page=1&utm_source=e2e&tag=a&tag=b`,
           );
-          expect(pageOne.status, `${locale} ${hubPath} page one`).toBe(308);
-          const pageOneLocation = sameOriginPath(
-            pageOne.headers.get("location") ?? "",
-            E2E_BASE_URL as string,
+          expect(
+            [200, 308],
+            `${locale} ${hubPath} page-one transport`,
+          ).toContain(pageOne.status);
+          const pageOneLocation = await semanticRedirectPath(
+            pageOne,
+            `${locale} ${hubPath} page one`,
           );
           expect(pageOneLocation).toBe(
             `${buildLocalePath(locale, hubPath)}?utm_source=e2e&tag=a&tag=b`,
+          );
+          await expectCanonicalResponse(
+            await e2eResponse(pageOneLocation),
+            buildLocalePath(locale, hubPath),
+            `${locale} ${hubPath} page one destination`,
           );
 
           const invalidPage = await e2eResponse(
             `${buildLocalePath(locale, hubPath)}?page=${pageCount + 1}`,
           );
-          expect(invalidPage.status, `${locale} ${hubPath} invalid page`).toBe(
-            404,
+          await expectSemanticNotFound(
+            invalidPage,
+            `${locale} ${hubPath} invalid page`,
+            locale,
           );
-          expect(invalidPage.headers.get("x-robots-tag")).toBe("noindex");
-          expect(invalidPage.headers.get("content-type")).toContain(
-            "text/html",
-          );
-          const invalidDocument = new JSDOM(await invalidPage.text()).window
-            .document;
-          expect(
-            invalidDocument.querySelector("h1")?.textContent?.trim(),
-            `${locale} ${hubPath} visible 404`,
-          ).toBe("404");
-
-          const prefetchHeaders: Array<Record<string, string>> = [
-            { purpose: "prefetch" },
-            { "next-router-prefetch": "1" },
-          ];
-          for (const headers of prefetchHeaders) {
-            const invalid = await e2eResponse(
-              `${buildLocalePath(locale, hubPath)}?page=${pageCount + 1}`,
-              { headers },
-            );
-            expect(
-              invalid.status,
-              `${locale} ${hubPath} ${JSON.stringify(headers)}`,
-            ).toBe(404);
-            expect(invalid.headers.get("x-robots-tag")).toBe("noindex");
-          }
         }
 
         const depths = clickDepths(graph, homePath);
@@ -717,7 +825,8 @@ describe("hub pagination and rendered reachability", () => {
         }
       }
 
-      for (const { hubPath, pageCount } of LANDING_HUBS) {
+      for (const { collection, hubPath } of LANDING_HUBS) {
+        const pageCount = publishedHubPageCount(collection);
         for (let page = 1; page <= pageCount; page++) {
           const reference = memberships.get(`en:${hubPath}:${page}`);
           for (const locale of CONTENT_LOCALES) {
@@ -730,9 +839,9 @@ describe("hub pagination and rendered reachability", () => {
       }
 
       const malformed = await e2eResponse("/en/blog?page=2junk");
-      expect(malformed.status).toBe(404);
+      await expectSemanticNotFound(malformed, "malformed page query", "en");
       const repeated = await e2eResponse("/en/blog?page=2&page=3");
-      expect(repeated.status).toBe(404);
+      await expectSemanticNotFound(repeated, "repeated page query", "en");
 
       const appOnly = await e2eResponse("/fr/blog?page=1&utm_source=e2e");
       expect(appOnly.status).toBe(307);
@@ -742,6 +851,22 @@ describe("hub pagination and rendered reachability", () => {
           E2E_BASE_URL as string,
         ),
       ).toBe("/en/blog?page=1&utm_source=e2e");
+      const contentLocalePageOne = await e2eResponse(
+        "/en/blog?page=1&utm_source=e2e",
+      );
+      expect([200, 308], "content-locale page-one transport").toContain(
+        contentLocalePageOne.status,
+      );
+      const finalLocation = await semanticRedirectPath(
+        contentLocalePageOne,
+        "content-locale page one",
+      );
+      expect(finalLocation).toBe("/en/blog?utm_source=e2e");
+      await expectCanonicalResponse(
+        await e2eResponse(finalLocation),
+        "/en/blog",
+        "app-only locale destination",
+      );
 
       for (let offset = 0; offset < details.length; offset += 16) {
         await Promise.all(

--- a/tests/conventions/hub-reachability.test.ts
+++ b/tests/conventions/hub-reachability.test.ts
@@ -127,7 +127,6 @@ import { LANDING_HUBS } from "@/core/seo/landing-hubs";
 import { CONTENT_LOCALES, buildLocalePath } from "@/i18n/locale-registry";
 import { PUBLIC_ROUTES } from "@/i18n/routing";
 
-const ENFORCED = true;
 const CLICK_BOUND = 4;
 const E2E_BASE_URL = process.env.HUB_E2E_BASE_URL?.replace(/\/+$/u, "");
 

--- a/tests/conventions/internal-link-targets.test.ts
+++ b/tests/conventions/internal-link-targets.test.ts
@@ -12,7 +12,11 @@ import {
   selectFooterSlugs,
 } from "@/app/components/footer-selection";
 import { ROUTE_SOURCE_MAP } from "@/core/fumadocs/route-source-map";
-import { HUB_PAGE_PARAM, resolveHubPage } from "@/core/seo/hub-pagination";
+import {
+  HUB_PAGE_PARAM,
+  hubPageCount,
+  resolveHubPage,
+} from "@/core/seo/hub-pagination";
 import { LANDING_HUBS } from "@/core/seo/landing-hubs";
 import {
   CONTENT_LOCALES,
@@ -260,7 +264,10 @@ function hasValidHubQuery(target: NormalizedTarget): boolean {
   if (!params.has(HUB_PAGE_PARAM)) return true;
   const values = params.getAll(HUB_PAGE_PARAM);
   const raw = values.length === 1 ? values[0] : values;
-  return resolveHubPage(raw, hub.pageCount).kind === "page";
+  const pageCount = hubPageCount(
+    collectionSlugs(hub.collection, DEFAULT_LOCALE).length,
+  );
+  return resolveHubPage(raw, pageCount).kind === "page";
 }
 
 function matchesCodeBackedRoute(path: string): boolean {

--- a/tests/conventions/internal-link-targets.test.ts
+++ b/tests/conventions/internal-link-targets.test.ts
@@ -1,0 +1,508 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { REPO_ROOT, walkFiles } from "./walk";
+
+import {
+  FOOTER_COLUMN_SIZE,
+  FOOTER_PREFERRED_SLUGS,
+  type FooterCollection,
+  selectFooterSlugs,
+} from "@/app/components/footer-selection";
+import { ROUTE_SOURCE_MAP } from "@/core/fumadocs/route-source-map";
+import { HUB_PAGE_PARAM, resolveHubPage } from "@/core/seo/hub-pagination";
+import { LANDING_HUBS } from "@/core/seo/landing-hubs";
+import {
+  CONTENT_LOCALES,
+  DEFAULT_LOCALE,
+  type ContentLocale,
+  type RoutingLocale,
+  isContentLocale,
+  routingLocaleFromUrlSegment,
+} from "@/i18n/locale-registry";
+import { PUBLIC_ROUTES } from "@/i18n/routing";
+
+vi.mock("@/core/fumadocs/source", async () => {
+  const { existsSync, readdirSync } = await import("node:fs");
+  const { extname, join } = await import("node:path");
+
+  const source = (collection: string, basePath: string) => ({
+    getPage(path: string[], locale: string) {
+      const slug = path.at(-1);
+      return slug &&
+        existsSync(
+          join(process.cwd(), "content", collection, locale, `${slug}.mdx`),
+        )
+        ? { url: `${basePath}/${slug}`.replace(/^\/{2,}/u, "/") }
+        : undefined;
+    },
+    getPages(locale: string) {
+      const directory = join(process.cwd(), "content", collection, locale);
+      if (!existsSync(directory)) return [];
+      return readdirSync(directory, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+        .map((entry) => ({
+          url: `${basePath}/${entry.name.slice(0, -".mdx".length)}`.replace(
+            /^\/{2,}/u,
+            "/",
+          ),
+        }));
+    },
+  });
+
+  return {
+    affiliateSource: source("affiliate", ""),
+    apiDocsSource: source("api", "/docs/openapi"),
+    apiOverviewSource: source("api-overview", "/docs/openapi"),
+    authSource: source("auth", "/auth"),
+    automationSource: source("automation", "/n8n-crm"),
+    blogPostsSource: source("blog-posts", "/blog"),
+    blogSource: source("blog", ""),
+    comparePagesSource: source("compare-pages", "/compare"),
+    compareSource: source("compare", ""),
+    docsSource: source("docs", "/docs"),
+    featurePagesSource: source("feature-pages", "/features"),
+    featuresAllSource: source("features-all", "/features"),
+    featuresSource: source("features", ""),
+    forPagesSource: source("for-pages", "/for"),
+    forSource: source("for", ""),
+    helpAndFeedbackSource: source("help-and-feedback", ""),
+    homepageSource: source("homepage", ""),
+    legalSource: source("legal", ""),
+    pricingSource: source("pricing", ""),
+  };
+});
+
+const ENFORCED = true;
+
+const CONTENT_ROOT = join(REPO_ROOT, "content");
+const CODE_BACKED_ROUTE_FILES = {
+  "/contact": "app/[locale]/(public)/contact/page.tsx",
+  "/auth/pending": "app/[locale]/(public)/auth/pending/page.tsx",
+  "/auth/error": "app/[locale]/(public)/auth/error/page.tsx",
+  "/auth/verify-email": "app/[locale]/(public)/auth/verify-email/page.tsx",
+  "/invitation/:token": "app/[locale]/(public)/invitation/[token]/route.ts",
+} as const;
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u;
+const FRONTMATTER_HREF = /^\s*(?:-\s*)?([a-z0-9_-]*href)\s*:\s*(.*?)\s*$/iu;
+const JSX_HREF =
+  /\bhref\s*=\s*(?:"([^"\r\n]*)"|'([^'\r\n]*)'|\{\s*"([^"\r\n]*)"\s*\}|\{\s*'([^'\r\n]*)'\s*\})/gu;
+const MARKDOWN_LINK =
+  /(?<!!)\[[^\]\r\n]*\]\(\s*(?:<([^>\r\n]+)>|((?:\\.|[^)\s])+))(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/gu;
+const MARKDOWN_DEFINITION = /^\s*\[[^\]\r\n]+\]:\s*(?:<([^>\r\n]+)>|(\S+))/gmu;
+
+type ContentLink = {
+  file: string;
+  line: number;
+  sourceLocale: ContentLocale;
+  target: string;
+};
+
+type NormalizedTarget = {
+  locale: RoutingLocale | null;
+  path: string;
+  query: string;
+};
+
+type ContentSource = {
+  getPage(path: string[], locale: string): unknown;
+  getPages(locale: string): readonly { url: string }[];
+};
+
+function rootRelative(target: string | null | undefined): target is string {
+  return (
+    typeof target === "string" &&
+    target.startsWith("/") &&
+    !target.startsWith("//")
+  );
+}
+
+function lineAt(source: string, offset: number): number {
+  let line = 1;
+  for (let index = 0; index < offset; index++)
+    if (source.charCodeAt(index) === 10) line++;
+  return line;
+}
+
+function yamlString(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+
+  if (value.startsWith('"')) {
+    const match = /^"((?:\\.|[^"\\])*)"/u.exec(value);
+    if (!match) return null;
+    try {
+      return JSON.parse(`"${match[1]}"`) as string;
+    } catch {
+      return null;
+    }
+  }
+
+  if (value.startsWith("'")) {
+    const match = /^'((?:''|[^'])*)'/u.exec(value);
+    return match ? match[1].replaceAll("''", "'") : null;
+  }
+
+  return value.replace(/\s+#.*$/u, "").trim() || null;
+}
+
+function frontmatterHref(raw: string, file: string, line: number): string {
+  const value = raw.trim();
+  const unsupported =
+    !value ||
+    /^[>|*&!\[{]/u.test(value) ||
+    /^(?:null|~)(?:\s+#.*)?$/iu.test(value);
+  const parsed = unsupported ? null : yamlString(raw);
+
+  if (parsed === null) {
+    throw new Error(`${file}:${line} uses unsupported frontmatter href syntax`);
+  }
+
+  return parsed;
+}
+
+function linksInDocument(
+  source: string,
+  file: string,
+  sourceLocale: ContentLocale,
+): ContentLink[] {
+  const links: ContentLink[] = [];
+  const seen = new Set<string>();
+  const record = (target: string | null | undefined, line: number) => {
+    if (!rootRelative(target)) return;
+    const key = `${line}\0${target}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    links.push({ file, line, sourceLocale, target });
+  };
+
+  const frontmatter = FRONTMATTER.exec(source);
+  if (frontmatter) {
+    const firstLine = lineAt(source, frontmatter.index) + 1;
+    for (const [index, line] of frontmatter[1].split(/\r?\n/u).entries()) {
+      const field = FRONTMATTER_HREF.exec(line);
+      if (field) {
+        const lineNumber = firstLine + index;
+        record(frontmatterHref(field[2], file, lineNumber), lineNumber);
+      }
+    }
+  }
+
+  // Mask frontmatter without changing offsets so prose and JSX line numbers
+  // still point at the original source file.
+  const body = frontmatter
+    ? source.replace(FRONTMATTER, (value) => value.replace(/[^\r\n]/gu, " "))
+    : source;
+
+  for (const match of body.matchAll(MARKDOWN_LINK))
+    record(match[1] ?? match[2], lineAt(body, match.index ?? 0));
+  for (const match of body.matchAll(MARKDOWN_DEFINITION))
+    record(match[1] ?? match[2], lineAt(body, match.index ?? 0));
+  for (const match of body.matchAll(JSX_HREF))
+    record(
+      match[1] ?? match[2] ?? match[3] ?? match[4],
+      lineAt(body, match.index ?? 0),
+    );
+
+  return links;
+}
+
+export function normalizeTarget(target: string): NormalizedTarget | null {
+  const base = "https://internal.invalid";
+  const url = new URL(target, base);
+  if (url.origin !== base) return null;
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const prefixedLocale = segments[0]
+    ? routingLocaleFromUrlSegment(segments[0])
+    : null;
+  if (prefixedLocale) segments.shift();
+
+  const path = segments.length === 0 ? "/" : `/${segments.join("/")}`;
+  return {
+    locale: prefixedLocale,
+    path: path.length > 1 ? path.replace(/\/+$/u, "") : path,
+    query: url.search,
+  };
+}
+
+function contentBackedTargets(locale: ContentLocale): Set<string> {
+  const targets = new Set<string>(
+    Object.keys(CODE_BACKED_ROUTE_FILES).filter(
+      (route) => !route.includes(":"),
+    ),
+  );
+
+  for (const [route, routeMapping] of Object.entries(ROUTE_SOURCE_MAP)) {
+    const { path, source } = routeMapping as {
+      path: string[];
+      source: ContentSource;
+    };
+
+    if (route.includes(":")) {
+      for (const page of source.getPages(locale)) {
+        const target = normalizeTarget(page.url);
+        if (target) targets.add(target.path);
+      }
+    } else if (source.getPage(path, locale)) {
+      targets.add(route);
+    }
+  }
+
+  return targets;
+}
+
+function hasValidHubQuery(target: NormalizedTarget): boolean {
+  const hub = LANDING_HUBS.find(({ hubPath }) => hubPath === target.path);
+  if (!hub) return true;
+
+  const params = new URLSearchParams(target.query);
+  if (!params.has(HUB_PAGE_PARAM)) return true;
+  const values = params.getAll(HUB_PAGE_PARAM);
+  const raw = values.length === 1 ? values[0] : values;
+  return resolveHubPage(raw, hub.pageCount).kind === "page";
+}
+
+function matchesCodeBackedRoute(path: string): boolean {
+  return Object.keys(CODE_BACKED_ROUTE_FILES).some((route) => {
+    const pattern = route
+      .replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")
+      .replace(/:[a-z0-9_]+/giu, "[^/]+");
+    return new RegExp(`^${pattern}$`, "u").test(path);
+  });
+}
+
+function targetResolves(
+  target: string,
+  sourceLocale: ContentLocale,
+  targetsByLocale: Map<ContentLocale, Set<string>>,
+) {
+  const normalized = normalizeTarget(target);
+  if (!normalized) return true;
+  if (normalized.locale && !isContentLocale(normalized.locale)) return false;
+  const targetLocale = normalized.locale ?? sourceLocale;
+  const published =
+    targetsByLocale.get(targetLocale)?.has(normalized.path) ||
+    matchesCodeBackedRoute(normalized.path);
+  return Boolean(published && hasValidHubQuery(normalized));
+}
+
+function contentLinks(): ContentLink[] {
+  const found: ContentLink[] = [];
+
+  for (const path of walkFiles(
+    CONTENT_ROOT,
+    (candidate) => extname(candidate) === ".mdx",
+  )) {
+    const source = readFileSync(path, "utf8");
+    const file = relative(REPO_ROOT, path).split(sep).join("/");
+    const localeSegment = relative(CONTENT_ROOT, path).split(sep)[1];
+    if (!isContentLocale(localeSegment))
+      throw new Error(`${file} is outside a registered content locale`);
+    found.push(...linksInDocument(source, file, localeSegment));
+  }
+
+  return found;
+}
+
+function collectionSlugs(collection: string, locale: ContentLocale): string[] {
+  const directory = join(CONTENT_ROOT, collection, locale);
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === ".mdx")
+    .map((entry) => entry.name.slice(0, -".mdx".length))
+    .sort();
+}
+
+describe("internal link targets", () => {
+  it("accounts for every public route at one explicit content-or-code contract", () => {
+    const mapped = Object.keys(ROUTE_SOURCE_MAP);
+    const codeBacked = Object.keys(CODE_BACKED_ROUTE_FILES);
+
+    expect([...mapped, ...codeBacked].sort()).toEqual(
+      [...PUBLIC_ROUTES].sort(),
+    );
+    for (const file of Object.values(CODE_BACKED_ROUTE_FILES)) {
+      expect(
+        existsSync(join(REPO_ROOT, file)),
+        `${file} does not back its declared public route`,
+      ).toBe(true);
+    }
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
+    "resolves every literal internal link in MDX, including frontmatter CTAs",
+    () => {
+      const links = contentLinks();
+      const targetsByLocale = new Map(
+        CONTENT_LOCALES.map((locale) => [locale, contentBackedTargets(locale)]),
+      );
+      const problems = links
+        .filter(
+          (link) =>
+            !targetResolves(link.target, link.sourceLocale, targetsByLocale),
+        )
+        .map((link) => `${link.file}:${link.line} -> ${link.target}`);
+
+      expect(
+        links.length,
+        "expected root-relative links under content/",
+      ).toBeGreaterThan(0);
+      expect(
+        problems,
+        `content links with no published route:\n${problems.join("\n")}`,
+      ).toEqual([]);
+    },
+    30_000,
+  );
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
+    "derives six live footer links per collection and locale",
+    () => {
+      const selections = new Map<string, string[]>();
+      const problems: string[] = [];
+
+      for (const collection of Object.keys(
+        FOOTER_PREFERRED_SLUGS,
+      ) as FooterCollection[]) {
+        for (const locale of CONTENT_LOCALES) {
+          const published = collectionSlugs(collection, locale);
+          const selected = selectFooterSlugs(collection, published);
+          selections.set(`${collection}/${locale}`, selected);
+
+          if (selected.length !== FOOTER_COLUMN_SIZE) {
+            problems.push(
+              `${collection}/${locale} yields ${selected.length}, expected ${FOOTER_COLUMN_SIZE}`,
+            );
+          }
+          for (const slug of selected) {
+            if (!published.includes(slug))
+              problems.push(
+                `${collection}/${locale} selected absent slug ${slug}`,
+              );
+          }
+        }
+
+        const reference = selections.get(`${collection}/${DEFAULT_LOCALE}`);
+        for (const locale of CONTENT_LOCALES)
+          expect(selections.get(`${collection}/${locale}`)).toEqual(reference);
+      }
+
+      expect(
+        problems,
+        `footer columns with invalid derived links:\n${problems.join("\n")}`,
+      ).toEqual([]);
+    },
+  );
+
+  it("tops up a footer column deterministically when a preferred page disappears", () => {
+    const preferred = FOOTER_PREFERRED_SLUGS["for-pages"];
+    const available = [
+      ...preferred.slice(1),
+      "zzz-replacement",
+      "aaa-replacement",
+    ];
+
+    expect(selectFooterSlugs("for-pages", available)).toEqual([
+      ...preferred.slice(1),
+      "aaa-replacement",
+    ]);
+    expect(selectFooterSlugs("for-pages", preferred.slice(0, 2))).toEqual([
+      ...preferred.slice(0, 2),
+    ]);
+  });
+
+  it("extracts literal Markdown, JSX, and frontmatter hrefs without a parser dependency", () => {
+    const links = linksInDocument(
+      `---\nbuttonLeftHref: /pricing\nnestedButtonHref: '/blog?page=2'\n---\n[inline](/pricing)\n\n[plans]: /pricing#plans\n\n<Card\n  href={'/features/all'}\n/>`,
+      "synthetic.mdx",
+      DEFAULT_LOCALE,
+    );
+
+    expect(links.map(({ target }) => target)).toEqual([
+      "/pricing",
+      "/blog?page=2",
+      "/pricing",
+      "/pricing#plans",
+      "/features/all",
+    ]);
+  });
+
+  it("fails closed on frontmatter href syntax the bounded scanner cannot interpret", () => {
+    expect(() =>
+      linksInDocument(
+        `---\nbuttonHref: >-\n  /missing\n---`,
+        "folded.mdx",
+        DEFAULT_LOCALE,
+      ),
+    ).toThrow("folded.mdx:2 uses unsupported frontmatter href syntax");
+    expect(() =>
+      linksInDocument(
+        `---\nbuttonHref: *shared-target\n---`,
+        "alias.mdx",
+        DEFAULT_LOCALE,
+      ),
+    ).toThrow("alias.mdx:2 uses unsupported frontmatter href syntax");
+  });
+
+  it("keeps hub query semantics instead of discarding the page parameter", () => {
+    const targetsByLocale = new Map(
+      CONTENT_LOCALES.map((locale) => [locale, contentBackedTargets(locale)]),
+    );
+
+    expect(
+      targetResolves("/blog?page=2", DEFAULT_LOCALE, targetsByLocale),
+    ).toBe(true);
+    expect(
+      targetResolves("/blog?page=1", DEFAULT_LOCALE, targetsByLocale),
+    ).toBe(false);
+    expect(
+      targetResolves("/blog?page=99", DEFAULT_LOCALE, targetsByLocale),
+    ).toBe(false);
+    expect(
+      targetResolves("/blog?page=2&page=3", DEFAULT_LOCALE, targetsByLocale),
+    ).toBe(false);
+    expect(targetResolves("/contact", DEFAULT_LOCALE, targetsByLocale)).toBe(
+      true,
+    );
+    expect(targetResolves("/fr/pricing", DEFAULT_LOCALE, targetsByLocale)).toBe(
+      false,
+    );
+  });
+
+  it("normalizes locale prefixes, fragments, and trailing slashes without losing queries", () => {
+    expect(normalizeTarget("/pricing#plans")).toEqual({
+      locale: null,
+      path: "/pricing",
+      query: "",
+    });
+    expect(normalizeTarget("/pricing?ref=footer")).toEqual({
+      locale: null,
+      path: "/pricing",
+      query: "?ref=footer",
+    });
+    expect(normalizeTarget("/for/healthcare/")).toEqual({
+      locale: null,
+      path: "/for/healthcare",
+      query: "",
+    });
+    expect(normalizeTarget("/de/for/healthcare")).toEqual({
+      locale: "de",
+      path: "/for/healthcare",
+      query: "",
+    });
+    expect(normalizeTarget("/fr/pricing")).toEqual({
+      locale: "fr",
+      path: "/pricing",
+      query: "",
+    });
+    expect(normalizeTarget("/")).toEqual({
+      locale: null,
+      path: "/",
+      query: "",
+    });
+  });
+});

--- a/tests/conventions/internal-link-targets.test.ts
+++ b/tests/conventions/internal-link-targets.test.ts
@@ -88,7 +88,7 @@ const FRONTMATTER_HREF = /^\s*(?:-\s*)?([a-z0-9_-]*href)\s*:\s*(.*?)\s*$/iu;
 const JSX_HREF =
   /\bhref\s*=\s*(?:"([^"\r\n]*)"|'([^'\r\n]*)'|\{\s*"([^"\r\n]*)"\s*\}|\{\s*'([^'\r\n]*)'\s*\})/gu;
 const MARKDOWN_LINK =
-  /(?<!!)\[[^\]\r\n]*\]\(\s*(?:<([^>\r\n]+)>|((?:\\.|[^)\s])+))(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/gu;
+  /(?<!!)\[[^\]\r\n]*\]\(\s*(?:<([^>\r\n]+)>|((?:\\.|[^)\\\s])+))(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/gu;
 const MARKDOWN_DEFINITION = /^\s*\[[^\]\r\n]+\]:\s*(?:<([^>\r\n]+)>|(\S+))/gmu;
 
 type ContentLink = {
@@ -437,6 +437,13 @@ describe("internal link targets", () => {
         DEFAULT_LOCALE,
       ),
     ).toThrow("alias.mdx:2 uses unsupported frontmatter href syntax");
+  });
+
+  it("does not backtrack through a long malformed Markdown escape sequence", () => {
+    const malformed = `[broken](/${"\\".repeat(4_096)}`;
+    expect(linksInDocument(malformed, "malformed.mdx", DEFAULT_LOCALE)).toEqual(
+      [],
+    );
   });
 
   it("keeps hub query semantics instead of discarding the page parameter", () => {

--- a/tests/conventions/internal-link-targets.test.ts
+++ b/tests/conventions/internal-link-targets.test.ts
@@ -75,8 +75,6 @@ vi.mock("@/core/fumadocs/source", async () => {
   };
 });
 
-const ENFORCED = true;
-
 const CONTENT_ROOT = join(REPO_ROOT, "content");
 const CODE_BACKED_ROUTE_FILES = {
   "/contact": "app/[locale]/(public)/contact/page.tsx",
@@ -333,70 +331,63 @@ describe("internal link targets", () => {
     }
   });
 
-  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
-    "resolves every literal internal link in MDX, including frontmatter CTAs",
-    () => {
-      const links = contentLinks();
-      const targetsByLocale = new Map(
-        CONTENT_LOCALES.map((locale) => [locale, contentBackedTargets(locale)]),
-      );
-      const problems = links
-        .filter(
-          (link) =>
-            !targetResolves(link.target, link.sourceLocale, targetsByLocale),
-        )
-        .map((link) => `${link.file}:${link.line} -> ${link.target}`);
+  it("resolves every literal internal link in MDX, including frontmatter CTAs", () => {
+    const links = contentLinks();
+    const targetsByLocale = new Map(
+      CONTENT_LOCALES.map((locale) => [locale, contentBackedTargets(locale)]),
+    );
+    const problems = links
+      .filter(
+        (link) =>
+          !targetResolves(link.target, link.sourceLocale, targetsByLocale),
+      )
+      .map((link) => `${link.file}:${link.line} -> ${link.target}`);
 
-      expect(
-        links.length,
-        "expected root-relative links under content/",
-      ).toBeGreaterThan(0);
-      expect(
-        problems,
-        `content links with no published route:\n${problems.join("\n")}`,
-      ).toEqual([]);
-    },
-    30_000,
-  );
+    expect(
+      links.length,
+      "expected root-relative links under content/",
+    ).toBeGreaterThan(0);
+    expect(
+      problems,
+      `content links with no published route:\n${problems.join("\n")}`,
+    ).toEqual([]);
+  }, 30_000);
 
-  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
-    "derives six live footer links per collection and locale",
-    () => {
-      const selections = new Map<string, string[]>();
-      const problems: string[] = [];
+  it("derives six live footer links per collection and locale", () => {
+    const selections = new Map<string, string[]>();
+    const problems: string[] = [];
 
-      for (const collection of Object.keys(
-        FOOTER_PREFERRED_SLUGS,
-      ) as FooterCollection[]) {
-        for (const locale of CONTENT_LOCALES) {
-          const published = collectionSlugs(collection, locale);
-          const selected = selectFooterSlugs(collection, published);
-          selections.set(`${collection}/${locale}`, selected);
+    for (const collection of Object.keys(
+      FOOTER_PREFERRED_SLUGS,
+    ) as FooterCollection[]) {
+      for (const locale of CONTENT_LOCALES) {
+        const published = collectionSlugs(collection, locale);
+        const selected = selectFooterSlugs(collection, published);
+        selections.set(`${collection}/${locale}`, selected);
 
-          if (selected.length !== FOOTER_COLUMN_SIZE) {
-            problems.push(
-              `${collection}/${locale} yields ${selected.length}, expected ${FOOTER_COLUMN_SIZE}`,
-            );
-          }
-          for (const slug of selected) {
-            if (!published.includes(slug))
-              problems.push(
-                `${collection}/${locale} selected absent slug ${slug}`,
-              );
-          }
+        if (selected.length !== FOOTER_COLUMN_SIZE) {
+          problems.push(
+            `${collection}/${locale} yields ${selected.length}, expected ${FOOTER_COLUMN_SIZE}`,
+          );
         }
-
-        const reference = selections.get(`${collection}/${DEFAULT_LOCALE}`);
-        for (const locale of CONTENT_LOCALES)
-          expect(selections.get(`${collection}/${locale}`)).toEqual(reference);
+        for (const slug of selected) {
+          if (!published.includes(slug))
+            problems.push(
+              `${collection}/${locale} selected absent slug ${slug}`,
+            );
+        }
       }
 
-      expect(
-        problems,
-        `footer columns with invalid derived links:\n${problems.join("\n")}`,
-      ).toEqual([]);
-    },
-  );
+      const reference = selections.get(`${collection}/${DEFAULT_LOCALE}`);
+      for (const locale of CONTENT_LOCALES)
+        expect(selections.get(`${collection}/${locale}`)).toEqual(reference);
+    }
+
+    expect(
+      problems,
+      `footer columns with invalid derived links:\n${problems.join("\n")}`,
+    ).toEqual([]);
+  });
 
   it("tops up a footer column deterministically when a preferred page disappears", () => {
     const preferred = FOOTER_PREFERRED_SLUGS["for-pages"];


### PR DESCRIPTION
## Summary

- Adds executable shipping gates for hero coverage, literal internal-link resolution (including frontmatter CTAs), footer integrity, static-route collisions, and rendered landing-page reachability.
- Paginates `/blog`, `/compare`, `/features/all`, and `/for` at 24 cards per page, with strict page queries, page-specific canonical/hreflang metadata, and sitemap entries for pages 2+.
- Uses a bounded square-root pager so the 2,256-item backlog remains reachable within four clicks from the localized home page without rendering all 94 page numbers on every hub.
- Removes the public `Crawl-delay` while preserving the preview/subdomain `Disallow: /` behavior.

## Context

Implements [CUS-196](https://linear.app/customermates/issue/CUS-196/close-the-locale-parity-orphan-page-and-hero-coverage-holes).

This replaces closed PR #49, rebuilt selectively on current `main` (`74f0a00f`). Locale-parity hardening and the previously identified content-link repairs already landed through earlier changes, so this PR does not duplicate them. No MDX, package, lockfile, locale-catalog, database, or schema files change.

Key design decisions:

- `ROUTE_SOURCE_MAP` remains the content-route authority. `LANDING_HUBS` is only the typed relationship between each collection, hub, and detail route; page counts are derived from the default-locale published source.
- Pagination is owned by the four App Router pages, not by `proxy.ts`. An absent `page` means page 1; explicit `page=1` permanently normalizes to the clean localized hub while preserving unrelated and repeated query values; only canonical integers from 2 through the final page render; malformed, repeated, zero-padded, unsafe, and out-of-range values call `notFound()`.
- App-only locales still receive the existing temporary content-locale fallback first, preserving the complete query. The resolved content-locale page then applies pagination normalization or not-found handling.
- Next.js may stream these page-level outcomes. Consequently, `permanentRedirect()` can be represented by either a 308 response or an HTML meta redirect, and `notFound()` by either a 404 or streamed 200 HTML carrying `noindex`. Tests assert the semantic redirect target, final same-origin canonical destination, localized `noindex`, and absence of a canonical on invalid pages rather than requiring one transport status.
- Every valid page has a same-origin self-canonical and reciprocal `en`, `de`, and `x-default` alternates for the same page number. Page 1 stays out of the query-form sitemap; pages 2+ are included.
- Default-locale slug ordering fixes page membership across locales, so corresponding hreflang pages contain equivalent slugs.
- The rendered E2E crawls production HTML from `next start`. The separate 2,256-item case is explicitly a pager-topology proof, not a claim that backlog content was rendered.

This follows Next's documented streaming behavior for [loading boundaries](https://nextjs.org/docs/app/api-reference/file-conventions/loading#status-codes), [`notFound()`](https://nextjs.org/docs/app/api-reference/functions/not-found), and [`permanentRedirect()`](https://nextjs.org/docs/app/api-reference/functions/permanentRedirect).

## Validation

Fresh on final local commit `da8f77d3`, using the isolated CUS-196 worktree and disposable PostgreSQL 16 container:

- `yarn db:reset` — migrations, synthetic seed, and workflow schema passed
- `yarn openapi:generate && yarn raw-docs:generate` — passed with no tracked drift
- `yarn typecheck` — passed
- `yarn lint` — passed with zero warnings
- database-enabled `yarn test` — 270 files passed; 2,096 tests passed; one intentional server-gated E2E skip
- `yarn i18n:audit` — passed; advisory findings only, parity remains test-enforced
- `yarn build` — production build passed
- `HUB_E2E_BASE_URL=http://localhost:40196 yarn vitest run tests/conventions/hub-reachability.test.ts` — 11/11 passed against that build's `next start`
- Headless Chrome verification — hydrated pager navigation, page-one normalization, localized invalid-page UI, app-only locale fallback, and canonical state passed with no console/page errors or Next error overlay

The rendered crawl covered:

- 16 localized hub responses and all 336 localized detail routes
- exact 24-card partitions and EN/DE page-membership parity
- localized home → hub → pager → detail reachability, maximum depth 4
- exact rendered footer detail links
- same-origin self-canonicals, reciprocal `en/de/x-default` hreflang, and the exact paginated sitemap set
- semantic page-one and invalid-query outcomes, malformed/repeated/out-of-range values, content-locale fallback, and robots behavior
- maximum current hub response: 343,991 bytes; maximum 24 cards and 109 anchors

## Impact and rollback

User-visible changes are bounded hub pages, accessible previous/next/numbered navigation, canonical pagination URLs, and removal of the public crawl throttle. At the current content count the sitemap grows from 412 to 420 URLs. There are no migrations, content rewrites, or external-system writes.

Rollback is one revert. It restores unpaginated hubs and the former crawl directive without database or content reconciliation.

## Human checkpoint before merge

- Code Owner approval and squash merge remain human-only.
- The workflow emits `rendered-hubs`, but the live ruleset currently requires only `ci` and `repository-policy`. A governance owner must require `rendered-hubs` or fold it into required `ci` before merge.
