### PR TITLE
feat(scripts): mint a local session for any imported user

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "db:reset": "bash ee/scripts/reset-db.sh",
     "db:use-live-data": "bash scripts/use-live-data.sh",
     "dev": "prisma generate && yarn workflow:setup && yarn openapi:generate && yarn raw-docs:generate && next dev --turbopack -p 4000",
+    "dev:become": "tsx scripts/mint-local-session.ts",
     "email:dev": "APP_MODE=cloud email dev --dir components/emails",
     "i18n:audit": "tsx scripts/audit-i18n.ts",
     "lint": "eslint . --ext .ts,.tsx,.json,.jsonc,.json5 -c .eslintrc.json --max-warnings 0",

--- a/scripts/mint-local-session.ts
+++ b/scripts/mint-local-session.ts
@@ -4,104 +4,53 @@ import { createHmac, randomBytes, randomUUID } from "node:crypto";
 
 import { PrismaPg } from "@prisma/adapter-pg";
 
-import { PrismaClient, Status, SubscriptionStatus } from "@/generated/prisma";
-import { isSubscriptionExpired } from "@/ee/subscription/entitlements";
-import { mustVerifyEmail } from "@/features/auth/email-verification-grace";
+import { PrismaClient } from "@/generated/prisma";
 
-const COOKIE_PREFIX = "app";
-const COOKIE_NAME = `${COOKIE_PREFIX}.session_token`;
+const COOKIE_NAME = "app.session_token";
 const SESSION_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
