### PR TITLE
refactor(sidebar): drop the unmounted SidebarRail primitive

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -248,32 +248,6 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
   );
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
-  const t = useTranslations();
-  const { toggleSidebar } = useSidebar();
-
-  return (
-    <button
-      aria-label={t("Common.sidebar.toggle")}
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-sidebar-border sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      data-sidebar="rail"
-      data-slot="sidebar-rail"
-      tabIndex={-1}
-      title={t("Common.sidebar.toggle")}
-      onClick={toggleSidebar}
-      {...props}
-    />
-  );
-}
-
 function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   return (
     <main
@@ -661,7 +635,6 @@ export {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,
-  SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,


### PR DESCRIPTION
## Summary

Deletes `SidebarRail` and its barrel export from `components/ui/sidebar.tsx`. The component was never mounted anywhere in the app.

25 lines removed, one file, no behaviour change.

## Context

`SidebarRail` renders a full-height 16px strip at the sidebar's edge that toggles the sidebar on click. It was exported from the sidebar primitives barrel but never rendered: on `origin/main`, `grep -rn 'SidebarRail' --include='*.tsx' .` returned only the function definition and the export line. Nothing references the `sidebar-rail` data-slot in CSS or tests either.

It surfaced during an audit of native `title` attributes, because it was the only element in the repo carrying a native `title` character-identical to its own `aria-label` (both `t("Common.sidebar.toggle")`). That made it look like an easy consistency fix until the component turned out never to render, at which point converting its tooltip would have changed nothing a user could see.

The sidebar already has a working toggle: `SidebarTrigger` is mounted at `app/components/shell-header.tsx:17`. So the rail was not covering a missing affordance.

### What this PR does not do

`SidebarRail` is one of seven unused exports in this file. The others are `SidebarGroupAction`, `SidebarInput`, `SidebarMenuAction`, `SidebarMenuBadge`, `SidebarMenuSkeleton` and `SidebarSeparator`. Unused primitives are also normal elsewhere under `components/ui/`: `dropdown-menu.tsx` has 3 of 15 exports unused, `select.tsx` 5 of 10, `breadcrumb.tsx` 1 of 7.

This PR removes only `SidebarRail`, the one that came out of the tooltip audit. It is deliberately not a sweep of the other six or of `components/ui/` generally.

Worth flagging for whoever picks that up: `components/ui/` is a vendored shadcn surface (`components.json` is present and pinned to the shadcn schema), so each deletion is a divergence that a future `shadcn add sidebar` will reintroduce or conflict with. There is no dead-export tooling in the repo (no knip, ts-prune or equivalent) to keep this enforced, so a broader sweep would need that decision made first.

## Validation

Run in an isolated worktree off `origin/main` (`a0c776f3`) with its own dependencies.

- `grep -rn 'SidebarRail\|sidebar-rail'` across `.tsx`, `.ts` and `.css`: no remaining references.
- Confirmed `useTranslations`, `useSidebar` and `cn` are all still used elsewhere in the file, so no import is orphaned. `unused-imports/no-unused-imports` is a warning and `yarn lint` runs with `--max-warnings 0`, so an orphan would have failed the lint below.
- `yarn lint`: clean.
- `yarn typecheck`: clean.
- `yarn conventions:check`: 40 files, 300 passed, 1 skipped. This includes `overlay-contract.test.ts`, whose `FIXED_SURFACE_ALLOWLIST` lists `components/ui/sidebar.tsx` and whose stale-allowlist assertion would have failed if this deletion had removed the file's last raw fixed surface.
- `yarn test`: 2573 passed, 51 skipped. The only failing file is `features/user/__tests__/registration-real-db.test.ts`, which hardcodes Postgres on port 5432; it fails identically on unmodified `origin/main` in this environment.
- `yarn build`: succeeds.

## Impact and rollback

None at runtime. The component was unreachable, so no rendered output, styling, or behaviour changes. No i18n keys were removed: `Common.sidebar.toggle` is still used by `SidebarTrigger`.

The only externally visible effect is that `SidebarRail` is no longer importable from `@/components/ui/sidebar`. Nothing in the repo imports it today.

Rollback is `git revert` of the single commit, or re-adding the component from upstream shadcn.
