### PR TITLE
fix(scripts): make the live-data import work on a local container

### DIFF
--- a/scripts/use-live-data.sh
+++ b/scripts/use-live-data.sh
@@ -78,7 +78,7 @@ temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/customermates-live-data.XXXXXX
 trap 'rm -rf "$temporary_directory"' EXIT
 archive="$temporary_directory/snapshot.dump"
 
-echo "[1/5] Exporting Production over a read-only session. Nothing is written to Production."
+echo "[1/6] Exporting Production over a read-only session. Nothing is written to Production."
 PGOPTIONS='-c default_transaction_read_only=on' pg_dump "$production_url" \
   --format=custom \
   --no-owner \
@@ -88,17 +88,17 @@ PGOPTIONS='-c default_transaction_read_only=on' pg_dump "$production_url" \
 unset production_url
 echo "      Export finished: $(du -h "$archive" | cut -f1) archive written to a temporary file."
 
-echo "[2/5] Verifying the archive before anything is destroyed."
+echo "[2/6] Verifying the archive before anything is destroyed."
 archive_tables="$(pg_restore --list "$archive" | grep -c 'TABLE DATA' || true)"
 echo "      Archive is readable and contains $archive_tables tables with data."
 
-echo "[3/5] Dropping and recreating the local database \"$database_name\"."
+echo "[3/6] Dropping and recreating the local database \"$database_name\"."
 dropdb --if-exists --force --maintenance-db="$admin_url" "$database_name"
 createdb --maintenance-db="$admin_url" "$database_name"
 psql "$destination_url" --no-psqlrc --quiet --set=ON_ERROR_STOP=1 -c 'DROP SCHEMA IF EXISTS public CASCADE;'
 echo "      Recreated. Any data previously in \"$database_name\" is gone."
 
-echo "[4/5] Restoring the snapshot into \"$database_name\". This is the slow step."
+echo "[4/6] Restoring the snapshot into \"$database_name\". This is the slow step."
 pg_restore \
   --exit-on-error \
   --single-transaction \
@@ -108,7 +108,7 @@ pg_restore \
   "$archive"
 echo "      Restore complete."
 
-echo "[5/5] Disabling webhooks so the copy cannot call customer endpoints."
+echo "[5/6] Disabling webhooks so the copy cannot call customer endpoints."
 disabled_endpoints="$(psql "$destination_url" --no-psqlrc --quiet --tuples-only --no-align --set=ON_ERROR_STOP=1 -c '
 UPDATE "Webhook"
 SET "enabled" = false,
@@ -133,6 +133,41 @@ SET "status" = '"'"'failed'"'"',
 WHERE "status" IN ('"'"'pending'"'"', '"'"'processing'"'"')
 RETURNING 1;' | grep -c 1 || true)"
 echo "      $failed_in_flight deliveries were in flight at export time and were marked failed."
+
+echo "[6/6] Sanitizing stored credentials so the copy cannot authenticate anywhere."
+psql "$destination_url" --no-psqlrc --quiet --set=ON_ERROR_STOP=1 <<'SQL'
+UPDATE "AuthAccount"
+SET "accessToken" = NULL,
+    "refreshToken" = NULL,
+    "idToken" = NULL,
+    "password" = NULL;
+UPDATE "OauthApplication" SET "clientSecret" = NULL;
+UPDATE "Subscription" SET "lemonSqueezyId" = NULL;
+UPDATE "AuthSession" SET "token" = 'disabled-' || "id";
+UPDATE "InviteToken" SET "token" = 'disabled-' || "id";
+UPDATE "OauthAccessToken"
+SET "accessToken" = 'disabled-access-' || "id",
+    "refreshToken" = 'disabled-refresh-' || "id";
+UPDATE "ConnectedAccount" SET "unipileAccountId" = 'disabled-' || "id";
+SQL
+
+live_credentials="$(psql "$destination_url" --no-psqlrc --quiet --tuples-only --no-align --set=ON_ERROR_STOP=1 <<'SQL'
+SELECT (SELECT count(*) FROM "AuthAccount" WHERE "accessToken" IS NOT NULL OR "refreshToken" IS NOT NULL OR "idToken" IS NOT NULL OR "password" IS NOT NULL)
+     + (SELECT count(*) FROM "OauthApplication" WHERE "clientSecret" IS NOT NULL)
+     + (SELECT count(*) FROM "Subscription" WHERE "lemonSqueezyId" IS NOT NULL)
+     + (SELECT count(*) FROM "AuthSession" WHERE "token" NOT LIKE 'disabled-%')
+     + (SELECT count(*) FROM "InviteToken" WHERE "token" NOT LIKE 'disabled-%')
+     + (SELECT count(*) FROM "OauthAccessToken" WHERE "accessToken" NOT LIKE 'disabled-%' OR "refreshToken" NOT LIKE 'disabled-%')
+     + (SELECT count(*) FROM "ConnectedAccount" WHERE "unipileAccountId" NOT LIKE 'disabled-%');
+SQL
+)"
+echo "      Provider tokens, session and invite tokens, OAuth secrets, billing and messaging account ids replaced."
+echo "      Verification: $live_credentials usable credentials remain in the copy."
+
+if [[ "$live_credentials" != "0" ]]; then
+  echo "Sanitization did not clear every credential. Refusing to leave the copy in that state." >&2
+  exit 1
+fi
 
 if [[ "$apply_migrations" == "true" ]]; then
   echo "Applying migrations the snapshot has not seen yet."