-type Relaxation = "verify-email" | "activate" | "complete-onboarding" | "activate-subscription";
-
-const RELAXATIONS: readonly Relaxation[] = [
-  "verify-email",
-  "activate",
-  "complete-onboarding",
-  "activate-subscription",
-];
-
-type Options = {
-  email: string;
-  relaxations: Set<Relaxation>;
-};
-
-function usage(): never {
-  const flags = RELAXATIONS.map((name) => `  --${name}`).join("\n");
-  console.error(
-    [
-      "Usage: yarn dev:become <email> [--verify-email] [--activate] [--complete-onboarding] [--activate-subscription] [--relax-all]",
-      "",
-      "Mints a signed session cookie for an existing user in the LOCAL database.",
-      "Without flags nothing is mutated: the imported account state is reported as-is.",
-      "",
-      "Optional state relaxations (each overwrites imported production state):",
-      flags,
-      "  --relax-all",
-    ].join("\n"),
-  );
-  process.exit(1);
-}
-
-function parseOptions(argv: readonly string[]): Options {
-  const [email, ...flags] = argv;
-  if (!email || email.startsWith("--")) usage();
-
-  const relaxations = new Set<Relaxation>();
-  for (const flag of flags) {
-    if (flag === "--relax-all") {
-      for (const name of RELAXATIONS) relaxations.add(name);
-      continue;
-    }
-    const name = flag.replace(/^--/, "") as Relaxation;
-    if (!flag.startsWith("--") || !RELAXATIONS.includes(name)) {
-      console.error(`Unknown option: ${flag}`);
-      usage();
-    }
-    relaxations.add(name);
+function resolveEmail(argv: readonly string[]): string {
+  const [email, ...rest] = argv;
+  if (!email || rest.length > 0) {
+    console.error("Usage: yarn dev:become <email>");
+    process.exit(1);
   }
 
-  return { email: email.trim().toLowerCase(), relaxations };
+  return email.trim().toLowerCase();
 }
 
-function resolveDatabaseUrl(): string {
+function resolveLocalDatabaseUrl(): string {
   const databaseUrl = process.env.DIRECT_URL?.trim() || process.env.DATABASE_URL?.trim();
   if (!databaseUrl) throw new Error("DATABASE_URL must be configured.");
+
+  const hostname = new URL(databaseUrl).hostname;
+  if (!LOCAL_HOSTNAMES.has(hostname)) {
+    throw new Error(
+      `Refusing to run against a non-local database (host ${hostname}). This tool only ever targets a disposable local copy.`,
+    );
+  }
+
   return databaseUrl;
 }
 
-function assertLocalDestination(databaseUrl: string): void {
-  const hostname = new URL(databaseUrl).hostname;
-  if (LOCAL_HOSTNAMES.has(hostname)) return;
-
-  throw new Error(
-    `Refusing to run against a non-local database (host ${hostname}). This tool only ever targets a disposable local copy.`,
-  );
-}
-
-function assertSessionModeSupported(): void {
-  if (process.env.APP_MODE?.trim() !== "demo") return;
-
-  throw new Error(
-    'APP_MODE is "demo", which replaces any session with the synthetic seed user on every request. Set APP_MODE="self-hosted" and restart the dev server before minting a session.',
-  );
-}
-
-function signCookieValue(token: string, secret: string): string {
-  const signature = createHmac("sha256", secret).update(token).digest("base64");
-  return encodeURIComponent(`${token}.${signature}`);
-}
-
-async function main(): Promise<void> {
-  const { email, relaxations } = parseOptions(process.argv.slice(2));
-
-  const databaseUrl = resolveDatabaseUrl();
-  assertLocalDestination(databaseUrl);
-  assertSessionModeSupported();
+function resolveSecret(): string {
+  if (process.env.APP_MODE?.trim() === "demo") {
+    throw new Error(
+      'APP_MODE is "demo", which replaces any session with the synthetic seed user on every request. Set APP_MODE="self-hosted" and restart the dev server first.',
+    );
+  }
 
   const secret = process.env.BETTER_AUTH_SECRET?.trim();
   if (!secret) throw new Error("BETTER_AUTH_SECRET must be configured.");
+
+  return secret;
+}
+
+async function main(): Promise<void> {
+  const email = resolveEmail(process.argv.slice(2));
+  const databaseUrl = resolveLocalDatabaseUrl();
+  const secret = resolveSecret();
 
   const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: databaseUrl }) });
 
@@ -109,101 +58,20 @@ async function main(): Promise<void> {
     const authUser = await prisma.authUser.findFirst({ where: { email } });
     if (!authUser) throw new Error(`No AuthUser found for ${email} in the local database.`);
 
-    if (relaxations.has("verify-email") && !authUser.emailVerified) {
-      await prisma.authUser.update({ where: { id: authUser.id }, data: { emailVerified: true } });
-      authUser.emailVerified = true;
-      console.log("Relaxed: AuthUser.emailVerified set to true.");
-    }
-
-    const user = await prisma.user.findUnique({ where: { email }, include: { role: true } });
-
-    if (user && relaxations.has("activate") && user.status !== Status.active) {
-      await prisma.user.update({ where: { id: user.id }, data: { status: Status.active } });
-      user.status = Status.active;
-      console.log("Relaxed: User.status set to active.");
-    }
-
-    if (user && relaxations.has("complete-onboarding") && user.onboardingWizardCompletedAt == null) {
-      const onboardingWizardCompletedAt = new Date();
-      await prisma.user.update({ where: { id: user.id }, data: { onboardingWizardCompletedAt } });
-      user.onboardingWizardCompletedAt = onboardingWizardCompletedAt;
-      console.log("Relaxed: User.onboardingWizardCompletedAt backfilled.");
-    }
-
-    if (user && relaxations.has("activate-subscription")) {
-      await prisma.subscription.upsert({
-        where: { companyId: user.companyId },
-        create: { companyId: user.companyId, status: SubscriptionStatus.active, trialEndDate: null },
-        update: { status: SubscriptionStatus.active, trialEndDate: null },
-      });
-      console.log("Relaxed: Subscription set to active.");
-    }
-
     const token = randomBytes(32).toString("hex");
     const expiresAt = new Date(Date.now() + SESSION_LIFETIME_MS);
-    await prisma.authSession.create({
-      data: { id: randomUUID(), token, userId: authUser.id, expiresAt },
-    });
+    await prisma.authSession.create({ data: { id: randomUUID(), token, userId: authUser.id, expiresAt } });
 
-    const state = await resolveExpectedAccountState(prisma, authUser, user);
+    const signature = createHmac("sha256", secret).update(token).digest("base64");
+    const cookie = encodeURIComponent(`${token}.${signature}`);
 
+    console.log(`Signed in as ${email} until ${expiresAt.toISOString()}.`);
     console.log("");
-    console.log(`Minted a session for ${email} (expires ${expiresAt.toISOString()}).`);
-    console.log(`Expected account state on first protected request: ${state.state}`);
-    if (state.remedy) console.log(`  ${state.remedy}`);
-    console.log("");
-    console.log(`Cookie name:  ${COOKIE_NAME}`);
-    console.log(`Cookie value: ${signCookieValue(token, secret)}`);
-    console.log("");
-    console.log("Set it in the browser console on the app origin, then reload:");
-    console.log(
-      `  document.cookie = "${COOKIE_NAME}=${signCookieValue(token, secret)}; path=/; max-age=${SESSION_LIFETIME_MS / 1000}"`,
-    );
+    console.log("Run this in the browser console on the app origin, then reload:");
+    console.log(`  document.cookie = "${COOKIE_NAME}=${cookie}; path=/; max-age=${SESSION_LIFETIME_MS / 1000}"`);
   } finally {
     await prisma.$disconnect();
   }
-}
-
-type ExpectedState = { state: string; remedy?: string };
-
-async function resolveExpectedAccountState(
-  prisma: PrismaClient,
-  authUser: { emailVerified: boolean; createdAt: Date },
-  user: { status: Status; companyId: string; onboardingWizardCompletedAt: Date | null; role: { isSystemRole: boolean } | null } | null,
-): Promise<ExpectedState> {
-  if (mustVerifyEmail(authUser)) {
-    return { state: "overdueVerification", remedy: "Redirects to /auth/verify-email. Re-run with --verify-email to bypass." };
-  }
-  if (!user) {
-    return {
-      state: "unregistered",
-      remedy: "No User row matches this email, so the app redirects to /onboarding/wizard. The AuthUser exists but has no tenant identity.",
-    };
-  }
-  if (user.status === Status.inactive) {
-    return { state: "inactive", remedy: "Redirects to /auth/error?type=inactiveUser. Re-run with --activate to bypass." };
-  }
-  if (user.status === Status.pendingAuthorization) {
-    return { state: "pending", remedy: "Redirects to /auth/pending. Re-run with --activate to bypass." };
-  }
-  if (user.role?.isSystemRole && user.onboardingWizardCompletedAt == null) {
-    return { state: "onboarding", remedy: "Redirects to /onboarding/wizard. Re-run with --complete-onboarding to bypass." };
-  }
-
-  if (process.env.APP_MODE?.trim() !== "demo") {
-    const subscription = await prisma.subscription.findUnique({ where: { companyId: user.companyId } });
-    if (!subscription) {
-      return {
-        state: "error",
-        remedy: "The company has no Subscription row and the route guard throws rather than redirecting. Re-run with --activate-subscription.",
-      };
-    }
-    if (isSubscriptionExpired(subscription)) {
-      return { state: "subscription", remedy: "Redirects to /subscription-expired. Re-run with --activate-subscription to bypass." };
-    }
-  }
-
-  return { state: "allowed" };
 }
 
 main().catch((error: unknown) => {

--- a/scripts/mint-local-session.ts
+++ b/scripts/mint-local-session.ts
@@ -1,0 +1,212 @@
+import "dotenv/config";
+
+import { createHmac, randomBytes, randomUUID } from "node:crypto";
+
+import { PrismaPg } from "@prisma/adapter-pg";
+
+import { PrismaClient, Status, SubscriptionStatus } from "@/generated/prisma";
+import { isSubscriptionExpired } from "@/ee/subscription/entitlements";
+import { mustVerifyEmail } from "@/features/auth/email-verification-grace";
+
+const COOKIE_PREFIX = "app";
+const COOKIE_NAME = `${COOKIE_PREFIX}.session_token`;
+const SESSION_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+type Relaxation = "verify-email" | "activate" | "complete-onboarding" | "activate-subscription";
+
+const RELAXATIONS: readonly Relaxation[] = [
+  "verify-email",
+  "activate",
+  "complete-onboarding",
+  "activate-subscription",
+];
+
+type Options = {
+  email: string;
+  relaxations: Set<Relaxation>;
+};
+
+function usage(): never {
+  const flags = RELAXATIONS.map((name) => `  --${name}`).join("\n");
+  console.error(
+    [
+      "Usage: yarn dev:become <email> [--verify-email] [--activate] [--complete-onboarding] [--activate-subscription] [--relax-all]",
+      "",
+      "Mints a signed session cookie for an existing user in the LOCAL database.",
+      "Without flags nothing is mutated: the imported account state is reported as-is.",
+      "",
+      "Optional state relaxations (each overwrites imported production state):",
+      flags,
+      "  --relax-all",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function parseOptions(argv: readonly string[]): Options {
+  const [email, ...flags] = argv;
+  if (!email || email.startsWith("--")) usage();
+
+  const relaxations = new Set<Relaxation>();
+  for (const flag of flags) {
+    if (flag === "--relax-all") {
+      for (const name of RELAXATIONS) relaxations.add(name);
+      continue;
+    }
+    const name = flag.replace(/^--/, "") as Relaxation;
+    if (!flag.startsWith("--") || !RELAXATIONS.includes(name)) {
+      console.error(`Unknown option: ${flag}`);
+      usage();
+    }
+    relaxations.add(name);
+  }
+
+  return { email: email.trim().toLowerCase(), relaxations };
+}
+
+function resolveDatabaseUrl(): string {
+  const databaseUrl = process.env.DIRECT_URL?.trim() || process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) throw new Error("DATABASE_URL must be configured.");
+  return databaseUrl;
+}
+
+function assertLocalDestination(databaseUrl: string): void {
+  const hostname = new URL(databaseUrl).hostname;
+  if (LOCAL_HOSTNAMES.has(hostname)) return;
+
+  throw new Error(
+    `Refusing to run against a non-local database (host ${hostname}). This tool only ever targets a disposable local copy.`,
+  );
+}
+
+function assertSessionModeSupported(): void {
+  if (process.env.APP_MODE?.trim() !== "demo") return;
+
+  throw new Error(
+    'APP_MODE is "demo", which replaces any session with the synthetic seed user on every request. Set APP_MODE="self-hosted" and restart the dev server before minting a session.',
+  );
+}
+
+function signCookieValue(token: string, secret: string): string {
+  const signature = createHmac("sha256", secret).update(token).digest("base64");
+  return encodeURIComponent(`${token}.${signature}`);
+}
+
+async function main(): Promise<void> {
+  const { email, relaxations } = parseOptions(process.argv.slice(2));
+
+  const databaseUrl = resolveDatabaseUrl();
+  assertLocalDestination(databaseUrl);
+  assertSessionModeSupported();
+
+  const secret = process.env.BETTER_AUTH_SECRET?.trim();
+  if (!secret) throw new Error("BETTER_AUTH_SECRET must be configured.");
+
+  const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: databaseUrl }) });
+
+  try {
+    const authUser = await prisma.authUser.findFirst({ where: { email } });
+    if (!authUser) throw new Error(`No AuthUser found for ${email} in the local database.`);
+
+    if (relaxations.has("verify-email") && !authUser.emailVerified) {
+      await prisma.authUser.update({ where: { id: authUser.id }, data: { emailVerified: true } });
+      authUser.emailVerified = true;
+      console.log("Relaxed: AuthUser.emailVerified set to true.");
+    }
+
+    const user = await prisma.user.findUnique({ where: { email }, include: { role: true } });
+
+    if (user && relaxations.has("activate") && user.status !== Status.active) {
+      await prisma.user.update({ where: { id: user.id }, data: { status: Status.active } });
+      user.status = Status.active;
+      console.log("Relaxed: User.status set to active.");
+    }
+
+    if (user && relaxations.has("complete-onboarding") && user.onboardingWizardCompletedAt == null) {
+      const onboardingWizardCompletedAt = new Date();
+      await prisma.user.update({ where: { id: user.id }, data: { onboardingWizardCompletedAt } });
+      user.onboardingWizardCompletedAt = onboardingWizardCompletedAt;
+      console.log("Relaxed: User.onboardingWizardCompletedAt backfilled.");
+    }
+
+    if (user && relaxations.has("activate-subscription")) {
+      await prisma.subscription.upsert({
+        where: { companyId: user.companyId },
+        create: { companyId: user.companyId, status: SubscriptionStatus.active, trialEndDate: null },
+        update: { status: SubscriptionStatus.active, trialEndDate: null },
+      });
+      console.log("Relaxed: Subscription set to active.");
+    }
+
+    const token = randomBytes(32).toString("hex");
+    const expiresAt = new Date(Date.now() + SESSION_LIFETIME_MS);
+    await prisma.authSession.create({
+      data: { id: randomUUID(), token, userId: authUser.id, expiresAt },
+    });
+
+    const state = await resolveExpectedAccountState(prisma, authUser, user);
+
+    console.log("");
+    console.log(`Minted a session for ${email} (expires ${expiresAt.toISOString()}).`);
+    console.log(`Expected account state on first protected request: ${state.state}`);
+    if (state.remedy) console.log(`  ${state.remedy}`);
+    console.log("");
+    console.log(`Cookie name:  ${COOKIE_NAME}`);
+    console.log(`Cookie value: ${signCookieValue(token, secret)}`);
+    console.log("");
+    console.log("Set it in the browser console on the app origin, then reload:");
+    console.log(
+      `  document.cookie = "${COOKIE_NAME}=${signCookieValue(token, secret)}; path=/; max-age=${SESSION_LIFETIME_MS / 1000}"`,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+type ExpectedState = { state: string; remedy?: string };
+
+async function resolveExpectedAccountState(
+  prisma: PrismaClient,
+  authUser: { emailVerified: boolean; createdAt: Date },
+  user: { status: Status; companyId: string; onboardingWizardCompletedAt: Date | null; role: { isSystemRole: boolean } | null } | null,
+): Promise<ExpectedState> {
+  if (mustVerifyEmail(authUser)) {
+    return { state: "overdueVerification", remedy: "Redirects to /auth/verify-email. Re-run with --verify-email to bypass." };
+  }
+  if (!user) {
+    return {
+      state: "unregistered",
+      remedy: "No User row matches this email, so the app redirects to /onboarding/wizard. The AuthUser exists but has no tenant identity.",
+    };
+  }
+  if (user.status === Status.inactive) {
+    return { state: "inactive", remedy: "Redirects to /auth/error?type=inactiveUser. Re-run with --activate to bypass." };
+  }
+  if (user.status === Status.pendingAuthorization) {
+    return { state: "pending", remedy: "Redirects to /auth/pending. Re-run with --activate to bypass." };
+  }
+  if (user.role?.isSystemRole && user.onboardingWizardCompletedAt == null) {
+    return { state: "onboarding", remedy: "Redirects to /onboarding/wizard. Re-run with --complete-onboarding to bypass." };
+  }
+
+  if (process.env.APP_MODE?.trim() !== "demo") {
+    const subscription = await prisma.subscription.findUnique({ where: { companyId: user.companyId } });
+    if (!subscription) {
+      return {
+        state: "error",
+        remedy: "The company has no Subscription row and the route guard throws rather than redirecting. Re-run with --activate-subscription.",
+      };
+    }
+    if (isSubscriptionExpired(subscription)) {
+      return { state: "subscription", remedy: "Redirects to /subscription-expired. Re-run with --activate-subscription to bypass." };
+    }
+  }
+
+  return { state: "allowed" };
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds `yarn dev:become <email>`, which mints a signed Better Auth session cookie for any user in the **local** database. This is the missing piece for reproducing a customer issue against a local production snapshot: `yarn db:use-live-data` restores the data, but there is no way to sign in as the affected user.

Closes CUS-234 on the product side.

## Context

The obvious alternative was to neuter credentials inside the imported copy. Rejected for three reasons:

- It couples an incident-time tool to Better Auth's internal scrypt format (`<32-hex salt>:<128-hex key>`, N=16384 r=16 p=1), which a routine dependency bump can silently break.
- It does not work for Google and Microsoft users, who have no `providerId='credential'` row. Better Auth returns the identical `INVALID_EMAIL_OR_PASSWORD` for "no credential account" and "wrong password", so the failure is undiagnosable under time pressure.
- It gives every imported production identity the same known password.

Minting a session avoids all three and needs no password hashing at all.

The script does one thing: find the `AuthUser`, insert an `AuthSession`, and sign the cookie the way `better-call` does (HMAC-SHA256 over the token with the raw secret, standard base64, `token.signature`, URL-encoded). The session is valid regardless of where the guard chain then sends the browser. Landing on the verification, onboarding, trial, or inactive screen is the customer's real state, which is exactly what a reproduction should show.

Three refusals are kept, because each is the difference between working and appearing to do nothing:

- Any destination whose host is not localhost, so it can never touch a hosted database. Same direction as CUS-30.
- `APP_MODE=demo`, where `proxy.ts` replaces the session with the synthetic seed user on the very next request, making a successful mint look like a no-op.
- An unknown email, rather than a mystery redirect to signin.

## Validation

Verified end to end against seeded synthetic data on a local Postgres, dev server in `self-hosted` mode.

| Request to `/en/dashboard` | Result |
| --- | --- |
| No cookie | `307` to `/en/auth/signin?callbackURL=...` |
| Minted cookie | `200`, authenticated dashboard, `Max Bergmann` and `data-slot="sidebar"` present, no signin form |

Restricted state behaves as intended rather than failing: with `User.status='inactive'`, a minted session still authenticates and the response carries Next's RSC redirect payload `auth/error?type=inactiveUser;307;`, so the browser follows to the inactive-user screen instead of to signin.

All four argument paths exercised: a Neon-shaped host aborts by hostname, `APP_MODE=demo` aborts with the proxy explanation, an unknown email reports no matching AuthUser, and a missing argument prints usage.

Gates: `yarn typecheck`, `yarn lint` (zero warnings), `yarn conventions:check` (296 tests, 38 files).

## Impact and rollback

Additive. One 80-line script under `scripts/`, one `package.json` entry, no application code and no schema change. It cannot run against anything but localhost. Rollback is deleting the file and the script entry.

Note for reviewers: `COOKIE_NAME` must stay in sync with `advanced.cookiePrefix` in `core/auth/better-auth.ts`. Nothing enforces that today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)