### PR TITLE
fix(data-view): tone and center the filter chip value skeleton

### DIFF
--- a/components/data-view/filter-modal/__tests__/filter-chip-display.test.ts
+++ b/components/data-view/filter-modal/__tests__/filter-chip-display.test.ts
@@ -67,6 +67,32 @@ describe("FilterChipValue", () => {
     expect(html.match(/Unavailable/g)).toHaveLength(1);
   });
 
+  it("tints the pending value placeholder with the chip colour and centers it", () => {
+    selectItems.mockReturnValue({
+      items: [],
+      getItems: undefined,
+      isLoading: true,
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(FilterChipValue, {
+        customColumns: [],
+        filter: {
+          field: "organizationIds",
+          operator: "in",
+          value: ["15c1df79-6c87-46f7-8de4-02a1f49c83be"],
+        } as never,
+        label: "Organization",
+        operator: "in",
+      }),
+    );
+
+    expect(html).toContain("data-filter-value-loading");
+    expect(html).toContain("bg-current/40");
+    expect(html).not.toContain("bg-placeholder");
+    expect(html).toContain("align-middle");
+  });
+
   it("preserves literal customer-entered filter text", () => {
     selectItems.mockReturnValue({
       items: [],

--- a/components/data-view/filter-modal/filter-chip-display.tsx
+++ b/components/data-view/filter-modal/filter-chip-display.tsx
@@ -60,7 +60,7 @@ export const FilterChipValue = observer(
           {prefix}
 
           <span data-filter-value-loading aria-label={t("Loading.text")} role="status">
-            <SelectionValueSkeleton className="h-4" />
+            <SelectionValueSkeleton barClassName="h-2.5 w-14 rounded-full" className="h-3" tone="current" />
           </span>
         </>
       );

--- a/components/forms/__tests__/selection-loading.test.ts
+++ b/components/forms/__tests__/selection-loading.test.ts
@@ -13,6 +13,21 @@ describe("selection loading", () => {
     expect(html).toContain("motion-reduce:animate-none");
   });
 
+  it("centers the value placeholder on the surrounding text instead of its baseline", () => {
+    const html = renderToStaticMarkup(createElement(SelectionValueSkeleton));
+
+    expect(html).toContain("align-middle");
+  });
+
+  it("keeps the neutral tone by default and inherits the surface colour on request", () => {
+    expect(renderToStaticMarkup(createElement(SelectionValueSkeleton))).toContain("bg-placeholder");
+
+    const toned = renderToStaticMarkup(createElement(SelectionValueSkeleton, { tone: "current" }));
+
+    expect(toned).toContain("bg-current/40");
+    expect(toned).not.toContain("bg-placeholder");
+  });
+
   it("renders option-shaped rows under one accessible status", () => {
     const html = renderToStaticMarkup(createElement(SelectionOptionsSkeleton, { label: "Loading options" }));
 

--- a/components/forms/selection-loading.tsx
+++ b/components/forms/selection-loading.tsx
@@ -1,10 +1,24 @@
+import type { SkeletonTone } from "@/components/ui/skeleton";
+
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/core/utils/cn";
 
-export function SelectionValueSkeleton({ className }: { className?: string }) {
+export function SelectionValueSkeleton({
+  barClassName,
+  className,
+  tone,
+}: {
+  barClassName?: string;
+  className?: string;
+  tone?: SkeletonTone;
+}) {
   return (
-    <span aria-hidden="true" className={cn("inline-flex h-5 items-center", className)} data-selection-loading="value">
-      <Skeleton className="h-3.5 w-20 rounded-sm" />
+    <span
+      aria-hidden="true"
+      className={cn("inline-flex h-5 items-center align-middle", className)}
+      data-selection-loading="value"
+    >
+      <Skeleton className={cn("h-3.5 w-20 rounded-sm", barClassName)} tone={tone} />
     </span>
   );
 }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,14 +1,23 @@
 import { cn } from "@/core/utils/cn";
 
-type Props = React.ComponentProps<"div"> & {
-  animated?: boolean;
+export type SkeletonTone = "placeholder" | "current";
+
+const TONE_CLASS: Record<SkeletonTone, string> = {
+  placeholder: "bg-placeholder",
+  current: "bg-current/40",
 };
 
-function Skeleton({ animated = true, className, ...props }: Props) {
+type Props = React.ComponentProps<"div"> & {
+  animated?: boolean;
+  tone?: SkeletonTone;
+};
+
+function Skeleton({ animated = true, className, tone = "placeholder", ...props }: Props) {
   return (
     <div
-      className={cn("rounded-md bg-placeholder", animated && "animate-pulse motion-reduce:animate-none", className)}
+      className={cn("rounded-md", TONE_CLASS[tone], animated && "animate-pulse motion-reduce:animate-none", className)}
       data-slot="skeleton"
+      data-tone={tone}
       {...props}
     />
   );

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -2,11 +2,6 @@ import { cn } from "@/core/utils/cn";
 
 export type SkeletonTone = "placeholder" | "current";
 
-const TONE_CLASS: Record<SkeletonTone, string> = {
-  placeholder: "bg-placeholder",
-  current: "bg-current/40",
-};
-
 type Props = React.ComponentProps<"div"> & {
   animated?: boolean;
   tone?: SkeletonTone;
@@ -15,7 +10,12 @@ type Props = React.ComponentProps<"div"> & {
 function Skeleton({ animated = true, className, tone = "placeholder", ...props }: Props) {
   return (
     <div
-      className={cn("rounded-md", TONE_CLASS[tone], animated && "animate-pulse motion-reduce:animate-none", className)}
+      className={cn(
+        "rounded-md",
+        tone === "current" ? "bg-current/40" : "bg-placeholder",
+        animated && "animate-pulse motion-reduce:animate-none",
+        className,
+      )}
       data-slot="skeleton"
       data-tone={tone}
       {...props}


### PR DESCRIPTION
## Summary

Reworks the loading placeholder shown inside an active filter chip while entity-id values are resolved to labels. The bar now takes the chip's own colour instead of the neutral placeholder gray, and it is optically centered on the text it stands in for.

- `components/ui/skeleton.tsx`: new `tone` prop, `"placeholder"` (default, unchanged) or `"current"` which paints `bg-current/40`.
- `components/forms/selection-loading.tsx`: `SelectionValueSkeleton` gains `align-middle` and a `barClassName` passthrough so a caller can size the bar rather than only the wrapper.
- `components/data-view/filter-modal/filter-chip-display.tsx`: the pending value renders as a chip-toned pill (`h-2.5 w-14 rounded-full`) sized like the 11px label it replaces.

## Context

On the entity overviews, a filter such as contacts where organization is in (Bayer, BMW) stores entity ids. After a reload those ids have to be resolved to labels, and the chip shows a placeholder meanwhile. Two things were wrong with it.

The chip is `variant="default"`, i.e. `bg-primary/20 text-primary`, but the bar used the neutral `bg-placeholder` token (`#e6e6ea` light, `#222228` dark), so a light-gray block sat inside a primary-tinted chip and read as a foreign element.

`SelectionValueSkeleton` renders an `inline-flex` wrapper around a block-level `Skeleton` div, nested inside two plain inline `span`s. Inline-level boxes sit on the text baseline, so the bar's bottom edge landed on the baseline and the bar hung above the chip's optical center; the badge's own `items-center` never reached it because the intermediate spans are inline text boxes. Measured in the running app: chip center 83.0px against bar center 81.4px, and the 16px inline box also inflated the line box from 13px to 19.2px, so the chip content shifted when the labels arrived.

Deriving the tone from `currentColor` rather than hardcoding primary keeps it correct for every chip variant and for both themes. The three neutral call sites (`form-select`, `form-autocomplete`, `filter-input-select`) pass no `tone` and are visually unchanged.

## Validation

- Verified in a local instance against seeded data, on `/en/contacts` filtered to two organizations, in both light and dark themes, with the resolution deliberately throttled so the placeholder could be inspected.
- Measured after the change: bar center 83.6px against chip center 83.0px, and the label span is 15.7px tall in both the loading and the resolved state, so there is no vertical reflow when the labels arrive.
- New tests: tone default vs `current`, and `align-middle`, in `components/forms/__tests__/selection-loading.test.ts`; the chip loading branch in `components/data-view/filter-modal/__tests__/filter-chip-display.test.ts`.
- `yarn typecheck`, `yarn lint --max-warnings=0`, and `yarn vitest run` over the two suites plus `tests/conventions/technical-id-loading-contract.test.ts` all pass.

## Impact and rollback

Presentation only, scoped to a transient loading state. No schema, API, or data-flow change, and no behavioural change once the labels resolve. `Skeleton`'s new prop is additive with the previous appearance as its default, so every other skeleton in the app is untouched. Rollback is a straight revert of the commit.

Closes CUS-238
