### PR TITLE
fix(user): keep the requested id when scoping user lookups to readown viewers

### DIFF
--- a/features/user/__tests__/user-lookup-access-scoping.database.test.ts
+++ b/features/user/__tests__/user-lookup-access-scoping.database.test.ts
@@ -1,0 +1,78 @@
+import type { TenantUser } from "@/features/user/user.schema";
+
+import { randomUUID } from "node:crypto";
+
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { Action, Resource } from "@/generated/prisma";
+
+import { runWithTenant } from "@/core/decorators/tenant-context";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { createMockUserWithPermissions } from "@/tests/helpers/mock-user";
+import { PrismaUserRepo } from "../prisma-user.repository";
+
+const databaseUrl = getLocalDatabaseTestUrl();
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase("user lookup access scoping on PostgreSQL", () => {
+  const client = new Client({ connectionString: databaseUrl ?? undefined });
+  const companyId = randomUUID();
+  const viewerId = randomUUID();
+  const colleagueId = randomUUID();
+
+  const viewer = (action: Action): TenantUser => ({
+    ...createMockUserWithPermissions([{ resource: Resource.users, action }]),
+    id: viewerId,
+    companyId,
+  });
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.query('INSERT INTO "Company" ("id", "updatedAt") VALUES ($1, CURRENT_TIMESTAMP)', [companyId]);
+    await client.query(
+      'INSERT INTO "User" ("id", "email", "firstName", "lastName", "companyId", "updatedAt") VALUES ($1, $2, $3, $4, $7, CURRENT_TIMESTAMP), ($5, $6, $3, $4, $7, CURRENT_TIMESTAMP)',
+      [
+        viewerId,
+        `viewer-${viewerId}@example.com`,
+        "Read",
+        "Own",
+        colleagueId,
+        `mate-${colleagueId}@example.com`,
+        companyId,
+      ],
+    );
+  });
+
+  afterAll(async () => {
+    await client.query('DELETE FROM "User" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "Company" WHERE "id" = $1', [companyId]);
+    await client.end();
+  });
+
+  it("returns null when a readOwn viewer asks for a colleague", async () => {
+    const user = await runWithTenant(viewer(Action.readOwn), () => new PrismaUserRepo().getUserById(colleagueId));
+
+    expect(user).toBeNull();
+  });
+
+  it("returns the viewer's own record to a readOwn viewer", async () => {
+    const user = await runWithTenant(viewer(Action.readOwn), () => new PrismaUserRepo().getUserById(viewerId));
+
+    expect(user?.id).toBe(viewerId);
+  });
+
+  it("returns the colleague to a readAll viewer", async () => {
+    const user = await runWithTenant(viewer(Action.readAll), () => new PrismaUserRepo().getUserById(colleagueId));
+
+    expect(user?.id).toBe(colleagueId);
+  });
+
+  it("resolves only the requested ids for a readOwn viewer", async () => {
+    const found = await runWithTenant(viewer(Action.readOwn), () =>
+      new PrismaUserRepo().findIds(new Set([colleagueId])),
+    );
+
+    expect(found).toEqual(new Set());
+  });
+});

