### PR TITLE
fix(openapi): stop the sendEmail description breaking its docs page

### DIFF
--- a/ee/messaging/outbound/send-email.openapi.ts
+++ b/ee/messaging/outbound/send-email.openapi.ts
@@ -10,7 +10,7 @@ export const sendEmailOperation: ZodOpenApiOperationObject = {
   operationId: "sendEmail",
   summary: "Send an email",
   description:
-    "Sends a real email (or reply) from a connected email account. Provide either threadId (reply; takes precedence if both are given) or connectedAccountId (new email). cc and bcc are plain email strings, unlike to which uses the { identifier } object form.",
+    "Sends a real email (or reply) from a connected email account. Provide either threadId (reply; takes precedence if both are given) or connectedAccountId (new email). cc and bcc are plain email strings, unlike `to` which uses the `{ identifier }` object form.",
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {

--- a/public/v1/openapi.json
+++ b/public/v1/openapi.json
@@ -33329,7 +33329,7 @@
       "post": {
         "operationId": "sendEmail",
         "summary": "Send an email",
-        "description": "Sends a real email (or reply) from a connected email account. Provide either threadId (reply; takes precedence if both are given) or connectedAccountId (new email). cc and bcc are plain email strings, unlike to which uses the { identifier } object form.",
+        "description": "Sends a real email (or reply) from a connected email account. Provide either threadId (reply; takes precedence if both are given) or connectedAccountId (new email). cc and bcc are plain email strings, unlike `to` which uses the `{ identifier }` object form.",
         "tags": [
           "messaging"
         ],

--- a/tests/conventions/openapi-mdx-safe-descriptions.test.ts
+++ b/tests/conventions/openapi-mdx-safe-descriptions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { generateOpenApiSpec } from "@/core/openapi/openapi-spec";
+
+const HTTP_VERBS = new Set(["get", "post", "put", "patch", "delete"]);
+const INLINE_CODE_SPAN = /`[^`]*`/g;
+const MDX_HOSTILE = /[{}<]/;
+
+type Operation = { summary?: unknown; description?: unknown };
+
+function operationProse(): { location: string; text: string }[] {
+  const spec = generateOpenApiSpec() as { paths?: Record<string, Record<string, unknown>> };
+  const prose: { location: string; text: string }[] = [];
+  for (const [path, entry] of Object.entries(spec.paths ?? {})) {
+    for (const [verb, operation] of Object.entries(entry)) {
+      if (!HTTP_VERBS.has(verb)) continue;
+      const { summary, description } = operation as Operation;
+      for (const [field, text] of [
+        ["summary", summary],
+        ["description", description],
+      ] as const) {
+        if (typeof text === "string") prose.push({ location: `${verb} ${path} :: ${field}`, text });
+      }
+    }
+  }
+  return prose;
+}
+
+describe("openapi mdx safe descriptions", () => {
+  it("keeps operation summaries and descriptions free of unfenced MDX expression syntax", () => {
+    const violations = operationProse()
+      .filter(({ text }) => MDX_HOSTILE.test(text.replace(INLINE_CODE_SPAN, "")))
+      .map(({ location, text }) => `${location} must fence MDX expression syntax in backticks: ${text}`);
+    expect(violations).toEqual([]);
+  });
+
+  it("reads at least one operation so the walk cannot pass vacuously", () => {
+    expect(operationProse().length).toBeGreaterThan(0);
+  });
+
+  it("still rejects expression syntax that is not fenced", () => {
+    const unfenced = "uses the { identifier } object form";
+    expect(MDX_HOSTILE.test(unfenced.replace(INLINE_CODE_SPAN, ""))).toBe(true);
+    expect(MDX_HOSTILE.test("uses the `{ identifier }` object form".replace(INLINE_CODE_SPAN, ""))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The `sendEmail` OpenAPI operation description contained a bare `{ identifier }`. Fence it in backticks, and add a conventions test that rejects unfenced MDX expression syntax in any operation summary or description.

## Context

Sentry `CUSTOMERMATES-35` and `CUSTOMERMATES-4E` (same defect, split only by symbolication) report `ReferenceError: identifier is not defined` on `GET /[locale]/docs/openapi/[slug]`, 13 production events, most recent a few hours ago.

`scripts/generate-openapi.ts` runs `generateFiles({ includeDescription: true })`, which inlines the operation description into the **body** of the generated MDX. MDX v3 reads `{ ... }` in prose as a JavaScript expression container, so `{ identifier }` compiled to a reference to an undefined module-scope variable. Compilation succeeds because that is valid syntax, so it only fails when the page renders.

This is the only operation-level description in the published spec that carries brace characters. The five other brace-bearing strings are schema *property* descriptions, which `<APIPage>` renders from JSON at runtime and never MDX-parses, so they are deliberately left alone and the test is scoped to operation level.

`generate-openapi.ts` copies the `en` output to every content locale, which is why `/de` failed identically.

## Validation

Reproduced and fixed locally on a dev server, both directions:

- Before: `GET /en/docs/openapi/sendEmail` returns **HTTP 200 but a broken page** (498 KB instead of 836 KB, description paragraph absent). The dev log shows the compiled MDX throwing at `children: [..., identifier, " object form."]` with `digest: '2766838551'`. Note it is not a clean 500, since the render error happens after the stream is committed.
- After: `/en` and `/de` both return 200 with the description paragraph present.
- New test fails on the unfenced string and passes on the fenced one (asserted explicitly in the test itself, so it cannot pass vacuously).
- `yarn lint` clean, `yarn typecheck` clean, `yarn vitest run tests/conventions` 303 passed / 41 files.

The two `ECONNREFUSED` errors in the conventions run are the local `.env` pointing at a Postgres container that is not running, not a regression from this change.

## Impact and rollback

Documentation-only behaviour change, on one public docs page. No schema, runtime or API contract change; the description text is the sole spec edit. Rollback is a straight revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)