### PR TITLE
fix(filters): give currency filter values one canonical string contract

### DIFF
--- a/components/data-view/filter-modal/inputs/__tests__/filter-input-number.test.ts
+++ b/components/data-view/filter-modal/inputs/__tests__/filter-input-number.test.ts
@@ -1,0 +1,200 @@
+import type { Root } from "react-dom/client";
+import type { ReactElement } from "react";
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FilterOperatorKey } from "@/core/base/base-query-builder";
+import { FilterSchema } from "@/core/base/base-get.schema";
+import {
+  formatLocalizedNumber,
+  parseLocalizedNumber,
+  parseLocalizedNumberToCanonical,
+} from "@/core/stores/intl-number";
+
+const harness = vi.hoisted(() => ({
+  form: null as { getValue: (id: string) => unknown; onChange: ReturnType<typeof vi.fn>; isDisabled: boolean } | null,
+  intl: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@/components/forms/form-context", () => ({ useAppForm: () => harness.form }));
+vi.mock("@/core/stores/root-store.provider", () => ({ useRootStore: () => ({ intlStore: harness.intl }) }));
+
+import { FilterInputNumber } from "../filter-input-number";
+
+const FIELD = "17000000-0000-4000-8000-000000000001";
+const INPUT_ID = "filters[0].value";
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+
+function makeIntl(locale: string) {
+  return {
+    formatNumber: (n: number | undefined) =>
+      formatLocalizedNumber(n, locale, {
+        style: "decimal",
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+        useGrouping: true,
+      }),
+    formatNumberForEditing: (n: number | undefined) =>
+      formatLocalizedNumber(n, locale, { maximumFractionDigits: 20, useGrouping: false }),
+    parseNumber: vi.fn((value: string) => parseLocalizedNumber(value, locale)),
+    parseNumberToCanonical: vi.fn((value: string) => parseLocalizedNumberToCanonical(value, locale)),
+  };
+}
+
+function mount(element: ReactElement) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+  act(() => root.render(element));
+
+  return container;
+}
+
+function renderInput(locale: string, stored: unknown) {
+  const intl = makeIntl(locale);
+  harness.intl = intl;
+  harness.form = { getValue: () => stored, onChange: vi.fn(), isDisabled: false };
+
+  const container = mount(createElement(FilterInputNumber, { id: INPUT_ID, isValidFilter: true }));
+  const input = container.querySelector("input");
+  if (!input) throw new Error("filter number input did not render");
+
+  return { input, intl, form: harness.form };
+}
+
+function type(input: HTMLInputElement, text: string) {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  act(() => {
+    setter?.call(input, text);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function blur(input: HTMLInputElement) {
+  act(() => {
+    input.dispatchEvent(new FocusEvent("blur"));
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+}
+
+function lastCommitted(form: { onChange: ReturnType<typeof vi.fn> }) {
+  const calls = form.onChange.mock.calls;
+  return calls.length ? calls[calls.length - 1][1] : undefined;
+}
+
+afterEach(() => {
+  act(() => roots.splice(0).forEach((root) => root.unmount()));
+  containers.splice(0).forEach((container) => container.remove());
+  vi.clearAllMocks();
+});
+
+describe("FilterInputNumber commits a canonical string", () => {
+  it.each([
+    ["en-US", "1,234.5"],
+    ["de-DE", "1.234,5"],
+    ["fr-FR", "1 234,5"],
+  ])("emits the same locale-independent string for %s entry", (locale, typed) => {
+    const { input, form } = renderInput(locale, undefined);
+
+    type(input, typed);
+
+    expect(lastCommitted(form)).toBe("1234.5");
+    expect(typeof lastCommitted(form)).toBe("string");
+  });
+
+  it("never commits a JavaScript number, which is what the filter schema rejects", () => {
+    const { input, form } = renderInput("en-US", undefined);
+
+    type(input, "10");
+    blur(input);
+
+    for (const [, committed] of form.onChange.mock.calls) expect(typeof committed).not.toBe("number");
+  });
+
+  it("uses the canonical parser rather than the numeric one", () => {
+    const { input, intl } = renderInput("en-US", undefined);
+
+    type(input, "42");
+    blur(input);
+
+    expect(intl.parseNumberToCanonical).toHaveBeenCalled();
+    expect(intl.parseNumber).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["0", "0"],
+    ["-50", "-50"],
+    ["0.25", "0.25"],
+    ["1234.5678", "1234.5678"],
+  ])("preserves sign and precision for %s", (typed, expected) => {
+    const { input, form } = renderInput("en-US", undefined);
+
+    type(input, typed);
+
+    expect(lastCommitted(form)).toBe(expected);
+  });
+
+  it("commits undefined when the field is cleared so the filter is dropped rather than queried", () => {
+    const { input, form } = renderInput("en-US", "10");
+
+    type(input, "");
+
+    expect(lastCommitted(form)).toBeUndefined();
+  });
+
+  it("commits a canonical string on blur as well as on change", () => {
+    const { input, form } = renderInput("en-US", undefined);
+
+    type(input, "1,234.5");
+    form.onChange.mockClear();
+    blur(input);
+
+    expect(lastCommitted(form)).toBe("1234.5");
+  });
+
+  it("renders a stored canonical string as a localized display value", () => {
+    const { input } = renderInput("de-DE", "1234.5");
+
+    expect(input.value).toBe("1.234,5");
+  });
+});
+
+describe("what the input commits is what the filter transport accepts", () => {
+  it.each([
+    [FilterOperatorKey.equals],
+    [FilterOperatorKey.gt],
+    [FilterOperatorKey.gte],
+    [FilterOperatorKey.lt],
+    [FilterOperatorKey.lte],
+  ])("round trips through FilterSchema unchanged for %s", (operator) => {
+    const { input, form } = renderInput("en-US", undefined);
+
+    type(input, "1,234.5");
+    const committed = lastCommitted(form);
+
+    expect(FilterSchema.parse({ field: FIELD, operator, value: committed })).toEqual({
+      field: FIELD,
+      operator,
+      value: "1234.5",
+    });
+  });
+
+  it("emits a string where the previous implementation emitted a number of the same value", () => {
+    const { input, form } = renderInput("en-US", undefined);
+
+    type(input, "1,234.5");
+    const committed = lastCommitted(form);
+    const previousImplementation = parseLocalizedNumber("1,234.5", "en-US");
+
+    expect(typeof previousImplementation).toBe("number");
+    expect(typeof committed).toBe("string");
+    expect(Number(committed)).toBe(previousImplementation);
+  });
+});

--- a/components/data-view/filter-modal/inputs/filter-input-number.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-number.tsx
@@ -6,6 +6,7 @@ import { observer } from "mobx-react-lite";
 import { useAppForm } from "@/components/forms/form-context";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/core/utils/cn";
+import { filterNumberValue } from "@/core/base/filter-value";
 import { useRootStore } from "@/core/stores/root-store.provider";
 
 type Props = {
@@ -18,7 +19,7 @@ export const FilterInputNumber = observer(({ id, isValidFilter }: Props) => {
   const { intlStore } = useRootStore();
   const fmt = useCallback((n: number | undefined) => intlStore.formatNumber(n), [intlStore]);
 
-  const storeNumber = store?.getValue(id) as number | undefined;
+  const storeNumber = filterNumberValue(store?.getValue(id));
   const [focused, setFocused] = useState(false);
   const [text, setText] = useState<string>(() => fmt(storeNumber));
 
@@ -36,14 +37,14 @@ export const FilterInputNumber = observer(({ id, isValidFilter }: Props) => {
       value={text}
       onBlur={() => {
         setFocused(false);
-        const parsed = intlStore.parseNumber(text);
-        setText(fmt(parsed));
-        store?.onChange(id, parsed);
+        const canonical = intlStore.parseNumberToCanonical(text);
+        setText(fmt(filterNumberValue(canonical)));
+        store?.onChange(id, canonical);
       }}
       onChange={(e) => {
         const next = e.target.value;
         setText(next);
-        store?.onChange(id, intlStore.parseNumber(next));
+        store?.onChange(id, intlStore.parseNumberToCanonical(next));
       }}
       onFocus={() => {
         setText(intlStore.formatNumberForEditing(storeNumber));

--- a/core/base/__tests__/currency-filter-contract.test.ts
+++ b/core/base/__tests__/currency-filter-contract.test.ts
@@ -5,13 +5,15 @@ import { describe, expect, it, vi } from "vitest";
 
 import { FilterSchema } from "@/core/base/base-get.schema";
 import { FilterOperatorKey, defaultValidateFilters } from "@/core/base/base-query-builder";
-import { canonicalFilterNumber, filterNumberValue, isCanonicalFilterNumber } from "@/core/base/filter-value";
+import { canonicalFilterNumber, filterNumberValue } from "@/core/base/filter-value";
 import { parseLocalizedNumberToCanonical } from "@/core/stores/intl-number";
 import { decodeGetParams, encodeGetParams } from "@/core/utils/get-params";
 import { validateCustomFieldCurrency } from "@/core/validation/validate-custom-field-currency";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 
 const CURRENCY_FIELD = "16000000-0000-4000-8000-0000000000c1";
+
+const PLAIN_DECIMAL = /^-?\d+(?:\.\d+)?$/u;
 
 const CURRENCY_VALUE_OPERATORS = [
   FilterOperatorKey.equals,
@@ -48,7 +50,8 @@ describe("canonical currency filter values", () => {
     expect(canonicalFilterNumber(1234.5)).toBe("1234.5");
     expect(canonicalFilterNumber(0)).toBe("0");
     expect(canonicalFilterNumber(-0)).toBe("0");
-    expect(isCanonicalFilterNumber(canonicalFilterNumber(1e21) ?? "")).toBe(true);
+    expect(canonicalFilterNumber(1e21)).toMatch(PLAIN_DECIMAL);
+    expect(canonicalFilterNumber(1e-7)).toMatch(PLAIN_DECIMAL);
     expect(canonicalFilterNumber(1e21)).not.toContain("e");
     expect(canonicalFilterNumber(Number.NaN)).toBeUndefined();
     expect(canonicalFilterNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
@@ -167,7 +170,14 @@ describe("validateCustomFieldCurrency", () => {
     expect(ctx.addIssue).not.toHaveBeenCalled();
   });
 
-  it.each(["1e+21", " ", "1,5", "1.234,5", "12abc"])("reports %s as an invalid currency value", (value) => {
+  it.each([".5", "5.", "+50", "1e-7"])("keeps accepting the record-write form %s", (value) => {
+    const ctx = createMockCtx();
+    validateCustomFieldCurrency(value, ctx, ["value"]);
+
+    expect(ctx.addIssue).not.toHaveBeenCalled();
+  });
+
+  it.each(["1,5", "1.234,5", "12abc"])("reports %s as an invalid currency value", (value) => {
     const ctx = createMockCtx();
     validateCustomFieldCurrency(value, ctx, ["value"]);
 

--- a/core/base/__tests__/currency-filter-contract.test.ts
+++ b/core/base/__tests__/currency-filter-contract.test.ts
@@ -1,0 +1,202 @@
+import type { Filter } from "@/core/base/base-get.schema";
+import type { z } from "zod";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { FilterSchema } from "@/core/base/base-get.schema";
+import { FilterOperatorKey, defaultValidateFilters } from "@/core/base/base-query-builder";
+import { canonicalFilterNumber, filterNumberValue, isCanonicalFilterNumber } from "@/core/base/filter-value";
+import { parseLocalizedNumberToCanonical } from "@/core/stores/intl-number";
+import { decodeGetParams, encodeGetParams } from "@/core/utils/get-params";
+import { validateCustomFieldCurrency } from "@/core/validation/validate-custom-field-currency";
+import { CustomErrorCode } from "@/core/validation/validation.types";
+
+const CURRENCY_FIELD = "16000000-0000-4000-8000-0000000000c1";
+
+const CURRENCY_VALUE_OPERATORS = [
+  FilterOperatorKey.equals,
+  FilterOperatorKey.gt,
+  FilterOperatorKey.gte,
+  FilterOperatorKey.lt,
+  FilterOperatorKey.lte,
+] as const;
+
+const CURRENCY_FILTERABLE_FIELD = {
+  field: CURRENCY_FIELD,
+  operators: [...CURRENCY_VALUE_OPERATORS, FilterOperatorKey.isNull, FilterOperatorKey.isNotNull],
+};
+
+function createMockCtx() {
+  return { addIssue: vi.fn() } as unknown as z.RefinementCtx & { addIssue: ReturnType<typeof vi.fn> };
+}
+
+describe("canonical currency filter values", () => {
+  it("gives the same canonical string for the same amount typed in different locales", () => {
+    expect(parseLocalizedNumberToCanonical("1,234.5", "en-US")).toBe("1234.5");
+    expect(parseLocalizedNumberToCanonical("1.234,5", "de-DE")).toBe("1234.5");
+    expect(parseLocalizedNumberToCanonical("1 234,5", "fr-FR")).toBe("1234.5");
+  });
+
+  it("normalizes trailing separators, plus signs and bare fractions to a plain decimal", () => {
+    expect(parseLocalizedNumberToCanonical("5.", "en-US")).toBe("5");
+    expect(parseLocalizedNumberToCanonical(".5", "en-US")).toBe("0.5");
+    expect(parseLocalizedNumberToCanonical("-1234.25", "en-US")).toBe("-1234.25");
+    expect(parseLocalizedNumberToCanonical("0", "en-US")).toBe("0");
+  });
+
+  it("emits only plain decimal strings, never exponent notation", () => {
+    expect(canonicalFilterNumber(1234.5)).toBe("1234.5");
+    expect(canonicalFilterNumber(0)).toBe("0");
+    expect(canonicalFilterNumber(-0)).toBe("0");
+    expect(isCanonicalFilterNumber(canonicalFilterNumber(1e21) ?? "")).toBe(true);
+    expect(canonicalFilterNumber(1e21)).not.toContain("e");
+    expect(canonicalFilterNumber(Number.NaN)).toBeUndefined();
+    expect(canonicalFilterNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("reads a stored canonical string back as the number the input displays", () => {
+    expect(filterNumberValue("1234.5")).toBe(1234.5);
+    expect(filterNumberValue("-0.25")).toBe(-0.25);
+    expect(filterNumberValue("")).toBeUndefined();
+    expect(filterNumberValue(undefined)).toBeUndefined();
+    expect(filterNumberValue("1,5")).toBeUndefined();
+  });
+});
+
+describe("FilterSchema currency values", () => {
+  it.each(CURRENCY_VALUE_OPERATORS)("accepts the number the currency input used to emit for %s", (operator) => {
+    expect(FilterSchema.parse({ field: CURRENCY_FIELD, operator, value: 1234.5 })).toEqual({
+      field: CURRENCY_FIELD,
+      operator,
+      value: "1234.5",
+    });
+  });
+
+  it.each(CURRENCY_VALUE_OPERATORS)("keeps accepting the canonical string form for %s", (operator) => {
+    expect(FilterSchema.parse({ field: CURRENCY_FIELD, operator, value: "1234.5" })).toEqual({
+      field: CURRENCY_FIELD,
+      operator,
+      value: "1234.5",
+    });
+  });
+
+  it.each([0, -50, 0.25, -0.25])("normalizes %s without losing sign or precision", (value) => {
+    const parsed = FilterSchema.parse({ field: CURRENCY_FIELD, operator: FilterOperatorKey.equals, value });
+
+    expect(parsed).toEqual({
+      field: CURRENCY_FIELD,
+      operator: FilterOperatorKey.equals,
+      value: String(value === 0 ? 0 : value),
+    });
+    expect(Number((parsed as { value: string }).value)).toBe(value);
+  });
+
+  it.each([FilterOperatorKey.isNull, FilterOperatorKey.isNotNull])("keeps %s value-less", (operator) => {
+    expect(FilterSchema.parse({ field: CURRENCY_FIELD, operator, value: undefined })).toEqual({
+      field: CURRENCY_FIELD,
+      operator,
+    });
+  });
+
+  it("leaves the relative window operator on its own numeric contract", () => {
+    expect(FilterSchema.parse({ field: "createdAt", operator: FilterOperatorKey.inLastDays, value: 30 })).toEqual({
+      field: "createdAt",
+      operator: FilterOperatorKey.inLastDays,
+      value: 30,
+    });
+  });
+
+  it("normalizes numbers inside membership and range values", () => {
+    expect(FilterSchema.parse({ field: CURRENCY_FIELD, operator: FilterOperatorKey.between, value: [1, 10] })).toEqual({
+      field: CURRENCY_FIELD,
+      operator: FilterOperatorKey.between,
+      value: ["1", "10"],
+    });
+  });
+
+  it("still rejects a value that is not a number at all", () => {
+    expect(FilterSchema.safeParse({ field: CURRENCY_FIELD, operator: FilterOperatorKey.gt, value: {} }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("currency filter URL round trip", () => {
+  it.each(CURRENCY_VALUE_OPERATORS)("restores %s to the value the session already holds", (operator) => {
+    const applied = FilterSchema.parse({ field: CURRENCY_FIELD, operator, value: 1234.5 });
+
+    const encoded = encodeGetParams({ filters: [applied] });
+    const restored = decodeGetParams(encoded).filters;
+
+    expect(encoded.getAll("filters")).toEqual([`${CURRENCY_FIELD}:${operator}:1234.5`]);
+    expect(restored).toEqual([applied]);
+  });
+
+  it("keeps an existing string-form URL usable", () => {
+    const legacy = new URLSearchParams();
+    legacy.append("filters", `${CURRENCY_FIELD}:gte:1234.5`);
+
+    const restored = decodeGetParams(legacy).filters ?? [];
+
+    expect(restored).toEqual([{ field: CURRENCY_FIELD, operator: FilterOperatorKey.gte, value: "1234.5" }]);
+    expect(FilterSchema.parse(restored[0])).toEqual(restored[0]);
+  });
+});
+
+describe("saved currency filter presets", () => {
+  const PresetFilters = FilterSchema.array();
+
+  it("accepts a preset holding a currency filter in either transport form", () => {
+    expect(
+      PresetFilters.parse([
+        { field: CURRENCY_FIELD, operator: FilterOperatorKey.gte, value: 1000 },
+        { field: CURRENCY_FIELD, operator: FilterOperatorKey.lt, value: "2000" },
+      ]),
+    ).toEqual([
+      { field: CURRENCY_FIELD, operator: FilterOperatorKey.gte, value: "1000" },
+      { field: CURRENCY_FIELD, operator: FilterOperatorKey.lt, value: "2000" },
+    ]);
+  });
+});
+
+describe("validateCustomFieldCurrency", () => {
+  it.each(["100.50", "0", "-50", "1234.5678"])("accepts the canonical form %s", (value) => {
+    const ctx = createMockCtx();
+    validateCustomFieldCurrency(value, ctx, ["value"]);
+
+    expect(ctx.addIssue).not.toHaveBeenCalled();
+  });
+
+  it.each(["1e+21", " ", "1,5", "1.234,5", "12abc"])("reports %s as an invalid currency value", (value) => {
+    const ctx = createMockCtx();
+    validateCustomFieldCurrency(value, ctx, ["value"]);
+
+    expect(ctx.addIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { error: CustomErrorCode.customFieldInvalidCurrency } }),
+    );
+  });
+});
+
+describe("defaultValidateFilters for currency fields", () => {
+  it.each(CURRENCY_VALUE_OPERATORS)("keeps a canonical %s filter and its string value", (operator) => {
+    const filters = [FilterSchema.parse({ field: CURRENCY_FIELD, operator, value: 10 })];
+
+    expect(defaultValidateFilters({ filters, filterableFields: [CURRENCY_FILTERABLE_FIELD] })).toEqual([
+      { field: CURRENCY_FIELD, operator, value: "10" },
+    ]);
+  });
+
+  it("canonicalizes a residual number before it reaches the query", () => {
+    const filters = [{ field: CURRENCY_FIELD, operator: FilterOperatorKey.gt, value: 10 }] as unknown as Filter[];
+
+    expect(defaultValidateFilters({ filters, filterableFields: [CURRENCY_FILTERABLE_FIELD] })).toEqual([
+      { field: CURRENCY_FIELD, operator: FilterOperatorKey.gt, value: "10" },
+    ]);
+  });
+
+  it("drops an empty currency value instead of querying for it", () => {
+    const filters = [{ field: CURRENCY_FIELD, operator: FilterOperatorKey.equals, value: "" }] as unknown as Filter[];
+
+    expect(defaultValidateFilters({ filters, filterableFields: [CURRENCY_FILTERABLE_FIELD] })).toEqual([]);
+  });
+});

--- a/core/base/base-get.schema.ts
+++ b/core/base/base-get.schema.ts
@@ -4,13 +4,13 @@ import { z } from "zod";
 import { Prisma } from "@/generated/prisma";
 
 import { FilterOperatorKey } from "./base-query-builder";
-import { normalizeLegacyRelationFilterInput } from "./filter-compat";
+import { normalizeFilterInput } from "./filter-compat";
 
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { CustomColumnDtoSchema } from "@/features/custom-column/custom-column.schema";
 
 export const FilterSchema = z.preprocess(
-  normalizeLegacyRelationFilterInput,
+  normalizeFilterInput,
   z.discriminatedUnion("operator", [
     z
       .object({

--- a/core/base/base-query-builder.ts
+++ b/core/base/base-query-builder.ts
@@ -12,7 +12,7 @@ import { CustomColumnType } from "@/generated/prisma";
 
 import { FilterFieldKey } from "@/core/types/filter-field-key";
 import { isCustomField } from "@/core/utils/custom-field";
-import { normalizeLegacyRelationFilter } from "@/core/base/filter-compat";
+import { normalizeFilter } from "@/core/base/filter-compat";
 
 export interface SortableField {
   field: string;
@@ -547,7 +547,7 @@ export function defaultValidateFilters(args: {
 
     if (!hasValidStructure) continue;
 
-    const filter = normalizeLegacyRelationFilter(candidate);
+    const filter = normalizeFilter(candidate);
     const fieldConfig = filterableFields.find((f) => f.field === filter.field);
     if (!fieldConfig || !fieldConfig.operators.includes(filter.operator)) continue;
 

--- a/core/base/filter-compat.ts
+++ b/core/base/filter-compat.ts
@@ -1,8 +1,10 @@
 import type { Filter } from "./base-get.schema";
 
+import { normalizeFilterNumberValueInput } from "./filter-value";
+
 const RELATION_EXISTENCE_OPERATORS = new Set(["hasNone", "hasSome"]);
 
-export function normalizeLegacyRelationFilterInput(input: unknown): unknown {
+function normalizeLegacyRelationFilterInput(input: unknown): unknown {
   if (!input || typeof input !== "object" || Array.isArray(input)) return input;
 
   const filter = input as Record<string, unknown>;
@@ -23,10 +25,14 @@ export function normalizeLegacyRelationFilterInput(input: unknown): unknown {
   return input;
 }
 
-export function normalizeLegacyRelationFilter(filter: Filter): Filter {
-  return normalizeLegacyRelationFilterInput(filter) as Filter;
+export function normalizeFilterInput(input: unknown): unknown {
+  return normalizeLegacyRelationFilterInput(normalizeFilterNumberValueInput(input));
 }
 
-export function normalizeLegacyRelationFilters(filters: Filter[]): Filter[] {
-  return filters.map(normalizeLegacyRelationFilter);
+export function normalizeFilter(filter: Filter): Filter {
+  return normalizeFilterInput(filter) as Filter;
+}
+
+export function normalizeFilters(filters: Filter[]): Filter[] {
+  return filters.map(normalizeFilter);
 }

--- a/core/base/filter-value.ts
+++ b/core/base/filter-value.ts
@@ -18,10 +18,6 @@ function expandExponential(text: string): string {
   return `${sign}${digits.slice(0, pointIndex)}.${digits.slice(pointIndex)}`;
 }
 
-export function isCanonicalFilterNumber(value: string): boolean {
-  return PLAIN_DECIMAL_NUMBER.test(value);
-}
-
 export function canonicalFilterNumber(value: number): string | undefined {
   if (!Number.isFinite(value)) return undefined;
 

--- a/core/base/filter-value.ts
+++ b/core/base/filter-value.ts
@@ -1,0 +1,68 @@
+const PLAIN_DECIMAL_NUMBER = /^-?\d+(?:\.\d+)?$/u;
+
+const NUMBER_VALUE_EXEMPT_OPERATORS = new Set(["inLastDays"]);
+
+const EXPONENTIAL_NUMBER = /^(-?)(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/u;
+
+function expandExponential(text: string): string {
+  const match = EXPONENTIAL_NUMBER.exec(text);
+  if (!match) return text;
+
+  const [, sign, integerDigits, fractionDigits = "", exponentText] = match;
+  const digits = `${integerDigits}${fractionDigits}`;
+  const pointIndex = integerDigits.length + Number(exponentText);
+
+  if (pointIndex <= 0) return `${sign}0.${"0".repeat(-pointIndex)}${digits}`;
+  if (pointIndex >= digits.length) return `${sign}${digits}${"0".repeat(pointIndex - digits.length)}`;
+
+  return `${sign}${digits.slice(0, pointIndex)}.${digits.slice(pointIndex)}`;
+}
+
+export function isCanonicalFilterNumber(value: string): boolean {
+  return PLAIN_DECIMAL_NUMBER.test(value);
+}
+
+export function canonicalFilterNumber(value: number): string | undefined {
+  if (!Number.isFinite(value)) return undefined;
+
+  const direct = String(value);
+  if (PLAIN_DECIMAL_NUMBER.test(direct)) return direct;
+
+  const expanded = expandExponential(direct);
+
+  return PLAIN_DECIMAL_NUMBER.test(expanded) ? expanded : undefined;
+}
+
+export function filterNumberValue(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function canonicalFilterValue(value: unknown): unknown {
+  if (typeof value !== "number") return value;
+
+  return canonicalFilterNumber(value) ?? value;
+}
+
+export function normalizeFilterNumberValueInput(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+
+  const filter = input as Record<string, unknown>;
+  if (!("value" in filter)) return input;
+  if (NUMBER_VALUE_EXEMPT_OPERATORS.has(filter.operator as string)) return input;
+
+  const { value } = filter;
+
+  if (Array.isArray(value)) {
+    if (!value.some((entry) => typeof entry === "number")) return input;
+
+    return { ...filter, value: value.map(canonicalFilterValue) };
+  }
+
+  const canonical = canonicalFilterValue(value);
+
+  return canonical === value ? input : { ...filter, value: canonical };
+}

--- a/core/stores/intl-number.ts
+++ b/core/stores/intl-number.ts
@@ -59,7 +59,7 @@ function hasValidIntegerGrouping(groups: string[], syntax: LocaleNumberSyntax): 
   );
 }
 
-export function parseLocalizedNumber(raw: string, locale: string | undefined): number | undefined {
+export function parseLocalizedNumberToCanonical(raw: string, locale: string | undefined): string | undefined {
   const syntax = getLocaleNumberSyntax(locale);
   let normalized = raw.trim();
   if (!normalized || normalized === syntax.minus || normalized === syntax.plus) return undefined;
@@ -89,9 +89,15 @@ export function parseLocalizedNumber(raw: string, locale: string | undefined): n
   const groups = integerPart ? integerPart.split(syntax.group) : ["0"];
   if (!hasValidIntegerGrouping(groups, syntax)) return undefined;
 
-  const canonical = `${sign}${groups.join("")}${fractionPart === undefined ? "" : `.${fractionPart}`}`;
-  const parsed = Number(canonical);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const integerDigits = groups.join("") || "0";
+  const signPrefix = sign === "-" ? "-" : "";
+  const canonical = fractionPart ? `${signPrefix}${integerDigits}.${fractionPart}` : `${signPrefix}${integerDigits}`;
+  return Number.isFinite(Number(canonical)) ? canonical : undefined;
+}
+
+export function parseLocalizedNumber(raw: string, locale: string | undefined): number | undefined {
+  const canonical = parseLocalizedNumberToCanonical(raw, locale);
+  return canonical === undefined ? undefined : Number(canonical);
 }
 
 export function formatLocalizedNumber(

--- a/core/stores/intl.store.ts
+++ b/core/stores/intl.store.ts
@@ -13,7 +13,7 @@ import { Currency } from "@/generated/prisma";
 import type { AppLocale } from "@/i18n/locale-registry";
 
 import { DEFAULT_LOCALE, formattingTagFor, isFormattingLocale } from "@/i18n/locale-registry";
-import { formatLocalizedNumber, parseLocalizedNumber } from "./intl-number";
+import { formatLocalizedNumber, parseLocalizedNumber, parseLocalizedNumberToCanonical } from "./intl-number";
 
 const TIMEAGO_LOCALES = { de, en, es, fr, it } satisfies Record<AppLocale, Parameters<typeof register>[1]>;
 
@@ -101,6 +101,10 @@ export class IntlStore {
 
   parseNumber(value: string, locale = this.formattingLocale): number | undefined {
     return parseLocalizedNumber(value, locale);
+  }
+
+  parseNumberToCanonical(value: string, locale = this.formattingLocale): string | undefined {
+    return parseLocalizedNumberToCanonical(value, locale);
   }
 
   get collator(): Intl.Collator {

--- a/core/utils/get-params.ts
+++ b/core/utils/get-params.ts
@@ -1,7 +1,7 @@
 import type { Filter, GetQueryParams, PaginationRequest, SortDescriptor } from "@/core/base/base-get.schema";
 
 import { FilterOperatorKey } from "../base/base-query-builder";
-import { normalizeLegacyRelationFilter } from "../base/filter-compat";
+import { normalizeFilter } from "../base/filter-compat";
 
 export function encodeGetParams(params: GetQueryParams = {}): URLSearchParams {
   const sp = new URLSearchParams();
@@ -26,7 +26,7 @@ export function encodeGetParams(params: GetQueryParams = {}): URLSearchParams {
 
   if (params.filters && params.filters.length > 0) {
     for (const candidate of params.filters) {
-      const f = normalizeLegacyRelationFilter(candidate);
+      const f = normalizeFilter(candidate);
       const valuePart = serializeFilterValue(f.operator, "value" in f ? f.value : undefined);
       const token =
         valuePart !== undefined && valuePart !== null && valuePart !== ""

--- a/core/validation/validate-custom-field-currency.ts
+++ b/core/validation/validate-custom-field-currency.ts
@@ -1,5 +1,6 @@
-import { z } from "zod";
+import type { z } from "zod";
 
+import { isCanonicalFilterNumber } from "@/core/base/filter-value";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 
 export function validateCustomFieldCurrency(
@@ -11,8 +12,10 @@ export function validateCustomFieldCurrency(
   const isArray = Array.isArray(value);
 
   for (let i = 0; i < values.length; i++) {
-    const numberResult = z.coerce.number().safeParse(values[i]);
-    if (!numberResult.success) {
+    const candidate = values[i];
+    const isCanonical = typeof candidate === "string" && isCanonicalFilterNumber(candidate.trim());
+
+    if (!isCanonical) {
       ctx.addIssue({
         code: "custom",
         params: { error: CustomErrorCode.customFieldInvalidCurrency },

--- a/core/validation/validate-custom-field-currency.ts
+++ b/core/validation/validate-custom-field-currency.ts
@@ -1,6 +1,5 @@
-import type { z } from "zod";
+import { z } from "zod";
 
-import { isCanonicalFilterNumber } from "@/core/base/filter-value";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 
 export function validateCustomFieldCurrency(
@@ -12,10 +11,8 @@ export function validateCustomFieldCurrency(
   const isArray = Array.isArray(value);
 
   for (let i = 0; i < values.length; i++) {
-    const candidate = values[i];
-    const isCanonical = typeof candidate === "string" && isCanonicalFilterNumber(candidate.trim());
-
-    if (!isCanonical) {
+    const numberResult = z.coerce.number().safeParse(values[i]);
+    if (!numberResult.success) {
       ctx.addIssue({
         code: "custom",
         params: { error: CustomErrorCode.customFieldInvalidCurrency },

--- a/features/contacts/__tests__/currency-filter-query.database.test.ts
+++ b/features/contacts/__tests__/currency-filter-query.database.test.ts
@@ -1,0 +1,136 @@
+import type { TenantUser } from "@/features/user/user.schema";
+
+import { randomUUID } from "node:crypto";
+
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { Action, CustomColumnType, EntityType, Resource } from "@/generated/prisma";
+
+import { FilterSchema } from "@/core/base/base-get.schema";
+import { FilterOperatorKey } from "@/core/base/base-query-builder";
+import { runWithTenant } from "@/core/decorators/tenant-context";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { createMockUserWithPermissions } from "@/tests/helpers/mock-user";
+import { PrismaContactRepo } from "../prisma-contact.repository";
+
+const databaseUrl = getLocalDatabaseTestUrl();
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase("currency filter queries on PostgreSQL", () => {
+  const client = new Client({ connectionString: databaseUrl ?? undefined });
+  const companyId = randomUUID();
+  const columnId = randomUUID();
+
+  const amounts = { minusFifty: -50, zero: 0, two: 2, ten: 10 };
+  const contactIds = {
+    minusFifty: randomUUID(),
+    zero: randomUUID(),
+    two: randomUUID(),
+    ten: randomUUID(),
+    unset: randomUUID(),
+  };
+
+  const viewer: TenantUser = {
+    ...createMockUserWithPermissions([{ resource: Resource.contacts, action: Action.readAll }]),
+    id: randomUUID(),
+    companyId,
+  };
+
+  async function idsMatching(operator: FilterOperatorKey, value?: number | string) {
+    const filter = FilterSchema.parse(
+      value === undefined ? { field: columnId, operator } : { field: columnId, operator, value },
+    );
+
+    const items = await runWithTenant(viewer, () => new PrismaContactRepo().getItems({ filters: [filter] }));
+
+    return new Set(items.map((item) => item.id));
+  }
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.query('INSERT INTO "Company" ("id", "updatedAt") VALUES ($1, CURRENT_TIMESTAMP)', [companyId]);
+    await client.query(
+      'INSERT INTO "CustomColumn" ("id", "label", "type", "entityType", "companyId", "updatedAt") VALUES ($1, $2, $3::"CustomColumnType", $4::"EntityType", $5, CURRENT_TIMESTAMP)',
+      [columnId, "Contract value", CustomColumnType.currency, EntityType.contact, companyId],
+    );
+
+    for (const [key, id] of Object.entries(contactIds)) {
+      await client.query(
+        'INSERT INTO "Contact" ("id", "firstName", "lastName", "companyId", "updatedAt") VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)',
+        [id, "Synthetic", key, companyId],
+      );
+
+      const amount = amounts[key as keyof typeof amounts];
+      if (amount === undefined) continue;
+
+      await client.query(
+        'INSERT INTO "CustomFieldValue" ("id", "entityType", "columnId", "value", "numericValue", "type", "companyId", "contactId", "updatedAt") VALUES ($1, $2::"EntityType", $3, $4, $5, $6::"CustomColumnType", $7, $8, CURRENT_TIMESTAMP)',
+        [randomUUID(), EntityType.contact, columnId, String(amount), amount, CustomColumnType.currency, companyId, id],
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await client.query('DELETE FROM "CustomFieldValue" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "Contact" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "CustomColumn" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "Company" WHERE "id" = $1', [companyId]);
+    await client.end();
+  });
+
+  it("compares numerically rather than lexicographically for gt", async () => {
+    const matched = await idsMatching(FilterOperatorKey.gt, 2);
+
+    expect(matched).toEqual(new Set([contactIds.ten]));
+  });
+
+  it("compares numerically rather than lexicographically for lt", async () => {
+    const matched = await idsMatching(FilterOperatorKey.lt, 10);
+
+    expect(matched).toEqual(new Set([contactIds.minusFifty, contactIds.zero, contactIds.two]));
+  });
+
+  it("includes the boundary for gte and lte", async () => {
+    expect(await idsMatching(FilterOperatorKey.gte, 2)).toEqual(new Set([contactIds.two, contactIds.ten]));
+    expect(await idsMatching(FilterOperatorKey.lte, 0)).toEqual(new Set([contactIds.minusFifty, contactIds.zero]));
+  });
+
+  it.each([
+    ["minusFifty", amounts.minusFifty],
+    ["zero", amounts.zero],
+    ["two", amounts.two],
+    ["ten", amounts.ten],
+  ])("matches %s exactly with equals", async (key, amount) => {
+    const matched = await idsMatching(FilterOperatorKey.equals, amount);
+
+    expect(matched).toEqual(new Set([contactIds[key as keyof typeof contactIds]]));
+  });
+
+  it("returns the same records for the number and canonical string transport forms", async () => {
+    expect(await idsMatching(FilterOperatorKey.gt, 2)).toEqual(await idsMatching(FilterOperatorKey.gt, "2"));
+    expect(await idsMatching(FilterOperatorKey.equals, -50)).toEqual(
+      await idsMatching(FilterOperatorKey.equals, "-50"),
+    );
+  });
+
+  it("separates records with and without a value", async () => {
+    expect(await idsMatching(FilterOperatorKey.isNull)).toEqual(new Set([contactIds.unset]));
+    expect(await idsMatching(FilterOperatorKey.isNotNull)).toEqual(
+      new Set([contactIds.minusFifty, contactIds.zero, contactIds.two, contactIds.ten]),
+    );
+  });
+
+  it("keeps the count consistent with the returned items", async () => {
+    const filter = FilterSchema.parse({ field: columnId, operator: FilterOperatorKey.gte, value: 0 });
+
+    const [items, total] = await runWithTenant(viewer, async () => {
+      const repo = new PrismaContactRepo();
+
+      return Promise.all([repo.getItems({ filters: [filter] }), repo.getCount({ filters: [filter] })]);
+    });
+
+    expect(items).toHaveLength(3);
+    expect(total).toBe(3);
+  });
+});

--- a/features/p13n/prisma-p13n.repository.ts
+++ b/features/p13n/prisma-p13n.repository.ts
@@ -9,7 +9,7 @@ import type { P13nRepo } from "@/core/base/base-get.interactor";
 import { Prisma } from "@/generated/prisma";
 
 import { BaseRepository } from "@/core/base/base-repository";
-import { normalizeLegacyRelationFilters } from "@/core/base/filter-compat";
+import { normalizeFilters } from "@/core/base/filter-compat";
 
 export type SavedFilterPreset = {
   id: string;
@@ -32,7 +32,7 @@ export interface P13nEntry {
 }
 
 function normalizeStoredFilters(value: unknown): Filter[] | undefined {
-  return Array.isArray(value) ? normalizeLegacyRelationFilters(value as unknown as Filter[]) : undefined;
+  return Array.isArray(value) ? normalizeFilters(value as unknown as Filter[]) : undefined;
 }
 
 function normalizeStoredFilterPresets(value: unknown): SavedFilterPreset[] | undefined {

--- a/features/widget/prisma-widget.repository.ts
+++ b/features/widget/prisma-widget.repository.ts
@@ -18,7 +18,7 @@ import { BREAKPOINTS } from "@/constants/breakpoints";
 import { getWidgetCalculatorRepo } from "@/core/di";
 import { ActivityWidgetDtoSchema } from "./widget.schema";
 import { activityFilterableFieldsForViewer } from "@/ee/messaging/activities/activity-filterable-fields";
-import { normalizeLegacyRelationFilters } from "@/core/base/filter-compat";
+import { normalizeFilters } from "@/core/base/filter-compat";
 
 export class PrismaWidgetRepo
   extends BaseRepository
@@ -92,7 +92,7 @@ export class PrismaWidgetRepo
 
     if (row.kind === WidgetKind.activityTimeline) {
       const timelineFilters = Array.isArray(row.timelineFilters)
-        ? normalizeLegacyRelationFilters(row.timelineFilters as unknown as Filter[])
+        ? normalizeFilters(row.timelineFilters as unknown as Filter[])
         : (row.timelineFilters ?? []);
       const parsed = ActivityWidgetDtoSchema.safeParse({
         ...base,
@@ -106,8 +106,8 @@ export class PrismaWidgetRepo
 
     const entityType = row.entityType as EntityType;
     const aggregationType = row.aggregationType as AggregationType;
-    const entityFilters = normalizeLegacyRelationFilters((row.entityFilters as unknown as Filter[] | null) ?? []);
-    const dealFilters = normalizeLegacyRelationFilters((row.dealFilters as unknown as Filter[] | null) ?? []);
+    const entityFilters = normalizeFilters((row.entityFilters as unknown as Filter[] | null) ?? []);
+    const dealFilters = normalizeFilters((row.dealFilters as unknown as Filter[] | null) ?? []);
     const chart = {
       ...base,
       kind: WidgetKind.chart,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ const domTestFiles = [
   "app/[locale]/(protected)/__tests__/protected-layout.test.ts",
   "app/components/navigation/__tests__/navigation-switch.test.ts",
   "components/data-view/__tests__/data-view-url-sync.test.ts",
+  "components/data-view/filter-modal/inputs/__tests__/filter-input-number.test.ts",
   "components/forms/__tests__/selection-command.test.ts",
   "features/messaging/activities/__tests__/use-owned-activities-store.test.ts",
 ];


### PR DESCRIPTION
## Summary

Currency custom-field filters applied from the shared data-view popover never reached the database. The filter input wrote a JavaScript `number` into the filter form while `FilterSchema`'s single-value branch requires a `string`, so the request was rejected at the server-action boundary and the user saw a generic unexpected-error toast with no rows. The same filter restored from a URL worked, because the URL serializer had already stringified it.

This establishes one canonical boundary representation, a plain decimal string, and normalizes to it exactly once.

Closes [CUS-48](https://linear.app/customermates/issue/CUS-48/fix-currency-custom-field-filtering-errors-across-entity-data-views).

## Context

`FilterInputNumber` emitted `intlStore.parseNumber(...)`, a `number`, on every keystroke and on blur. Currency columns expose only `equals/gt/gte/lt/lte`, which all land on the single-value branch declaring `value: z.string()` with no coercion under zod 4. Every data-view get interactor carries `@Validate(GetQueryParamsSchema)` and that schema includes `filters`, so `unwrapValidated` threw the `ZodError` before the interactor ran. Saved presets failed the same way through `UpsertFilterPresetInteractor`.

Design decisions:

- **String is the canonical form, not number.** The single-value branch is shared with text and date fields, so it cannot be numeric. The record-write path had already settled on the same answer: the custom-field editor commits `String(n)`.
- **Canonicalize without a float round trip.** `parseLocalizedNumber` already built a canonical string internally before calling `Number` on it. That string is now exposed as `parseLocalizedNumberToCanonical` and stored directly, so the user's typed precision survives. `1,234.5` in English and `1.234,5` in German both produce `1234.5`.
- **Normalize once, at the boundary that already existed.** `FilterSchema` already ran a `z.preprocess` for legacy relation filters. Composing the numeric normalization there covers server actions, presets, widget and personalization reads, URL encoding, and the query builder from a single definition. A legacy `number` from a REST or MCP caller is now accepted rather than rejected, which is the backward compatibility the contract needs. `inLastDays` keeps its own numeric contract.

`normalizeLegacyRelationFilter*` is renamed to `normalizeFilter*` because it no longer only handles relation legacy.

**No behavior outside filtering changes.** An earlier revision of this branch also tightened `validateCustomFieldCurrency`; an independent review established that this validator is shared with the record-write path via `validateCustomFieldValues`, and that path is not canonicalized. `CustomFieldValueInputSchema` coerces with `z.coerce.string()` and the record editor commits `String(n)`, so `".5"`, `"5."`, `"+50"` and exponent forms reach the validator directly and were accepted by `z.coerce.number()`. Tightening it would have rejected contact, organization, deal, service and task writes that succeed today. Commit `1fe652ab` reverts that validator to its original form and adds regression coverage pinning those write forms as accepted.

## Validation

Base `origin/main` `243e13c9b19c7da8fc3a2792356e5880d889c31e`. Head `1fe652ab8cc53fec60854cc4d23bc254d5bf2f7e`. Commands run against a disposable local PostgreSQL 16 with synthetic fixtures only.

| Gate | Result |
| --- | --- |
| `yarn typecheck` | pass |
| `yarn lint` | pass, zero warnings |
| `yarn conventions:check` | 40 files, 300 passed, 1 skipped |
| `RUN_DATABASE_TESTS=true yarn test` | 315 files, 2695 passed, 1 skipped, 0 failed |
| `yarn build` | pass |
| `yarn openapi:generate` / `yarn raw-docs:generate` | no change attributable to this diff |

New focused coverage:

- `components/data-view/filter-modal/inputs/__tests__/filter-input-number.test.ts`, 18 cases, jsdom: renders `FilterInputNumber` and asserts what it commits. The same amount typed as `1,234.5` (en-US), `1.234,5` (de-DE) and `1 234,5` (fr-FR) all commit the identical locale-independent string `1234.5`; nothing committed is ever a JavaScript number; the canonical parser is used and `parseNumber` is never called; sign and precision survive; clearing commits `undefined`; blur matches change; and the committed value round trips through `FilterSchema` unchanged for all five value-taking currency operators. **Verified to discriminate:** temporarily restoring `origin/main`'s input implementation fails 11 of the 18 cases.

- `core/base/__tests__/currency-filter-contract.test.ts`, 48 cases: locale-independent canonicalization (en-US, de-DE, fr-FR), plain-decimal output with no exponent notation, every currency operator through `FilterSchema` in both transport forms, URL round-trip identity, preset acceptance, `defaultValidateFilters` behavior, and the record-write validator forms that must keep working.
- `features/contacts/__tests__/currency-filter-query.database.test.ts`, 10 cases against real PostgreSQL: proves comparison is numeric rather than lexicographic using values where the two orders differ (`gt 2` returns 10; `lt 10` returns 2), boundary behavior for `gte`/`lte`, exact `equals` for negative, zero and positive amounts, `isNull`/`isNotNull`, identical results for the number and string transport forms, and item/count parity.

Browser acceptance on a locally served instance, seeded with synthetic amounts `-50, 0, 2, 2, 10, 10, 1234.5`:

- Applying `Contract value ≥ 10` through the popover took the table from 30 rows to 3, updated the URL to `filters=<id>:gte:10`, and raised no error toast. This is the interaction that failed before.
- Applying `≥ 1234.5` returned 1 row and wrote the locale-independent `1234.5` to the URL while the input displayed `1,234.5`.
- A full page reload of that URL restored the same 3 rows.
- Saving a named preset persisted `"value": "1234.5"` to `P13n.savedFilterPresets`, and re-saving round-tripped it through `FilterSchema` intact.
- With the user's formatting locale set to German, typing `1.234,5` produced the same `1234.5` in the URL and the same single row.

Preview `https://fix-currency-filter-value-contract.customermates.com` is live: public routes return 200, protected routes correctly redirect to sign-in, and `sitemap.xml` and `/v1/openapi.json` serve. The authenticated currency journey was run locally rather than on the preview, because exercising it there would require entering credentials.

Two things I could not close out, neither attributable to this diff:

- Selecting a saved preset did not populate the filter draft in my synthetic browser driving. A non-currency control preset behaved identically, so this is not currency-specific. I could not separate real behavior from my instrument, so I am recording it rather than claiming a defect.
- `public/v1/openapi.json` on `main` regenerates with an extra `snapshot` boolean unrelated to filters. I reverted that hunk to keep this diff scoped; CI regenerates without diff-checking, so it is not failing anything today.

## Impact and rollback

Code-only. No migration, no schema change, no dependency change, no production data touched. `DECIMAL(20,4)` storage and the `numericValue` comparison path are unchanged.

Compatibility is preserved in both directions: existing string-form URLs and presets keep working unchanged, and numeric-form values from REST or MCP callers, which are rejected today, are now accepted and normalized. No validation contract is narrowed anywhere, so no input that is accepted today becomes invalid.

Revert the two commits to restore previous behavior. No data repair is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)