### PR TITLE
fix(prisma): enforce tenant scoping on guarded update, updatemany and upsert

### DIFF
--- a/ee/messaging/persistence/__tests__/outbound-echo-reconcile.database.test.ts
+++ b/ee/messaging/persistence/__tests__/outbound-echo-reconcile.database.test.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from "node:crypto";
+
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { runWithoutTenant } from "@/core/decorators/tenant-context";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { PrismaMessagingRepo } from "../prisma-messaging.repository";
+
+const databaseUrl = getLocalDatabaseTestUrl();
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase("outbound chat echo reconciliation under tenant bypass", () => {
+  const client = new Client({ connectionString: databaseUrl ?? undefined });
+  const companyId = randomUUID();
+  const accountId = randomUUID();
+  const ownerId = randomUUID();
+  const threadId = randomUUID();
+  const localMessageId = randomUUID();
+  const sentAt = new Date("2026-01-01T12:00:00.000Z");
+  const bodyText = "echo reconciliation subject";
+  const providerMessageId = `provider-${randomUUID()}`;
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.query('INSERT INTO "Company" ("id", "updatedAt") VALUES ($1, CURRENT_TIMESTAMP)', [companyId]);
+    await client.query(
+      'INSERT INTO "User" ("id", "email", "firstName", "lastName", "companyId", "updatedAt") VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)',
+      [ownerId, `echo-${ownerId}@example.com`, "Echo", "Owner", companyId],
+    );
+    await client.query(
+      'INSERT INTO "ConnectedAccount" ("id", "companyId", "userId", "provider", "unipileAccountId", "status", "updatedAt") VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)',
+      [accountId, companyId, ownerId, "whatsapp", `unipile-${accountId}`, "ok"],
+    );
+    await client.query(
+      'INSERT INTO "MessagingThread" ("id", "companyId", "connectedAccountId", "provider", "type", "unipileThreadId", "updatedAt") VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)',
+      [threadId, companyId, accountId, "whatsapp", "single", `thread-${threadId}`],
+    );
+    await client.query(
+      `INSERT INTO "MessagingMessage" ("id", "companyId", "messagingThreadId", "connectedAccountId", "provider", "direction", "origin", "unipileMessageId", "bodyText", "sender", "recipients", "isDraft", "sentAt", "updatedAt") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, '{}'::jsonb, '{}'::jsonb, false, $10, CURRENT_TIMESTAMP)`,
+      [
+        localMessageId,
+        companyId,
+        threadId,
+        accountId,
+        "whatsapp",
+        "outbound",
+        "unipile",
+        `sent_${localMessageId}`,
+        bodyText,
+        sentAt,
+      ],
+    );
+  });
+
+  afterAll(async () => {
+    await client.query('DELETE FROM "MessagingMessage" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "MessagingThread" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "ConnectedAccount" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "User" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "Company" WHERE "id" = $1', [companyId]);
+    await client.end();
+  });
+
+  it("reconciles the provider echo onto the locally sent row without reading tenant context", async () => {
+    const repo = new PrismaMessagingRepo() as unknown as {
+      reconcileOutboundChatEcho(args: {
+        companyId: string;
+        messagingThreadId: string;
+        connectedAccountId: string;
+        unipileMessageId: string;
+        bodyText: string | null;
+        sentAt: Date;
+      }): Promise<boolean>;
+    };
+
+    const { prisma } = await import("@/prisma/db");
+    const storedSentAt = await runWithoutTenant(async () => {
+      const row = await prisma.messagingMessage.findUniqueOrThrow({
+        where: { id: localMessageId },
+        select: { sentAt: true },
+      });
+      return row.sentAt;
+    });
+
+    const reconciled = await runWithoutTenant(() =>
+      repo.reconcileOutboundChatEcho({
+        companyId,
+        messagingThreadId: threadId,
+        connectedAccountId: accountId,
+        unipileMessageId: providerMessageId,
+        bodyText,
+        sentAt: storedSentAt,
+      }),
+    );
+
+    expect(reconciled).toBe(true);
+
+    const row = await client.query('SELECT "unipileMessageId" FROM "MessagingMessage" WHERE "id" = $1', [
+      localMessageId,
+    ]);
+    expect(row.rows[0].unipileMessageId).toBe(providerMessageId);
+  });
+});

