### PR TITLE
refactor(entity-detail): align panel labels with field labels

### DIFF
--- a/components/data-view/header/filter-popover.tsx
+++ b/components/data-view/header/filter-popover.tsx
@@ -83,14 +83,14 @@ export const FilterPopover = observer(function FilterPopover({ store, compact, i
       aria-label={t("Common.ariaLabels.tooltipFilters")}
       className={cn(
         "relative",
-        compact ? "text-muted-foreground hover:text-foreground size-4 hover:bg-transparent" : "h-8",
+        compact ? "text-muted-foreground hover:text-foreground size-3 rounded-sm hover:bg-transparent" : "h-8",
       )}
       id={id}
       size={compact ? "icon-xs" : "sm"}
       type="button"
       variant={compact ? "ghost" : "secondary"}
     >
-      <Filter className="size-3.5" />
+      <Filter className={compact ? "size-3" : "size-3.5"} />
 
       {activeFilterCount > 0 && (
         <span

--- a/components/entity-detail/entity-detail-layout.tsx
+++ b/components/entity-detail/entity-detail-layout.tsx
@@ -8,7 +8,7 @@ import type {
   FormEntityDto,
 } from "@/core/base/base-custom-column-entity-modal.store";
 
-import { Pencil, SquarePen, Plus, Trash2 } from "lucide-react";
+import { Pencil, Plus, Trash2 } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
@@ -297,15 +297,7 @@ export const EntityDetailLayout = observer(function EntityDetailLayout<
           )}
         >
           <div className="flex flex-col bg-background @4xl/detail:min-h-0 @4xl/detail:overflow-auto">
-            <div className="flex items-center gap-2 px-4 pt-3 pb-1 shrink-0 min-h-8">
-              <Icon className="size-3.5 text-muted-foreground" icon={SquarePen} />
-
-              <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                {t("Common.actions.labelData")}
-              </span>
-            </div>
-
-            <div className="p-4 pt-2 @4xl/detail:flex-1 @4xl/detail:min-h-0">
+            <div className="p-4 @4xl/detail:flex-1 @4xl/detail:min-h-0">
               {masterData}
 
               {isEditingCustomField && canManage && (

--- a/components/entity-detail/entity-detail-page-skeleton.tsx
+++ b/components/entity-detail/entity-detail-page-skeleton.tsx
@@ -19,21 +19,17 @@ function FormFieldSkeleton({ animated, short = false }: { animated: boolean; sho
 function SectionHeader({
   animated,
   labelWidth,
-  master = false,
-  timeline = false,
+  endAction = false,
 }: {
   animated: boolean;
   labelWidth: string;
-  master?: boolean;
-  timeline?: boolean;
+  endAction?: boolean;
 }) {
   return (
-    <div
-      className={cn("flex shrink-0 items-center gap-2 px-4 pt-4", timeline ? "pb-2" : "pb-1", master && "min-h-8 pt-3")}
-    >
-      <Shape animated={animated} className="size-3.5 rounded" />
-
+    <div className="flex h-4 shrink-0 items-center px-4 pt-4 pb-1.5 box-content">
       <Shape breathe animated={animated} className={cn("h-2.5", labelWidth)} motionPhase={1} />
+
+      {endAction && <Shape animated={animated} className="ml-auto size-3 rounded" />}
     </div>
   );
 }
@@ -53,9 +49,7 @@ export function EntityDetailPageSkeleton({ animated = true }: Props) {
           className="flex flex-col bg-background @4xl/detail:min-h-0 @4xl/detail:overflow-auto"
           data-skeleton-group="0"
         >
-          <SectionHeader master animated={animated} labelWidth="w-20" />
-
-          <div className="p-4 pt-2 @4xl/detail:min-h-0 @4xl/detail:flex-1">
+          <div className="p-4 @4xl/detail:min-h-0 @4xl/detail:flex-1">
             <div className="flex w-full flex-col gap-4">
               <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
                 <div data-skeleton-group="1">
@@ -81,7 +75,7 @@ export function EntityDetailPageSkeleton({ animated = true }: Props) {
           >
             <SectionHeader animated={animated} labelWidth="w-16" />
 
-            <div className="min-h-0 flex-1 overflow-auto p-4 pt-2">
+            <div className="min-h-0 flex-1 overflow-auto px-4 pb-4">
               <Shape animated={animated} className="min-h-52 w-full" motionPhase={2} />
             </div>
           </div>
@@ -90,9 +84,9 @@ export function EntityDetailPageSkeleton({ animated = true }: Props) {
             className="flex flex-col bg-background @4xl/detail:min-h-0 @4xl/detail:flex-1 @4xl/detail:overflow-hidden"
             data-skeleton-group="2"
           >
-            <SectionHeader timeline animated={animated} labelWidth="w-20" />
+            <SectionHeader endAction animated={animated} labelWidth="w-20" />
 
-            <div className="min-h-0 flex-1 overflow-auto px-2 pt-2 pb-4">
+            <div className="min-h-0 flex-1 overflow-auto px-2 pb-4">
               {TIMELINE_ROWS.map((row) => (
                 <div key={row} className="flex items-start gap-3 rounded-md p-2" data-skeleton-group={row % 4}>
                   <Shape animated={animated} className="size-8 shrink-0 rounded-lg" />

--- a/components/entity-detail/entity-notes-panel.tsx
+++ b/components/entity-detail/entity-notes-panel.tsx
@@ -6,13 +6,11 @@ import type {
   FormEntityDto,
 } from "@/core/base/base-custom-column-entity-modal.store";
 
-import { FileText } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
 import { useRef } from "react";
 
 import { Editor } from "@/components/editor/editor";
-import { Icon } from "@/components/shared/icon";
 import { cn } from "@/core/utils/cn";
 
 type Props<Form extends FormEntityDto, Dto extends EntityDto> = {
@@ -52,18 +50,14 @@ export const EntityNotesPanel = observer(function EntityNotesPanel<Form extends 
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex items-center gap-2 px-4 pt-4 pb-1 shrink-0">
-        <Icon className="size-3.5 text-muted-foreground" icon={FileText} />
-
-        <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-          {t("Common.actions.labelNotes")}
-        </span>
+      <div className="flex items-center gap-1.5 px-4 pt-4 pb-1.5 shrink-0">
+        <span className="text-xs font-normal text-muted-foreground">{t("Common.actions.labelNotes")}</span>
       </div>
 
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- forwards clicks in the empty padding to the already-interactive ProseMirror editor inside */}
       <div
         ref={containerRef}
-        className={cn("flex-1 min-h-0 overflow-auto p-4 pt-2", readOnly ? "cursor-default" : "cursor-text")}
+        className={cn("flex-1 min-h-0 overflow-auto px-4 pb-4", readOnly ? "cursor-default" : "cursor-text")}
         onMouseDown={handleContainerMouseDown}
       >
         <Editor data={store.form.notes} readOnly={readOnly} onChange={handleNotesChange} />

--- a/features/messaging/activities/activities-panel.tsx
+++ b/features/messaging/activities/activities-panel.tsx
@@ -10,7 +10,6 @@ import { Clock } from "lucide-react";
 
 import { FilterPopover } from "@/components/data-view/header/filter-popover";
 import { DataViewActiveFiltersBar } from "@/components/data-view/header/active-filters-bar";
-import { Icon } from "@/components/shared/icon";
 import { PageState } from "@/components/page-state/page-state";
 
 import { ActivitiesList, TimelineEmptyState, TimelineNotice } from "./activities-list";
@@ -79,12 +78,8 @@ export const EntityTimelinePanel = observer(({ entityType, entityId, initial }: 
   return (
     <ActivityQueryProvider filters={store.filters} scope={store.scope}>
       <div className="flex h-full flex-col">
-        <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2">
-          <Icon className="text-muted-foreground size-3.5" icon={Clock} />
-
-          <span className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
-            {t("Common.actions.labelHistory")}
-          </span>
+        <div className="flex shrink-0 items-center gap-1.5 px-4 pt-4 pb-1.5">
+          <span className="text-muted-foreground text-xs font-normal">{t("Common.actions.labelHistory")}</span>
 
           <div className="ml-auto flex items-center gap-1.5">
             <FilterPopover compact store={store} />
@@ -93,7 +88,7 @@ export const EntityTimelinePanel = observer(({ entityType, entityId, initial }: 
 
         <DataViewActiveFiltersBar noBorder store={store} />
 
-        <div className="min-h-0 flex-1 overflow-auto px-2 pt-2 pb-4">
+        <div className="min-h-0 flex-1 overflow-auto px-2 pb-4">
           {store.scopeTruncated && store.items.length > 0 && (
             <TimelineNotice label={t("EntityTimeline.scopeTooBroad")} />
           )}

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -106,7 +106,6 @@
       "deleteCustomFields": "Feld löschen",
       "discard": "Verwerfen",
       "editCustomFields": "Feld bearbeiten",
-      "labelData": "Daten",
       "labelHistory": "Verlauf",
       "labelNotes": "Notizen",
       "loadMore": "Mehr laden",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -106,7 +106,6 @@
       "deleteCustomFields": "Delete Field",
       "discard": "Discard",
       "editCustomFields": "Edit Field",
-      "labelData": "Data",
       "labelHistory": "History",
       "labelNotes": "Notes",
       "loadMore": "Load more",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -106,7 +106,6 @@
       "deleteCustomFields": "Eliminar campo",
       "discard": "Descartar",
       "editCustomFields": "Editar campo",
-      "labelData": "Datos",
       "labelHistory": "Historial",
       "labelNotes": "Notas",
       "loadMore": "Cargar más",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -106,7 +106,6 @@
       "deleteCustomFields": "Supprimer le champ",
       "discard": "Abandonner",
       "editCustomFields": "Modifier le champ",
-      "labelData": "Données",
       "labelHistory": "Historique",
       "labelNotes": "Notes",
       "loadMore": "Charger plus",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -106,7 +106,6 @@
       "deleteCustomFields": "Elimina campo",
       "discard": "Scarta",
       "editCustomFields": "Modifica campo",
-      "labelData": "Dati",
       "labelHistory": "Cronologia",
       "labelNotes": "Note",
       "loadMore": "Carica altro",


### PR DESCRIPTION
## Summary

The entity detail pages carried a section header above each of the three panels: a 14px lucide icon plus an 11px uppercase tracked label. That is a second label style competing with the form's own field labels one line below it, and on the data panel it says nothing the fields do not already say.

- The data header is gone. The form starts at `First Name`.
- The notes and history labels lose their icons and adopt the field-label style verbatim (`text-xs font-normal text-muted-foreground`, sentence case), on the same baseline as the first row of field labels.
- The history filter still floats right in its label row, and now matches the dimensions of the `IconButton` that sits next to the `Channels` label on contacts: a 12x12 box with a `size-3` icon, down from a 16x16 box with a 14px icon.
- `EntityDetailPageSkeleton` moves with the layout, so the skeleton-to-content transition does not jump.
- `Common.actions.labelData` is now unused and is removed from all five locale files.

## Context

CUS-237. `FilterPopover`'s `compact` variant exists only for this history panel (`data-view-toolbar.tsx` uses the default), so resizing it does not touch the list toolbars.

One thing worth naming, because it is easy to get wrong by eye: `FormLabel` renders through `ui/label.tsx`, whose base sets `leading-none`, but the `text-xs` added on top wins and the computed line-height is 16px, not 12px. A panel label given `leading-none` therefore top-aligns with a field label while its text sits 2px higher. The panel labels deliberately carry no leading utility so both boxes are 16px.

## Validation

Verified in a local instance (`yarn dev`, seeded database, demo mode) rather than by inspection, measuring the live DOM rects on `/en/contacts/<id>`:

| element | x | y | height |
|---|---|---|---|
| `First Name` label | 272 | 88 | 16 |
| `Notes` label | 857 | 88 | 16 |
| `History` label | 1248 | 88 | 16 |
| first input | 272 | 110 | 36 |
| notes editor | 857 | 110 | 24 |

All three labels share a baseline, and both content areas start at the same offset below it. The history filter measures 12x12 at x=1564 (floated right); the `Channels` go-to button measures 12x12. No `svg` remains inside any panel label.

Also checked on `/en/deals/<id>`, which reaches the same layout through a different master-data view, and the loading skeleton was observed mid-navigation with the data panel starting directly at its first field row.

- `yarn typecheck` clean.
- `yarn lint` clean (0 warnings, `--max-warnings 0`).
- `npx vitest run tests/conventions components/entity-detail features/messaging`: 52 files, 403 passed, 1 skipped. Covers `page-state-contract`, `entity-detail-layout`, `entity-detail-page-state` and `i18n-parity`, which is the gate on the locale-key removal.

## Impact and rollback

Presentational only. No schema, no API, no store or interactor changes, and no behaviour change to filtering itself. The one shared component touched outside the detail pages is `FilterPopover`, and only its `compact` branch, whose sole consumer is the panel in this PR.

Rollback is a straight revert of the commit. The removed `labelData` key comes back with it.

Closes CUS-237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
