### PR TITLE
fix(data-view): align the sort-direction tooltip and accessible name

### DIFF
--- a/components/data-view/header/display-options.tsx
+++ b/components/data-view/header/display-options.tsx
@@ -110,6 +110,8 @@ export const DataViewDisplayOptions = observer(function DataViewDisplayOptions<E
 
   const currentSortField = store.sortDescriptor?.field ?? "";
   const currentSortDirection = store.sortDescriptor?.direction ?? "asc";
+  const currentSortDirectionLabel =
+    currentSortDirection === "asc" ? t("Common.sort.ascending") : t("Common.sort.descending");
   const currentGroupingId = store.groupingColumnId ?? "";
   const hasActiveOption = Boolean(currentSortField) || Boolean(currentGroupingId) || store.hiddenColumns.length > 0;
 
@@ -298,9 +300,7 @@ export const DataViewDisplayOptions = observer(function DataViewDisplayOptions<E
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
-                          aria-label={
-                            currentSortDirection === "asc" ? t("Common.sort.descending") : t("Common.sort.ascending")
-                          }
+                          aria-label={currentSortDirectionLabel}
                           className="h-8 shrink-0"
                           size="icon"
                           variant="secondary"
@@ -314,9 +314,7 @@ export const DataViewDisplayOptions = observer(function DataViewDisplayOptions<E
                         </Button>
                       </TooltipTrigger>
 
-                      <TooltipContent>
-                        {currentSortDirection === "asc" ? t("Common.sort.ascending") : t("Common.sort.descending")}
-                      </TooltipContent>
+                      <TooltipContent>{currentSortDirectionLabel}</TooltipContent>
                     </Tooltip>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

The sort-direction toggle in the data-view display options described its direction in opposite senses in `aria-label` and `TooltipContent`. Both now read from a single `currentSortDirectionLabel`, so they cannot drift apart again.

No visible copy changes. One file, four lines.

## Context

The two ternaries were exact mirror images of each other:

| `currentSortDirection` | `aria-label` | `TooltipContent` | icon | click sets |
|---|---|---|---|---|
| `asc` | "Descending" | "Ascending" | `ArrowUpAZ` | `desc` |
| `desc` | "Ascending" | "Descending" | `ArrowDownAZ` | `asc` |

The intent was legible in code: `aria-label` named the action, `TooltipContent` named the current state. It still fails in use, for two reasons.

Both resolve to a bare adjective with no verb and no state qualifier, so nothing lets a user tell which reading applies. More decisively, the tooltip is not a sighted-only channel. Radix wires `TooltipContent` as the trigger's `aria-describedby`, so a single screen-reader user on a single button received accessible name "Descending" and accessible description "Ascending" back to back. `components/ui/tooltip.tsx:21-23` only suppresses the focus-open when the element does not match `:focus-visible`, and keyboard focus does match, so the tooltip opened and delivered the contradiction on every tab stop. That also put the control in breach of WCAG 2.5.3 Label in Name (Level A), since the visible label shared no text with the accessible name.

Both channels now report the current state, which is the reading the icon already committed to. The visible tooltip text is byte-for-byte unchanged in both directions.

## Why this PR is not the tooltip unification it started as

This began as an audit of why some hover tooltips render themed and instant while others render as delayed OS boxes. There are four mechanisms in the tree: the Radix/shadcn `Tooltip`, the native `title` attribute at 13 sites, an SVG `<title>` in the horizontal bar chart, and the recharts tooltip. Converting the native ones to Radix turned out to be the wrong call almost everywhere, so this PR deliberately does none of it.

**10 of the 13 native sites are truncation reveal.** The `title` text is identical to visible text carrying `truncate min-w-0`, so the browser shows the tooltip only when the string is actually clipped. Radix has no equivalent. Converting means either a tooltip that fires on every hover including when nothing is truncated, which is worse than today, or a `ResizeObserver` per element to reimplement what the browser already does for free. Left alone: `deal-services-selection.tsx:132,157,165`, `attachment-row.tsx:53,76,86`, `message-attachment.tsx:32,47`, `widget-filter-chip.tsx:27`, `channel-icon-stack.tsx:36`.

**3 more `title` attributes are iframe accessible names**, not tooltips, and are required: `email-frame.tsx:90`, `browser-frame.tsx:97`, `youtube-embed.tsx:17`.

That leaves two, and neither is worth taking here:

- `sidebar.tsx:270` (`SidebarRail`) carries a `title` character-identical to its own `aria-label`, which looked like the one free conversion. It is **dead code**: `SidebarRail` is exported from `components/ui/sidebar.tsx` but never mounted anywhere in the app. Converting it would change nothing a user can see.
- `data-table.tsx:347` (column-resize handle) also has a `title` redundant with its `aria-label`, and it is the most frequently hovered native tooltip in the product. But every `TooltipProvider` in the tree resolves to `delayDuration={0}`, so converting it would replace the native ~1s delay with an instant tooltip covering the neighbouring column header every time a user approaches a divider to drag it. That needs a deliberate per-tooltip delay, and an unmerged local branch already has 246 lines of changes to that same file covering this affordance.

## Two findings worth separate follow-ups

- **`SidebarRail` is dead code.** Exported, never rendered. Either mount it or drop it.
- **`app-chip.tsx:77`'s local `TooltipProvider` must not be removed** in any future provider consolidation, even though it looks redundant against the one in `SidebarProvider`. `AppChip` renders on marketing and blog pages, which resolve to the provider-less `public` shell in `navigation-switch.tsx:124-135`, and Radix creates its provider context with no default value, so `Tooltip.Root` throws rather than degrading. Removing it would break anonymous traffic only, which is exactly the traffic not exercised while signed in. The clean fix is to give the public shell its own provider first.

No convention test was added. A rule banning native `title` would need a 13-entry allowlist, which documents the exceptions without preventing anything.

## Validation

Run in an isolated worktree off `origin/main` with its own dependencies, Postgres, migrations and seed.

- `yarn lint`: clean.
- `yarn typecheck`: clean.
- `yarn conventions:check`: 40 files, 300 passed, 1 skipped.
- `yarn test`: 2573 passed, 51 skipped. The only failing file is `features/user/__tests__/registration-real-db.test.ts`, which hardcodes Postgres on port 5432 and is unrelated to this change.
- Manual, against a live local instance at `/en/contacts`: opened display options with sort field "Name". Ascending state shows icon `arrow-up-az`, visible tooltip "Ascending", `aria-label` "Ascending", and the `aria-describedby` target resolves to a `role="tooltip"` node reading "Ascending". Clicking flips the list to descending order, the icon to `arrow-down-az`, and `aria-label` to "Descending". Name and description agree in both directions.

## Impact and rollback

Low. One file, no exported signature changes, no i18n keys added or removed, no visible copy changed, no data or migration risk. Rollback is `git revert` of the single commit.