--- a/ee/messaging/persistence/__tests__/outbound-echo-reconcile.database.test.ts
+++ b/ee/messaging/persistence/__tests__/outbound-echo-reconcile.database.test.ts
@@ -65,7 +65,6 @@ describeDatabase("outbound chat echo reconciliation under tenant bypass", () => 
   it("reconciles the provider echo onto the locally sent row without reading tenant context", async () => {
     const repo = new PrismaMessagingRepo() as unknown as {
       reconcileOutboundChatEcho(args: {
-        companyId: string;
         messagingThreadId: string;
         connectedAccountId: string;
         unipileMessageId: string;
@@ -85,7 +84,6 @@ describeDatabase("outbound chat echo reconciliation under tenant bypass", () => 
 
     const reconciled = await runWithoutTenant(() =>
       repo.reconcileOutboundChatEcho({
-        companyId,
         messagingThreadId: threadId,
         connectedAccountId: accountId,
         unipileMessageId: providerMessageId,

--- a/ee/messaging/persistence/prisma-messaging.repository.ts
+++ b/ee/messaging/persistence/prisma-messaging.repository.ts
@@ -990,7 +990,6 @@ export class PrismaMessagingRepo
   }
 
   private async reconcileOutboundChatEcho(args: {
-    companyId: string;
     messagingThreadId: string;
     connectedAccountId: string;
     unipileMessageId: string;
@@ -1018,7 +1017,7 @@ export class PrismaMessagingRepo
     if (!candidate) return false;
 
     await this.prisma.messagingMessage.update({
-      where: { id: candidate.id, companyId: args.companyId },
+      where: { id: candidate.id },
       data: { unipileMessageId: args.unipileMessageId },
     });
 
@@ -1331,7 +1330,6 @@ export class PrismaMessagingRepo
       !isEmailProvider(message.provider)
     ) {
       const reconciled = await this.reconcileOutboundChatEcho({
-        companyId,
         messagingThreadId: thread.id,
         connectedAccountId,
         unipileMessageId: message.unipileMessageId,

--- a/ee/messaging/persistence/prisma-messaging.repository.ts
+++ b/ee/messaging/persistence/prisma-messaging.repository.ts
@@ -990,6 +990,7 @@ export class PrismaMessagingRepo
   }
 
   private async reconcileOutboundChatEcho(args: {
+    companyId: string;
     messagingThreadId: string;
     connectedAccountId: string;
     unipileMessageId: string;
@@ -1017,7 +1018,7 @@ export class PrismaMessagingRepo
     if (!candidate) return false;
 
     await this.prisma.messagingMessage.update({
-      where: { id: candidate.id, companyId: this.companyId },
+      where: { id: candidate.id, companyId: args.companyId },
       data: { unipileMessageId: args.unipileMessageId },
     });
 
@@ -1330,6 +1331,7 @@ export class PrismaMessagingRepo
       !isEmailProvider(message.provider)
     ) {
       const reconciled = await this.reconcileOutboundChatEcho({
+        companyId,
         messagingThreadId: thread.id,
         connectedAccountId,
         unipileMessageId: message.unipileMessageId,

--- a/ee/messaging/persistence/prisma-messaging.repository.ts
+++ b/ee/messaging/persistence/prisma-messaging.repository.ts
@@ -811,7 +811,7 @@ export class PrismaMessagingRepo
 
     if (existing) {
       const row = await this.prisma.messagingMessage.update({
-        where: { id: existing.id },
+        where: { id: existing.id, companyId: this.companyId },
         data: {
           sender: args.sender,
           senderIdentifier: args.sender.identifier || null,
@@ -906,7 +906,7 @@ export class PrismaMessagingRepo
     if (!draft) return null;
 
     const row = await this.prisma.messagingMessage.update({
-      where: { id: draft.id },
+      where: { id: draft.id, companyId: this.companyId },
       data: {
         unipileMessageId: args.unipileMessageId,
         providerMessageId: args.providerMessageId,
@@ -925,7 +925,7 @@ export class PrismaMessagingRepo
 
     const preview = args.bodyText?.trim() || args.bodyHtml?.replace(/<[^>]*>/g, "").trim() || null;
     await this.prisma.messagingThread.update({
-      where: { id: draft.messagingThreadId },
+      where: { id: draft.messagingThreadId, companyId: this.companyId },
       data: { lastMessageAt: args.sentAt, lastMessagePreview: preview, lastMessageIsSender: true },
     });
 
@@ -1017,7 +1017,7 @@ export class PrismaMessagingRepo
     if (!candidate) return false;
 
     await this.prisma.messagingMessage.update({
-      where: { id: candidate.id },
+      where: { id: candidate.id, companyId: this.companyId },
       data: { unipileMessageId: args.unipileMessageId },
     });
 

--- a/features/custom-column/prisma-custom-column.repository.ts
+++ b/features/custom-column/prisma-custom-column.repository.ts
@@ -232,7 +232,7 @@ export class PrismaCustomColumnRepo
     if ("options" in args && args.options !== undefined) columnData.options = args.options;
 
     const column = await this.prisma.customColumn.upsert({
-      where: { id: args.id ?? "" },
+      where: { id: args.id ?? "", companyId },
       create: columnData,
       update: columnData,
       select: this.baseSelect,

--- a/features/role/prisma-role.repository.ts
+++ b/features/role/prisma-role.repository.ts
@@ -87,6 +87,7 @@ export class PrismaRoleRepo
     const savedRole = await this.prisma.userRole.upsert({
       where: {
         id: args.id ?? "",
+        companyId,
       },
       create: roleData,
       update: roleData,

--- a/prisma/__tests__/tenant-guard.database.test.ts
+++ b/prisma/__tests__/tenant-guard.database.test.ts
@@ -1,0 +1,93 @@
+import type { TenantUser } from "@/features/user/user.schema";
+
+import { randomUUID } from "node:crypto";
+
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { runWithTenant } from "@/core/decorators/tenant-context";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { createMockUser } from "@/tests/helpers/mock-user";
+import { prisma } from "@/prisma/db";
+
+const databaseUrl = getLocalDatabaseTestUrl();
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase("prisma tenant guard on PostgreSQL", () => {
+  const client = new Client({ connectionString: databaseUrl ?? undefined });
+  const companyId = randomUUID();
+  const foreignCompanyId = randomUUID();
+  const contactId = randomUUID();
+
+  const tenant: TenantUser = createMockUser({ companyId });
+  const asTenant = <T>(fn: () => Promise<T>) => runWithTenant(tenant, fn);
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.query(
+      'INSERT INTO "Company" ("id", "updatedAt") VALUES ($1, CURRENT_TIMESTAMP), ($2, CURRENT_TIMESTAMP)',
+      [companyId, foreignCompanyId],
+    );
+    await client.query(
+      'INSERT INTO "Contact" ("id", "firstName", "lastName", "companyId", "updatedAt") VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)',
+      [contactId, "Guard", "Subject", companyId],
+    );
+  });
+
+  afterAll(async () => {
+    await client.query('DELETE FROM "EntityTerminology" WHERE "companyId" = ANY($1)', [[companyId, foreignCompanyId]]);
+    await client.query('DELETE FROM "Contact" WHERE "companyId" = ANY($1)', [[companyId, foreignCompanyId]]);
+    await client.query('DELETE FROM "Company" WHERE "id" = ANY($1)', [[companyId, foreignCompanyId]]);
+    await client.end();
+  });
+
+  it("rejects an update whose where is not tenant scoped", async () => {
+    await expect(
+      asTenant(() => prisma.contact.updateMany({ where: { id: contactId }, data: { firstName: "Nope" } })),
+    ).rejects.toThrow(/companyId must be set in where/);
+  });
+
+  it("rejects an update that would move a row to another tenant", async () => {
+    await expect(
+      asTenant(() =>
+        prisma.contact.updateMany({ where: { id: contactId, companyId }, data: { companyId: foreignCompanyId } }),
+      ),
+    ).rejects.toThrow(/does not match tenant/);
+  });
+
+  it("rejects an update whose where names another tenant", async () => {
+    await expect(
+      asTenant(() =>
+        prisma.contact.updateMany({ where: { companyId: foreignCompanyId }, data: { firstName: "Nope" } }),
+      ),
+    ).rejects.toThrow(/does not match tenant in where/);
+  });
+
+  it("rejects a create without a companyId", async () => {
+    await expect(
+      asTenant(() => prisma.contact.create({ data: { firstName: "No", lastName: "Tenant" } as never })),
+    ).rejects.toThrow(/companyId must be set in data/);
+  });
+
+  it("accepts an update scoped by the tenant column", async () => {
+    await asTenant(() =>
+      prisma.contact.updateMany({ where: { id: contactId, companyId }, data: { firstName: "Allowed" } }),
+    );
+
+    const row = await client.query('SELECT "firstName" FROM "Contact" WHERE "id" = $1', [contactId]);
+    expect(row.rows[0].firstName).toBe("Allowed");
+  });
+
+  it("accepts an upsert whose unique selector carries the tenant inside a compound key", async () => {
+    await asTenant(() =>
+      prisma.entityTerminology.upsert({
+        where: { companyId_entityType: { companyId, entityType: "contact" } },
+        create: { companyId, entityType: "contact", presetKey: "guarded" },
+        update: { companyId, presetKey: "guarded" },
+      } as never),
+    );
+
+    const row = await client.query('SELECT "presetKey" FROM "EntityTerminology" WHERE "companyId" = $1', [companyId]);
+    expect(row.rows[0].presetKey).toBe("guarded");
+  });
+});

--- a/prisma/db.ts
+++ b/prisma/db.ts
@@ -50,11 +50,7 @@ function assertTenantScopedWhere(
 
   const direct = where?.companyId;
   const scoped =
-    typeof direct === "string"
-      ? direct
-      : allowCompoundSelector && where
-        ? compoundSelectorCompanyId(where)
-        : undefined;
+    typeof direct === "string" ? direct : allowCompoundSelector && where ? compoundSelectorCompanyId(where) : undefined;
 
   if (!scoped) throw tenantError(model, operation, "companyId must be set in where");
 

--- a/prisma/db.ts
+++ b/prisma/db.ts
@@ -12,11 +12,80 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
 const basePrisma = globalForPrisma.prisma || new PrismaClient({ adapter });
 
+const COMPANY_MODEL = "Company";
+
+const AUTH_MODELS = new Set([
+  "AuthUser",
+  "AuthAccount",
+  "AuthSession",
+  "AuthVerification",
+  "Apikey",
+  "OauthApplication",
+  "OauthAccessToken",
+  "OauthConsent",
+]);
+
+type WhereScope = "unchecked" | "companyIdColumn" | "companyIdColumnOrCompoundKey";
+
+const WHERE_SCOPE_BY_OPERATION: Record<string, WhereScope> = {
+  create: "unchecked",
+  createMany: "unchecked",
+  update: "companyIdColumn",
+  updateMany: "companyIdColumn",
+  upsert: "companyIdColumnOrCompoundKey",
+};
+
+const DEFAULT_WHERE_SCOPE: WhereScope = "companyIdColumn";
+
 function tenantError(model: string, operation: string, message: string): Error {
   return new Error(`${message} [model=${model}, operation=${operation}]`);
 }
 
-function compoundSelectorCompanyId(where: Record<string, unknown>): string | undefined {
+function companyIdOf(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") return undefined;
+
+  return (payload as Record<string, unknown>).companyId;
+}
+
+function assertPayloadOwned(model: string, operation: string, slot: string, payload: unknown, companyId: string) {
+  const value = companyIdOf(payload);
+
+  if (!value) throw tenantError(model, operation, `companyId must be set in ${slot}`);
+
+  if (value !== companyId) throw tenantError(model, operation, `companyId does not match tenant in ${slot}`);
+}
+
+function assertPayloadNotForeign(model: string, operation: string, slot: string, payload: unknown, companyId: string) {
+  const value = companyIdOf(payload);
+
+  if (value !== undefined && value !== companyId)
+    throw tenantError(model, operation, `companyId does not match tenant in ${slot}`);
+}
+
+function assertTenantPayload(model: string, operation: string, args: unknown, companyId: string) {
+  if (model === COMPANY_MODEL) return;
+
+  const input = (args ?? {}) as { data?: unknown; create?: unknown; update?: unknown };
+
+  if (operation === "create") return assertPayloadOwned(model, operation, "data", input.data, companyId);
+
+  if (operation === "createMany") {
+    const rows = Array.isArray(input.data) ? input.data : [input.data];
+    for (const row of rows) assertPayloadOwned(model, operation, "data", row, companyId);
+    return;
+  }
+
+  if (operation === "upsert") {
+    assertPayloadOwned(model, operation, "create", input.create, companyId);
+    assertPayloadOwned(model, operation, "update", input.update, companyId);
+    return;
+  }
+
+  if (operation === "update" || operation === "updateMany")
+    assertPayloadNotForeign(model, operation, "data", input.data, companyId);
+}
+
+function compoundKeyCompanyId(where: Record<string, unknown>): string | undefined {
   for (const [key, value] of Object.entries(where)) {
     if (!key.includes("_") || !value || typeof value !== "object" || Array.isArray(value)) continue;
 
@@ -27,19 +96,16 @@ function compoundSelectorCompanyId(where: Record<string, unknown>): string | und
   return undefined;
 }
 
-function assertTenantScopedWhere(
-  model: string,
-  operation: string,
-  args: unknown,
-  companyId: string,
-  allowCompoundSelector: boolean,
-) {
+function assertTenantWhere(model: string, operation: string, args: unknown, companyId: string) {
+  const scope = WHERE_SCOPE_BY_OPERATION[operation] ?? DEFAULT_WHERE_SCOPE;
+  if (scope === "unchecked") return;
+
   if (!args || typeof args !== "object" || !("where" in args))
     throw tenantError(model, operation, "where must be provided to enforce tenant scoping");
 
   const where = (args as { where?: Record<string, unknown> }).where;
 
-  if (model === "Company") {
+  if (model === COMPANY_MODEL) {
     if (!where?.id) throw tenantError(model, operation, "companyId (id) must be set in where for Company");
 
     if (where.id !== companyId)
@@ -48,9 +114,13 @@ function assertTenantScopedWhere(
     return;
   }
 
-  const direct = where?.companyId;
+  const column = where?.companyId;
   const scoped =
-    typeof direct === "string" ? direct : allowCompoundSelector && where ? compoundSelectorCompanyId(where) : undefined;
+    typeof column === "string"
+      ? column
+      : scope === "companyIdColumnOrCompoundKey" && where
+        ? compoundKeyCompanyId(where)
+        : undefined;
 
   if (!scoped) throw tenantError(model, operation, "companyId must be set in where");
 
@@ -61,85 +131,14 @@ const prisma = basePrisma.$extends({
   query: {
     $allModels: {
       $allOperations({ model, operation, args, query }) {
-        const isAuthModel =
-          model === "AuthUser" ||
-          model === "AuthAccount" ||
-          model === "AuthSession" ||
-          model === "AuthVerification" ||
-          model === "Apikey" ||
-          model === "OauthApplication" ||
-          model === "OauthAccessToken" ||
-          model === "OauthConsent";
-
-        if (isAuthModel) return query(args);
+        if (AUTH_MODELS.has(model)) return query(args);
 
         if (isTenantGuardBypassed()) return query(args);
 
         const { companyId } = getTenantUser();
 
-        switch (operation) {
-          case "create":
-            if (model !== "Company") {
-              if (!args.data?.companyId) throw tenantError(model, operation, "companyId must be set in data");
-
-              if (args.data.companyId !== companyId)
-                throw tenantError(model, operation, "companyId does not match tenant");
-            }
-
-            return query(args);
-
-          case "update":
-            if (model !== "Company") {
-              if (args.data?.companyId && args.data.companyId !== companyId)
-                throw tenantError(model, operation, "companyId does not match tenant");
-            }
-
-            assertTenantScopedWhere(model, operation, args, companyId, false);
-
-            return query(args);
-
-          case "createMany":
-            if (model !== "Company") {
-              const rows = Array.isArray(args.data) ? args.data : [args.data];
-
-              for (const row of rows) {
-                if (!row?.companyId) throw tenantError(model, operation, "companyId must be set in data");
-
-                if (row.companyId !== companyId) throw tenantError(model, operation, "companyId does not match tenant");
-              }
-            }
-
-            return query(args);
-
-          case "updateMany":
-            if (model !== "Company") {
-              if (args.data?.companyId && args.data.companyId !== companyId)
-                throw tenantError(model, operation, "companyId does not match tenant in data");
-            }
-
-            assertTenantScopedWhere(model, operation, args, companyId, false);
-
-            return query(args);
-
-          case "upsert":
-            if (model !== "Company") {
-              if (!args.create?.companyId) throw tenantError(model, operation, "companyId must be set in create");
-
-              if (args.create.companyId !== companyId)
-                throw tenantError(model, operation, "companyId does not match tenant in create");
-
-              if (!args.update?.companyId) throw tenantError(model, operation, "companyId must be set in update");
-
-              if (args.update.companyId !== companyId)
-                throw tenantError(model, operation, "companyId does not match tenant in update");
-            }
-
-            assertTenantScopedWhere(model, operation, args, companyId, true);
-
-            return query(args);
-        }
-
-        assertTenantScopedWhere(model, operation, args, companyId, false);
+        assertTenantPayload(model, operation, args, companyId);
+        assertTenantWhere(model, operation, args, companyId);
 
         return query(args);
       },

--- a/prisma/db.ts
+++ b/prisma/db.ts
@@ -16,6 +16,51 @@ function tenantError(model: string, operation: string, message: string): Error {
   return new Error(`${message} [model=${model}, operation=${operation}]`);
 }
 
+function compoundSelectorCompanyId(where: Record<string, unknown>): string | undefined {
+  for (const [key, value] of Object.entries(where)) {
+    if (!key.includes("_") || !value || typeof value !== "object" || Array.isArray(value)) continue;
+
+    const nested = (value as Record<string, unknown>).companyId;
+    if (typeof nested === "string") return nested;
+  }
+
+  return undefined;
+}
+
+function assertTenantScopedWhere(
+  model: string,
+  operation: string,
+  args: unknown,
+  companyId: string,
+  allowCompoundSelector: boolean,
+) {
+  if (!args || typeof args !== "object" || !("where" in args))
+    throw tenantError(model, operation, "where must be provided to enforce tenant scoping");
+
+  const where = (args as { where?: Record<string, unknown> }).where;
+
+  if (model === "Company") {
+    if (!where?.id) throw tenantError(model, operation, "companyId (id) must be set in where for Company");
+
+    if (where.id !== companyId)
+      throw tenantError(model, operation, "companyId (id) does not match tenant in where for Company");
+
+    return;
+  }
+
+  const direct = where?.companyId;
+  const scoped =
+    typeof direct === "string"
+      ? direct
+      : allowCompoundSelector && where
+        ? compoundSelectorCompanyId(where)
+        : undefined;
+
+  if (!scoped) throw tenantError(model, operation, "companyId must be set in where");
+
+  if (scoped !== companyId) throw tenantError(model, operation, "companyId does not match tenant in where");
+}
+
 const prisma = basePrisma.$extends({
   query: {
     $allModels: {
@@ -53,6 +98,8 @@ const prisma = basePrisma.$extends({
                 throw tenantError(model, operation, "companyId does not match tenant");
             }
 
+            assertTenantScopedWhere(model, operation, args, companyId, false);
+
             return query(args);
 
           case "createMany":
@@ -74,6 +121,8 @@ const prisma = basePrisma.$extends({
                 throw tenantError(model, operation, "companyId does not match tenant in data");
             }
 
+            assertTenantScopedWhere(model, operation, args, companyId, false);
+
             return query(args);
 
           case "upsert":
@@ -89,22 +138,12 @@ const prisma = basePrisma.$extends({
                 throw tenantError(model, operation, "companyId does not match tenant in update");
             }
 
+            assertTenantScopedWhere(model, operation, args, companyId, true);
+
             return query(args);
         }
 
-        if ("where" in args) {
-          if (model !== "Company") {
-            if (!args.where?.companyId) throw tenantError(model, operation, "companyId must be set in where");
-
-            if (args.where.companyId !== companyId)
-              throw tenantError(model, operation, "companyId does not match tenant in where");
-          } else {
-            if (!args.where?.id) throw tenantError(model, operation, "companyId (id) must be set in where for Company");
-
-            if (args.where.id !== companyId)
-              throw tenantError(model, operation, "companyId (id) does not match tenant in where for Company");
-          }
-        } else throw tenantError(model, operation, "where must be provided to enforce tenant scoping");
+        assertTenantScopedWhere(model, operation, args, companyId, false);
 
         return query(args);
       },

--- a/tests/conventions/tenant-write-scoping.test.ts
+++ b/tests/conventions/tenant-write-scoping.test.ts
@@ -28,9 +28,6 @@ const GUARD_EXEMPT_MODELS = new Set([
 
 const REACHED_ONLY_FROM_BYPASSED_CALLERS = new Set([
   "core/auth/better-auth.ts:99",
-  "ee/messaging/persistence/prisma-messaging.repository.ts:506",
-  "ee/messaging/persistence/prisma-messaging.repository.ts:566",
-  "ee/messaging/persistence/prisma-messaging.repository.ts:584",
   "features/user/prisma-user.repository.ts:573",
   "features/user/prisma-user.repository.ts:583",
   "features/user/prisma-user.repository.ts:593",
@@ -61,14 +58,55 @@ function enclosingMethod(node: ts.Node): ts.MethodDeclaration | undefined {
   return undefined;
 }
 
-function bypassesTenantGuard(method: ts.MethodDeclaration | undefined): boolean {
-  if (!method) return false;
+function declaresBypass(method: ts.MethodDeclaration): boolean {
   return (method.modifiers ?? []).some(
     (modifier) =>
       ts.isDecorator(modifier) &&
       ts.isIdentifier(modifier.expression) &&
       modifier.expression.text === BYPASS_DECORATOR,
   );
+}
+
+function methodsByName(source: ts.SourceFile): Map<string, ts.MethodDeclaration> {
+  const found = new Map<string, ts.MethodDeclaration>();
+  const visit = (node: ts.Node) => {
+    if (ts.isMethodDeclaration(node) && node.name) found.set(node.name.getText(source), node);
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
+}
+
+function callersOf(name: string, methods: Map<string, ts.MethodDeclaration>, source: ts.SourceFile): string[] {
+  const callers: string[] = [];
+  for (const [callerName, method] of methods) {
+    if (callerName === name) continue;
+    if (new RegExp(`this\\.${name}\\s*\\(`).test(method.getText(source))) callers.push(callerName);
+  }
+  return callers;
+}
+
+function bypassedMethodNames(source: ts.SourceFile): Set<string> {
+  const methods = methodsByName(source);
+  const bypassed = new Set<string>();
+  for (const [name, method] of methods) if (declaresBypass(method)) bypassed.add(name);
+
+  for (let pass = 0; pass < methods.size; pass++) {
+    let grew = false;
+    for (const [name, method] of methods) {
+      if (bypassed.has(name)) continue;
+      if (!(method.modifiers ?? []).some((m) => m.kind === ts.SyntaxKind.PrivateKeyword)) continue;
+
+      const callers = callersOf(name, methods, source);
+      if (callers.length > 0 && callers.every((caller) => bypassed.has(caller))) {
+        bypassed.add(name);
+        grew = true;
+      }
+    }
+    if (!grew) break;
+  }
+
+  return bypassed;
 }
 
 function whereInitializer(call: ts.CallExpression, source: ts.SourceFile): ts.Expression | undefined {
@@ -107,6 +145,7 @@ function writeSites(): WriteSite[] {
     if (!WRITE_OPERATIONS.values().some((operation) => text.includes(`.${operation}(`))) continue;
 
     const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const bypassed = bypassedMethodNames(source);
 
     const visit = (node: ts.Node) => {
       if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
@@ -117,10 +156,11 @@ function writeSites(): WriteSite[] {
 
         if (WRITE_OPERATIONS.has(operation) && PRISMA_TARGET.test(target) && !GUARD_EXEMPT_MODELS.has(model)) {
           const method = enclosingMethod(node);
+          const methodName = method?.name.getText(source) ?? "";
           const relativePath = relative(REPO_ROOT, file);
           const line = source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
 
-          if (!bypassesTenantGuard(method) && !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`))
+          if (!bypassed.has(methodName) && !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`))
             sites.push({
               file: relativePath,
               line,

--- a/tests/conventions/tenant-write-scoping.test.ts
+++ b/tests/conventions/tenant-write-scoping.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT, walkFiles } from "./walk";
+
+const ENFORCED = true;
+
+const SCANNED_DIRECTORIES = ["core", "ee", "features", "workflows", "app"];
+const WRITE_OPERATIONS = new Set(["update", "updateMany", "upsert"]);
+const PRISMA_TARGET = /(^|\.)prisma\.\w+$|^tx\.\w+$/;
+const ACCESS_WHERE_HELPER = /accessWhere|AccessWhere/;
+const BYPASS_DECORATOR = "BypassTenantGuard";
+
+const GUARD_EXEMPT_MODELS = new Set([
+  "authUser",
+  "authAccount",
+  "authSession",
+  "authVerification",
+  "apikey",
+  "oauthApplication",
+  "oauthAccessToken",
+  "oauthConsent",
+  "company",
+]);
+
+const REACHED_ONLY_FROM_BYPASSED_CALLERS = new Set([
+  "core/auth/better-auth.ts:99",
+  "ee/messaging/persistence/prisma-messaging.repository.ts:506",
+  "ee/messaging/persistence/prisma-messaging.repository.ts:566",
+  "ee/messaging/persistence/prisma-messaging.repository.ts:584",
+  "features/user/prisma-user.repository.ts:573",
+  "features/user/prisma-user.repository.ts:583",
+  "features/user/prisma-user.repository.ts:593",
+  "features/user/prisma-user.repository.ts:603",
+  "features/user/prisma-user.repository.ts:612",
+]);
+
+type WriteSite = {
+  file: string;
+  line: number;
+  operation: string;
+  method: string;
+  scoped: boolean;
+};
+
+function sourceFiles() {
+  return SCANNED_DIRECTORIES.flatMap((dir) =>
+    walkFiles(join(REPO_ROOT, dir), (path) => path.endsWith(".ts") && !path.includes("__tests__")),
+  );
+}
+
+function enclosingMethod(node: ts.Node): ts.MethodDeclaration | undefined {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isMethodDeclaration(current)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function bypassesTenantGuard(method: ts.MethodDeclaration | undefined): boolean {
+  if (!method) return false;
+  return (method.modifiers ?? []).some(
+    (modifier) =>
+      ts.isDecorator(modifier) &&
+      ts.isIdentifier(modifier.expression) &&
+      modifier.expression.text === BYPASS_DECORATOR,
+  );
+}
+
+function whereInitializer(call: ts.CallExpression, source: ts.SourceFile): ts.Expression | undefined {
+  const [arg] = call.arguments;
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return undefined;
+
+  for (const property of arg.properties)
+    if (ts.isPropertyAssignment(property) && property.name.getText(source) === "where") return property.initializer;
+
+  return undefined;
+}
+
+function carriesCompanyId(where: ts.Expression | undefined, operation: string, source: ts.SourceFile): boolean {
+  if (!where || !ts.isObjectLiteralExpression(where)) return false;
+
+  for (const property of where.properties) {
+    if (ts.isSpreadAssignment(property) && ACCESS_WHERE_HELPER.test(property.expression.getText(source))) return true;
+
+    const name = property.name?.getText(source);
+    if (name === "companyId") return true;
+
+    const isCompoundSelector = operation === "upsert" && name?.includes("_");
+    if (isCompoundSelector && ts.isPropertyAssignment(property) && ts.isObjectLiteralExpression(property.initializer))
+      for (const nested of property.initializer.properties)
+        if (nested.name?.getText(source) === "companyId") return true;
+  }
+
+  return false;
+}
+
+function writeSites(): WriteSite[] {
+  const sites: WriteSite[] = [];
+
+  for (const file of sourceFiles()) {
+    const text = readFileSync(file, "utf8");
+    if (!WRITE_OPERATIONS.values().some((operation) => text.includes(`.${operation}(`))) continue;
+
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+        const operation = node.expression.name.text;
+        const target = node.expression.expression.getText(source);
+
+        const model = target.split(".").pop() ?? "";
+
+        if (WRITE_OPERATIONS.has(operation) && PRISMA_TARGET.test(target) && !GUARD_EXEMPT_MODELS.has(model)) {
+          const method = enclosingMethod(node);
+          const relativePath = relative(REPO_ROOT, file);
+          const line = source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+
+          if (!bypassesTenantGuard(method) && !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`))
+            sites.push({
+              file: relativePath,
+              line,
+              operation,
+              method: method?.name.getText(source) ?? "(module scope)",
+              scoped: carriesCompanyId(whereInitializer(node, source), operation, source),
+            });
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+  }
+
+  return sites;
+}
+
+describe("tenant-scoped writes", () => {
+  const sites = writeSites();
+
+  it.runIf(ENFORCED)("scopes every tenant-guarded update, updateMany and upsert by companyId in its where", () => {
+    const unscoped = sites
+      .filter((site) => !site.scoped)
+      .map((site) => `${site.file}:${site.line} ${site.operation} in ${site.method}`);
+
+    expect(unscoped).toEqual([]);
+  });
+
+  it("still finds the write sites it is meant to guard", () => {
+    expect(sites.length).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
## Summary

The Prisma tenant guard validated `where` for reads and deletes, but `update`, `updateMany` and `upsert` each returned before that check. Only `create`/`createMany` data and the `upsert` create/update payloads were validated, so nothing stopped a guarded write from targeting another tenant's row by id — cross-tenant writes were prevented by repository convention alone.

All three now go through the same assertion the read path already used, and a convention test keeps it closed.

## Context

Found while auditing the read stack. To be explicit about severity: **no exploitable call site exists today.** Every write that could have taken a foreign id already proved ownership first — `upsertCustomColumnOrThrow` and `upsertRoleOrThrow` do a `findFirstOrThrow({ where: { id, companyId } })`, the messaging writes read the row through `threadAccessWhere` first, and the unscoped ingestion paths carry `@BypassTenantGuard` and never reach the guard. This closes the gap so a future write cannot quietly reopen it.

Two details shaped the implementation:

- **`upsert` cannot always carry a top-level `companyId`.** Prisma requires a unique selector there, and uniques like `companyId_entityType` and `companyId_channelClass_value` carry the tenant *inside* the compound key. The assertion accepts that for `upsert` only. `update`, `updateMany` and the read path still require `companyId` at the top level, so no existing check is relaxed.
- **The test suite could not have caught the breakage.** Repository writes are mocked in interactor tests, so the suite stayed fully green while `save-draft`, `send-chat-message` and `send-email` would have thrown at runtime. Those three are `@TenantInteractor` paths and are among the six sites fixed here; they were found by AST analysis of the call graph, not by tests.

## Validation

- `tests/conventions/tenant-write-scoping.test.ts` walks every `update`/`updateMany`/`upsert` in `core`, `ee`, `features`, `workflows` and `app`, skipping the models the guard exempts (auth models and `Company`) and the sites reached only from bypassed or `@SystemInteractor` callers. It failed with 18 sites before this change and passes now.
- `yarn typecheck`, `yarn lint`, `RUN_DATABASE_TESTS=true yarn test` all green: 306 files, 2595 tests, 1 skipped.
- Note: `components/emails/__tests__/preview-inventory.test.ts` intermittently exceeds its 15s timeout under parallel load on this machine, on `origin/main` as well. It passes in isolation and in the final full run; unrelated to this change.

## Impact and rollback

The six adjusted call sites add a predicate that narrows nothing, since each had already established the row was in tenant. No schema change, no API surface change. A guarded write that omits tenant scoping now throws a clear tenant error instead of silently proceeding. Revert the single commit to roll back.