--- a/features/user/__tests__/user-lookup-access-scoping.test.ts
+++ b/features/user/__tests__/user-lookup-access-scoping.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { Action, Resource } from "@/generated/prisma";
+
+import { runWithTenant } from "@/core/decorators/tenant-context";
+import { createMockUserWithPermissions } from "@/tests/helpers/mock-user";
+
+const { fake } = vi.hoisted(() => {
+  const calls: { op: string; args: any }[] = [];
+  const rows: Array<{ id: string; companyId: string }> = [];
+
+  const matches = (row: { id: string; companyId: string }, where: any): boolean => {
+    if (!where) return true;
+    if (where.companyId !== undefined && row.companyId !== where.companyId) return false;
+    if (typeof where.id === "string" && row.id !== where.id) return false;
+    if (where.id?.in && !where.id.in.includes(row.id)) return false;
+    for (const clause of where.AND ?? []) if (!matches(row, clause)) return false;
+    return true;
+  };
+
+  return {
+    fake: {
+      calls,
+      rows,
+      reset() {
+        calls.length = 0;
+        rows.length = 0;
+      },
+      prisma: {
+        user: {
+          findMany: (args: any) => {
+            calls.push({ op: "findMany", args });
+            return Promise.resolve(rows.filter((row) => matches(row, args?.where)).map(({ id }) => ({ id })));
+          },
+          findFirst: (args: any) => {
+            calls.push({ op: "findFirst", args });
+            return Promise.resolve(rows.find((row) => matches(row, args?.where)) ?? null);
+          },
+        },
+      },
+    },
+  };
+});
+
+vi.mock("@/prisma/db", () => ({ prisma: fake.prisma }));
+
+import { PrismaUserRepo } from "../prisma-user.repository";
+
+const COMPANY = "test-company-id";
+const SELF = "test-user-id";
+const COLLEAGUE = "22000000-0000-4000-8000-000000000002";
+
+const readOwn = () => createMockUserWithPermissions([{ resource: Resource.users, action: Action.readOwn }]);
+const readAll = () => createMockUserWithPermissions([{ resource: Resource.users, action: Action.readAll }]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fake.reset();
+  fake.rows.push({ id: SELF, companyId: COMPANY }, { id: COLLEAGUE, companyId: COMPANY });
+});
+
+describe("PrismaUserRepo.getUserById keeps the requested id under readOwn scoping", () => {
+  it("returns null for a colleague instead of substituting the caller", async () => {
+    const user = await runWithTenant(readOwn(), () => new PrismaUserRepo().getUserById(COLLEAGUE));
+
+    expect(user).toBeNull();
+  });
+
+  it("still returns the caller's own record", async () => {
+    const user = await runWithTenant(readOwn(), () => new PrismaUserRepo().getUserById(SELF));
+
+    expect(user?.id).toBe(SELF);
+  });
+
+  it("returns the requested colleague for a readAll viewer", async () => {
+    const user = await runWithTenant(readAll(), () => new PrismaUserRepo().getUserById(COLLEAGUE));
+
+    expect(user?.id).toBe(COLLEAGUE);
+  });
+
+  it("keeps companyId at the top level of the where so the tenant guard can read it", async () => {
+    await runWithTenant(readOwn(), () => new PrismaUserRepo().getUserById(COLLEAGUE));
+
+    expect(fake.calls.at(-1)?.args.where.companyId).toBe(COMPANY);
+  });
+});
+
+describe("PrismaUserRepo.findIds keeps the requested id set under readOwn scoping", () => {
+  it("does not report an id that was never requested", async () => {
+    const found = await runWithTenant(readOwn(), () => new PrismaUserRepo().findIds(new Set([COLLEAGUE])));
+
+    expect(found).toEqual(new Set());
+  });
+
+  it("resolves the caller's own id when it is requested", async () => {
+    const found = await runWithTenant(readOwn(), () => new PrismaUserRepo().findIds(new Set([SELF, COLLEAGUE])));
+
+    expect(found).toEqual(new Set([SELF]));
+  });
+
+  it("keeps companyId at the top level of the where so the tenant guard can read it", async () => {
+    await runWithTenant(readOwn(), () => new PrismaUserRepo().findIds(new Set([COLLEAGUE])));
+
+    expect(fake.calls.at(-1)?.args.where.companyId).toBe(COMPANY);
+  });
+});

--- a/features/user/prisma-user.repository.ts
+++ b/features/user/prisma-user.repository.ts
@@ -201,8 +201,8 @@ export class PrismaUserRepo
 
     const users = await this.prisma.user.findMany({
       where: {
-        id: { in: Array.from(ids) },
         ...this.accessWhere("user"),
+        AND: [{ id: { in: Array.from(ids) } }],
       },
       select: { id: true },
     });
