### PR TITLE
fix(company): make the signed-in user's own member modal fully read-only

### DIFF
--- a/app/[locale]/(protected)/company/components/user/__tests__/user-modal.store.test.ts
+++ b/app/[locale]/(protected)/company/components/user/__tests__/user-modal.store.test.ts
@@ -1,0 +1,150 @@
+import type { RootStore } from "@/core/stores/root.store";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { autorun } from "mobx";
+import { CountryCode, Status } from "@/generated/prisma";
+
+import { UserModalStore } from "../user-modal.store";
+
+const actions = vi.hoisted(() => ({
+  getUserByIdAction: vi.fn(),
+  getRolesAction: vi.fn(),
+  adminUpdateUserDetailsAction: vi.fn(),
+}));
+
+vi.mock("../../../actions", () => actions);
+
+const SIGNED_IN_USER_ID = "30000000-0000-4000-8000-000000000001";
+const OTHER_USER_ID = "30000000-0000-4000-8000-000000000002";
+
+const userRecord = (id: string) => ({
+  id,
+  email: id === SIGNED_IN_USER_ID ? "max@example.com" : "colleague@example.com",
+  firstName: "Test",
+  lastName: "User",
+  roleId: "40000000-0000-4000-8000-000000000001",
+  status: Status.active,
+  country: CountryCode.de,
+  avatarUrl: null,
+});
+
+const makeRootStore = ({ signedInUserId, canManage }: { signedInUserId: string | null; canManage: boolean }) =>
+  ({
+    registerModalStore: vi.fn(),
+    userStore: {
+      user: signedInUserId ? userRecord(signedInUserId) : null,
+      canManage: () => canManage,
+    },
+    rolesStore: { setItems: vi.fn() },
+    usersStore: { customColumns: [], refresh: vi.fn() },
+  }) as unknown as RootStore;
+
+const loadUserInto = async (store: UserModalStore, id: string) => {
+  actions.getUserByIdAction.mockResolvedValue({ user: userRecord(id) });
+  actions.getRolesAction.mockResolvedValue([]);
+  await store.loadById(id);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("UserModalStore own-profile read-only contract", () => {
+  it("treats the signed-in user's own record as read-only", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    await loadUserInto(store, SIGNED_IN_USER_ID);
+
+    expect(store.isOwnProfile).toBe(true);
+    expect(store.isReadOnly).toBe(true);
+    expect(store.isDisabled).toBe(true);
+  });
+
+  it("leaves another user's record editable for a manager", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    await loadUserInto(store, OTHER_USER_ID);
+
+    expect(store.isOwnProfile).toBe(false);
+    expect(store.isReadOnly).toBe(false);
+    expect(store.isDisabled).toBe(false);
+  });
+
+  it("keeps the permission-driven read-only state for a user without manage rights", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: false }));
+
+    await loadUserInto(store, OTHER_USER_ID);
+
+    expect(store.isOwnProfile).toBe(false);
+    expect(store.isReadOnly).toBe(true);
+  });
+
+  it("does not treat a never-loaded modal as the signed-in user's own record", () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    expect(store.loadedUserId).toBeNull();
+    expect(store.isOwnProfile).toBe(false);
+    expect(store.isReadOnly).toBe(false);
+  });
+
+  it("does not treat any record as own profile while no user is signed in", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: null, canManage: true }));
+
+    await loadUserInto(store, SIGNED_IN_USER_ID);
+
+    expect(store.isOwnProfile).toBe(false);
+  });
+
+  it("identifies the record by user id rather than by the email in the form", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    await loadUserInto(store, SIGNED_IN_USER_ID);
+    store.onChange("email", "someone.else@example.com");
+
+    expect(store.isOwnProfile).toBe(true);
+    expect(store.isReadOnly).toBe(true);
+  });
+
+  it("clears the previously loaded record before resolving the next one", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    await loadUserInto(store, SIGNED_IN_USER_ID);
+    actions.getUserByIdAction.mockResolvedValue({ user: null });
+    await store.loadById(OTHER_USER_ID);
+
+    expect(store.loadedUserId).toBeNull();
+    expect(store.isOwnProfile).toBe(false);
+  });
+
+  it("re-evaluates the read-only state when the modal switches to another record", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+    const observed: boolean[] = [];
+    const stop = autorun(() => observed.push(store.isReadOnly));
+
+    await loadUserInto(store, SIGNED_IN_USER_ID);
+    await loadUserInto(store, OTHER_USER_ID);
+    stop();
+
+    expect(observed).toContain(true);
+    expect(observed.at(-1)).toBe(false);
+  });
+
+  it("never invokes the admin update action for the signed-in user's own record", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    await loadUserInto(store, SIGNED_IN_USER_ID);
+    await store.onSubmit();
+
+    expect(actions.adminUpdateUserDetailsAction).not.toHaveBeenCalled();
+  });
+
+  it("still submits another user's record", async () => {
+    const store = new UserModalStore(makeRootStore({ signedInUserId: SIGNED_IN_USER_ID, canManage: true }));
+
+    await loadUserInto(store, OTHER_USER_ID);
+    actions.adminUpdateUserDetailsAction.mockResolvedValue({ ok: true, data: userRecord(OTHER_USER_ID) });
+    await store.onSubmit();
+
+    expect(actions.adminUpdateUserDetailsAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/[locale]/(protected)/company/components/user/user-modal.store.ts
+++ b/app/[locale]/(protected)/company/components/user/user-modal.store.ts
@@ -2,7 +2,7 @@ import type { FormEvent } from "react";
 import type { AdminUpdateUserDetailsData } from "@/features/user/upsert/admin-update-user-details.interactor";
 import type { RootStore } from "@/core/stores/root.store";
 
-import { action, computed, makeObservable, toJS } from "mobx";
+import { action, computed, makeObservable, observable, toJS } from "mobx";
 import { CountryCode, Resource, Status } from "@/generated/prisma";
 
 import { adminUpdateUserDetailsAction, getRolesAction, getUserByIdAction } from "../../actions";
@@ -10,6 +10,8 @@ import { adminUpdateUserDetailsAction, getRolesAction, getUserByIdAction } from 
 import { BaseModalStore } from "@/core/base/base-modal.store";
 
 export class UserModalStore extends BaseModalStore<AdminUpdateUserDetailsData> {
+  public loadedUserId: string | null = null;
+
   constructor(rootStore: RootStore) {
     super(
       rootStore,
@@ -28,9 +30,10 @@ export class UserModalStore extends BaseModalStore<AdminUpdateUserDetailsData> {
     makeObservable(this, {
       onSubmit: action,
       loadById: action,
+      setLoadedUserId: action,
 
+      loadedUserId: observable,
       isOwnProfile: computed,
-      isDisabledOrOwnProfile: computed,
       customColumns: computed,
     });
   }
@@ -40,15 +43,22 @@ export class UserModalStore extends BaseModalStore<AdminUpdateUserDetailsData> {
   }
 
   get isOwnProfile() {
-    return this.form.email === this.rootStore.userStore.user?.email;
+    const signedInUserId = this.rootStore.userStore.user?.id;
+
+    return signedInUserId !== undefined && this.loadedUserId === signedInUserId;
   }
 
-  get isDisabledOrOwnProfile() {
-    return this.isOwnProfile || this.isDisabled;
+  get isReadOnly(): boolean {
+    return this.isOwnProfile || super.isReadOnly;
   }
+
+  setLoadedUserId = (loadedUserId: string | null) => {
+    this.loadedUserId = loadedUserId;
+  };
 
   loadById = async (id: string) => {
     this.setIsLoading(true);
+    this.setLoadedUserId(null);
 
     try {
       const [{ user }, roles] = await Promise.all([getUserByIdAction({ id }), getRolesAction()]);
@@ -58,6 +68,7 @@ export class UserModalStore extends BaseModalStore<AdminUpdateUserDetailsData> {
       if (!user) return;
 
       this.setError(undefined);
+      this.setLoadedUserId(user.id);
 
       this.openWith({
         email: user.email,
@@ -75,6 +86,8 @@ export class UserModalStore extends BaseModalStore<AdminUpdateUserDetailsData> {
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
+    if (this.isReadOnly) return;
+
     this.setIsLoading(true);
 
     try {

--- a/app/[locale]/(protected)/company/components/user/user-modal.tsx
+++ b/app/[locale]/(protected)/company/components/user/user-modal.tsx
@@ -25,7 +25,7 @@ import { roleDisplayName } from "@/features/role/role-display-name";
 export const CompanyUserModal = observer(() => {
   const t = useTranslations();
   const { userModalStore: store, rolesStore } = useRootStore();
-  const { form, savedState, isOwnProfile, isDisabledOrOwnProfile } = store;
+  const { form, savedState, isOwnProfile } = store;
 
   return (
     <AppModal store={store} title={t("CompanyUserModal.title")}>
@@ -50,7 +50,7 @@ export const CompanyUserModal = observer(() => {
               <FormInput required id="lastName" />
             </div>
 
-            <FormAutocompleteCountry required disabled={isDisabledOrOwnProfile} id="country" value={form.country} />
+            <FormAutocompleteCountry required id="country" value={form.country} />
 
             <FormSelect
               required
@@ -66,7 +66,6 @@ export const CompanyUserModal = observer(() => {
 
             <FormSelectChip
               required
-              disabled={isDisabledOrOwnProfile}
               disabledKeys={new Set([Status.pendingAuthorization])}
               id="status"
               items={USER_STATUS_OPTIONS}
@@ -88,12 +87,7 @@ export const CompanyUserModal = observer(() => {
             )}
           </AppCardBody>
 
-          <FormActions
-            showInitially
-            anchorScope="member-modal"
-            overrideDisabled={isDisabledOrOwnProfile}
-            store={store}
-          />
+          <FormActions showInitially anchorScope="member-modal" store={store} />
         </AppCard>
       </AppForm>
     </AppModal>

--- a/components/forms/form-select-chip.tsx
+++ b/components/forms/form-select-chip.tsx
@@ -69,7 +69,7 @@ export const FormSelectChip = observer(
           disabled={isDisabled}
           open={isReadOnly ? false : undefined}
           value={value}
-          onValueChange={(next) => store?.onChange(id, next)}
+          onValueChange={isReadOnly ? undefined : (next) => store?.onChange(id, next)}
         >
           <SelectTrigger
             aria-invalid={hasError}

--- a/components/forms/form-select.tsx
+++ b/components/forms/form-select.tsx
@@ -78,7 +78,9 @@ export const FormSelect = observer(
           disabled={isLoading}
           open={isReadOnly ? false : undefined}
           value={value}
-          onValueChange={(next) => (onValueChange ? onValueChange(next) : store?.onChange(id, next))}
+          onValueChange={
+            isReadOnly ? undefined : (next) => (onValueChange ? onValueChange(next) : store?.onChange(id, next))
+          }
         >
           <SelectTrigger
             aria-busy={optionsLoading || undefined}


### PR DESCRIPTION
Closes [CUS-219](https://linear.app/customermates/issue/CUS-219/make-the-current-users-assigned-user-modal-fully-read-only).

## Summary

Opening your own user record from an assigned-user avatar gave you a modal that was only half locked. Email, country and status were guarded and Save was disabled, but **first name, last name, role and avatar URL stayed fully interactive**. You could edit them, the form went dirty, a Reset button appeared beside a permanently disabled Save, and closing raised an unsaved-changes prompt for edits that had nowhere to go.

The own-profile state now lives in the store's read-only contract rather than being spread across call sites, so every control inherits it and a newly added field cannot silently miss the guard.

## Context

**Severity: this is a UI-consistency defect, not a security hole.** `AdminUpdateUserDetailsInteractor` already rejects a self-edit outright before any write:

```ts
if (targetUserId === getTenantUser().id) throw new Error("Cannot update own details.");
```

Nothing was ever persistable. The modal was offering edits the server would refuse.

Three things made this larger than adding four props:

- **`FormSelect` has no `disabled` prop**, and its `readOnly` only forces the Radix popover shut. Radix trigger typeahead still calls `onValueChange` on a focused, closed trigger, so a "read-only" select stayed keyboard-mutable. Both select primitives now detach the writer when read-only. No caller passes `readOnly` explicitly, so this only affects store-driven read-only forms.
- **`FormActions` gates only Save.** The reset button renders on `dirty` alone. Rather than add another override, making the fields genuinely unwritable means the form can never go dirty, so Reset never renders and the unsaved-changes prompt never fires. `overrideDisabled` became redundant and is gone.
- **The client compared emails while the server compares ids.** `isOwnProfile` now keys off the loaded user id, matching the server guard, and `onSubmit` refuses to run when the store is read-only.

One deliberate visual change: country and status previously rendered greyed out via `disabled` while the other fields rendered read-only. All seven now use one read-only affordance, which also keeps the controls focusable and `aria-readonly` rather than skipped by screen readers.

## Validation

`yarn typecheck`, `yarn lint:check`, `yarn conventions:check` (300 tests), `yarn test` (**307 files, 2578 tests, 51 skipped, 0 failing**), `yarn raw-docs:generate` and `yarn build` all green.

Note: `features/user/__tests__/registration-real-db.test.ts` reads `process.env.DATABASE_URL`, which vitest never sets, so it fails with `ECONNREFUSED` unless the var is exported. It is not gated behind `RUN_DATABASE_TESTS` like `tests/helpers/database-test.ts` is. Green here with the var exported against a local container; unrelated to this change.

New `user-modal.store.test.ts` (10 tests) covers own profile, another user viewed by a manager, the existing permission-driven read-only state, the never-loaded modal, no signed-in user, id-not-email identification, stale-record clearing, submission refusal, and that `isReadOnly` stays reactive when the modal switches records.

Exercised on a local self-hosted instance with synthetic seed data, signed in as the seeded admin:

- **Own record:** `email`, `firstName`, `lastName`, `avatarUrl` all `readOnly`; `country`, `roleId`, `status` all `aria-readonly="true"`; Save disabled; no Reset; warning visible with a focusable link to `/en/profile/settings`.
- **Another user's record:** first name, last name and avatar URL editable, no warning, selects interactive.
- **Keyboard A/B on the exact hole:** the same `keydown` sequence on the role trigger, without ever opening the dropdown, changed Sofia Rossi's role from "Sales Manager" to "Customer Success" (Reset appeared, Save enabled), while the signed-in user's own role stayed "Admin" with no Reset and Save still disabled. Nothing was saved; the seeded role is unchanged.

## Impact and rollback

Four controls on one modal become non-editable for the signed-in user's own record only. A manager's ability to edit other users, and the existing permission-driven read-only behaviour, are both unchanged and covered by tests. The two select primitives stop emitting change events while read-only, which no caller relied on. No schema, migration, API or translation change. Revert the single commit to roll back.
