### PR TITLE
fix(messaging): stop probing offset pagination against cursor-only providers

### DIFF
--- a/ee/messaging/ingest/backfill/__tests__/paginate.test.ts
+++ b/ee/messaging/ingest/backfill/__tests__/paginate.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { MOCK_ENV_MODULE } from "@/tests/helpers/interactor-test-setup";
+
+vi.mock("@/env", () => MOCK_ENV_MODULE);
+
+import { paginateStep, UNIPILE_MAX_LIMIT } from "../paginate";
+import { UnipileRequestError } from "../../../messaging.service";
+
+function page(count: number, nextCursor?: string) {
+  return { data: Array.from({ length: count }, (_, index) => ({ id: `${index}` })), next_cursor: nextCursor };
+}
+
+function cursorPaginationError() {
+  return new UnipileRequestError(
+    400,
+    "provider/invalid_parameters",
+    '{"object":"Error","status":400,"type":"provider/invalid_parameters","title":"Invalid parameters","detail":"Google Calendar use cursor for pagination.","req_id":"req-9jg"}',
+  );
+}
+
+describe("paginateStep", () => {
+  it("follows next_cursor while the provider keeps returning one", async () => {
+    const fetchPage = vi.fn().mockResolvedValueOnce(page(UNIPILE_MAX_LIMIT, "c1")).mockResolvedValueOnce(page(3));
+    const handled: unknown[] = [];
+
+    const result = await paginateStep({
+      startCursor: null,
+      limit: UNIPILE_MAX_LIMIT,
+      fetchPage,
+      handleItem: (item) => {
+        handled.push(item);
+
+        return Promise.resolve();
+      },
+    });
+
+    expect(result).toEqual({ nextCursor: null, done: true });
+    expect(fetchPage.mock.calls[1][0]).toEqual({ cursor: "c1" });
+    expect(handled).toHaveLength(UNIPILE_MAX_LIMIT + 3);
+  });
+
+  it("advances by offset for a provider that paginates by offset", async () => {
+    const fetchPage = vi.fn().mockResolvedValueOnce(page(UNIPILE_MAX_LIMIT)).mockResolvedValueOnce(page(2));
+
+    const result = await paginateStep({
+      startCursor: null,
+      limit: UNIPILE_MAX_LIMIT,
+      fetchPage,
+      handleItem: () => Promise.resolve(),
+    });
+
+    expect(fetchPage.mock.calls[1][0]).toEqual({ offset: UNIPILE_MAX_LIMIT });
+    expect(result).toEqual({ nextCursor: null, done: true });
+  });
+
+  it("stops cleanly when a cursor-only provider rejects the offset probe", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page(UNIPILE_MAX_LIMIT))
+      .mockRejectedValueOnce(cursorPaginationError());
+
+    const result = await paginateStep({
+      startCursor: null,
+      limit: UNIPILE_MAX_LIMIT,
+      fetchPage,
+      handleItem: () => Promise.resolve(),
+    });
+
+    expect(result).toEqual({ nextCursor: null, done: true });
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it("still surfaces an unrelated bad-request failure", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page(UNIPILE_MAX_LIMIT))
+      .mockRejectedValueOnce(
+        new UnipileRequestError(400, "provider/invalid_parameters", '{"detail":"Unknown field."}'),
+      );
+
+    await expect(
+      paginateStep({
+        startCursor: null,
+        limit: UNIPILE_MAX_LIMIT,
+        fetchPage,
+        handleItem: () => Promise.resolve(),
+      }),
+    ).rejects.toBeInstanceOf(UnipileRequestError);
+  });
+});

--- a/ee/messaging/ingest/backfill/paginate.ts
+++ b/ee/messaging/ingest/backfill/paginate.ts
@@ -1,3 +1,5 @@
+import { isUnipileCursorPaginationRequired } from "../../messaging.service";
+
 export const UNIPILE_MAX_LIMIT = 25;
 export const UNIPILE_EMAIL_MAX_LIMIT = 100;
 export const BACKFILL_EMAIL_TIMEOUT_MS = 90_000;