@@ -213,8 +213,8 @@ export class PrismaUserRepo
   async getUserById(id: string) {
     const user = await this.prisma.user.findFirst({
       where: {
-        id,
         ...this.accessWhere("user"),
+        AND: [{ id }],
       },
       select: this.userSelect,
     });

--- a/tests/conventions/access-where-composition.test.ts
+++ b/tests/conventions/access-where-composition.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT, walkFiles } from "./walk";
+
+const ENFORCED = true;
+
+const SCANNED_DIRECTORIES = ["core", "ee", "features", "workflows", "app"];
+
+const CRM_ACCESS_KEYS = ["companyId", "users"];
+
+const HELPER_KEYS: Record<string, string[]> = {
+  'accessWhere("user")': ["companyId", "id"],
+  'accessWhere("contact")': CRM_ACCESS_KEYS,
+  'accessWhere("organization")': CRM_ACCESS_KEYS,
+  'accessWhere("deal")': CRM_ACCESS_KEYS,
+  'accessWhere("service")': CRM_ACCESS_KEYS,
+  'accessWhere("task")': CRM_ACCESS_KEYS,
+  "threadAccessWhere(": ["companyId", "OR"],
+  "calendarAccessWhere(": ["companyId", "connectedAccount"],
+  "calendarEventAccessWhere(": ["companyId", "connectedAccount"],
+  "accountActivityAccessWhere(": ["companyId", "connectedAccount"],
+  "folderMessageWhere(": ["OR"],
+  "threadFolderMembershipWhere(": ["OR"],
+  "threadHasActivityWhere(": ["OR"],
+};
+
+type Collision = { file: string; line: number; key: string; helper: string };
+
+function sourceFiles() {
+  return SCANNED_DIRECTORIES.flatMap((dir) =>
+    walkFiles(join(REPO_ROOT, dir), (path) => path.endsWith(".ts") && !path.includes("__tests__")),
+  );
+}
+
+function helperFor(expression: string): [string, string[]] | undefined {
+  for (const [needle, keys] of Object.entries(HELPER_KEYS)) if (expression.includes(needle)) return [needle, keys];
+  return undefined;
+}
+
+function collisions(): { found: Collision[]; helpersSeen: Set<string> } {
+  const found: Collision[] = [];
+  const helpersSeen = new Set<string>();
+
+  for (const file of sourceFiles()) {
+    const text = readFileSync(file, "utf8");
+    if (!/accessWhere|AccessWhere|folderMessageWhere|threadHasActivityWhere/.test(text)) continue;
+
+    for (const helper of Object.keys(HELPER_KEYS)) if (text.includes(helper)) helpersSeen.add(helper);
+
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+
+    const visit = (node: ts.Node) => {
+      if (ts.isObjectLiteralExpression(node)) {
+        const properties = node.properties;
+
+        for (const property of properties) {
+          if (!ts.isSpreadAssignment(property)) continue;
+
+          const match = helperFor(property.expression.getText(source));
+          if (!match) continue;
+
+          const [helper, keys] = match;
+          helpersSeen.add(helper);
+
+          for (const sibling of properties) {
+            if (sibling === property) continue;
+
+            const name = sibling.name?.getText(source);
+            if (!name || !keys.includes(name)) continue;
+
+            found.push({
+              file: relative(REPO_ROOT, file),
+              line: source.getLineAndCharacterOfPosition(sibling.getStart()).line + 1,
+              key: name,
+              helper,
+            });
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+  }
+
+  return { found, helpersSeen };
+}
+
+describe("access-where composition", () => {
+  const { found, helpersSeen } = collisions();
+
+  it.runIf(ENFORCED)("never spreads an access predicate beside a key that predicate also sets", () => {
+    const clashes = found.map((c) => `${c.file}:${c.line} key '${c.key}' collides with ${c.helper}`);
+
+    expect(clashes).toEqual([]);
+  });
+
+  it("keeps the helper key map in step with the helpers that exist", () => {
+    const unused = Object.keys(HELPER_KEYS).filter((helper) => !helpersSeen.has(helper));
+
+    expect(unused).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`accessWhere("user")` returns `{ id: userId, companyId }` for a `readOwn` viewer. `getUserById` and `findIds` both spread it **after** the caller's own `id` constraint, so the spread silently overwrote that constraint.

- `getUserById(colleagueId)` returned the **caller's own record** instead of `null`.
- `findIds(ids)` resolved the caller's id even when it was never in the requested set.

`readAll` viewers were unaffected, because their access where is `{ companyId }` with no `id` key.

## Context

Found while auditing the read stack's access-control layer. The bug is invisible for administrators and only affects roles narrowed to `users: readOwn`, which is why it has not surfaced: a `readOwn` viewer opening a colleague's record silently sees their own instead of a not-found.

The naive fix (moving everything into `AND`) is wrong here: the Prisma tenant guard in `prisma/db.ts` reads **top-level** `args.where.companyId` and throws when it is absent, so burying `companyId` inside `AND` would make every user lookup fail. The fix keeps the access where spread first, so `companyId` stays top-level, and carries the requested id in an `AND` clause so both constraints survive.

## Validation

- New regression test `features/user/__tests__/user-lookup-access-scoping.test.ts` (7 cases). Verified it **fails without the fix** on exactly the two buggy behaviours and passes with it.
- Two of its cases assert `companyId` remains top-level in the emitted `where`, pinning the tenant-guard interaction described above.
- `yarn typecheck`, `yarn lint`, and `RUN_DATABASE_TESTS=true yarn test` all green: 306 files, 2600 tests, 1 skipped.

## Impact and rollback

Behaviour change confined to `users: readOwn` roles: `getUserById` now returns `null` for other users rather than the caller's own record, and `findIds` no longer reports unrequested ids. No schema change, no API surface change. Revert the single commit to roll back.