### PR TITLE
fix(messaging): treat a webhook for a removed account as a no-op

### DIFF
--- a/ee/messaging/__tests__/messaging-service-drift.test.ts
+++ b/ee/messaging/__tests__/messaging-service-drift.test.ts
@@ -236,6 +236,7 @@ describe("getAccount consumer drift policies", () => {
     const messagingService = { getAccount: vi.fn().mockRejectedValue(new z.ZodError([])) };
     const repo = {
       findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockResolvedValue(account),
+      findAccountByUnipileIdUnscoped: vi.fn().mockResolvedValue(account),
       updateAccountUnscoped: vi.fn().mockResolvedValue(undefined),
     };
     const backgroundTaskService = { dispatch: vi.fn().mockResolvedValue(undefined) };
@@ -260,6 +261,7 @@ describe("getAccount consumer drift policies", () => {
     const messagingService = { getAccount: vi.fn().mockRejectedValue(new Error("Unipile v2 request failed: 500")) };
     const repo = {
       findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockResolvedValue(account),
+      findAccountByUnipileIdUnscoped: vi.fn().mockResolvedValue(account),
       updateAccountUnscoped: vi.fn().mockResolvedValue(undefined),
     };
     const backgroundTaskService = { dispatch: vi.fn() };

--- a/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
@@ -60,6 +60,7 @@ function build(
   };
   const accountRepo = {
     findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockResolvedValue(account),
+    findAccountByUnipileIdUnscoped: vi.fn().mockResolvedValue(account),
   };
   const eventService = { publish: vi.fn().mockResolvedValue(undefined) };
   const messagingService = {

--- a/ee/messaging/webhooks/__tests__/process-email-folder-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-email-folder-webhook.test.ts
@@ -35,6 +35,7 @@ const folders = [
 function build(account: unknown, folderItems: unknown[]) {
   const accountRepo = {
     findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockResolvedValue(account),
+    findAccountByUnipileIdUnscoped: vi.fn().mockResolvedValue(account),
     updateAccountUnscoped: vi.fn().mockResolvedValue(undefined),
   };
   const messagingService = {

--- a/ee/messaging/webhooks/__tests__/process-webhook-missing-account.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-webhook-missing-account.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { createMockUser } from "@/tests/helpers/mock-user";
+import {
+  MOCK_ENV_MODULE,
+  createMockDiModule,
+  MOCK_ZOD_MODULE,
+  MOCK_PRISMA_DB_MODULE,
+} from "@/tests/helpers/interactor-test-setup";
+
+const mockUser = createMockUser();
+
+vi.mock("@/env", () => MOCK_ENV_MODULE);
+vi.mock("@/core/di", () => ({ ...createMockDiModule(() => mockUser) }));
+vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
+vi.mock("@/prisma/db", () => MOCK_PRISMA_DB_MODULE);
+
+import { ProcessAccountStatusWebhookInteractor } from "../account/process-account-status-webhook.interactor";
+import { ProcessEmailFolderWebhookInteractor } from "../email/process-email-folder-webhook.interactor";
+
+function accountRepoReturning(account: unknown) {
+  return {
+    findAccountByUnipileIdUnscoped: vi.fn().mockResolvedValue(account),
+    findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockRejectedValue(
+      Object.assign(
+        new Error("An operation failed because it depends on one or more records that were required but not found."),
+        {
+          name: "PrismaClientKnownRequestError",
+          code: "P2025",
+        },
+      ),
+    ),
+    updateAccountUnscoped: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("webhook handlers for an account that no longer exists", () => {
+  it("returns without writing when the status webhook cannot resolve its account", async () => {
+    const accountRepo = accountRepoReturning(null);
+    const interactor = new ProcessAccountStatusWebhookInteractor(accountRepo as never);
+
+    await expect(
+      interactor.invoke({ type: "account.status.disconnected", account_id: "acc_uni-gone" }),
+    ).resolves.toBeUndefined();
+
+    expect(accountRepo.updateAccountUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("returns without calling unipile when the folder webhook cannot resolve its account", async () => {
+    const accountRepo = accountRepoReturning(null);
+    const messagingService = { listFolders: vi.fn() };
+    const interactor = new ProcessEmailFolderWebhookInteractor(accountRepo as never, messagingService as never);
+
+    await expect(
+      interactor.invoke({ type: "email.folder.update", account_id: "acc_uni-gone" }),
+    ).resolves.toBeUndefined();
+
+    expect(messagingService.listFolders).not.toHaveBeenCalled();
+    expect(accountRepo.updateAccountUnscoped).not.toHaveBeenCalled();
+  });
+});

--- a/ee/messaging/webhooks/__tests__/webhook-mapper-null.test.ts
+++ b/ee/messaging/webhooks/__tests__/webhook-mapper-null.test.ts
@@ -32,7 +32,10 @@ const account = {
 } as any;
 
 function accountRepo() {
-  return { findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockResolvedValue(account) };
+  return {
+    findAccountByUnipileIdOrThrowUnscoped: vi.fn().mockResolvedValue(account),
+    findAccountByUnipileIdUnscoped: vi.fn().mockResolvedValue(account),
+  };
 }
 
 beforeEach(() => vi.clearAllMocks());

--- a/ee/messaging/webhooks/account/process-account-ready-webhook.interactor.ts
+++ b/ee/messaging/webhooks/account/process-account-ready-webhook.interactor.ts
@@ -23,8 +23,8 @@ export class ProcessAccountReadyWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     await this.accountRepo.updateAccountUnscoped({
       unipileAccountId: account.unipileAccountId,

--- a/ee/messaging/webhooks/account/process-account-reconnect-webhook.interactor.ts
+++ b/ee/messaging/webhooks/account/process-account-reconnect-webhook.interactor.ts
@@ -28,8 +28,8 @@ export class ProcessAccountReconnectWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     let status: ConnectedAccountStatus = ConnectedAccountStatus.ok;
     try {

--- a/ee/messaging/webhooks/account/process-account-remove-webhook.interactor.ts
+++ b/ee/messaging/webhooks/account/process-account-remove-webhook.interactor.ts
@@ -19,8 +19,8 @@ export class ProcessAccountRemoveWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     await this.accountRepo.updateAccountUnscoped({
       unipileAccountId: account.unipileAccountId,

--- a/ee/messaging/webhooks/account/process-account-status-webhook.interactor.ts
+++ b/ee/messaging/webhooks/account/process-account-status-webhook.interactor.ts
@@ -25,8 +25,8 @@ export class ProcessAccountStatusWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const status = mapUnipileStatus(envelope.type.slice("account.status.".length));
     const stalled =

--- a/ee/messaging/webhooks/calendar/process-calendar-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/calendar/process-calendar-delete-webhook.interactor.ts
@@ -28,8 +28,8 @@ export class ProcessCalendarDeleteWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const calendar = await this.calendarRepo.deleteCalendarUnscoped({
       connectedAccountId: account.id,

--- a/ee/messaging/webhooks/calendar/process-calendar-event-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/calendar/process-calendar-event-delete-webhook.interactor.ts
@@ -28,8 +28,8 @@ export class ProcessCalendarEventDeleteWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const event = await this.calendarRepo.deleteCalendarEventUnscoped({
       connectedAccountId: account.id,

--- a/ee/messaging/webhooks/calendar/process-calendar-event-upsert-webhook.interactor.ts
+++ b/ee/messaging/webhooks/calendar/process-calendar-event-upsert-webhook.interactor.ts
@@ -31,8 +31,8 @@ export class ProcessCalendarEventUpsertWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const normalized = buildCalendarEvent(envelope.payload);
     if (!normalized) throw new UnmappableWebhookPayloadError(envelope.payload.id || null);

--- a/ee/messaging/webhooks/calendar/process-calendar-upsert-webhook.interactor.ts
+++ b/ee/messaging/webhooks/calendar/process-calendar-upsert-webhook.interactor.ts
@@ -29,8 +29,8 @@ export class ProcessCalendarUpsertWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const calendar = await this.calendarRepo.upsertCalendarUnscoped({
       companyId: account.companyId,

--- a/ee/messaging/webhooks/chat/process-chat-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/chat/process-chat-delete-webhook.interactor.ts
@@ -28,8 +28,8 @@ export class ProcessChatDeleteWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const thread = await this.ingest.deleteChatThreadUnscoped({
       companyId: account.companyId,

--- a/ee/messaging/webhooks/chat/process-chat-update-webhook.interactor.ts
+++ b/ee/messaging/webhooks/chat/process-chat-update-webhook.interactor.ts
@@ -31,8 +31,8 @@ export class ProcessChatUpdateWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const chat = envelope.payload;
     const type: MessagingThreadType | undefined = chat.is_group ? "group" : chat.is_channel ? "channel" : undefined;

--- a/ee/messaging/webhooks/email/process-email-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/email/process-email-delete-webhook.interactor.ts
@@ -60,8 +60,8 @@ export class ProcessEmailDeleteWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const existing = await this.ingest.findMessageByUnipileIdUnscoped({
       connectedAccountId: account.id,

--- a/ee/messaging/webhooks/email/process-email-folder-webhook.interactor.ts
+++ b/ee/messaging/webhooks/email/process-email-folder-webhook.interactor.ts
@@ -26,8 +26,8 @@ export class ProcessEmailFolderWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const page = await this.messagingService.listFolders({ accountId: account.unipileAccountId });
     const folders = (page.data ?? []).flatMap((raw) => {

--- a/ee/messaging/webhooks/email/process-email-new-webhook.interactor.ts
+++ b/ee/messaging/webhooks/email/process-email-new-webhook.interactor.ts
@@ -31,8 +31,8 @@ export class ProcessEmailNewWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const message = buildEmailMessage(envelope.payload.email, {
       provider: account.provider,

--- a/ee/messaging/webhooks/message/process-message-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/message/process-message-delete-webhook.interactor.ts
@@ -28,8 +28,8 @@ export class ProcessMessageDeleteWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const deleted = await this.ingest.markMessageDeletedUnscoped({
       companyId: account.companyId,

--- a/ee/messaging/webhooks/message/process-message-new-webhook.interactor.ts
+++ b/ee/messaging/webhooks/message/process-message-new-webhook.interactor.ts
@@ -31,8 +31,8 @@ export class ProcessMessageNewWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const message = normalizeChatMessage(envelope.payload, account.provider);
     if (!message) {

--- a/ee/messaging/webhooks/message/process-message-reaction-webhook.interactor.ts
+++ b/ee/messaging/webhooks/message/process-message-reaction-webhook.interactor.ts
@@ -36,8 +36,8 @@ export class ProcessMessageReactionWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const { message_id, reaction } = envelope.payload;
     const reactions: MessageReactionEntry[] = [

--- a/ee/messaging/webhooks/relation/process-relation-webhook.interactor.ts
+++ b/ee/messaging/webhooks/relation/process-relation-webhook.interactor.ts
@@ -29,8 +29,8 @@ export class ProcessRelationWebhookInteractor {
 
   @Enforce(Schema)
   async invoke(envelope: Payload): Promise<void> {
-    const account = await this.accountRepo.findAccountByUnipileIdOrThrowUnscoped(envelope.account_id);
-    if (account.status === ConnectedAccountStatus.deleted) return;
+    const account = await this.accountRepo.findAccountByUnipileIdUnscoped(envelope.account_id);
+    if (!account || account.status === ConnectedAccountStatus.deleted) return;
 
     const user = envelope.payload.user;
     const fullName = user.display_name ?? ([user.first_name, user.last_name].filter(Boolean).join(" ").trim() || null);


### PR DESCRIPTION
## Summary

Webhook handlers resolved their `ConnectedAccount` with `findUniqueOrThrow`, so a webhook for an account whose row is gone raised `P2025` instead of finishing. Resolve it without throwing and let the existing `deleted` guard cover the absent case too.

## Context

Sentry `CUSTOMERMATES-3B`, `GET /api/cron/reprocess-webhook-events`, **516 occurrences**:

> `Invalid `prisma.connectedAccount.findUniqueOrThrow()` invocation: An operation failed because it depends on one or more records that were required but not found.`

This one symbolicated cleanly, so the path is exact:

```
app/api/cron/reprocess-webhook-events/route.ts:14
  ee/messaging/ingest/reprocess-stuck-webhook-events.interactor.ts:28
    ee/messaging/webhooks/process-unipile-webhook.interactor.ts:57
      ee/messaging/webhooks/account/process-account-status-webhook.interactor.ts:28
```

with `eventType: account.status.disconnected`.

Disconnecting an account is a hard delete, not a soft one: `prisma-connected-account.repository.ts:494` calls `connectedAccount.deleteMany`. Unipile then sends `account.status.disconnected` for an account we no longer hold, and the stuck-event cron replays whatever was already queued, so the same event fails on every sweep. That replay is why the occurrence count is so much higher than the number of accounts involved.

Every one of these handlers already opens with the same two lines: resolve the account, then `return` if its status is `deleted`. A row that has been removed means exactly what a row marked `deleted` means, so the fix is to make the two cases behave alike rather than to special-case the error. The non-throwing `findAccountByUnipileIdUnscoped` already exists on the same repo and is already used by `process-account-add-webhook`, so no new repository surface was needed.

Applied uniformly to all 17 handlers rather than only the one in the stack trace: the shape was byte-identical at every site, and any handler can receive a webhook for a removed account. Fixing one would have left the same defect in sixteen others.

Deliberately not done: matching `P2025` centrally in `process-unipile-webhook.interactor.ts`. That would suppress a genuine "required record missing" bug anywhere else in a handler, which is the opposite of what the triage policy asks for.

## Validation

- New `process-webhook-missing-account.test.ts`: the status handler and the folder handler each return cleanly for an unresolvable account, write nothing, and in the folder case never call Unipile. The mock for the old finder rejects with a `P2025`-shaped error so the test reproduces the production failure rather than a generic one.
- Confirmed it is a real regression test: reverting `process-account-status-webhook.interactor.ts` to `findUniqueOrThrow` fails exactly that case.
- Updated the four existing test files whose repo mocks only provided the throwing finder.
- Full suite: 2629 passed / 314 files, `yarn lint` clean, `yarn typecheck` clean. TypeScript narrows the now-nullable account through the existing guard with no cast.

The 10 `ECONNREFUSED` errors locally are `*.database.test.ts` files reaching for a Postgres container that is not running here.

## Impact and rollback

Touches 17 webhook handlers with an identical two-line change each. Behaviour is unchanged whenever the account exists; the only difference is that a missing row now ends the handler quietly instead of throwing, which also stops the stuck-event cron re-raising the same event on every sweep. Rollback is a straight revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)