@@ -44,7 +46,15 @@ export async function paginateStep(opts: {
 
   for (let page = 0; page < PAGE_SAFETY; page++) {
     await paceUnipileRequest();
-    const result = await opts.fetchPage(mode === "offset" ? { offset } : { cursor });
+
+    let result;
+    try {
+      result = await opts.fetchPage(mode === "offset" ? { offset } : { cursor });
+    } catch (error) {
+      if (mode === "offset" && isUnipileCursorPaginationRequired(error)) return { nextCursor: null, done: true };
+      throw error;
+    }
+
     const items = result.data ?? [];
 
     for (const item of items) await opts.handleItem(item);

--- a/ee/messaging/messaging.service.ts
+++ b/ee/messaging/messaging.service.ts
@@ -169,6 +169,13 @@ export function isUnipileTimeout(err: unknown): boolean {
   return err instanceof UnipileRequestError && err.status === 0;
 }
 
+export function isUnipileCursorPaginationRequired(err: unknown): boolean {
+  if (!(err instanceof UnipileRequestError) || err.status !== 400) return false;
+  if (!(err.errorType ?? "").endsWith("/invalid_parameters")) return false;
+
+  return /cursor for pagination/i.test(err.bodyText);
+}
+
 export function isUnipileResourceNotFound(err: unknown): boolean {
   if (!(err instanceof UnipileRequestError)) return false;
 


### PR DESCRIPTION
## Summary

`paginateStep` inferred a provider's pagination style from whether the first page carried `next_cursor`. Stop inferring, and treat the provider's own rejection as the authoritative answer.

## Context

Sentry `CUSTOMERMATES-3X` (50 events) and `CUSTOMERMATES-4G` (6 events), both on `POST /.well-known/workflow/v1/step`:

> `UnipileRequestError: Unipile v2 request failed: 400 ... "detail":"Google Calendar use cursor for pagination."`

`paginate.ts` decided the style with `if (!mode) mode = result.next_cursor ? "cursor" : "offset"`. A missing `next_cursor` is ambiguous. It means either the provider paginates by offset, or that page was the last one. The code always resolved it to the first reading, so a cursor-only provider whose first page came back exactly full (`>= UNIPILE_MAX_LIMIT`, 25) was classified as offset-paginated. The offset branch then declined to terminate, advanced `offset`, and the next request carried `offset=25` to Google Calendar's cursor-only events endpoint.

Inference cannot be made correct here. The Unipile SDK documents both parameters on the same endpoint as provider-dependent:

> "An offset used for pagination, if supported by the provider, else use `cursor`."

So "offset-provider page 1, exactly full" and "cursor-provider last page, exactly full" are indistinguishable from one response. Rather than guess, keep the existing walk and let the provider answer: if a request in offset mode is rejected specifically because the provider requires cursors, there are no further pages to fetch, so end the walk cleanly instead of reporting the rejection.

This is deliberately narrow. `isUnipileCursorPaginationRequired` matches only a 400 whose error type ends in `/invalid_parameters` and whose body names cursor pagination, so any other bad request still surfaces. Offset-paginated providers are untouched, which matters because terminating on a missing `next_cursor` instead would have silently truncated their backfills after one page.

## Validation

- New `ee/messaging/ingest/backfill/__tests__/paginate.test.ts`, 4 cases: cursor walk, offset walk, the cursor-only rejection, and an unrelated 400 that must still throw.
- Confirmed the test is a real regression test: with the guard removed, "stops cleanly when a cursor-only provider rejects the offset probe" fails and the other three still pass.
- `yarn vitest run ee/messaging` 355 passed / 40 files, `yarn lint` clean, `yarn typecheck` clean.

The `ECONNREFUSED` errors in the local vitest run are the local `.env` pointing at a Postgres container that is not running, not a regression from this change.

## Impact and rollback

Affects the Unipile backfill and resync walk only. The change is additive: one new exported predicate and one catch clause that ends the walk on a specific provider rejection. No behaviour change for any request that succeeds, and no change to offset-paginated providers. Rollback is a straight revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)