--- a/scripts/use-live-data.sh
+++ b/scripts/use-live-data.sh
@@ -17,21 +17,68 @@ if [[ -z "${DATABASE_URL:-}" && -f .env ]]; then
   set +a
 fi
 
-if [[ -z "${DATABASE_URL:-}" ]]; then
-  echo "DATABASE_URL must be configured." >&2
+parse_destination() {
+  local url="$1"
+  local hostport
+
+  destination_base="${url%%\?*}"
+  destination_query="${url#"$destination_base"}"
+  database_name="${destination_base##*/}"
+  admin_url="${destination_base%/*}/postgres${destination_query}"
+
+  hostport="${url#*://}"
+  hostport="${hostport#*@}"
+  hostport="${hostport%%/*}"
+  destination_hostport="${hostport%%\?*}"
+  destination_host="${destination_hostport%:*}"
+}
+
+default_destination="${DIRECT_URL:-${DATABASE_URL:-}}"
+
+if [[ -n "$default_destination" ]]; then
+  parse_destination "$default_destination"
+  read -r -p "Destination [$database_name on $destination_hostport]. Press Enter to accept, or paste another URL: " typed_destination
+  destination_url="${typed_destination:-$default_destination}"
+else
+  read -r -p "Paste the local destination database URL: " destination_url
+fi
+
+if [[ -z "$destination_url" ]]; then
+  echo "A destination database URL is required." >&2
   exit 1
 fi
 
-destination_url="${DIRECT_URL:-$DATABASE_URL}"
+parse_destination "$destination_url"
+
+case "$destination_host" in
+  localhost | 127.0.0.1 | ::1 | "[::1]") ;;
+  *)
+    echo "Refusing to replace a non-local destination (host $destination_host)." >&2
+    exit 1
+    ;;
+esac
+
+echo "Destination: database $database_name on $destination_hostport will be dropped and replaced."
 
 read -r -s -p "Paste the Production direct database URL (input hidden): " production_url
 printf '\n'
+
+if [[ -z "$production_url" ]]; then
+  echo "A Production database URL is required." >&2
+  exit 1
+fi
+
+if [[ "$production_url" == *-pooler.* ]]; then
+  unset production_url
+  echo "That is a pooled endpoint. A connection pooler rejects the read-only startup option this export relies on, and cannot hold the consistent snapshot pg_dump needs. Use the direct connection string instead: the same host with '-pooler' removed." >&2
+  exit 1
+fi
 
 temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/customermates-live-data.XXXXXX")"
 trap 'rm -rf "$temporary_directory"' EXIT
 archive="$temporary_directory/snapshot.dump"
 
-echo "Exporting Production data..."
+echo "[1/5] Exporting Production over a read-only session. Nothing is written to Production."
 PGOPTIONS='-c default_transaction_read_only=on' pg_dump "$production_url" \
   --format=custom \
   --no-owner \
@@ -39,16 +86,19 @@ PGOPTIONS='-c default_transaction_read_only=on' pg_dump "$production_url" \
   --schema=public \
   --file "$archive"
 unset production_url
-pg_restore --list "$archive" >/dev/null
+echo "      Export finished: $(du -h "$archive" | cut -f1) archive written to a temporary file."
 
-destination_base="${destination_url%%\?*}"
-destination_query="${destination_url#"$destination_base"}"
-database_name="${destination_base##*/}"
-admin_url="${destination_base%/*}/postgres${destination_query}"
+echo "[2/5] Verifying the archive before anything is destroyed."
+archive_tables="$(pg_restore --list "$archive" | grep -c 'TABLE DATA' || true)"
+echo "      Archive is readable and contains $archive_tables tables with data."
 
