### PR TITLE
refactor(ui): render every hover tooltip through the shared primitive

### DIFF
--- a/app/[locale]/(protected)/contacts/components/channel-icon-stack.tsx
+++ b/app/[locale]/(protected)/contacts/components/channel-icon-stack.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 
 import { OverlappingStack } from "@/components/shared/overlapping-stack";
 import { StackDropdownItem } from "@/components/shared/stack-dropdown-item";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { channelLabelKey } from "@/ee/messaging/provider";
 import { getChannelIcon } from "@/ee/messaging/provider-icon";
 import { channelDisplayLabel } from "@/ee/messaging/thread-display";
@@ -31,12 +32,15 @@ export function ChannelIconStack({ identifiers, maxVisible = 3, className, onIte
       renderBadge={(provider) => {
         const Icon = getChannelIcon(provider);
         return (
-          <span
-            className="bg-foreground/10 dark:bg-foreground/15 flex size-6 items-center justify-center overflow-hidden rounded-full"
-            title={t(`Common.providers.${channelLabelKey(provider)}`)}
-          >
-            <Icon className="size-6" />
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="bg-foreground/10 dark:bg-foreground/15 flex size-6 items-center justify-center overflow-hidden rounded-full">
+                <Icon className="size-6" />
+              </span>
+            </TooltipTrigger>
+
+            <TooltipContent>{t(`Common.providers.${channelLabelKey(provider)}`)}</TooltipContent>
+          </Tooltip>
         );
       }}
       renderOverflow={(count) => (

--- a/app/[locale]/(protected)/dashboard/components/widget-filter-chip.tsx
+++ b/app/[locale]/(protected)/dashboard/components/widget-filter-chip.tsx
@@ -24,7 +24,6 @@ export function WidgetFilterChip({ customColumns, filter, label, onOpen }: Props
       className="hover:bg-muted/50 hover:text-foreground cursor-pointer transition-[color,background-color,transform] active:scale-[0.97] motion-reduce:transition-none"
       role="button"
       tabIndex={0}
-      title={label}
       {...{ [WIDGET_INTERACTIVE_ATTRIBUTE]: "true" }}
       onClick={(event) => {
         event.stopPropagation();

--- a/app/[locale]/(protected)/deals/components/deal-services-selection.tsx
+++ b/app/[locale]/(protected)/deals/components/deal-services-selection.tsx
@@ -11,6 +11,7 @@ import { FormNumberInput } from "@/components/forms/form-number-input";
 import { FormAutocomplete } from "@/components/forms/form-autocomplete";
 import { FormAutocompleteItem } from "@/components/forms/form-autocomplete-item";
 import { Icon } from "@/components/shared/icon";
+import { TruncatedText } from "@/components/shared/truncated-text";
 import { useEntityHref } from "@/components/entity-detail/hooks/use-entity-drawer-stack";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { AppChip } from "@/components/chip/app-chip";
@@ -127,12 +128,9 @@ export const DealServicesSelection = observer(() => {
                 />
               </div>
 
-              <span
-                className="text-x-md text-right font-mono tabular-nums text-foreground/80 truncate min-w-0"
-                title={lineTotal > 0 ? intlStore.formatCurrency(lineTotal) : undefined}
-              >
+              <TruncatedText className="text-x-md text-right font-mono tabular-nums text-foreground/80">
                 {lineTotal > 0 ? intlStore.formatCurrency(lineTotal) : ""}
-              </span>
+              </TruncatedText>
 
               {canManage ? (
                 <Button size="icon" type="button" variant="destructiveOutline" onClick={() => deleteService(index)}>
@@ -152,20 +150,14 @@ export const DealServicesSelection = observer(() => {
                 {t("DealModal.totalLabel")}
               </span>
 
-              <span
-                className="text-x-md text-right font-mono tabular-nums font-medium pt-1 truncate min-w-0 px-3"
-                title={intlStore.formatNumber(totalQuantity)}
-              >
+              <TruncatedText className="text-x-md text-right font-mono tabular-nums font-medium pt-1 px-3">
                 {intlStore.formatNumber(totalQuantity)}
-              </span>
+              </TruncatedText>
             </div>
 
-            <span
-              className="text-x-md text-right font-mono tabular-nums font-medium truncate min-w-0 pt-1"
-              title={intlStore.formatCurrency(totalValue)}
-            >
+            <TruncatedText className="text-x-md text-right font-mono tabular-nums font-medium pt-1">
               {intlStore.formatCurrency(totalValue)}
-            </span>
+            </TruncatedText>
 
             <span />
           </>

--- a/app/[locale]/(protected)/inbox/components/attachment-row.tsx
+++ b/app/[locale]/(protected)/inbox/components/attachment-row.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import type { LucideIcon } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { useRef } from "react";
 import { Download, X } from "lucide-react";
 
 import { Icon } from "@/components/shared/icon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useIsTruncated } from "@/core/utils/use-is-truncated";
 import { cn } from "@/core/utils/cn";
 
 import { attachmentRowClass } from "./attachment-classify";
@@ -33,12 +38,17 @@ export function AttachmentRow({
   onRemove,
   removeLabel,
 }: Props) {
+  const nameRef = useRef<HTMLSpanElement | null>(null);
+  const isTruncated = useIsTruncated(nameRef, name);
+
   const body = (
     <>
       <Icon className={cn("size-5 shrink-0", accent)} icon={fileIcon} />
 
       <span className="flex min-w-0 flex-1 flex-col text-left">
-        <span className="truncate font-medium">{name}</span>
+        <span ref={nameRef} className="truncate font-medium">
+          {name}
+        </span>
 
         {subtitle ? <span className="text-muted-foreground truncate text-[11px]">{subtitle}</span> : null}
       </span>
@@ -47,12 +57,26 @@ export function AttachmentRow({
 
   const downloadIcon = <Icon className="text-muted-foreground size-4 shrink-0" icon={Download} />;
 
+  const withNameTooltip = (control: ReactElement) => {
+    if (!isTruncated) return control;
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{control}</TooltipTrigger>
+
+        <TooltipContent className="max-w-xs">{name}</TooltipContent>
+      </Tooltip>
+    );
+  };
+
   if (onRemove) {
     return (
       <div className={cn(attachmentRowClass(false), className)}>
-        <button className="flex min-w-0 flex-1 items-center gap-2.5" title={name} type="button" onClick={onOpen}>
-          {body}
-        </button>
+        {withNameTooltip(
+          <button className="flex min-w-0 flex-1 items-center gap-2.5" type="button" onClick={onOpen}>
+            {body}
+          </button>,
+        )}
 
         <button
           aria-label={removeLabel}
@@ -67,26 +91,20 @@ export function AttachmentRow({
   }
 
   if (href) {
-    return (
-      <a
-        className={cn(attachmentRowClass(true), className)}
-        download={download}
-        href={href}
-        rel="noreferrer"
-        title={name}
-      >
+    return withNameTooltip(
+      <a className={cn(attachmentRowClass(true), className)} download={download} href={href} rel="noreferrer">
         {body}
 
         {downloadIcon}
-      </a>
+      </a>,
     );
   }
 
-  return (
-    <button className={cn(attachmentRowClass(true), className)} title={name} type="button" onClick={onOpen}>
+  return withNameTooltip(
+    <button className={cn(attachmentRowClass(true), className)} type="button" onClick={onOpen}>
       {body}
 
       {downloadIcon}
-    </button>
+    </button>,
   );
 }

--- a/app/[locale]/(protected)/inbox/components/message-attachment.tsx
+++ b/app/[locale]/(protected)/inbox/components/message-attachment.tsx
@@ -3,6 +3,7 @@
 import { Ban, ExternalLink } from "lucide-react";
 
 import { Icon } from "@/components/shared/icon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import {
   type AttachmentMeta,
@@ -29,7 +30,7 @@ export function MessageAttachment({ messageId, att, t }: Props) {
 
   if (att.unavailable) {
     return (
-      <span className={attachmentRowClass(false, "opacity-70")} title={t("Inbox.attachmentUnavailable")}>
+      <span className={attachmentRowClass(false, "opacity-70")}>
         <Icon className="text-muted-foreground size-5 shrink-0" icon={Ban} />
 
         <span className="truncate">{t("Inbox.attachmentUnavailable")}</span>
@@ -39,13 +40,7 @@ export function MessageAttachment({ messageId, att, t }: Props) {
 
   if (kind === "post" && att.linkUrl) {
     return (
-      <a
-        className={attachmentRowClass(true)}
-        href={att.linkUrl}
-        rel="noreferrer noopener"
-        target="_blank"
-        title={t("Inbox.attachmentLinkedinPost")}
-      >
+      <a className={attachmentRowClass(true)} href={att.linkUrl} rel="noreferrer noopener" target="_blank">
         <Icon className="text-muted-foreground size-5 shrink-0" icon={ExternalLink} />
 
         <span className="truncate">{t("Inbox.attachmentLinkedinPost")}</span>
@@ -55,11 +50,17 @@ export function MessageAttachment({ messageId, att, t }: Props) {
 
   if (kind === "unsupported") {
     return (
-      <span className={attachmentRowClass(false, "opacity-80")} title={t("Inbox.attachmentUnsupported")}>
-        <Icon className="text-muted-foreground size-5 shrink-0" icon={Ban} />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={attachmentRowClass(false, "opacity-80")}>
+            <Icon className="text-muted-foreground size-5 shrink-0" icon={Ban} />
 
-        <span className="truncate">{t("Inbox.attachmentUnknown")}</span>
-      </span>
+            <span className="truncate">{t("Inbox.attachmentUnknown")}</span>
+          </span>
+        </TooltipTrigger>
+
+        <TooltipContent className="max-w-xs">{t("Inbox.attachmentUnsupported")}</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/app/[locale]/(protected)/inbox/components/message-item.tsx
+++ b/app/[locale]/(protected)/inbox/components/message-item.tsx
@@ -11,6 +11,7 @@ import { ImageOff, Pencil, Send, Trash2 } from "lucide-react";
 import { AppChip } from "@/components/chip/app-chip";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isEmailProvider } from "@/ee/messaging/provider";
 import { isPlainTextEmailBody, splitQuotedText } from "@/ee/messaging/email-quote";
 import { deriveMessageSender, displayableIdentifier, isUnipileUnsupportedBody } from "@/ee/messaging/thread-display";
@@ -256,14 +257,21 @@ export const MessageItem = observer(({ message, accountOwner, senderAvatarUrl, i
           {pendingFiles.length > 0 && (
             <div className="flex flex-col gap-1.5 p-1.5">
               {pendingFiles.map((file, fileIndex) => {
-                const { Icon: FileTypeIcon, accent } = describeFile({ mime: file.type, fileName: file.name });
+                const { Icon: FileTypeIcon, accent } = describeFile({
+                  mime: file.type,
+                  fileName: file.name,
+                });
                 return (
                   <AttachmentRow
                     key={`${file.name}-${fileIndex}`}
                     accent={accent}
                     fileIcon={FileTypeIcon}
                     name={file.name}
-                    subtitle={attachmentSubtitle(t, { mime: file.type, fileName: file.name, size: file.size })}
+                    subtitle={attachmentSubtitle(t, {
+                      mime: file.type,
+                      fileName: file.name,
+                      size: file.size,
+                    })}
                     onOpen={() => downloadLocalFile(file)}
                   />
                 );
@@ -275,27 +283,37 @@ export const MessageItem = observer(({ message, accountOwner, senderAvatarUrl, i
             <div className="flex flex-wrap items-center gap-2 px-3 py-1.5">
               {isDraft ? (
                 <span className="flex items-center gap-1">
-                  <Button
-                    aria-label={t("Inbox.compose.draftEdit")}
-                    size="icon-xs"
-                    title={t("Inbox.compose.draftEdit")}
-                    type="button"
-                    variant="secondary"
-                    onClick={() => compose.loadDraft(message)}
-                  >
-                    <Pencil />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        aria-label={t("Inbox.compose.draftEdit")}
+                        size="icon-xs"
+                        type="button"
+                        variant="secondary"
+                        onClick={() => compose.loadDraft(message)}
+                      >
+                        <Pencil />
+                      </Button>
+                    </TooltipTrigger>
 
-                  <Button
-                    aria-label={t("Inbox.compose.draftDiscard")}
-                    size="icon-xs"
-                    title={t("Inbox.compose.draftDiscard")}
-                    type="button"
-                    variant="softDestructive"
-                    onClick={() => void compose.discardDraft(message.id)}
-                  >
-                    <Trash2 />
-                  </Button>
+                    <TooltipContent>{t("Inbox.compose.draftEdit")}</TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        aria-label={t("Inbox.compose.draftDiscard")}
+                        size="icon-xs"
+                        type="button"
+                        variant="softDestructive"
+                        onClick={() => void compose.discardDraft(message.id)}
+                      >
+                        <Trash2 />
+                      </Button>
+                    </TooltipTrigger>
+
+                    <TooltipContent>{t("Inbox.compose.draftDiscard")}</TooltipContent>
+                  </Tooltip>
 
                   <Button
                     size="xs"

--- a/app/[locale]/(protected)/inbox/components/thread-settings.tsx
+++ b/app/[locale]/(protected)/inbox/components/thread-settings.tsx
@@ -82,7 +82,7 @@ export const ThreadSettings = observer(
               <Users className="size-3.5" />
             )
           }
-          title={t("Inbox.settings.tooltip")}
+          tooltip={t("Inbox.settings.tooltip")}
           variant="secondary"
           onClick={() => threadParticipantsStore.setOpen(true)}
         >

--- a/components/chip/app-chip.tsx
+++ b/components/chip/app-chip.tsx
@@ -2,11 +2,12 @@
 
 import type { ComponentProps, ReactNode } from "react";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useIsTruncated } from "@/core/utils/use-is-truncated";
 import { cn } from "@/core/utils/cn";
 
 const chipVariants = cva("", {
@@ -40,20 +41,7 @@ export function AppChip({
   ...props
 }: Props) {
   const labelRef = useRef<HTMLSpanElement | null>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useEffect(() => {
-    const el = labelRef.current;
-    if (!el) return;
-
-    const update = () => setIsTruncated(el.scrollWidth > el.clientWidth + 1);
-    update();
-
-    if (typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [children]);
+  const isTruncated = useIsTruncated(labelRef, children);
 
   const chip = (
     <Badge

--- a/components/chip/copyable-chip.tsx
+++ b/components/chip/copyable-chip.tsx
@@ -48,7 +48,7 @@ export function CopyableChip({ value, onClick, children, ...props }: Props) {
   return (
     <ClickableChip
       {...props}
-      title={t("Common.actions.copy")}
+      tooltip={t("Common.actions.copy")}
       onClick={handleClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/components/data-view/data-table.tsx
+++ b/components/data-view/data-table.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useNavigateToHref } from "@/components/entity-detail/hooks/use-entity-drawer-stack";
@@ -336,38 +337,43 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                   )}
 
                   {canResize && (
-                    <button
-                      aria-keyshortcuts="ArrowLeft ArrowRight Home Enter Space"
-                      aria-label={t("DataView.resizeColumn", {
-                        column: accessibleColumnLabel,
-                      })}
-                      className="group/resize-handle absolute inset-y-0 right-0 z-10 flex w-3 translate-x-1/2 cursor-col-resize touch-none select-none justify-center border-0 bg-transparent p-0 opacity-0 outline-none group-hover/resize-header:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-foreground/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background data-[state=resizing]:opacity-100 any-pointer-coarse:w-6 any-pointer-coarse:opacity-100"
-                      data-slot="column-resize-handle"
-                      data-state={isResizing ? "resizing" : undefined}
-                      title={t("DataView.resizeHint")}
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        if (event.detail === 0) resetColumnWidth(columnId);
-                      }}
-                      onDoubleClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        resetColumnWidth(columnId);
-                      }}
-                      onKeyDown={(event) => onResizeKeyDown(event, columnId)}
-                      onLostPointerCapture={cancelActiveResize}
-                      onPointerCancel={cancelActiveResize}
-                      onPointerDown={(event) => onResizePointerDown(event, columnId)}
-                      onPointerMove={onResizePointerMove}
-                      onPointerUp={onResizePointerUp}
-                    >
-                      <span
-                        aria-hidden="true"
-                        className="w-0.5 rounded-full bg-foreground/45 transition-colors group-hover/resize-handle:bg-foreground/70 group-focus-visible/resize-handle:bg-foreground/70 group-data-[state=resizing]/resize-handle:bg-foreground/70"
-                        data-slot="column-resize-indicator"
-                      />
-                    </button>
+                    <Tooltip delayDuration={500}>
+                      <TooltipTrigger asChild>
+                        <button
+                          aria-keyshortcuts="ArrowLeft ArrowRight Home Enter Space"
+                          aria-label={t("DataView.resizeColumn", {
+                            column: accessibleColumnLabel,
+                          })}
+                          className="group/resize-handle absolute inset-y-0 right-0 z-10 flex w-3 translate-x-1/2 cursor-col-resize touch-none select-none justify-center border-0 bg-transparent p-0 opacity-0 outline-none group-hover/resize-header:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-foreground/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background data-[state=resizing]:opacity-100 any-pointer-coarse:w-6 any-pointer-coarse:opacity-100"
+                          data-slot="column-resize-handle"
+                          data-state={isResizing ? "resizing" : undefined}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            if (event.detail === 0) resetColumnWidth(columnId);
+                          }}
+                          onDoubleClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            resetColumnWidth(columnId);
+                          }}
+                          onKeyDown={(event) => onResizeKeyDown(event, columnId)}
+                          onLostPointerCapture={cancelActiveResize}
+                          onPointerCancel={cancelActiveResize}
+                          onPointerDown={(event) => onResizePointerDown(event, columnId)}
+                          onPointerMove={onResizePointerMove}
+                          onPointerUp={onResizePointerUp}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="w-0.5 rounded-full bg-foreground/45 transition-colors group-hover/resize-handle:bg-foreground/70 group-focus-visible/resize-handle:bg-foreground/70 group-data-[state=resizing]/resize-handle:bg-foreground/70"
+                            data-slot="column-resize-indicator"
+                          />
+                        </button>
+                      </TooltipTrigger>
+
+                      <TooltipContent>{t("DataView.resizeHint")}</TooltipContent>
+                    </Tooltip>
                   )}
                 </TableHead>
               );

--- a/components/data-view/data-table.tsx
+++ b/components/data-view/data-table.tsx
@@ -297,7 +297,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                   }
                 >
                   {header.isPlaceholder ? null : (
-                    <div className="flex min-w-0 items-center gap-1 overflow-hidden">
+                    <div className="-ml-2 flex min-w-0 items-center gap-1 overflow-hidden pl-2">
                       {canSort ? (
                         <Button
                           className="-ml-2 h-8 min-w-0 shrink justify-start !px-2 font-medium uppercase tracking-wide text-muted-foreground"

--- a/components/data-view/header/display-options.tsx
+++ b/components/data-view/header/display-options.tsx
@@ -110,6 +110,8 @@ export const DataViewDisplayOptions = observer(function DataViewDisplayOptions<E
 
   const currentSortField = store.sortDescriptor?.field ?? "";
   const currentSortDirection = store.sortDescriptor?.direction ?? "asc";
+  const currentSortDirectionLabel =
+    currentSortDirection === "asc" ? t("Common.sort.ascending") : t("Common.sort.descending");
   const currentGroupingId = store.groupingColumnId ?? "";
   const hasActiveOption = Boolean(currentSortField) || Boolean(currentGroupingId) || store.hiddenColumns.length > 0;
 
@@ -298,9 +300,7 @@ export const DataViewDisplayOptions = observer(function DataViewDisplayOptions<E
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
-                          aria-label={
-                            currentSortDirection === "asc" ? t("Common.sort.descending") : t("Common.sort.ascending")
-                          }
+                          aria-label={currentSortDirectionLabel}
                           className="h-8 shrink-0"
                           size="icon"
                           variant="secondary"
@@ -314,9 +314,7 @@ export const DataViewDisplayOptions = observer(function DataViewDisplayOptions<E
                         </Button>
                       </TooltipTrigger>
 
-                      <TooltipContent>
-                        {currentSortDirection === "asc" ? t("Common.sort.ascending") : t("Common.sort.descending")}
-                      </TooltipContent>
+                      <TooltipContent>{currentSortDirectionLabel}</TooltipContent>
                     </Tooltip>
                   )}
                 </div>

--- a/components/shared/language-selector.tsx
+++ b/components/shared/language-selector.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { FormAutocompleteCountryItem } from "@/components/forms/form-autocomplete-country-item";
 import { FormAutocompleteItem } from "@/components/forms/form-autocomplete-item";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,17 +38,24 @@ export const LanguageSelector = observer(({ className }: Props) => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          aria-label={`${t("Common.language")}: ${currentLocaleLabel}`}
-          className={cn("size-8 rounded-md p-0 text-subdued", className)}
-          size="icon-sm"
-          title={currentLocaleLabel}
-          variant="ghost"
-        >
-          <span aria-hidden>{currentLocale.toUpperCase()}</span>
-        </Button>
-      </DropdownMenuTrigger>
+      <TooltipProvider>
+        <Tooltip>
+          <DropdownMenuTrigger asChild>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label={`${t("Common.language")}: ${currentLocaleLabel}`}
+                className={cn("size-8 rounded-md p-0 text-subdued", className)}
+                size="icon-sm"
+                variant="ghost"
+              >
+                <span aria-hidden>{currentLocale.toUpperCase()}</span>
+              </Button>
+            </TooltipTrigger>
+          </DropdownMenuTrigger>
+
+          <TooltipContent>{currentLocaleLabel}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
 
       <DropdownMenuContent align="start" className="min-w-40">
         {CONTENT_LOCALES.map((locale) => {

--- a/components/shared/theme-switcher.tsx
+++ b/components/shared/theme-switcher.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 
 import { Icon } from "@/components/shared/icon";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/core/utils/cn";
 import { Theme } from "@/generated/prisma";
 
@@ -46,17 +47,24 @@ export function ThemeSwitcher({ className, onThemeChange }: Props) {
   const selectedThemeLabel = selectedTheme === Theme.dark ? t("Common.themes.dark") : t("Common.themes.light");
 
   return (
-    <Button
-      aria-label={`${t("Common.ariaLabels.themeSwitcher")}: ${selectedThemeLabel}`}
-      aria-pressed={selectedTheme === Theme.dark}
-      className={cn("size-8 rounded-md p-0 text-subdued hover:text-foreground", className)}
-      data-theme={selectedTheme}
-      size="icon-sm"
-      title={selectedThemeLabel}
-      variant="ghost"
-      onClick={() => void handleThemeChange(nextTheme)}
-    >
-      <Icon aria-hidden icon={SelectedIcon} size="md" />
-    </Button>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            aria-label={`${t("Common.ariaLabels.themeSwitcher")}: ${selectedThemeLabel}`}
+            aria-pressed={selectedTheme === Theme.dark}
+            className={cn("size-8 rounded-md p-0 text-subdued hover:text-foreground", className)}
+            data-theme={selectedTheme}
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => void handleThemeChange(nextTheme)}
+          >
+            <Icon aria-hidden icon={SelectedIcon} size="md" />
+          </Button>
+        </TooltipTrigger>
+
+        <TooltipContent>{selectedThemeLabel}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/components/shared/truncated-text.tsx
+++ b/components/shared/truncated-text.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRef } from "react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useIsTruncated } from "@/core/utils/use-is-truncated";
+import { cn } from "@/core/utils/cn";
+
+type Props = {
+  children: string;
+  className?: string;
+};
+
+export function TruncatedText({ children, className }: Props) {
+  const textRef = useRef<HTMLSpanElement | null>(null);
+  const isTruncated = useIsTruncated(textRef, children);
+
+  const content = (
+    <span className={cn("flex min-w-0", className)}>
+      <span ref={textRef} className="truncate min-w-0">
+        {children}
+      </span>
+    </span>
+  );
+
+  if (!isTruncated) return content;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+
+      <TooltipContent className="max-w-xs">{children}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -39,7 +39,6 @@ function Avatar({
       )}
       data-size={size}
       data-slot="avatar"
-      title={title}
       {...props}
     >
       {children ?? (
@@ -52,14 +51,16 @@ function Avatar({
     </AvatarPrimitive.Root>
   );
 
-  if (!unlinked || !unlinkedLabel) return root;
+  const tooltipLabel = unlinked && unlinkedLabel ? unlinkedLabel : title;
+
+  if (!tooltipLabel) return root;
 
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{root}</TooltipTrigger>
 
-        <TooltipContent>{unlinkedLabel}</TooltipContent>
+        <TooltipContent className="whitespace-pre-line">{tooltipLabel}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -248,32 +248,6 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
   );
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
-  const t = useTranslations();
-  const { toggleSidebar } = useSidebar();
-
-  return (
-    <button
-      aria-label={t("Common.sidebar.toggle")}
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-sidebar-border sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      data-sidebar="rail"
-      data-slot="sidebar-rail"
-      tabIndex={-1}
-      title={t("Common.sidebar.toggle")}
-      onClick={toggleSidebar}
-      {...props}
-    />
-  );
-}
-
 function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   return (
     <main
@@ -661,7 +635,6 @@ export {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,
-  SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,

--- a/core/utils/use-is-truncated.ts
+++ b/core/utils/use-is-truncated.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import type { RefObject } from "react";
+
+import { useEffect, useState } from "react";
+
+export function useIsTruncated(ref: RefObject<HTMLElement | null>, dependency?: unknown) {
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const update = () => setIsTruncated(el.scrollWidth > el.clientWidth + 1);
+    update();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref, dependency]);
+
+  return isTruncated;
+}

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -887,7 +887,7 @@
     "editColumn": "Spalte bearbeiten",
     "noValue": "Kein Wert",
     "resizeColumn": "Größe der Spalte „{column}“ ändern. Ziehe oder verwende die Pfeiltasten; doppeltippe oder drücke zum Zurücksetzen die Eingabetaste.",
-    "resizeHint": "Zum Ändern der Größe ziehen. Zum Zurücksetzen doppelklicken, doppeltippen oder die Eingabetaste drücken.",
+    "resizeHint": "Zum Ändern der Größe ziehen. Zum Zurücksetzen doppelklicken.",
     "selectAllRows": "Alle Zeilen auswählen",
     "selectGroupingColumn": "Wähle eine Gruppierungsspalte aus, um die Kanban-Ansicht anzuzeigen.",
     "selectRow": "Zeile {id} auswählen"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -887,7 +887,7 @@
     "editColumn": "Edit column",
     "noValue": "No value",
     "resizeColumn": "Resize {column} column. Drag or use arrow keys to resize; double-tap or press Enter to reset.",
-    "resizeHint": "Drag to resize. Double-click, double-tap, or press Enter to reset.",
+    "resizeHint": "Drag to resize. Double-click to reset.",
     "selectAllRows": "Select all rows",
     "selectGroupingColumn": "Select a grouping column to see the Kanban view.",
     "selectRow": "Select row {id}"

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -887,7 +887,7 @@
     "editColumn": "Editar columna",
     "noValue": "Sin valor",
     "resizeColumn": "Redimensiona la columna {column}. Arrastra o usa las teclas de flecha; toca dos veces o pulsa Intro para restablecer.",
-    "resizeHint": "Arrastra para redimensionar. Haz doble clic, toca dos veces o pulsa Intro para restablecer.",
+    "resizeHint": "Arrastra para redimensionar. Haz doble clic para restablecer.",
     "selectAllRows": "Seleccionar todas las filas",
     "selectGroupingColumn": "Selecciona una columna de agrupación para ver la vista kanban.",
     "selectRow": "Seleccionar fila {id}"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -887,7 +887,7 @@
     "editColumn": "Modifier la colonne",
     "noValue": "Aucune valeur",
     "resizeColumn": "Redimensionnez la colonne « {column} ». Faites glisser ou utilisez les touches fléchées ; touchez deux fois ou appuyez sur Entrée pour réinitialiser.",
-    "resizeHint": "Faites glisser pour redimensionner. Double-cliquez, touchez deux fois ou appuyez sur Entrée pour réinitialiser.",
+    "resizeHint": "Faites glisser pour redimensionner. Double-cliquez pour réinitialiser.",
     "selectAllRows": "Sélectionner toutes les lignes",
     "selectGroupingColumn": "Sélectionnez une colonne de regroupement pour afficher la vue kanban.",
     "selectRow": "Sélectionner la ligne {id}"

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -887,7 +887,7 @@
     "editColumn": "Modifica colonna",
     "noValue": "Nessun valore",
     "resizeColumn": "Ridimensiona la colonna «{column}». Trascina o usa i tasti freccia; tocca due volte o premi Invio per ripristinare.",
-    "resizeHint": "Trascina per ridimensionare. Fai doppio clic, tocca due volte o premi Invio per ripristinare.",
+    "resizeHint": "Trascina per ridimensionare. Fai doppio clic per ripristinare.",
     "selectAllRows": "Seleziona tutte le righe",
     "selectGroupingColumn": "Seleziona una colonna di raggruppamento per visualizzare la vista kanban.",
     "selectRow": "Seleziona la riga {id}"


### PR DESCRIPTION
## Summary

Every hover tooltip in the app now renders through the shared shadcn primitive, so they all look the same. Native `title` attributes produced a second, OS-drawn tooltip: unthemed, delayed by about a second, no arrow, sitting directly beside instant themed ones.

Supersedes #78 and #79, whose commits are included here.

Three commits:

1. `fix(data-view)` sort-direction toggle: `aria-label` and `TooltipContent` described the direction in opposite senses.
2. `refactor(sidebar)` delete `SidebarRail`: exported but never mounted, and it carried a `title` identical to its own `aria-label`.
3. `refactor(ui)` the tooltip unification itself.

Measured on `/en/contacts` against a live local instance: **42 native-`title` elements before, 0 after**, with 34 channel icons and 8 resize grips now rendering the shared tooltip.

## Context

There were four hover-tooltip mechanisms: the shadcn/Radix `Tooltip`, the native `title` attribute, one SVG `<title>`, and the recharts chart tooltip. This removes the second one wherever it acted as a tooltip.

### Counting them was harder than it looks

A grep for `title=` on lowercase JSX tags **misses roughly a third of the real sites**. `title` passed to a capitalised component that spreads props onto the DOM is still a real HTML attribute: `AvatarPrimitive.Root` renders a `<span>`, `Button` spreads onto `<button>`, and `ClickableChip` reaches `<span>` through `AppChip` and `Badge`. That accounts for `avatar.tsx`, both `message-item.tsx` buttons, `language-selector.tsx`, `theme-switcher.tsx`, `copyable-chip.tsx` and `thread-settings.tsx`.

The full reconciliation: 136 raw `title=` hits = 16 native lowercase tags + 120 component props, of which 7 props reach the DOM. Anyone re-auditing this must recurse into prop expressions.

### Truncation reveal keeps its gate

Most native titles restated text that CSS had clipped, and the browser shows those only when the text actually overflows. Converting them ungated would fire a tooltip on every hover even when nothing is truncated, which is worse than what it replaces.

`AppChip` already solved this with a `ResizeObserver` comparing `scrollWidth` to `clientWidth`. That logic is lifted into `core/utils/use-is-truncated.ts` and reused, so `AppChip` loses its inline copy rather than gaining a second implementation.

Two measurement details that are easy to get wrong:

- **The observed node must be the element that truncates, not the trigger.** In `attachment-row.tsx` the trigger is a flex row whose `scrollWidth` never reports the overflow; the ref belongs on the inner label span. The three branches there are mutually exclusive returns, so measurement is lifted to component level and each branch wraps through one shared helper.
- **Padding must not sit on the measured box.** `deal-services-selection.tsx` had `px-3` and `pt-1` on the same span as the text. `TruncatedText` therefore uses a two-node shape like `AppChip`: the outer node takes the caller's classes, the inner node truncates and is measured.

### Three sites are deletions, not conversions

- `message-attachment.tsx` "Attachment unavailable" and "LinkedIn post": the `title` was byte-identical to visible text and both strings are short enough that the gate would essentially never be true.
- `widget-filter-chip.tsx`: the `title` was a strict subset of what `FilterChipValue` already renders, and the line clamp lives on an ancestor, so an overflow gate could not work there anyway.

### Two sites needed more than a wrap

- **Column resize grip** (`data-table.tsx`) takes an explicit `delayDuration={500}`. Every `TooltipProvider` in the tree runs at `0`, and an instant tooltip covering the neighbouring header every time the pointer nears a divider would obstruct the drag. Radix `Tooltip.Root` accepts `delayDuration` and it overrides the provider, so this needs no extra provider.
- **`theme-switcher.tsx` and `language-selector.tsx`** mount their own `TooltipProvider`, matching the existing `AppChip` pattern. Both render only from `PublicNavbar`, which is mounted only by the `shellMode === "public"` branch of `navigation-switch.tsx`, the one branch with no `SidebarProvider` and therefore no ambient provider. Radix creates its provider context with no default value, so `Tooltip.Root` throws rather than degrading: a bare `Tooltip` there would have broken the page **for logged-out visitors only**, which is exactly the traffic never exercised in a signed-in dev session. `language-selector` additionally nests `TooltipTrigger` inside `DropdownMenuTrigger`, both `asChild`.

### What stays native, on purpose

- **Three `iframe` titles** (`email-frame.tsx`, `browser-frame.tsx`, `youtube-embed.tsx`) are required frame accessible names under WCAG 4.1.2, not tooltips.
- **The one SVG `<title>`** in `horizontal-bar-chart-with-labels.tsx`. Its truncation is computed in JS by `truncateToWidth`, not by CSS, so the overflow gate does not apply, and it sits inside a recharts `LabelList` render prop where a portalled Radix tooltip would fight the `ResponsiveContainer` re-render loop.

Please do not let a later cleanup codemod strip these four.

### Accessible names were checked, not assumed

Wrapping an icon-only control in a tooltip silently drops its name if the `title` was the only label, because Radix renders its hidden `role="tooltip"` node only while open. Every converted site keeps a name: the channel icons are `next/image` elements whose `alt` already carries the provider name, and the inbox buttons, theme switcher and language selector all keep their existing `aria-label`. `message-item`'s buttons are wrapped rather than swapped to `IconButton`, which cannot express `variant="secondary"` or `variant="softDestructive"`.

## Validation

Run in an isolated worktree off `origin/main` with its own dependencies, Postgres, migrations and seed.

- `yarn lint`: clean.
- `yarn typecheck`: clean.
- `yarn test`: 2573 passed, 51 skipped. The only failing file is `features/user/__tests__/registration-real-db.test.ts`, which hardcodes Postgres on port 5432 and fails identically on unmodified `origin/main` in this environment.
- `yarn build`: succeeds.
- Live instance, `/en/contacts`: native-`title` elements went 42 to 0; 322 tooltip triggers present, 34 of them channel icons; hovering a column divider renders the themed tooltip rather than the OS one, confirmed visually.
- A hydration warning appears on this page, and it reproduces identically on unmodified `origin/main`, so it is pre-existing and not introduced here.

## Impact and rollback

Behavioural, and visible on hover across contacts, inbox, deals, dashboard and the public navbar. No data, schema or API surface is touched. No i18n keys were added or removed.

Worth knowing when reviewing:

- Tooltip timing changes from about a second to instant everywhere except the resize grip, which is deliberately delayed.
- `TooltipTrigger asChild` on a non-interactive `<span>` makes it keyboard focusable, which adds tab stops in the inbox attachment list. That is an accessibility improvement but it does change tab order.
- Tooltips now dismiss on pointer-down like the rest of the app's tooltips, rather than lingering as native ones did.

Rollback is `git revert` of the three commits, or of the final commit alone to keep the two fixes.
