### PR TITLE
fix(observability): classify inactive-user and wrapped webhook failures as expected

### DIFF
--- a/core/errors/__tests__/app-errors.test.ts
+++ b/core/errors/__tests__/app-errors.test.ts
@@ -81,6 +81,16 @@ describe("isExpectedError", () => {
     expect(isExpectedError({ name: "FatalError", message: "Webhook target responded 503 down" })).toBe(true);
   });
 
+  it("recognizes a webhook failure wrapped by the workflow retry-exhaustion message", () => {
+    expect(
+      isExpectedError({
+        name: "FatalError",
+        message:
+          'Step "step//./workflows/deliver-webhook//deliverStep" failed after 5 retries: Webhook target responded 500 Internal Server Error',
+      }),
+    ).toBe(true);
+  });
+
   it("recognizes a DemoModeError that lost its class identity across a serialization boundary, by message", () => {
     expect(isExpectedError({ name: "Error", message: DEMO_MODE_MESSAGE })).toBe(true);
     expect(isExpectedError(new Error(DEMO_MODE_MESSAGE))).toBe(true);

--- a/core/errors/app-errors.ts
+++ b/core/errors/app-errors.ts
@@ -85,7 +85,7 @@ export function isExpectedError(err: unknown): boolean {
   const message = (err as { message?: unknown } | null | undefined)?.message;
   if (typeof message !== "string") return false;
 
-  return message.startsWith(WEBHOOK_FAILURE_MESSAGE_PREFIX) || message.startsWith(DEMO_MODE_MESSAGE);
+  return message.includes(WEBHOOK_FAILURE_MESSAGE_PREFIX) || message.startsWith(DEMO_MODE_MESSAGE);
 }
 
 export function appErrorResponse(err: unknown): { message: string; statusCode: number } | null {

--- a/features/user/__tests__/user-service-active-guard.test.ts
+++ b/features/user/__tests__/user-service-active-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { Status } from "@/generated/prisma";
+import { ForbiddenError, isExpectedError, appErrorResponse } from "@/core/errors/app-errors";
+import { UserService } from "../user.service";
+import type { FindUserRepo } from "../user.service";
+import type { AuthService } from "@/features/auth/auth.service";
+import type { TenantUser } from "../user.schema";
+
+function serviceFor(status: Status) {
+  const user = { id: "user-1", email: "someone@example.com", status } as unknown as TenantUser;
+  const authService = { getSession: () => Promise.resolve({ user: { email: user.email } }) } as unknown as AuthService;
+  const repo = {
+    findCurrentUserUnscoped: () => Promise.resolve(user),
+    findCurrentUserOrThrowUnscoped: () => Promise.resolve(user),
+  } as unknown as FindUserRepo;
+
+  return new UserService(authService, repo);
+}
+
+describe("UserService.getActiveUserOrThrow", () => {
+  it("returns the user when the account is active", async () => {
+    await expect(serviceFor(Status.active).getActiveUserOrThrow()).resolves.toMatchObject({ id: "user-1" });
+  });
+
+  it("rejects an inactive account as a forbidden request rather than an unexpected failure", async () => {
+    const error = await serviceFor(Status.inactive)
+      .getActiveUserOrThrow()
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(ForbiddenError);
+    expect(appErrorResponse(error)).toEqual({ message: "User is not active", statusCode: 403 });
+    expect(isExpectedError(error)).toBe(true);
+  });
+});

--- a/features/user/user.service.ts
+++ b/features/user/user.service.ts
@@ -43,7 +43,7 @@ export class UserService {
   async getActiveUserOrThrow() {
     const user = await this.getUserOrThrow();
 
-    if (user.status !== Status.active) throw new Error("User is not active");
+    if (user.status !== Status.active) throw new ForbiddenError("User is not active");
 
     return user;
   }


### PR DESCRIPTION
## Summary

Two expected conditions were reaching Sentry as unexpected failures. Raise `ForbiddenError` for a deactivated account, and stop anchoring the webhook filter to the start of the message.

## Context

**Inactive user** (`CUSTOMERMATES-46`, `CUSTOMERMATES-4D`, `CUSTOMERMATES-47`, 4 production events on `POST /api/v1/mcp`). `UserService.getActiveUserOrThrow` threw a bare `Error("User is not active")`. A deactivated account calling the API is an ordinary authorization rejection, not a defect, but a bare `Error` is invisible to `isExpectedError`, so it was reported and answered with a 500 instead of a 403. The permission check 28 lines below it in the same file already raises `ForbiddenError`, so this was an inconsistency rather than a deliberate choice.

**Wrapped webhook failure** (`CUSTOMERMATES-43`, `POST /.well-known/workflow/v1/step`). `isExpectedError` used `message.startsWith(WEBHOOK_FAILURE_MESSAGE_PREFIX)`. The workflow engine prepends its own text when a step exhausts its retries, so the message that actually arrives is:

> `Step "step//./workflows/deliver-webhook//deliverStep" failed after 5 retries: Webhook target responded 500 Internal Server Error`

which does not start with the prefix. A webhook failing against a customer's own endpoint is expected by design, including the non-retryable case, and the filter was written to cover exactly that. The existing test for this boundary passed only because its fixture message happened to start with the prefix, so the retry-exhaustion wrapper was never exercised.

Matching the prefix anywhere in the message is a deliberate widening. The string is distinctive, and the existing "does NOT suppress a genuine bug flattened to FatalError" cases stay false because they do not contain it. `DEMO_MODE_MESSAGE` is left anchored, since nothing wraps it and widening it would suppress more than it fixes.

## Validation

- Added an `isExpectedError` case using the verbatim production message from `CUSTOMERMATES-43`. Confirmed it fails against `startsWith` and passes against `includes`, with the other 17 cases unchanged.
- Added `features/user/__tests__/user-service-active-guard.test.ts`: an active account resolves, an inactive one raises `ForbiddenError`, maps to `{ statusCode: 403 }`, and is recognised by `isExpectedError`. Nothing previously pinned this behaviour.
- Full suite: 2630 passed / 314 files, `yarn lint` clean, `yarn typecheck` clean.

The 10 `ECONNREFUSED` errors locally are `*.database.test.ts` files reaching for a Postgres container that is not running here. They are gated behind `RUN_DATABASE_TESTS` in CI, so CI is the real signal for those.

## Impact and rollback

`POST /api/v1/mcp` now answers a deactivated account with 403 instead of 500. That is the intended status for this condition, but it is a visible response-code change for any client that was matching on 500. Sentry stops receiving both classes of event; neither is suppressed silently, since both remain ordinary rejections surfaced to the caller. Rollback is a straight revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)