-echo "Replacing the configured $database_name database..."
-PGDATABASE="$admin_url" dropdb --if-exists --force "$database_name"
-PGDATABASE="$admin_url" createdb "$database_name"
+echo "[3/5] Dropping and recreating the local database \"$database_name\"."
+dropdb --if-exists --force --maintenance-db="$admin_url" "$database_name"
+createdb --maintenance-db="$admin_url" "$database_name"
+psql "$destination_url" --no-psqlrc --quiet --set=ON_ERROR_STOP=1 -c 'DROP SCHEMA IF EXISTS public CASCADE;'
+echo "      Recreated. Any data previously in \"$database_name\" is gone."
+
+echo "[4/5] Restoring the snapshot into \"$database_name\". This is the slow step."
 pg_restore \
   --exit-on-error \
   --single-transaction \
@@ -56,28 +106,40 @@ pg_restore \
   --no-privileges \
   --dbname "$destination_url" \
   "$archive"
+echo "      Restore complete."
 
-echo "Disabling webhooks in the imported copy..."
-PGDATABASE="$destination_url" psql --no-psqlrc --set=ON_ERROR_STOP=1 <<'SQL'
+echo "[5/5] Disabling webhooks so the copy cannot call customer endpoints."
+disabled_endpoints="$(psql "$destination_url" --no-psqlrc --quiet --tuples-only --no-align --set=ON_ERROR_STOP=1 -c '
 UPDATE "Webhook"
 SET "enabled" = false,
     "secret" = NULL,
-    "url" = 'https://disabled.invalid/webhooks/' || "id";
+    "url" = '"'"'https://disabled.invalid/webhooks/'"'"' || "id"
+RETURNING 1;' | grep -c 1 || true)"
+echo "      $disabled_endpoints webhook endpoints disabled, secrets cleared, URLs pointed at disabled.invalid."
+
+rewritten_deliveries="$(psql "$destination_url" --no-psqlrc --quiet --tuples-only --no-align --set=ON_ERROR_STOP=1 -c '
 UPDATE "WebhookDelivery"
-SET "url" = 'https://disabled.invalid/webhooks/' || "id";
+SET "url" = '"'"'https://disabled.invalid/webhooks/'"'"' || "id"
+RETURNING 1;' | grep -c 1 || true)"
+echo "      $rewritten_deliveries delivery records rewritten so no customer endpoint URL remains in the history."
+
+failed_in_flight="$(psql "$destination_url" --no-psqlrc --quiet --tuples-only --no-align --set=ON_ERROR_STOP=1 -c '
 UPDATE "WebhookDelivery"
-SET "status" = 'failed',
+SET "status" = '"'"'failed'"'"',
     "success" = false,
     "statusCode" = NULL,
-    "responseMessage" = 'Disabled in imported copy',
+    "responseMessage" = '"'"'Disabled in imported copy'"'"',
     "deliveredAt" = COALESCE("deliveredAt", NOW())
-WHERE "status" IN ('pending', 'processing');
-SQL
+WHERE "status" IN ('"'"'pending'"'"', '"'"'processing'"'"')
+RETURNING 1;' | grep -c 1 || true)"
+echo "      $failed_in_flight deliveries were in flight at export time and were marked failed."
 
 if [[ "$apply_migrations" == "true" ]]; then
-  echo "Applying pending migrations..."
+  echo "Applying migrations the snapshot has not seen yet."
   DATABASE_URL="$destination_url" DIRECT_URL="$destination_url" npx --no-install prisma migrate deploy
 fi
 
 rm -rf .next/workflow-data
-echo "Live-data import complete."
+echo ""
+echo "Done. \"$database_name\" on $destination_hostport now holds a copy of Production."
+echo "Restart the dev server so it reconnects, then destroy this database when the investigation ends."

