### PR TITLE
fix(messaging): block Unipile calls in development

### DIFF
--- a/ee/messaging/__tests__/unipile-development-guard.test.ts
+++ b/ee/messaging/__tests__/unipile-development-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockUser } from "@/tests/helpers/mock-user";
+import {
+  MOCK_ENV_MODULE,
+  createMockDiModule,
+  MOCK_ZOD_MODULE,
+  MOCK_PRISMA_DB_MODULE,
+} from "@/tests/helpers/interactor-test-setup";
+
+const mockUser = createMockUser();
+
+vi.mock("@/env", () => ({
+  env: { ...MOCK_ENV_MODULE.env, NODE_ENV: "development", UNIPILE_API_KEY: "real-looking-key" },
+}));
+vi.mock("@/core/di", () => ({ ...createMockDiModule(() => mockUser) }));
+vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
+vi.mock("@/prisma/db", () => MOCK_PRISMA_DB_MODULE);
+vi.mock("@sentry/node", () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+
+import { MessagingService } from "../messaging.service";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Unipile development guard", () => {
+  it("refuses to build a client in development even when an API key is configured", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(new MessagingService().getAccount("acc_1")).rejects.toThrow("Unipile is unreachable in development");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/ee/messaging/messaging.service.ts
+++ b/ee/messaging/messaging.service.ts
@@ -257,6 +257,11 @@ export class MessagingService {
 
   private get sdk() {
     if (!this.sdkInstance) {
+      if (env.NODE_ENV === "development") {
+        throw new Error(
+          "Unipile is unreachable in development so a local copy of production data cannot act on real customer accounts",
+        );
+      }
       if (!env.UNIPILE_API_KEY) throw new Error("UNIPILE_API_KEY env var is not set");
 
       const client = createClient(


### PR DESCRIPTION
## Summary

`MessagingService` built its Unipile client straight from `env.UNIPILE_API_KEY` with no environment guard. `EmailService` has one (`features/email/email.service.ts:18-27` short-circuits to a console log when `NODE_ENV !== "production"`), so outbound mail cannot fire locally. The same line was never drawn for Unipile. This adds it.

## Context

The gap was latent because nobody could sign in to a local copy of production data, so no UI path reached the messaging interactors. `yarn db:use-live-data` neuters `Webhook` and `WebhookDelivery`, but restores `ConnectedAccount` rows with their production Unipile account ids intact.

Session minting (#67) removes that accident deliberately. Without this guard, signing in as a real customer user against a local snapshot makes these reachable with a live key in `.env`:

- `ee/messaging/outbound/send-chat-message.interactor.ts`
- `ee/messaging/outbound/send-email.interactor.ts`
- `ee/messaging/outbound/start-chat.interactor.ts`
- `ee/messaging/posts/create-relation-request.interactor.ts`
- `ee/messaging/connect/delete-connected-account.interactor.ts`

A misclick while reproducing a bug would send a LinkedIn message from a customer's real account or disconnect it in production.

The guard fires on `development` specifically rather than `!== "production"`. Vitest runs as `test`, so mocked suites that exercise the SDK boundary keep working, and the production runtime is untouched. The check sits at the top of the `sdk` getter, the single choke point for every Unipile call, and precedes the API-key check so the clearer message wins.

## Validation

New test `ee/messaging/__tests__/unipile-development-guard.test.ts` mocks `NODE_ENV: "development"` with a real-looking `UNIPILE_API_KEY`, asserts `getAccount` rejects with the guard message, and asserts `fetch` was never called, so no request leaves the process.

The existing `messaging-service-drift.test.ts` (16 tests, mocks `UNIPILE_API_KEY: "test-key"`) still passes unchanged, confirming test-mode usage is unaffected.

Full suite: 2554 passed, 40 skipped across 303 files. `yarn typecheck` and `yarn conventions:check` (296 tests) pass; `yarn lint` passes with zero warnings via the pre-commit hook.

One unrelated flake to note: `components/emails/__tests__/preview-inventory.test.ts` timed out at 15s during the full run under CPU contention and passes in isolation (13 tests). It renders React email previews and shares no code with this change.

## Impact and rollback

Behaviour changes only when `NODE_ENV === "development"`, where the local norm today is already an exception from the missing-key branch. Production and preview are unaffected. If local Unipile work is ever needed, this becomes the place to add an explicit opt-in rather than relying on a key being present. Rollback is reverting the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)