### PR TITLE
fix(seo): correct root-host detection and single-source the hub page count

### DIFF
--- a/app/[locale]/(static)/blog/page.tsx
+++ b/app/[locale]/(static)/blog/page.tsx
@@ -13,6 +13,7 @@ import { blogPostsSource, blogSource } from "@/core/fumadocs/source";
 import {
   HUB_PAGE_PARAM,
   hubPageCount,
+  hubPageCountForSource,
   hubPageHref,
   hubPageOneRedirectHref,
   paginateLocalizedHubPages,
@@ -28,10 +29,7 @@ type Props = {
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
   const query = await searchParams;
-  const resolution = resolveHubPage(
-    query[HUB_PAGE_PARAM],
-    hubPageCount(blogPostsSource.getPages(DEFAULT_LOCALE).length),
-  );
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCountForSource(blogPostsSource));
 
   if (resolution.kind === "not-found") notFound();
 

--- a/app/[locale]/(static)/compare/page.tsx
+++ b/app/[locale]/(static)/compare/page.tsx
@@ -12,6 +12,7 @@ import { comparePagesSource, compareSource } from "@/core/fumadocs/source";
 import {
   HUB_PAGE_PARAM,
   hubPageCount,
+  hubPageCountForSource,
   hubPageHref,
   hubPageOneRedirectHref,
   paginateLocalizedHubPages,
@@ -28,10 +29,7 @@ type Props = {
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
   const query = await searchParams;
-  const resolution = resolveHubPage(
-    query[HUB_PAGE_PARAM],
-    hubPageCount(comparePagesSource.getPages(DEFAULT_LOCALE).length),
-  );
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCountForSource(comparePagesSource));
 
   if (resolution.kind === "not-found") notFound();
 

--- a/app/[locale]/(static)/features/all/page.tsx
+++ b/app/[locale]/(static)/features/all/page.tsx
@@ -12,6 +12,7 @@ import { featurePagesSource, featuresAllSource } from "@/core/fumadocs/source";
 import {
   HUB_PAGE_PARAM,
   hubPageCount,
+  hubPageCountForSource,
   hubPageHref,
   hubPageOneRedirectHref,
   paginateLocalizedHubPages,
@@ -28,10 +29,7 @@ type Props = {
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
   const query = await searchParams;
-  const resolution = resolveHubPage(
-    query[HUB_PAGE_PARAM],
-    hubPageCount(featurePagesSource.getPages(DEFAULT_LOCALE).length),
-  );
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCountForSource(featurePagesSource));
 
   if (resolution.kind === "not-found") notFound();
 

--- a/app/[locale]/(static)/for/page.tsx
+++ b/app/[locale]/(static)/for/page.tsx
@@ -12,6 +12,7 @@ import { forPagesSource, forSource } from "@/core/fumadocs/source";
 import {
   HUB_PAGE_PARAM,
   hubPageCount,
+  hubPageCountForSource,
   hubPageHref,
   hubPageOneRedirectHref,
   paginateLocalizedHubPages,
@@ -28,10 +29,7 @@ type Props = {
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { locale } = await params;
   const query = await searchParams;
-  const resolution = resolveHubPage(
-    query[HUB_PAGE_PARAM],
-    hubPageCount(forPagesSource.getPages(DEFAULT_LOCALE).length),
-  );
+  const resolution = resolveHubPage(query[HUB_PAGE_PARAM], hubPageCountForSource(forPagesSource));
 
   if (resolution.kind === "not-found") notFound();
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -3,21 +3,13 @@ import type { MetadataRoute } from "next";
 import { headers } from "next/headers";
 
 import { env } from "@/env";
-
-function isSubdomain(host: string): boolean {
-  const parts = host.split(".");
-  const isLocalhost = host.includes("localhost");
-
-  if (isLocalhost) return false;
-
-  return parts.length > 2;
-}
+import { isSubdomainHost } from "@/core/seo/public-host";
 
 export default async function robots(): Promise<MetadataRoute.Robots> {
   const headersList = await headers();
   const host = headersList.get("host") || headersList.get("x-forwarded-host") || "";
 
-  const isSubdomainRequest = isSubdomain(host);
+  const isSubdomainRequest = isSubdomainHost(host);
 
   if (isSubdomainRequest) {
     return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { LocalizedRoute } from "@/core/seo/sitemap";
 
 import { env } from "@/env";
 import { assembleSitemap } from "@/core/seo/sitemap";
-import { hubPageCount, hubPageHref } from "@/core/seo/hub-pagination";
+import { hubPageCountForSource, hubPageHref } from "@/core/seo/hub-pagination";
 import { LANDING_HUBS } from "@/core/seo/landing-hubs";
 import { CONTENT_LOCALES, stripLocalePrefix } from "@/i18n/locale-registry";
 import { PUBLIC_ROUTES_SEO } from "@/i18n/routing";
@@ -46,7 +46,7 @@ function collectLocalizedRoutes(): LocalizedRoute[] {
 
     for (const hub of LANDING_HUBS) {
       const source = ROUTE_SOURCE_MAP[hub.detailRoute].source;
-      const pageCount = hubPageCount(source.getPages(locale).length);
+      const pageCount = hubPageCountForSource(source);
 
       for (let page = 2; page <= pageCount; page++) {
         localizedRoutes.push({

--- a/core/seo/__tests__/public-host.test.ts
+++ b/core/seo/__tests__/public-host.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { hostnameFromHost, isSubdomainHost } from "@/core/seo/public-host";
+
+describe("public host classification", () => {
+  it("strips a port before classifying", () => {
+    expect(hostnameFromHost("customermates.com")).toBe("customermates.com");
+    expect(hostnameFromHost("localhost:40196")).toBe("localhost");
+    expect(hostnameFromHost("127.0.0.1:40196")).toBe("127.0.0.1");
+    expect(hostnameFromHost("")).toBe("");
+  });
+
+  it.each([
+    ["customermates.com", false],
+    ["customermates.com:443", false],
+    ["app.customermates.com", true],
+    ["fix-page-shipping-contracts.customermates.com", true],
+    ["customermates-git-main-customermates.vercel.app", true],
+    ["localhost", false],
+    ["localhost:40196", false],
+    ["127.0.0.1", false],
+    ["127.0.0.1:40196", false],
+    ["0.0.0.0:3000", false],
+    ["192.168.1.14:40196", false],
+  ])("classifies %s as subdomain=%s", (host, expected) => {
+    expect(isSubdomainHost(host)).toBe(expected);
+  });
+
+  it("keeps a bare two-label host a root host and a three-label host a subdomain", () => {
+    expect(isSubdomainHost("example.com")).toBe(false);
+    expect(isSubdomainHost("a.example.com")).toBe(true);
+  });
+});

--- a/core/seo/hub-pagination.ts
+++ b/core/seo/hub-pagination.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_LOCALE } from "@/i18n/locale-registry";
+
 export const HUB_PAGE_SIZE = 24;
 
 export const HUB_PAGE_PARAM = "page";
@@ -25,6 +27,10 @@ type SourcePage = {
   url: string;
 };
 
+type HubPageCountSource = {
+  getPages: (locale: string) => readonly unknown[];
+};
+
 export type SluggedPage<T extends SourcePage> = {
   page: T;
   slug: string;
@@ -35,6 +41,10 @@ export function hubPageCount(total: number, size: number = HUB_PAGE_SIZE): numbe
   if (!Number.isSafeInteger(size) || size < 1) throw new RangeError("Hub page size must be a positive integer");
 
   return Math.max(1, Math.ceil(total / size));
+}
+
+export function hubPageCountForSource(source: HubPageCountSource): number {
+  return hubPageCount(source.getPages(DEFAULT_LOCALE).length);
 }
 
 export function resolveHubPage(raw: string | string[] | undefined, pageCount: number): HubPageResolution {

--- a/core/seo/public-host.ts
+++ b/core/seo/public-host.ts
@@ -1,0 +1,14 @@
+const IPV4_LITERAL = /^\d{1,3}(?:\.\d{1,3}){3}$/u;
+
+export function hostnameFromHost(host: string): string {
+  return host.split(":")[0] ?? "";
+}
+
+export function isSubdomainHost(host: string): boolean {
+  const hostname = hostnameFromHost(host);
+
+  if (hostname.includes("localhost")) return false;
+  if (IPV4_LITERAL.test(hostname)) return false;
+
+  return hostname.split(".").length > 2;
+}


### PR DESCRIPTION
## Summary

Two latent defects found while verifying CUS-196 / PR #64 against a local production build. Neither changes behavior on the current content tree.

**Root-host detection.** `app/robots.ts` split the raw `Host` header on `.` and called anything with more than two parts a subdomain. An IPv4 literal such as `127.0.0.1:40196` yields four parts, so a loopback or LAN host was served `Disallow: /`. The classifier is extracted to `core/seo/public-host.ts`, strips the port, and treats a bare IPv4 literal as a root host alongside `localhost`.

**Hub page count.** `app/sitemap.ts` derived the count from the *localized* collection while the four hub pages derived it from the *default-locale* collection. The default locale is what fixes page membership so EN page N and DE page N stay true hreflang equivalents. Both now call `hubPageCountForSource`, so one rule decides membership everywhere.

## Context

Closes the two non-blocking observations recorded on CUS-196 after PR #64 merged as `f40114dd`. Tracked as CUS-231.

Only IP-literal hosts change classification. Every real hostname is unaffected:

| Host | main | this branch |
| --- | --- | --- |
| `customermates.com` | `Allow: /` | `Allow: /` |
| `app.customermates.com` | `Disallow: /` | `Disallow: /` |
| `fix-x.customermates.com` | `Disallow: /` | `Disallow: /` |
| `www.customermates.com` | `Disallow: /` | `Disallow: /` |
| `localhost:40231` | `Allow: /` | `Allow: /` |
| `127.0.0.1:40231` | `Disallow: /` | **`Allow: /`** |
| `192.168.1.14:40231` | `Disallow: /` | **`Allow: /`** |

## Validation

Local, exact head `f4503730`, isolated worktree with a disposable PostgreSQL 16 container.

- `yarn typecheck` pass
- `yarn lint` pass, zero warnings
- `RUN_DATABASE_TESTS=true yarn test` pass: **271 files, 2,109 passed, 1 intentional skip** (up from 270/2,096 on `main` with the new classifier coverage)
- `yarn i18n:audit` pass, advisory findings only
- `yarn build` pass
- Rendered E2E against a local production server, started exactly as CI does: **11/11**
- Robots verified per host with real `Host` headers (table above)
- Sitemap unchanged: **420 URLs, exactly 8 paginated, no `page=1`**

## Impact and rollback

No schema, data, configuration, dependency, or external-system change. Each item is an independent `git revert`; reverting item 2 restores the localized derivation, which produces identical output on the current tree.

## Known limitation, deliberately not fixed here

CUS-231 originally aimed to make the `127.x` arm of the robots assertion in `tests/conventions/hub-reachability.test.ts` fully reachable. This change fixes the robots half, but the full rendered E2E still cannot pass against a `127.0.0.1` base URL for a second, unrelated reason: the proxy resolves redirect origins through `resolveRequestOrigin(req.nextUrl.origin, env.AUTH_ALLOWED_HOSTS, env.BASE_URL)`, so `/fr/blog?page=1` emits an absolute `Location` that is not same-origin when the app is addressed as `127.0.0.1`. That path is untouched by this branch (`proxy.ts`, `env.ts`, and `core/config/environment.ts` are not in the diff) and is recorded on CUS-231 for a separate decision. CI is unaffected: `.github/workflows/page-shipping-e2e.yml` crawls via `localhost`.

Separately discovered and **not** changed here: `www.customermates.com` classifies as a subdomain and is served `Disallow: /`. That host is attached to the Vercel project, so whether it is ever served directly rather than redirected to the apex is a live search-visibility decision rather than a cleanup. Filed for a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)