### PR TITLE
fix(openapi): regenerate the published spec and gate its freshness in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,13 @@ jobs:
           npx --no-install prisma db seed
       - run: yarn openapi:generate
       - run: yarn raw-docs:generate
+      - name: Verify generated files are committed
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Generated files are out of date. Run 'yarn openapi:generate' and commit the result."
+            git diff --stat
+            exit 1
+          fi
       - run: yarn typecheck
       - run: yarn lint
       - run: yarn test

--- a/public/v1/openapi.json
+++ b/public/v1/openapi.json
@@ -52774,6 +52774,9 @@
                           "columnId": {
                             "type": "string"
                           },
+                          "snapshot": {
+                            "type": "boolean"
+                          },
                           "previous": {},
                           "current": {}
                         },


### PR DESCRIPTION
## Summary

`public/v1/openapi.json` had drifted from the source it is generated from. It is the only tracked generated artifact in the repository and it is served publicly at `/v1/openapi.json`, so the published contract was simply wrong.

This regenerates it and adds a CI step so it cannot drift again.

Closes [CUS-245](https://linear.app/customermates/issue/CUS-245/regenerate-the-committed-openapi-spec-and-gate-it-in-ci).

## Context

`b6cecec5` ([#76](https://github.com/customermates/customermates/pull/76)) added `snapshot: z.boolean().optional()` to `AuditChangeSchema` in `features/audit-log/audit-log-changes.ts` without regenerating the spec. The last commit that touched the artifact was `f9d8f4f7` ([#42](https://github.com/customermates/customermates/pull/42)). Regenerating on a clean `origin/main` adds one `"snapshot": { "type": "boolean" }` property to the audit-changes payload object and changes nothing else, which is exactly the diff in this PR.

Nothing could catch it. The `ci` job already ran `yarn openapi:generate`, but only so the build had its inputs; it never compared the output to what was committed. Beyond the inaccurate published contract, the practical cost landed on unrelated pull requests: any branch that happened to regenerate picked up a stray hunk that had to be reverted by hand. That happened twice on [#84](https://github.com/customermates/customermates/pull/84), which is where this was noticed.

**Why a diff check is safe rather than flaky**, verified before writing the step:

- Nothing generated here is environment-dependent. The spec's `servers` entry is the relative `[{ "url": "/api" }]`, and the file contains no absolute URL, no `localhost`, and no `BASE_URL`-derived value.
- Every other generated output is untracked. `.gitignore` excludes `generated/` and `content/api/**/*.mdx`, so `raw-docs:generate` and the generated MDX API pages cannot dirty a checkout.
- Generation is deterministic. Two consecutive runs produced byte-identical output (`cmp` clean).

The step checks the whole tree rather than one path, so a future tracked generated artifact is covered automatically without anyone remembering to extend a list.

**Scope note.** Regenerating alone would have been a one-time patch of a recurring failure, so the gate is included deliberately rather than deferred. Both halves are in the issue's scope and were decided explicitly.

## Validation

Base `origin/main` `243e13c9b19c7da8fc3a2792356e5880d889c31e`. Head `45235cce`. Disposable local PostgreSQL 16, synthetic fixtures only.

| Gate | Result |
| --- | --- |
| `yarn typecheck` | pass |
| `yarn lint` | pass, zero warnings |
| `yarn conventions:check` | 40 files, 300 passed, 1 skipped |
| `RUN_DATABASE_TESTS=true yarn test` | 313 files, 2637 passed, 1 skipped, 0 failed |
| `yarn build` | pass, and the tree is still clean afterwards |

The new gate was exercised in both directions locally, rather than assumed:

- **Passes on this tree.** After `yarn openapi:generate` and `yarn raw-docs:generate`, `git diff --quiet` returns 0.
- **Fails on a stale tree.** Restoring `origin/main`'s spec, committing it, and re-running produces exit 1 and the message `Generated files are out of date. Run 'yarn openapi:generate' and commit the result.` followed by `public/v1/openapi.json | 3 +++`. That commit was then discarded, so it is not in this branch.

Because `pull_request` workflows run the definition from the head branch, this PR's own `ci` run executes the new step, which is the live proof that it passes on a correct tree.

## Impact and rollback

No product code, schema, migration, dependency, API behavior, or deployment configuration changes. The only content change is a property appearing in the published spec that the code has already been emitting since `b6cecec5`, so consumers see documentation catch up with reality rather than a contract change.

The one behavioral change is for contributors: a pull request that alters a schema feeding the spec must now regenerate and commit it, or `ci` fails with a message naming the command. That is the intent.

Revert the commit to restore both the previous spec and the previous CI behavior. If only the gate proves unwelcome, deleting that single workflow step leaves the corrected artifact in place. No data, schema, or deployment repair is required either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)