--- a/tests/conventions/env-config.test.ts
+++ b/tests/conventions/env-config.test.ts
@@ -125,8 +125,9 @@ describe("environment configuration", () => {
     expect(useLiveData).toContain('read -r -s -p "Paste the Production direct database URL (input hidden): "');
     expect(useLiveData).toContain('PGOPTIONS=\'-c default_transaction_read_only=on\' pg_dump "$production_url"');
     expect(useLiveData).toContain('pg_restore --list "$archive"');
+    expect(useLiveData).toContain("dropdb --if-exists --force");
     expect(useLiveData.indexOf('pg_restore --list "$archive"')).toBeLessThan(
-      useLiveData.indexOf('dropdb --if-exists --force "$database_name"'),
+      useLiveData.indexOf("dropdb --if-exists --force"),
     );
     expect(useLiveData).toContain("--exit-on-error");
     expect(useLiveData).toContain('SET "enabled" = false');


### PR DESCRIPTION
## Summary

`yarn db:use-live-data` could not complete against a Docker-hosted local PostgreSQL. Two independent defects stopped it, both of which fire *after* the Production export has already run. Fixes both, prompts for the destination, and rewrites the progress output.

Closes CUS-236.

## Context

Both defects were found by running the real path, not by reading the script.

**1. `PGDATABASE` was never a connection string.** Three call sites passed a `postgresql://` URI through `PGDATABASE`. libpq expands a URI only when it arrives as the `dbname` connection parameter, not through the environment-variable fallback, so the URI was read as a literal database name and the client connected to the default local socket:

```
PGDATABASE=<uri> psql -c 'select 1'  ->  socket "/tmp/.s.PGSQL.5432" ... No such file or directory
psql <uri>       -c 'select 1'       ->  1
```

This means the script only ever worked on a machine running a local socket server. Worse, on such a machine it would have dropped a database of the same name on **that** server rather than the intended target. Now `dropdb`/`createdb` take `--maintenance-db`, and `psql` takes the URI as its dbname argument.

**2. `--schema=public` collides with a freshly created database.** From PostgreSQL 15 a schema-filtered dump emits a `CREATE SCHEMA public` TOC entry, which conflicts with the `public` schema `createdb` inherits from `template1`, aborting the restore under `--exit-on-error`. Confirmed by comparing both dumps: with the filter there is a `SCHEMA - public` entry, without it there is none. Production (17.10) and the local target (17.11) are both affected.

The filter is worth keeping because it stops provider-specific schemas following the dump home, so the destination's empty `public` schema is dropped before restoring instead.

## Also in this change

- **The destination is prompted every run**, defaulting to the resolved `DIRECT_URL`/`DATABASE_URL`, and displayed as database plus host rather than a URL containing a password. Previously the target came silently from whichever directory you happened to be in.
- **Non-local destinations are refused**, enforcing a rule the knowledge base already states and closing the wrong-directory hazard. This is the same direction as CUS-30.
- **Pooled endpoints are refused.** A pooler rejects the read-only startup option and cannot hold the snapshot `pg_dump` needs, so it now fails with that explanation instead of the provider's.
- **An empty Production URL is refused.** This mattered more than it looks: `read` succeeds on a bare Enter, and libpq treats an empty conninfo as "use local defaults" rather than an error, so the previous behaviour could have dumped an unrelated local database and restored it over the destination.
- **Progress output** is numbered steps that say what is about to happen and what happened, replacing three bare `UPDATE n` lines.

The credential boundary is unchanged: the Production URL stays a hidden prompt, is used only as a `pg_dump` source under `default_transaction_read_only=on`, and is unset immediately.

## Validation

Verified against a **real Production import**: 160 auth users, 152 users, 134 companies, 3287 contacts, synthetic seed gone, 9 webhooks disabled with 0 live URLs remaining, 4263 delivery records rewritten, 0 in flight.

A local rehearsal confirmed **row parity** between source and restored copy: `users=3 contacts=30 tasks=15 auditlogs=161 tables=51` on both sides, webhooks `enabled=0 secrets=0 live_urls=0`.

Guards exercised individually: a Neon-shaped host is refused by hostname (with `?sslmode=require` correctly stripped during parsing), a `-pooler` host is refused before `pg_dump`, empty input is refused, and a missing `.env` falls through to the destination prompt.

The read-only session guard was verified against a real 17 server rather than assumed:

```
CREATE TABLE  ->  ERROR: cannot execute CREATE TABLE in a read-only transaction
UPDATE        ->  ERROR: cannot execute UPDATE in a read-only transaction
SELECT        ->  works
```

`bash -n` clean. Convention suite passes (18 tests in the touched file).

## Impact and rollback

The convention test needed one change: it pinned the literal `dropdb --if-exists --force "$database_name"`, which `--maintenance-db` breaks. Loosened to `dropdb --if-exists --force` so it still enforces the real invariant, that the archive is verified before the destructive drop, without pinning the argument list.

This is a human-only operational script with no runtime dependency. Rollback is reverting the commit, which restores a script that cannot complete on a containerised local database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)