### PR TITLE
fix(messaging): retire a disconnected-account webhook without reporting it

### DIFF
--- a/ee/messaging/messaging.service.ts
+++ b/ee/messaging/messaging.service.ts
@@ -169,6 +169,10 @@ export function isUnipileTimeout(err: unknown): boolean {
   return err instanceof UnipileRequestError && err.status === 0;
 }
 
+export function isUnipileDisconnectedAccount(err: unknown): err is UnipileRequestError {
+  return err instanceof UnipileRequestError && unipileErrorCode(err) === CustomErrorCode.unipileDisconnectedAccount;
+}
+
 export function isUnipileResourceNotFound(err: unknown): boolean {
   if (!(err instanceof UnipileRequestError)) return false;
 

--- a/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
@@ -20,6 +20,7 @@ import * as Sentry from "@sentry/node";
 
 import { ProcessUnipileWebhookInteractor } from "../process-unipile-webhook.interactor";
 import { UnmappableWebhookPayloadError } from "@/core/errors/app-errors";
+import { UnipileRequestError } from "../../messaging.service";
 
 const EVENT_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -55,6 +56,38 @@ describe("ProcessUnipileWebhookInteractor classification", () => {
     expect(events.markWebhookEventProcessedUnscoped).toHaveBeenCalledWith(EVENT_ID);
     expect(events.markWebhookEventFailedUnscoped).not.toHaveBeenCalled();
     expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("retires a disconnected-account rejection without reporting it", async () => {
+    const disconnected = new UnipileRequestError(
+      401,
+      "provider/invalid_authorization",
+      '{"object":"Error","status":401,"type":"provider/invalid_authorization","title":"Invalid authorization","detail":"Account is disconnected.","req_id":"req-8gb"}',
+    );
+    const handler = { invoke: vi.fn().mockRejectedValue(disconnected) };
+    const { interactor, events } = build(row({ type: "email.folder.update", account_id: "acc_1", payload: {} }), {
+      "email.folder.update": handler,
+    });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledWith(
+      expect.objectContaining({ id: EVENT_ID, terminal: true }),
+    );
+    expect(events.markWebhookEventProcessedUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("still reports an unrelated Unipile rejection", async () => {
+    const serverError = new UnipileRequestError(500, "api/unknown", '{"detail":"boom"}');
+    const handler = { invoke: vi.fn().mockRejectedValue(serverError) };
+    const { interactor } = build(row({ type: "email.folder.update", account_id: "acc_1", payload: {} }), {
+      "email.folder.update": handler,
+    });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).toHaveBeenCalledOnce();
   });
 
   it("marks a transient handler error non-terminal, captures it once, and does not rethrow", async () => {

--- a/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
+++ b/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
@@ -9,6 +9,7 @@ import type { UnipileWebhookEnvelope } from "../unipile.schema";
 
 import { UnipileWebhookEnvelopeSchema } from "../unipile.schema";
 import { UnmappableWebhookPayloadError } from "@/core/errors/app-errors";
+import { isUnipileDisconnectedAccount } from "../messaging.service";
 
 export type UnipileWebhookHandlerMap = Partial<
   Record<string, { invoke(envelope: UnipileWebhookEnvelope): Promise<void> }>
@@ -64,6 +65,12 @@ export class ProcessUnipileWebhookInteractor {
           terminal: true,
           unipileMessageId: err.unipileMessageId,
         });
+
+        return;
+      }
+
+      if (isUnipileDisconnectedAccount(err)) {
+        await this.events.markWebhookEventFailedUnscoped({ id, error: err.message, terminal: true });
 
         return;
       }


### PR DESCRIPTION
## Summary

Treat a Unipile `401 provider/invalid_authorization` in webhook processing as an expected external condition: retire the event as terminal instead of reporting it and scheduling a retry.

## Context

Sentry `CUSTOMERMATES-4F` (18 events), `CUSTOMERMATES-45` (4) and `CUSTOMERMATES-42` (3), all on `POST /api/webhooks/unipile/v2`:

> `UnipileRequestError: Unipile v2 request failed: 401 ... "detail":"Account is disconnected."`

The events carry `handled: yes` and the tags `webhookEventId` / `eventType`, which identifies the capture precisely as `process-unipile-webhook.interactor.ts:71`. The observed `eventType` is `email.folder.update`: `ProcessEmailFolderWebhookInteractor` guards only against `ConnectedAccountStatus.deleted` and then calls `listFolders`, which reaches Unipile through `requestData` and throws the raw 401.

Unipile keeps delivering webhooks for an account the user has disconnected, so every handler that calls back upstream is answered with 401. Retrying cannot succeed until the user reconnects, so the previous behaviour reported a user action as a defect and queued a retry guaranteed to fail identically.

Two things made a narrow fix possible rather than touching all twelve webhook interactors that share the `deleted`-only guard:

- `MessagingService.mapError` already classifies these types as `CustomErrorCode.unipileDisconnectedAccount` without capturing, so the intent was established; only the paths that call `requestData` directly were missing it. `isUnipileDisconnectedAccount` reuses `unipileErrorCode`, so it stays in step with the existing `UNIPILE_ERROR_CODES` table rather than duplicating the type list.
- `ProcessAccountStatusWebhookInteractor` already handles `account.status.disconnected` and writes `status: credentials` with `syncing: false`. The account record is therefore corrected on its own channel, and doing it again here would need the account repo injected into a wrapper that deliberately knows nothing about accounts.

The new branch sits beside the existing `UnmappableWebhookPayloadError` branch, which is the same shape of decision.

## Validation

- Added two cases to `process-unipile-webhook.test.ts` using the verbatim production error body: a disconnected rejection is retired as `terminal: true` with no `captureException` and no "processed" mark, and an unrelated Unipile 500 is still captured.
- Confirmed the first is a real regression test: with the branch removed it fails and the other 31 pass.
- `yarn vitest run ee/messaging` 353 passed / 39 files, `yarn lint` clean, `yarn typecheck` clean.

## Impact and rollback

Narrows what reaches Sentry from webhook processing by one specific, already-classified condition; every other failure still reports exactly as before. The behavioural change is that these events are now marked terminal rather than retried, which is what the retry budget was being spent on. Not addressed here: `CUSTOMERMATES-4W` (`request failed: 0`, 2 events) is a transient Unipile timeout on the same route and remains reported, since suppressing a timeout is a separate judgement about alerting. Rollback is a straight revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)