### PR TITLE
feat(data-view): apply and persist shared filter changes automatically

### DIFF
--- a/components/data-view/filter-modal/__tests__/edit-filters-modal.store.test.ts
+++ b/components/data-view/filter-modal/__tests__/edit-filters-modal.store.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store";
+import type { RootStore } from "@/core/stores/root.store";
+import type { Filter, FilterableField } from "@/core/base/base-get.schema";
+
+const { deleteFilterPresetAction, upsertFilterPresetAction } = vi.hoisted(() => ({
+  deleteFilterPresetAction: vi.fn(),
+  upsertFilterPresetAction: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("@/app/actions", () => ({ deleteFilterPresetAction, upsertFilterPresetAction }));
+
+import { EditFiltersModalStore, FILTER_AUTO_APPLY_DELAY_MS } from "../edit-filters-modal.store";
+
+type SavedPreset = { id: string; name: string; filters: unknown };
+
+const FILTERABLE_FIELDS: FilterableField[] = [
+  { field: "name", operators: ["contains", "equals", "isNull"] },
+  { field: "userIds", operators: ["in", "hasSome"] },
+] as unknown as FilterableField[];
+
+function tableStore(overrides: { filters?: Filter[]; savedFilterPresets?: SavedPreset[] } = {}) {
+  return {
+    customColumns: [],
+    filterableFields: FILTERABLE_FIELDS,
+    filters: overrides.filters ?? [],
+    p13nId: "contacts",
+    savedFilterPresets: overrides.savedFilterPresets ?? [],
+    setQueryOptions: vi.fn(),
+  };
+}
+
+function modalStore() {
+  const root = { registerModalStore: vi.fn(), localeStore: { getTranslation: (key: string) => key } };
+  return new EditFiltersModalStore(root as unknown as RootStore);
+}
+
+function openedOn(table: ReturnType<typeof tableStore>) {
+  const store = modalStore();
+  store.openFor(table as unknown as BaseDataViewStore<HasId>);
+  return store;
+}
+
+function committedFilters(table: ReturnType<typeof tableStore>, call = 0) {
+  return table.setQueryOptions.mock.calls[call]?.[0];
+}
+
+describe("EditFiltersModalStore auto-apply", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    upsertFilterPresetAction.mockReset();
+    deleteFilterPresetAction.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("commits a typed edit once, in the background, after the debounce elapses", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "a");
+    store.onChange("filters[0].value", "ac");
+    store.onChange("filters[0].value", "acme");
+
+    expect(table.setQueryOptions).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    expect(table.setQueryOptions).toHaveBeenCalledTimes(1);
+    expect(committedFilters(table)).toEqual({
+      filters: [{ field: "name", operator: "contains", value: "acme" }],
+      refreshMode: "background",
+    });
+  });
+
+  it("does not commit a typed edit before the debounce elapses", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].value", "acme");
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS - 1);
+
+    expect(table.setQueryOptions).not.toHaveBeenCalled();
+  });
+
+  it("applies an operator change immediately through the flush the inputs call", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "isNull");
+    store.flushPendingChanges();
+
+    expect(table.setQueryOptions).toHaveBeenCalledTimes(1);
+    expect(committedFilters(table)).toEqual({
+      filters: [{ field: "name", operator: "isNull", value: undefined }],
+      refreshMode: "background",
+    });
+
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+    expect(table.setQueryOptions).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps incomplete configurations out of the committed query", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[1].operator", "in");
+    store.onChange("filters[1].value", []);
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    expect(committedFilters(table)).toEqual({ filters: [], refreshMode: "background" });
+  });
+
+  it("drops a filter from the query when its value is cleared", () => {
+    const table = tableStore({ filters: [{ field: "name", operator: "contains", value: "acme" } as Filter] });
+    const store = openedOn(table);
+
+    store.onChange("filters[0].value", "");
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    expect(committedFilters(table)).toEqual({ filters: [], refreshMode: "background" });
+  });
+
+  it("leaves no unsaved-changes guard behind after an ordinary auto-apply", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "acme");
+    expect(store.hasUnsavedChanges).toBe(true);
+
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    expect(store.hasUnsavedChanges).toBe(false);
+  });
+
+  it("keeps unsaved named-preset edits guarded while still applying them", () => {
+    const table = tableStore({
+      savedFilterPresets: [
+        { id: "preset-1", name: "Mine", filters: [{ field: "name", operator: "contains", value: "a" }] },
+      ],
+    });
+    const store = openedOn(table);
+
+    store.onChange("presetId", "preset-1");
+    expect(store.hasUnsavedChanges).toBe(false);
+
+    store.onChange("filters[0].value", "b");
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    expect(committedFilters(table, 1)).toEqual({
+      filters: [{ field: "name", operator: "contains", value: "b" }],
+      refreshMode: "background",
+    });
+    expect(store.hasUnsavedChanges).toBe(true);
+  });
+
+  it("applies a selected named preset immediately", () => {
+    const table = tableStore({
+      savedFilterPresets: [
+        { id: "preset-1", name: "Mine", filters: [{ field: "name", operator: "contains", value: "acme" }] },
+      ],
+    });
+    const store = openedOn(table);
+
+    store.onChange("presetId", "preset-1");
+
+    expect(table.setQueryOptions).toHaveBeenCalledTimes(1);
+    expect(committedFilters(table)).toEqual({
+      filters: [{ field: "name", operator: "contains", value: "acme" }],
+      refreshMode: "background",
+    });
+  });
+
+  it("survives a stored preset whose filters are not a usable array", () => {
+    const table = tableStore({ savedFilterPresets: [{ id: "preset-1", name: "Broken", filters: null }] });
+    const store = openedOn(table);
+
+    expect(() => store.onChange("presetId", "preset-1")).not.toThrow();
+    expect(store.form.filters.map((filter) => filter.field)).toEqual(["name", "userIds"]);
+    expect(committedFilters(table)).toEqual({ filters: [], refreshMode: "background" });
+  });
+
+  it("flushes a pending edit when the overlay is dismissed", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "acme");
+    store.close();
+
+    expect(table.setQueryOptions).toHaveBeenCalledTimes(1);
+    expect(committedFilters(table)).toEqual({
+      filters: [{ field: "name", operator: "contains", value: "acme" }],
+      refreshMode: "background",
+    });
+  });
+
+  it("drops a pending edit when the filters are cleared", () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "acme");
+    store.cancelPendingAutoApply();
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    expect(table.setQueryOptions).not.toHaveBeenCalled();
+  });
+
+  it("never writes a preset when submitting outside preset mode", async () => {
+    const table = tableStore();
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "acme");
+    await store.onSubmit();
+
+    expect(upsertFilterPresetAction).not.toHaveBeenCalled();
+    expect(store.isOpen).toBe(true);
+    expect(committedFilters(table)).toEqual({
+      filters: [{ field: "name", operator: "contains", value: "acme" }],
+      refreshMode: "background",
+    });
+  });
+
+  it("writes the preset and closes only on an explicit save", async () => {
+    const table = tableStore();
+    const store = openedOn(table);
+    upsertFilterPresetAction.mockResolvedValue({ ok: true, data: {} });
+
+    store.onChange("presetId", "new");
+    store.onChange("name", "Hot leads");
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "acme");
+    await store.onSubmit();
+
+    expect(upsertFilterPresetAction).toHaveBeenCalledWith({
+      p13nId: "contacts",
+      name: "Hot leads",
+      presetId: undefined,
+      filters: [{ field: "name", operator: "contains", value: "acme" }],
+    });
+    expect(store.isOpen).toBe(false);
+  });
+});

--- a/components/data-view/filter-modal/__tests__/edit-filters-modal.store.test.ts
+++ b/components/data-view/filter-modal/__tests__/edit-filters-modal.store.test.ts
@@ -14,12 +14,17 @@ vi.mock("@/app/actions", () => ({ deleteFilterPresetAction, upsertFilterPresetAc
 
 import { EditFiltersModalStore, FILTER_AUTO_APPLY_DELAY_MS } from "../edit-filters-modal.store";
 
+import { ActivityFiltersSchema } from "@/ee/messaging/activities/activities.schema";
+
 type SavedPreset = { id: string; name: string; filters: unknown };
 
 const FILTERABLE_FIELDS: FilterableField[] = [
   { field: "name", operators: ["contains", "equals", "isNull"] },
-  { field: "userIds", operators: ["in", "hasSome"] },
+  { field: "userIds", operators: ["in", "notIn", "hasSome", "hasNone"] },
+  { field: "contactIds", operators: ["in", "notIn", "hasSome", "hasNone"] },
 ] as unknown as FilterableField[];
+
+const A_CONTACT = "60000000-0000-4000-8000-000000000008";
 
 function tableStore(overrides: { filters?: Filter[]; savedFilterPresets?: SavedPreset[] } = {}) {
   return {
@@ -183,7 +188,7 @@ describe("EditFiltersModalStore auto-apply", () => {
     const store = openedOn(table);
 
     expect(() => store.onChange("presetId", "preset-1")).not.toThrow();
-    expect(store.form.filters.map((filter) => filter.field)).toEqual(["name", "userIds"]);
+    expect(store.form.filters.map((filter) => filter.field)).toEqual(["name", "userIds", "contactIds"]);
     expect(committedFilters(table)).toEqual({ filters: [], refreshMode: "background" });
   });
 
@@ -212,6 +217,23 @@ describe("EditFiltersModalStore auto-apply", () => {
     vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
 
     expect(table.setQueryOptions).not.toHaveBeenCalled();
+  });
+
+  it("keeps a relation-existence operator from carrying a value into the timeline schema", () => {
+    const poisoned = { field: "contactIds", operator: "hasSome", value: [A_CONTACT] } as unknown as Filter;
+    const table = tableStore({ filters: [poisoned] });
+    const store = openedOn(table);
+
+    store.onChange("filters[0].operator", "contains");
+    store.onChange("filters[0].value", "acme");
+    vi.advanceTimersByTime(FILTER_AUTO_APPLY_DELAY_MS);
+
+    const committed = (committedFilters(table).filters as Filter[]).find((filter) => filter.field === "contactIds");
+
+    expect(committed).toEqual({ field: "contactIds", operator: "hasSome" });
+    expect("value" in (committed as object)).toBe(false);
+    expect(() => ActivityFiltersSchema.parse([committed])).not.toThrow();
+    expect(() => ActivityFiltersSchema.parse([poisoned])).toThrow();
   });
 
   it("never writes a preset when submitting outside preset mode", async () => {

--- a/components/data-view/filter-modal/__tests__/filter-value-class.test.ts
+++ b/components/data-view/filter-modal/__tests__/filter-value-class.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+
+import type { Filter } from "@/core/base/base-get.schema";
+import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
+
+import {
+  resolveFilterDateGranularity,
+  resolveFilterValueClass,
+  shouldPreserveFilterValue,
+} from "../filter-value-class";
+
+import { FilterOperatorKey } from "@/core/base/base-query-builder";
+import { FilterFieldKey } from "@/core/types/filter-field-key";
+import { FILTER_FIELD_DEFAULT_OPERATORS } from "@/core/types/filter-field-operators";
+
+const COLUMN_OPERATORS: Record<string, FilterOperatorKey[]> = {
+  singleSelect: [FilterOperatorKey.in, FilterOperatorKey.notIn, FilterOperatorKey.isNull, FilterOperatorKey.isNotNull],
+  currency: [
+    FilterOperatorKey.equals,
+    FilterOperatorKey.gt,
+    FilterOperatorKey.gte,
+    FilterOperatorKey.lt,
+    FilterOperatorKey.lte,
+    FilterOperatorKey.isNull,
+    FilterOperatorKey.isNotNull,
+  ],
+  date: [
+    FilterOperatorKey.gt,
+    FilterOperatorKey.gte,
+    FilterOperatorKey.lt,
+    FilterOperatorKey.lte,
+    FilterOperatorKey.between,
+    FilterOperatorKey.isNull,
+    FilterOperatorKey.isNotNull,
+  ],
+  dateRange: [
+    FilterOperatorKey.contains,
+    FilterOperatorKey.gt,
+    FilterOperatorKey.gte,
+    FilterOperatorKey.lt,
+    FilterOperatorKey.lte,
+    FilterOperatorKey.between,
+    FilterOperatorKey.isNull,
+    FilterOperatorKey.isNotNull,
+  ],
+  plain: [FilterOperatorKey.equals, FilterOperatorKey.contains, FilterOperatorKey.isNull, FilterOperatorKey.isNotNull],
+};
+
+const COLUMN_ID = "16000000-0000-4000-8000-000000000001";
+
+function column(type: string): CustomColumnDto[] {
+  return [{ id: COLUMN_ID, type, name: type }] as unknown as CustomColumnDto[];
+}
+
+function filter(field: string, operator: FilterOperatorKey | undefined, value: unknown): Filter {
+  return { field, operator, value } as unknown as Filter;
+}
+
+function valueFor(kind: string): unknown {
+  if (kind === "stringArray") return ["30000000-0000-4000-8000-000000000001"];
+  if (kind === "numericString") return "1000";
+  if (kind === "isoDate") return "2026-08-19T00:00:00.000Z";
+  if (kind === "isoRange") return ["2026-08-01T00:00:00.000Z", "2026-08-19T00:00:00.000Z"];
+  if (kind === "daysCount") return 30;
+  return "acme";
+}
+
+function orderedPairs(operators: FilterOperatorKey[]) {
+  return operators.flatMap((from) => operators.filter((to) => to !== from).map((to) => [from, to] as const));
+}
+
+describe("filter value class", () => {
+  it("gives every value-less operator the same class regardless of field", () => {
+    const standalone = [
+      FilterOperatorKey.isNull,
+      FilterOperatorKey.isNotNull,
+      FilterOperatorKey.hasNone,
+      FilterOperatorKey.hasSome,
+      FilterOperatorKey.hasUnset,
+      FilterOperatorKey.allSet,
+    ];
+
+    for (const operator of standalone) {
+      expect(resolveFilterValueClass(FilterFieldKey.userIds, operator)).toBe("none");
+      expect(resolveFilterValueClass(COLUMN_ID, operator, column("currency"))).toBe("none");
+    }
+  });
+
+  it("reports an unresolvable custom column rather than guessing a class", () => {
+    expect(resolveFilterValueClass(COLUMN_ID, FilterOperatorKey.equals, [])).toBe("unavailable");
+  });
+
+  it("classifies every operator each standard field actually offers", () => {
+    const expected: Record<string, string> = {
+      [FilterFieldKey.userIds]: "stringArray",
+      [FilterFieldKey.contactIds]: "stringArray",
+      [FilterFieldKey.timelineKind]: "stringArray",
+      [FilterFieldKey.participantContactId]: "stringArray",
+      [FilterFieldKey.url]: "text",
+    };
+
+    for (const [field, valueClass] of Object.entries(expected)) {
+      for (const operator of FILTER_FIELD_DEFAULT_OPERATORS[field as FilterFieldKey]) {
+        const resolved = resolveFilterValueClass(field, operator);
+        expect(resolved).toBe(resolved === "none" ? "none" : valueClass);
+      }
+    }
+  });
+
+  it("splits date fields by operator", () => {
+    expect(resolveFilterValueClass(FilterFieldKey.createdAt, FilterOperatorKey.gt)).toBe("isoDate");
+    expect(resolveFilterValueClass(FilterFieldKey.createdAt, FilterOperatorKey.between)).toBe("isoRange");
+    expect(resolveFilterValueClass(FilterFieldKey.createdAt, FilterOperatorKey.inLastDays)).toBe("daysCount");
+  });
+
+  it("uses day granularity only for the date-only custom column types", () => {
+    expect(resolveFilterDateGranularity(COLUMN_ID, column("date"))).toBe("day");
+    expect(resolveFilterDateGranularity(COLUMN_ID, column("dateRange"))).toBe("day");
+    expect(resolveFilterDateGranularity(COLUMN_ID, column("dateTime"))).toBe("minute");
+    expect(resolveFilterDateGranularity(FilterFieldKey.createdAt)).toBe("minute");
+  });
+});
+
+describe("preserving a filter value across an operator change", () => {
+  it("keeps the selection when a relation field flips between in and notIn", () => {
+    const current = filter(FilterFieldKey.userIds, FilterOperatorKey.in, valueFor("stringArray"));
+
+    expect(shouldPreserveFilterValue(current, FilterOperatorKey.notIn)).toBe(true);
+  });
+
+  it("keeps the entered text when a text field flips between equals and contains", () => {
+    const current = filter(COLUMN_ID, FilterOperatorKey.contains, "acme");
+
+    expect(shouldPreserveFilterValue(current, FilterOperatorKey.equals, column("plain"))).toBe(true);
+  });
+
+  it("keeps the entered amount across every currency comparison", () => {
+    for (const [from, to] of orderedPairs([
+      FilterOperatorKey.equals,
+      FilterOperatorKey.gt,
+      FilterOperatorKey.gte,
+      FilterOperatorKey.lt,
+      FilterOperatorKey.lte,
+    ])) {
+      const current = filter(COLUMN_ID, from, "1000");
+
+      expect(shouldPreserveFilterValue(current, to, column("currency"))).toBe(true);
+    }
+  });
+
+  it("keeps the chosen date across every date comparison", () => {
+    for (const [from, to] of orderedPairs([
+      FilterOperatorKey.gt,
+      FilterOperatorKey.gte,
+      FilterOperatorKey.lt,
+      FilterOperatorKey.lte,
+    ])) {
+      const current = filter(FilterFieldKey.createdAt, from, valueFor("isoDate"));
+
+      expect(shouldPreserveFilterValue(current, to)).toBe(true);
+    }
+  });
+
+  it("never carries a value onto a value-less operator", () => {
+    const current = filter(FilterFieldKey.userIds, FilterOperatorKey.in, valueFor("stringArray"));
+
+    expect(shouldPreserveFilterValue(current, FilterOperatorKey.hasSome)).toBe(false);
+    expect(shouldPreserveFilterValue(current, FilterOperatorKey.hasNone)).toBe(false);
+  });
+
+  it("never carries a value a value-less operator was already holding", () => {
+    const poisoned = filter(FilterFieldKey.userIds, FilterOperatorKey.hasSome, valueFor("stringArray"));
+
+    expect(shouldPreserveFilterValue(poisoned, FilterOperatorKey.in)).toBe(false);
+  });
+
+  it("clears whenever the value shape changes", () => {
+    const single = filter(FilterFieldKey.createdAt, FilterOperatorKey.gt, valueFor("isoDate"));
+    const range = filter(FilterFieldKey.createdAt, FilterOperatorKey.between, valueFor("isoRange"));
+    const days = filter(FilterFieldKey.createdAt, FilterOperatorKey.inLastDays, 30);
+
+    expect(shouldPreserveFilterValue(single, FilterOperatorKey.between)).toBe(false);
+    expect(shouldPreserveFilterValue(range, FilterOperatorKey.gt)).toBe(false);
+    expect(shouldPreserveFilterValue(single, FilterOperatorKey.inLastDays)).toBe(false);
+    expect(shouldPreserveFilterValue(days, FilterOperatorKey.gt)).toBe(false);
+    expect(shouldPreserveFilterValue(range, FilterOperatorKey.inLastDays)).toBe(false);
+  });
+
+  it("clears a value the new operator could not use even when the class matches", () => {
+    const emptySelection = filter(FilterFieldKey.userIds, FilterOperatorKey.in, []);
+    const blankText = filter(COLUMN_ID, FilterOperatorKey.contains, "");
+    const unparseableAmount = filter(COLUMN_ID, FilterOperatorKey.gt, "abc");
+
+    expect(shouldPreserveFilterValue(emptySelection, FilterOperatorKey.notIn)).toBe(false);
+    expect(shouldPreserveFilterValue(blankText, FilterOperatorKey.equals, column("plain"))).toBe(false);
+    expect(shouldPreserveFilterValue(unparseableAmount, FilterOperatorKey.lt, column("currency"))).toBe(false);
+  });
+
+  it("clears when the field renders a text input but the wire wants a list", () => {
+    const calendarField = filter(FilterFieldKey.calendarId, FilterOperatorKey.in, ["cal-1"]);
+
+    expect(resolveFilterValueClass(FilterFieldKey.calendarId, FilterOperatorKey.in)).toBe("text");
+    expect(shouldPreserveFilterValue(calendarField, FilterOperatorKey.notIn)).toBe(false);
+  });
+
+  it("clears every remaining reachable transition on a custom column", () => {
+    for (const [type, operators] of Object.entries(COLUMN_OPERATORS)) {
+      for (const [from, to] of orderedPairs(operators)) {
+        const fromClass = resolveFilterValueClass(COLUMN_ID, from, column(type));
+        const toClass = resolveFilterValueClass(COLUMN_ID, to, column(type));
+        const current = filter(COLUMN_ID, from, valueFor(fromClass));
+        const preserved = shouldPreserveFilterValue(current, to, column(type));
+
+        expect(preserved).toBe(fromClass !== "none" && toClass !== "none" && fromClass === toClass);
+      }
+    }
+  });
+
+  it("clears when the custom column backing the value cannot be resolved", () => {
+    const orphan = filter(COLUMN_ID, FilterOperatorKey.contains, "acme");
+
+    expect(shouldPreserveFilterValue(orphan, FilterOperatorKey.equals, [])).toBe(false);
+  });
+});

--- a/components/data-view/filter-modal/edit-filters-modal.store.ts
+++ b/components/data-view/filter-modal/edit-filters-modal.store.ts
@@ -11,9 +11,14 @@ import { upsertFilterPresetAction, deleteFilterPresetAction } from "@/app/action
 import { BaseModalStore } from "@/core/base/base-modal.store";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 
+export const FILTER_AUTO_APPLY_DELAY_MS = 300;
+
+const FILTER_DRAFT_PATH_PREFIX = "filters";
+
 export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData> {
   tableStore?: BaseDataViewStore<HasId>;
   expandedField: string | undefined = undefined;
+  private autoApplyTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 
   constructor(rootStore: RootStore) {
     super(rootStore, {
@@ -30,11 +35,13 @@ export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData
       savedPresets: computed,
       isEditingPreset: computed,
       isCreatingPreset: computed,
+      isPresetMode: computed,
 
       openFor: action,
       onSubmit: action,
       deletePreset: action,
       setExpandedField: action,
+      syncDraftFromTable: action,
     });
 
     reaction(
@@ -60,63 +67,120 @@ export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData
     return this.form.presetId === "new";
   }
 
+  get isPresetMode() {
+    return this.isCreatingPreset || this.isEditingPreset;
+  }
+
+  protected override afterChange(id: string): void {
+    if (!this.isOpen || !this.tableStore) return;
+    if (!id.startsWith(FILTER_DRAFT_PATH_PREFIX)) return;
+
+    this.scheduleAutoApply();
+  }
+
+  private scheduleAutoApply = () => {
+    this.cancelPendingAutoApply();
+    this.autoApplyTimer = setTimeout(() => {
+      this.autoApplyTimer = undefined;
+      this.autoApply();
+    }, FILTER_AUTO_APPLY_DELAY_MS);
+  };
+
+  cancelPendingAutoApply = () => {
+    if (this.autoApplyTimer === undefined) return;
+
+    clearTimeout(this.autoApplyTimer);
+    this.autoApplyTimer = undefined;
+  };
+
+  flushPendingChanges = () => {
+    if (this.autoApplyTimer === undefined) return;
+
+    this.cancelPendingAutoApply();
+    this.autoApply();
+  };
+
+  private autoApply = () => {
+    this.applyDraftToTable();
+    if (!this.isPresetMode) this.markDraftApplied();
+  };
+
+  private applyDraftToTable = () => {
+    const tableStore = this.tableStore;
+    if (!tableStore) return;
+
+    tableStore.setQueryOptions({ filters: this.validDraftFilters(), refreshMode: "background" });
+  };
+
+  private validDraftFilters = (): Filter[] => toJS(this.form.filters ?? []).filter(hasValidFilterConfiguration);
+
+  private markDraftApplied = () => {
+    this.onInitOrRefresh({});
+  };
+
   private updateFormFromPresetId = (presetId: string | undefined) => {
     if (!this.isOpen) return;
 
     if (presetId === "new") {
       this.onChange("presetId", "new");
       this.onChange("name", "");
-    } else if (presetId) {
-      const preset = this.tableStore?.savedFilterPresets?.find((p) => p.id === presetId);
-      if (preset) {
-        this.form = {
-          filters: this.mergeFiltersWithFilterableFields(this.tableStore?.filterableFields ?? [], preset.filters),
-          presetId: presetId,
-          p13nId: this.tableStore?.p13nId ?? "",
-          name: preset.name,
-        };
-      }
-    } else {
+      return;
+    }
+
+    if (!presetId) {
       this.onChange("presetId", undefined);
       this.onChange("name", "");
+      return;
     }
+
+    const preset = this.tableStore?.savedFilterPresets?.find((p) => p.id === presetId);
+    if (!preset) return;
+
+    this.cancelPendingAutoApply();
+    this.form = {
+      filters: this.mergeFiltersWithFilterableFields(this.tableStore?.filterableFields ?? [], preset.filters),
+      presetId: presetId,
+      p13nId: this.tableStore?.p13nId ?? "",
+      name: preset.name,
+    };
+    this.markDraftApplied();
+    this.applyDraftToTable();
   };
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
+    this.flushPendingChanges();
+
+    if (!this.isPresetMode) return;
+    if (!this.tableStore?.p13nId) {
+      this.close();
+      return;
+    }
+
     this.setIsLoading(true);
 
     try {
-      const validFilters = toJS(this.form.filters).filter(hasValidFilterConfiguration);
+      const res = await upsertFilterPresetAction({
+        p13nId: this.form.p13nId,
+        name: this.form.name,
+        presetId: this.isCreatingPreset ? undefined : this.form.presetId,
+        filters: this.validDraftFilters(),
+      });
 
-      if (this.tableStore?.p13nId && (this.isEditingPreset || this.isCreatingPreset)) {
-        const presetId = this.isCreatingPreset ? undefined : this.form.presetId;
-
-        const res = await upsertFilterPresetAction({
-          p13nId: this.form.p13nId,
-          name: this.form.name,
-          presetId,
-          filters: validFilters,
-        });
-
-        if (!res.ok) {
-          this.setError(res.error);
-          this.setIsLoading(false);
-          return;
-        }
+      if (!res.ok) {
+        this.setError(res.error);
+        return;
       }
 
+      this.markDraftApplied();
       this.close();
-      this.tableStore?.setQueryOptions({
-        filters: validFilters,
-        forceRefresh: true,
-      });
     } finally {
       this.setIsLoading(false);
     }
   };
 
   openFor = (tableStore: BaseDataViewStore<any>, expandField?: string) => {
+    this.cancelPendingAutoApply();
     this.tableStore = tableStore;
     const filterableFields = this.tableStore?.filterableFields ?? [];
     const currentFilters = tableStore.filters ?? [];
@@ -132,6 +196,17 @@ export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData
     });
   };
 
+  syncDraftFromTable = (tableStore: BaseDataViewStore<any>) => {
+    if (!this.isOpen || this.tableStore !== tableStore) return;
+
+    this.cancelPendingAutoApply();
+    this.form = {
+      ...this.form,
+      filters: this.mergeFiltersWithFilterableFields(tableStore.filterableFields ?? [], tableStore.filters ?? []),
+    };
+    if (!this.isPresetMode) this.markDraftApplied();
+  };
+
   deletePreset = async () => {
     if (!this.form.presetId || !this.tableStore?.p13nId) return;
 
@@ -144,13 +219,24 @@ export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData
       return;
     }
 
-    this.tableStore?.setQueryOptions({ filters: [], forceRefresh: true });
+    this.cancelPendingAutoApply();
+    this.tableStore?.setQueryOptions({ filters: [], forceRefresh: true, refreshMode: "background" });
     this.close();
   };
 
+  protected override prepareToClose(): boolean {
+    this.flushPendingChanges();
+    return true;
+  }
+
   private mergeFiltersWithFilterableFields = (filterableFields: FilterableField[], currentFilters: Filter[]) => {
     const existingFiltersMap = new Map<string, Filter>();
-    currentFilters.forEach((filter) => {
+    const knownFilters = Array.isArray(currentFilters) ? currentFilters : [];
+
+    knownFilters.forEach((filter) => {
+      if (!filter || typeof filter !== "object") return;
+      if (typeof filter.field !== "string") return;
+
       existingFiltersMap.set(filter.field, filter);
     });
 

--- a/components/data-view/filter-modal/edit-filters-modal.store.ts
+++ b/components/data-view/filter-modal/edit-filters-modal.store.ts
@@ -7,6 +7,7 @@ import type { Filter, FilterableField } from "@/core/base/base-get.schema";
 import { makeObservable, action, observable, computed, reaction, toJS } from "mobx";
 
 import { hasValidFilterConfiguration } from "@/components/data-view/table-view.utils";
+import { FilterOperatorKey } from "@/core/base/base-query-builder";
 import { upsertFilterPresetAction, deleteFilterPresetAction } from "@/app/actions";
 import { BaseModalStore } from "@/core/base/base-modal.store";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
@@ -112,7 +113,14 @@ export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData
     tableStore.setQueryOptions({ filters: this.validDraftFilters(), refreshMode: "background" });
   };
 
-  private validDraftFilters = (): Filter[] => toJS(this.form.filters ?? []).filter(hasValidFilterConfiguration);
+  private validDraftFilters = (): Filter[] =>
+    toJS(this.form.filters ?? [])
+      .filter(hasValidFilterConfiguration)
+      .map((filter) =>
+        filter.operator === FilterOperatorKey.hasSome || filter.operator === FilterOperatorKey.hasNone
+          ? { field: filter.field, operator: filter.operator }
+          : filter,
+      );
 
   private markDraftApplied = () => {
     this.onInitOrRefresh({});

--- a/components/data-view/filter-modal/filter-field.tsx
+++ b/components/data-view/filter-modal/filter-field.tsx
@@ -150,6 +150,7 @@ export const FilterField = observer(({ customColumns, filter, filterableFields, 
     if (isDisabled) return;
     form?.onChange(operatorId, next);
     form?.onChange(`${baseId}.value`, undefined);
+    form?.flushPendingChanges?.();
     onFilterChange?.(filter.field);
   }
 

--- a/components/data-view/filter-modal/filter-field.tsx
+++ b/components/data-view/filter-modal/filter-field.tsx
@@ -9,7 +9,12 @@ import { useTranslations } from "next-intl";
 import { useCallback } from "react";
 import { XIcon } from "lucide-react";
 
-import { hasValidFilterConfiguration, isCustomField } from "@/components/data-view/table-view.utils";
+import { hasValidFilterConfiguration } from "@/components/data-view/table-view.utils";
+import {
+  resolveFilterDateGranularity,
+  resolveFilterValueClass,
+  shouldPreserveFilterValue,
+} from "@/components/data-view/filter-modal/filter-value-class";
 import { FilterInputSelect } from "@/components/data-view/filter-modal/inputs/filter-input-select";
 import { FilterInputNumber } from "@/components/data-view/filter-modal/inputs/filter-input-number";
 import { FilterInputText } from "@/components/data-view/filter-modal/inputs/filter-input-text";
@@ -18,8 +23,9 @@ import { FilterInputIsoDateRange } from "@/components/data-view/filter-modal/inp
 import { FilterInputDaysCount } from "@/components/data-view/filter-modal/inputs/filter-input-days-count";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAppForm } from "@/components/forms/form-context";
-import { FilterFieldKey } from "@/core/types/filter-field-key";
-import { FilterOperatorKey, isStandaloneOperator } from "@/core/base/base-query-builder";
+import type { FilterOperatorKey } from "@/core/base/base-query-builder";
+
+import { isStandaloneOperator } from "@/core/base/base-query-builder";
 import { cn } from "@/core/utils/cn";
 
 type Props = {
@@ -44,14 +50,11 @@ export const FilterField = observer(({ customColumns, filter, filterableFields, 
 
   const renderFilterFieldBody = useCallback((): ReactElement => {
     const id = `${baseId}.value`;
-    const isBetween = operator === FilterOperatorKey.between;
-    const isInLastDays = operator === FilterOperatorKey.inLastDays;
-    const isCustomField_ = isCustomField(filter.field);
+    const valueClass = resolveFilterValueClass(filter.field, operator, customColumns);
+    const granularity = resolveFilterDateGranularity(filter.field, customColumns);
 
-    if (isCustomField_) {
-      const customColumn = customColumns?.find((col) => col.id === filter.field);
-
-      if (!customColumn) {
+    switch (valueClass) {
+      case "unavailable":
         return (
           <div
             data-filter-value-unavailable
@@ -61,95 +64,39 @@ export const FilterField = observer(({ customColumns, filter, filterableFields, 
             {t("Common.filters.unavailableValue")}
           </div>
         );
-      }
-
-      switch (customColumn?.type) {
-        case "singleSelect":
-          return (
-            <FilterInputSelect
-              customColumns={customColumns}
-              filter={filter}
-              id={id}
-              isValidFilter={isValidFilter}
-              onValueChange={() => onFilterChange?.(filter.field)}
-            />
-          );
-        case "currency":
-          return <FilterInputNumber id={id} isValidFilter={isValidFilter} />;
-        case "date":
-        case "dateRange":
-          if (isInLastDays) return <FilterInputDaysCount id={id} isValidFilter={isValidFilter} />;
-          return isBetween ? (
-            <FilterInputIsoDateRange granularity="day" id={id} isValidFilter={isValidFilter} />
-          ) : (
-            <FilterInputIsoDate granularity="day" id={id} isValidFilter={isValidFilter} />
-          );
-        case "dateTime":
-        case "dateTimeRange":
-          if (isInLastDays) return <FilterInputDaysCount id={id} isValidFilter={isValidFilter} />;
-          return isBetween ? (
-            <FilterInputIsoDateRange granularity="minute" id={id} isValidFilter={isValidFilter} />
-          ) : (
-            <FilterInputIsoDate granularity="minute" id={id} isValidFilter={isValidFilter} />
-          );
-        case "link":
-        case "plain":
-        case "email":
-        case "phone":
-          return <FilterInputText id={id} isValidFilter={isValidFilter} />;
-      }
+      case "stringArray":
+        return (
+          <FilterInputSelect
+            customColumns={customColumns}
+            filter={filter}
+            id={id}
+            isValidFilter={isValidFilter}
+            onValueChange={() => onFilterChange?.(filter.field)}
+          />
+        );
+      case "numericString":
+        return <FilterInputNumber id={id} isValidFilter={isValidFilter} />;
+      case "daysCount":
+        return <FilterInputDaysCount id={id} isValidFilter={isValidFilter} />;
+      case "isoRange":
+        return <FilterInputIsoDateRange granularity={granularity} id={id} isValidFilter={isValidFilter} />;
+      case "isoDate":
+        return <FilterInputIsoDate granularity={granularity} id={id} isValidFilter={isValidFilter} />;
+      default:
+        return <FilterInputText id={id} isValidFilter={isValidFilter} />;
     }
-
-    const relationFields = [
-      FilterFieldKey.userIds,
-      FilterFieldKey.contactIds,
-      FilterFieldKey.participantContactId,
-      FilterFieldKey.serviceIds,
-      FilterFieldKey.dealIds,
-      FilterFieldKey.organizationIds,
-      FilterFieldKey.taskIds,
-      FilterFieldKey.event,
-      FilterFieldKey.status,
-      FilterFieldKey.provider,
-      FilterFieldKey.state,
-      FilterFieldKey.timelineKind,
-      FilterFieldKey.timelineThreadId,
-      FilterFieldKey.connectedAccountId,
-      FilterFieldKey.participants,
-    ];
-
-    if (relationFields.includes(filter.field as FilterFieldKey)) {
-      return (
-        <FilterInputSelect
-          customColumns={customColumns}
-          filter={filter}
-          id={id}
-          isValidFilter={isValidFilter}
-          onValueChange={() => onFilterChange?.(filter.field)}
-        />
-      );
-    }
-
-    const dateFields = [FilterFieldKey.updatedAt, FilterFieldKey.createdAt];
-    if (dateFields.includes(filter.field as FilterFieldKey)) {
-      if (isInLastDays) return <FilterInputDaysCount id={id} isValidFilter={isValidFilter} />;
-      return isBetween ? (
-        <FilterInputIsoDateRange granularity="minute" id={id} isValidFilter={isValidFilter} />
-      ) : (
-        <FilterInputIsoDate granularity="minute" id={id} isValidFilter={isValidFilter} />
-      );
-    }
-
-    return <FilterInputText id={id} isValidFilter={isValidFilter} />;
-  }, [customColumns, filter, baseId, isValidFilter, onFilterChange, operator, filterableFields, t]);
+  }, [customColumns, filter, baseId, isValidFilter, onFilterChange, operator, t]);
 
   const operatorId = `${baseId}.operator`;
   const bodyShown = !isStandalone && !operatorIsEmpty;
 
   function handleOperatorChange(next: string | undefined) {
     if (isDisabled) return;
+
+    const keepValue = shouldPreserveFilterValue(filter, next as FilterOperatorKey | undefined, customColumns);
+
     form?.onChange(operatorId, next);
-    form?.onChange(`${baseId}.value`, undefined);
+    if (!keepValue) form?.onChange(`${baseId}.value`, undefined);
     form?.flushPendingChanges?.();
     onFilterChange?.(filter.field);
   }

--- a/components/data-view/filter-modal/filter-value-class.ts
+++ b/components/data-view/filter-modal/filter-value-class.ts
@@ -1,0 +1,127 @@
+import type { Filter } from "@/core/base/base-get.schema";
+import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
+
+import { hasValidFilterConfiguration, isCustomField } from "@/components/data-view/table-view.utils";
+import { FilterFieldKey } from "@/core/types/filter-field-key";
+import { FilterOperatorKey, isStandaloneOperator } from "@/core/base/base-query-builder";
+
+export type FilterValueClass =
+  | "none"
+  | "unavailable"
+  | "stringArray"
+  | "text"
+  | "numericString"
+  | "isoDate"
+  | "isoRange"
+  | "daysCount";
+
+export type FilterDateGranularity = "day" | "minute";
+
+const RELATION_FILTER_FIELDS = [
+  FilterFieldKey.userIds,
+  FilterFieldKey.contactIds,
+  FilterFieldKey.participantContactId,
+  FilterFieldKey.serviceIds,
+  FilterFieldKey.dealIds,
+  FilterFieldKey.organizationIds,
+  FilterFieldKey.taskIds,
+  FilterFieldKey.event,
+  FilterFieldKey.status,
+  FilterFieldKey.provider,
+  FilterFieldKey.state,
+  FilterFieldKey.timelineKind,
+  FilterFieldKey.timelineThreadId,
+  FilterFieldKey.connectedAccountId,
+  FilterFieldKey.participants,
+];
+
+const DATE_FILTER_FIELDS = [FilterFieldKey.updatedAt, FilterFieldKey.createdAt];
+
+const DAY_GRANULARITY_COLUMN_TYPES = ["date", "dateRange"];
+
+function dateValueClass(operator: FilterOperatorKey): FilterValueClass {
+  if (operator === FilterOperatorKey.inLastDays) return "daysCount";
+
+  return operator === FilterOperatorKey.between ? "isoRange" : "isoDate";
+}
+
+export function resolveFilterValueClass(
+  field: string,
+  operator: FilterOperatorKey | undefined,
+  customColumns?: CustomColumnDto[],
+): FilterValueClass {
+  if (!operator || isStandaloneOperator(operator)) return "none";
+
+  if (isCustomField(field)) {
+    const customColumn = customColumns?.find((column) => column.id === field);
+    if (!customColumn) return "unavailable";
+
+    switch (customColumn.type) {
+      case "singleSelect":
+        return "stringArray";
+      case "currency":
+        return "numericString";
+      case "date":
+      case "dateRange":
+      case "dateTime":
+      case "dateTimeRange":
+        return dateValueClass(operator);
+      case "link":
+      case "plain":
+      case "email":
+      case "phone":
+        return "text";
+    }
+
+    return "text";
+  }
+
+  if (RELATION_FILTER_FIELDS.includes(field as FilterFieldKey)) return "stringArray";
+  if (DATE_FILTER_FIELDS.includes(field as FilterFieldKey)) return dateValueClass(operator);
+
+  return "text";
+}
+
+export function resolveFilterDateGranularity(field: string, customColumns?: CustomColumnDto[]): FilterDateGranularity {
+  if (!isCustomField(field)) return "minute";
+
+  const customColumn = customColumns?.find((column) => column.id === field);
+
+  return customColumn && DAY_GRANULARITY_COLUMN_TYPES.includes(customColumn.type) ? "day" : "minute";
+}
+
+function isValueUsableAs(value: unknown, valueClass: FilterValueClass): boolean {
+  if (valueClass === "stringArray")
+    return Array.isArray(value) && value.length > 0 && value.every((entry) => typeof entry === "string");
+
+  if (valueClass === "text") return typeof value === "string" && value.length > 0;
+
+  if (valueClass === "numericString")
+    return (typeof value === "string" || typeof value === "number") && value !== "" && Number.isFinite(Number(value));
+
+  if (valueClass === "isoDate") return typeof value === "string" && !Number.isNaN(new Date(value).getTime());
+
+  return false;
+}
+
+export function shouldPreserveFilterValue(
+  filter: Filter,
+  next: FilterOperatorKey | undefined,
+  customColumns?: CustomColumnDto[],
+): boolean {
+  const previous = filter.operator as FilterOperatorKey | undefined;
+
+  if (!next || isStandaloneOperator(next)) return false;
+  if (!previous || isStandaloneOperator(previous)) return false;
+  if (previous === next) return true;
+  if (previous === FilterOperatorKey.between || next === FilterOperatorKey.between) return false;
+  if (previous === FilterOperatorKey.inLastDays || next === FilterOperatorKey.inLastDays) return false;
+
+  const valueClass = resolveFilterValueClass(filter.field, previous, customColumns);
+  if (valueClass !== resolveFilterValueClass(filter.field, next, customColumns)) return false;
+
+  const value = "value" in filter ? filter.value : undefined;
+  if (!isValueUsableAs(value, valueClass)) return false;
+
+  return hasValidFilterConfiguration({ ...filter, operator: next } as Filter);
+}

--- a/components/data-view/filter-modal/inputs/filter-input-days-count.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-days-count.tsx
@@ -24,6 +24,11 @@ export const FilterInputDaysCount = observer(({ id, isValidFilter }: Props) => {
     store?.onChange(id, next);
   }
 
+  function commitNow(next: number | undefined) {
+    commit(next);
+    store?.flushPendingChanges?.();
+  }
+
   return (
     <div className="flex flex-col gap-2 min-w-0">
       <div className="relative">
@@ -37,6 +42,7 @@ export const FilterInputDaysCount = observer(({ id, isValidFilter }: Props) => {
           step={1}
           type="number"
           value={value ?? ""}
+          onBlur={() => store?.flushPendingChanges?.()}
           onChange={(e) => {
             const next = e.target.value;
             if (next === "") {
@@ -65,7 +71,7 @@ export const FilterInputDaysCount = observer(({ id, isValidFilter }: Props) => {
             )}
             disabled={store?.isDisabled}
             type="button"
-            onClick={() => commit(days)}
+            onClick={() => commitNow(days)}
           >
             {t("Common.filters.daysPreset", { count: days })}
           </button>

--- a/components/data-view/filter-modal/inputs/filter-input-iso-date-range.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-iso-date-range.tsx
@@ -58,11 +58,13 @@ export const FilterInputIsoDateRange = observer(({ id, isValidFilter, granularit
     if (!range?.from || !range?.to) {
       if (!range?.from) {
         store?.onChange(id, undefined);
+        store?.flushPendingChanges?.();
         return;
       }
       return;
     }
     store?.onChange(id, [toLocalIso(range.from, dateOnly), toLocalIso(range.to, dateOnly)]);
+    store?.flushPendingChanges?.();
     setCurrentMonth(startOfMonth(range.from));
   }
 

--- a/components/data-view/filter-modal/inputs/filter-input-iso-date.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-iso-date.tsx
@@ -42,9 +42,11 @@ export const FilterInputIsoDate = observer(({ id, isValidFilter, granularity = "
   function commit(date: Date | undefined) {
     if (!date) {
       store?.onChange(id, undefined);
+      store?.flushPendingChanges?.();
       return;
     }
     store?.onChange(id, toLocalIso(date, dateOnly));
+    store?.flushPendingChanges?.();
     setCurrentMonth(startOfMonth(date));
   }
 

--- a/components/data-view/filter-modal/inputs/filter-input-number.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-number.tsx
@@ -40,6 +40,7 @@ export const FilterInputNumber = observer(({ id, isValidFilter }: Props) => {
         const canonical = intlStore.parseNumberToCanonical(text);
         setText(fmt(filterNumberValue(canonical)));
         store?.onChange(id, canonical);
+        store?.flushPendingChanges?.();
       }}
       onChange={(e) => {
         const next = e.target.value;

--- a/components/data-view/filter-modal/inputs/filter-input-select.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-select.tsx
@@ -109,6 +109,7 @@ export const FilterInputSelect = observer(({ customColumns, filter, id, isValidF
   function commit(next: string[] | undefined) {
     const value = next && next.length === 0 ? undefined : next;
     store?.onChange(id, value);
+    store?.flushPendingChanges?.();
     onValueChange?.(value);
     setInput("");
   }

--- a/components/data-view/filter-modal/inputs/filter-input-text.tsx
+++ b/components/data-view/filter-modal/inputs/filter-input-text.tsx
@@ -21,6 +21,7 @@ export const FilterInputText = observer(({ id, isValidFilter }: Props) => {
       disabled={store?.isDisabled}
       id={id}
       value={value}
+      onBlur={() => store?.flushPendingChanges?.()}
       onChange={(event) => store?.onChange(id, event.target.value)}
     />
   );

--- a/components/data-view/header/__tests__/filter-popover-actions.test.ts
+++ b/components/data-view/header/__tests__/filter-popover-actions.test.ts
@@ -1,0 +1,95 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ReactNode } from "react";
+import type { BaseDataViewStore } from "@/core/base/base-data-view.store";
+import type { EditFiltersModalStore } from "@/components/data-view/filter-modal/edit-filters-modal.store";
+
+const harness = vi.hoisted(() => ({ modalStore: { current: null as unknown } }));
+
+vi.mock("mobx-react-lite", () => ({ observer: <T>(component: T) => component }));
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("@/core/stores/root-store.provider", () => ({
+  useRootStore: () => ({ editFiltersModalStore: harness.modalStore.current }),
+}));
+vi.mock("@/components/modal/hooks/use-delete-confirmation", () => ({
+  useDeleteConfirmation: () => ({ showDeleteConfirmation: vi.fn() }),
+}));
+vi.mock("@/components/modal", () => ({
+  ResponsiveOverlay: ({ children, footer }: { children: ReactNode; footer: ReactNode }) =>
+    createElement("div", null, footer, children),
+}));
+vi.mock("@/components/data-view/filter-modal/filter-accordion", () => ({ FilterAccordion: () => null }));
+vi.mock("@/components/forms/form-context", () => ({ AppForm: ({ children }: { children: ReactNode }) => children }));
+vi.mock("@/components/forms/form-input", () => ({ FormInput: () => null }));
+vi.mock("@/components/ui/separator", () => ({ Separator: () => null }));
+vi.mock("../popover-section", () => ({ PopoverSection: ({ children }: { children: ReactNode }) => children }));
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => createElement("button", { type: "button" }, children),
+}));
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuContent: () => null,
+  DropdownMenuItem: () => null,
+  DropdownMenuSeparator: () => null,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { FilterPopover } from "../filter-popover";
+
+function dataViewStore() {
+  return {
+    customColumns: [],
+    filterableFields: [{ field: "name", operators: ["contains"] }],
+    filters: [{ field: "name", operator: "contains", value: "acme" }],
+  } as unknown as BaseDataViewStore<{ id: string }>;
+}
+
+function modalStore(overrides: { isCreatingPreset?: boolean; isEditingPreset?: boolean }) {
+  return {
+    close: vi.fn(),
+    expandedField: undefined,
+    flushPendingChanges: vi.fn(),
+    form: { filters: [{ field: "name", operator: "contains", value: "acme" }], name: "", presetId: undefined },
+    isCreatingPreset: overrides.isCreatingPreset ?? false,
+    isEditingPreset: overrides.isEditingPreset ?? false,
+    isOpen: true,
+    onChange: vi.fn(),
+    openFor: vi.fn(),
+    savedPresets: [],
+    setExpandedField: vi.fn(),
+    tableStore: undefined,
+  } as unknown as EditFiltersModalStore;
+}
+
+function render(overrides: { isCreatingPreset?: boolean; isEditingPreset?: boolean }) {
+  const store = dataViewStore();
+  harness.modalStore.current = modalStore(overrides);
+  return renderToStaticMarkup(createElement(FilterPopover, { store }));
+}
+
+describe("filter popover actions", () => {
+  it("offers no apply action while filters are applied automatically", () => {
+    const markup = render({});
+
+    expect(markup).not.toContain("Common.filters.apply");
+    expect(markup).not.toContain("Common.actions.save");
+    expect(markup).toContain("Common.actions.clear");
+  });
+
+  it("keeps an explicit save while a named preset is being edited", () => {
+    const markup = render({ isEditingPreset: true });
+
+    expect(markup).toContain("Common.actions.save");
+    expect(markup).toContain("Common.actions.clear");
+  });
+
+  it("keeps an explicit save while a named preset is being created", () => {
+    const markup = render({ isCreatingPreset: true });
+
+    expect(markup).toContain("Common.actions.save");
+    expect(markup).toContain("Common.actions.cancel");
+    expect(markup).not.toContain("Common.actions.clear");
+  });
+});

--- a/components/data-view/header/active-filters-bar.tsx
+++ b/components/data-view/header/active-filters-bar.tsx
@@ -46,7 +46,10 @@ export const DataViewActiveFiltersBar = observer(function DataViewActiveFiltersB
             className="max-w-md"
             startContent={<BookmarkIcon className="size-3 opacity-70" />}
             variant="secondary"
-            onClick={() => store.changeFilterPreset(preset.id)}
+            onClick={() => {
+              store.changeFilterPreset(preset.id);
+              editFiltersModalStore.syncDraftFromTable(store);
+            }}
           >
             <span className="truncate text-[11px]">{preset.name}</span>
           </ClickableChip>
@@ -99,6 +102,7 @@ export const DataViewActiveFiltersBar = observer(function DataViewActiveFiltersB
                 onClick={(e) => {
                   e.stopPropagation();
                   store.removeFilter(filter);
+                  editFiltersModalStore.syncDraftFromTable(store);
                 }}
               >
                 <XIcon className="size-3" />
@@ -123,7 +127,10 @@ export const DataViewActiveFiltersBar = observer(function DataViewActiveFiltersB
           size="xs"
           type="button"
           variant="secondary"
-          onClick={() => store.setQueryOptions({ filters: [], searchTerm: "" })}
+          onClick={() => {
+            store.setQueryOptions({ filters: [], searchTerm: "" });
+            editFiltersModalStore.syncDraftFromTable(store);
+          }}
         >
           {t("Common.filters.clearAll")}
         </Button>

--- a/components/data-view/header/filter-popover.tsx
+++ b/components/data-view/header/filter-popover.tsx
@@ -5,6 +5,7 @@ import type { BaseDataViewStore } from "@/core/base/base-data-view.store";
 import { BookmarkPlus, Check, ChevronDown, Filter, Trash2 } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
+import { useEffect } from "react";
 
 import { FilterAccordion } from "@/components/data-view/filter-modal/filter-accordion";
 import { cn } from "@/core/utils/cn";
@@ -37,6 +38,8 @@ export const FilterPopover = observer(function FilterPopover({ store, compact, i
   const { editFiltersModalStore: modalStore } = useRootStore();
   const { showDeleteConfirmation } = useDeleteConfirmation();
 
+  useEffect(() => () => modalStore.flushPendingChanges(), [modalStore]);
+
   if (store.filterableFields.length === 0) return null;
 
   const activeFilterCount = store.filters?.length ?? 0;
@@ -53,12 +56,13 @@ export const FilterPopover = observer(function FilterPopover({ store, compact, i
     else modalStore.close();
   }
 
-  function handleApply() {
+  function handleSavePreset() {
     void modalStore.onSubmit();
   }
 
   function handleClear() {
-    store.setQueryOptions({ filters: [], forceRefresh: true });
+    modalStore.cancelPendingAutoApply();
+    store.setQueryOptions({ filters: [], forceRefresh: true, refreshMode: "background" });
     modalStore.openFor(store);
   }
 
@@ -125,9 +129,11 @@ export const FilterPopover = observer(function FilterPopover({ store, compact, i
         </Button>
       )}
 
-      <Button className="h-8" disabled={cannotSavePreset} size="sm" type="button" onClick={handleApply}>
-        {isCreatingPreset || isEditingPreset ? t("Common.actions.save") : t("Common.filters.apply")}
-      </Button>
+      {(isCreatingPreset || isEditingPreset) && (
+        <Button className="h-8" disabled={cannotSavePreset} size="sm" type="button" onClick={handleSavePreset}>
+          {t("Common.actions.save")}
+        </Button>
+      )}
     </>
   );
 

--- a/core/base/__tests__/base-data-view-background-refresh.test.ts
+++ b/core/base/__tests__/base-data-view-background-refresh.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GetResult } from "../base-get.interactor";
+import type { GetQueryParams, Filter } from "../base-get.schema";
+import type { RootStore } from "@/core/stores/root.store";
+
+import { BaseDataViewStore } from "../base-data-view.store";
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/actions", () => ({
+  bulkDeleteEntitiesAction: vi.fn(),
+  bulkUpdateCustomFieldValuesAction: vi.fn(),
+  getCustomColumnsByEntityTypeAction: vi.fn(),
+  updateEntityCustomFieldValueAction: vi.fn(),
+  upsertP13nAction: vi.fn(),
+}));
+
+type Item = { id: string };
+
+class TestStore extends BaseDataViewStore<Item> {
+  nextRefresh: () => Promise<GetResult<Item>> = () => Promise.resolve({ items: [] });
+  requestedFilters: Array<Filter[] | undefined> = [];
+
+  get columnsDefinition() {
+    return [];
+  }
+
+  protected refreshAction(params?: GetQueryParams) {
+    this.requestedFilters.push(params?.filters);
+    return this.nextRefresh();
+  }
+}
+
+function rootStore() {
+  const loadingOverlayStore = { isLoading: false };
+  return {
+    loadingOverlayStore,
+    localeStore: { getTranslation: (key: string) => key },
+  } as unknown as RootStore;
+}
+
+function result(id: string): GetResult<Item> {
+  return { items: [{ id }], pagination: { page: 1, pageSize: 25, total: 1, totalPages: 1 } };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function filter(value: string): Filter {
+  return { field: "name", operator: "contains", value } as Filter;
+}
+
+function readyStore() {
+  const store = new TestStore(rootStore());
+  store.setItems(result("prior"));
+  store.requestedFilters = [];
+  return store;
+}
+
+describe("BaseDataViewStore background query refresh", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+  });
+
+  it("refreshes an auto-applied filter change without the visible loading state", async () => {
+    const store = readyStore();
+    const pending = deferred<GetResult<Item>>();
+    store.nextRefresh = () => pending.promise;
+
+    store.setQueryOptions({ filters: [filter("acme")], refreshMode: "background" });
+
+    expect(store.isRefreshing).toBe(false);
+    expect(store.dataRequest).toEqual({ status: "ready" });
+    expect(store.items).toEqual([{ id: "prior" }]);
+
+    pending.resolve(result("filtered"));
+    await settle();
+
+    expect(store.items).toEqual([{ id: "filtered" }]);
+    expect(store.dataRequest).toEqual({ status: "ready" });
+  });
+
+  it("keeps a single background request in flight and re-queries once with the newest filters", async () => {
+    const store = readyStore();
+    const first = deferred<GetResult<Item>>();
+    const second = deferred<GetResult<Item>>();
+    const queue = [first.promise, second.promise];
+    store.nextRefresh = () => queue.shift() as Promise<GetResult<Item>>;
+
+    store.setQueryOptions({ filters: [filter("a")], refreshMode: "background" });
+    store.setQueryOptions({ filters: [filter("ab")], refreshMode: "background" });
+    store.setQueryOptions({ filters: [filter("abc")], refreshMode: "background" });
+
+    expect(store.requestedFilters).toHaveLength(1);
+
+    first.resolve(result("stale"));
+    await settle();
+
+    expect(store.requestedFilters).toHaveLength(2);
+    expect(store.requestedFilters[1]).toEqual([filter("abc")]);
+
+    second.resolve(result("latest"));
+    await settle();
+
+    expect(store.requestedFilters).toHaveLength(2);
+    expect(store.items).toEqual([{ id: "latest" }]);
+  });
+
+  it("skips the request entirely when the committed filters are unchanged", () => {
+    const store = readyStore();
+    store.setQueryOptions({ filters: [filter("acme")], refreshMode: "background" });
+    store.requestedFilters = [];
+
+    store.setQueryOptions({ filters: [filter("acme")], refreshMode: "background" });
+
+    expect(store.requestedFilters).toHaveLength(0);
+  });
+
+  it("keeps prior rows and reports a localized toast when the newest request fails", async () => {
+    const store = readyStore();
+    store.nextRefresh = () => Promise.reject(new Error("refresh failed"));
+
+    store.setQueryOptions({ filters: [filter("acme")], refreshMode: "background" });
+    await settle();
+
+    expect(store.items).toEqual([{ id: "prior" }]);
+    expect(store.isRefreshing).toBe(false);
+    expect(toastError).toHaveBeenCalledWith("Common.notifications.unexpectedError", expect.anything());
+  });
+
+  it("still routes an unmarked query change through the visible refresh", async () => {
+    const store = readyStore();
+    const pending = deferred<GetResult<Item>>();
+    store.nextRefresh = () => pending.promise;
+
+    store.setQueryOptions({ filters: [filter("acme")] });
+
+    expect(store.isRefreshing).toBe(true);
+
+    pending.resolve(result("filtered"));
+    await settle();
+
+    expect(store.isRefreshing).toBe(false);
+  });
+});

--- a/core/base/base-data-view.store.ts
+++ b/core/base/base-data-view.store.ts
@@ -43,7 +43,7 @@ export type DataViewRequestState =
   | { readonly status: "refreshing" }
   | { readonly status: "refresh-error"; readonly error: unknown };
 
-type DataViewRefreshMode = "background" | "visible";
+export type DataViewRefreshMode = "background" | "visible";
 
 function readItemValueSums(item: unknown, fields: readonly string[]): GroupValueSums | undefined {
   const values = item as Record<string, unknown>;
@@ -91,6 +91,8 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
 
   private persistViewOptionsTimer?: number;
   private requestGeneration = 0;
+  private backgroundRefreshRunning = false;
+  private backgroundRefreshQueued = false;
   private requestState: DataViewRequestState = { status: "uninitialized" };
   private onChangesCallbacks: (() => void | Promise<void>)[] = [];
 
@@ -520,6 +522,7 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
     sortDescriptor?: SortDescriptor | undefined;
     searchTerm?: string;
     forceRefresh?: boolean;
+    refreshMode?: DataViewRefreshMode;
   }) => {
     let hasChanges = false;
     let queryShapeChanged = false;
@@ -561,7 +564,10 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
       this.resetGroupedTakeOverrides();
     }
 
-    if (hasChanges || updates.forceRefresh) this.refreshQueryInBackground();
+    if (!hasChanges && !updates.forceRefresh) return;
+
+    if (updates.refreshMode === "background") this.refreshInBackground();
+    else this.refreshQueryInBackground();
   };
 
   removeFilter = (filter: Filter) => {
@@ -726,6 +732,34 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
 
   private refreshQueryInBackground = (): void => {
     void this.refreshQuery().catch(() => undefined);
+  };
+
+  refreshInBackground = (): void => {
+    if (!this.isReady) return;
+
+    if (this.backgroundRefreshRunning) {
+      this.backgroundRefreshQueued = true;
+      return;
+    }
+
+    void this.drainBackgroundRefreshes();
+  };
+
+  private drainBackgroundRefreshes = async (): Promise<void> => {
+    this.backgroundRefreshRunning = true;
+
+    try {
+      do {
+        this.backgroundRefreshQueued = false;
+        try {
+          await this.executeRefresh("background", () => !this.backgroundRefreshQueued);
+        } catch {
+          this.toastError("Common.notifications.unexpectedError");
+        }
+      } while (this.backgroundRefreshQueued);
+    } finally {
+      this.backgroundRefreshRunning = false;
+    }
   };
 
   protected refreshAction(_params?: GetQueryParams): Promise<GetResult<Entity>> {

--- a/core/base/base-form.store.ts
+++ b/core/base/base-form.store.ts
@@ -122,6 +122,8 @@ export abstract class BaseFormStore<T extends object = object> extends BaseStore
 
   onSubmit?: (event?: FormEvent<HTMLFormElement>) => Promise<void>;
 
+  flushPendingChanges?: () => void;
+
   getValue = (id: string): unknown => {
     const path = this.normalizeJsonPath(id);
     return JSONPath({ path, json: this.form, wrap: false }) ?? undefined;
@@ -182,8 +184,13 @@ export abstract class BaseFormStore<T extends object = object> extends BaseStore
       if (parent == null || typeof parent !== "object") return;
       parent = (parent as Record<string, unknown>)[token];
     }
-    if (parent != null && typeof parent === "object") (parent as Record<string, unknown>)[leaf] = value;
+    if (parent == null || typeof parent !== "object") return;
+
+    (parent as Record<string, unknown>)[leaf] = value;
+    this.afterChange(id, value);
   };
+
+  protected afterChange(_id: string, _value: unknown): void {}
 
   private normalizeJsonPath(id: string): string {
     if (id.startsWith("$")) return id;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -427,7 +427,6 @@
       }
     },
     "filters": {
-      "apply": "Anwenden",
       "clearAll": "Alle entfernen",
       "clearSearch": "Suche löschen",
       "daysPlaceholder": "Tage",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -427,7 +427,6 @@
       }
     },
     "filters": {
-      "apply": "Apply",
       "clearAll": "Clear All",
       "clearSearch": "Clear search",
       "daysPlaceholder": "Days",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -427,7 +427,6 @@
       }
     },
     "filters": {
-      "apply": "Aplicar",
       "clearAll": "Borrar todo",
       "clearSearch": "Borrar la búsqueda",
       "daysPlaceholder": "Días",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -427,7 +427,6 @@
       }
     },
     "filters": {
-      "apply": "Appliquer",
       "clearAll": "Tout effacer",
       "clearSearch": "Effacer la recherche",
       "daysPlaceholder": "Jours",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -427,7 +427,6 @@
       }
     },
     "filters": {
-      "apply": "Applica",
       "clearAll": "Cancella tutto",
       "clearSearch": "Cancella la ricerca",
       "daysPlaceholder": "Giorni",


### PR DESCRIPTION
## Summary

Shared data-view filter popovers now apply and persist complete filter changes as the user makes them. The Apply action is gone from normal filtering; named presets still require an explicit Save, and that Save no longer doubles as the only way to use a preset.

Closes [CUS-186](https://linear.app/customermates/issue/CUS-186/auto-apply-and-persist-shared-data-view-filters).

- Operator, select, date, date-range and preset changes commit immediately. Text and numeric entry debounces by 300 ms and flushes on blur, overlay dismissal, navigation and preset save.
- Only configurations that pass `hasValidFilterConfiguration` reach a query or persistence, so a half-built filter is never sent.
- Auto-applied refreshes route through the existing `executeRefresh("background")` mode instead of the visible one, so results update without the full-screen loading overlay.
- Selecting a saved preset in the popover dropdown now applies it immediately, matching what the preset chips in the active-filters bar already did.
- Editing a filter while a preset is selected updates the view but leaves the stored preset untouched until Save, so a temporary adjustment to a saved preset is finally usable.

## Context

The popover previously edited `EditFiltersModalStore.form.filters` as a draft and committed to `BaseDataViewStore` only on Apply. Four things recorded on the issue shaped the implementation:

- **Apply was not the only commit path.** The popover body is wrapped in `<AppForm store={modalStore}>`, so Enter submits. `onSubmit` now flushes pending edits and only writes a preset when one is being created or edited.
- **The entity activity timeline is the hard-failure surface.** `ActivitiesStore.fetchPage` runs `ActivityFiltersSchema.parse` (not `safeParse`) over `.strict()` branches, so any mid-interaction shape throws and puts the timeline into refresh-error. Gating every commit on `hasValidFilterConfiguration` is what keeps that from happening; verified live by selecting an operator with no value and seeing no request and no error.
- **Newest-wins and a background mode already existed.** The gap was that `setQueryOptions` routed to the visible mode. `setQueryOptions` now takes an optional `refreshMode`, defaulting to today's behaviour for every existing caller. No second queue was introduced.
- **`Common.filters.apply`** is removed from all five locale catalogues, as the i18n parity gate requires.

Two behaviours were changed deliberately beyond the literal scope, both to avoid regressions the auto-apply path would otherwise introduce:

- **A superseded response could revert a newer edit.** A completed request commits `setItems`, which resets `store.filters` from the server's echoed filters. With rapid edits, request A's response could overwrite filters the user had already changed to C, and the queued re-run would then query A. The background drain now passes the store's existing `shouldCommit` guard so a superseded response is discarded rather than committed. A focused test covers this.
- **Removing a chip while the popover is open** left a stale draft that the next auto-apply would resurrect. `syncDraftFromTable` re-syncs the draft on chip removal, clear-all and preset-chip selection, and only when the popover is open for that store.

`mergeFiltersWithFilterableFields` is also guarded against a stored preset whose `filters` is not a usable array. That path is latent today (the write path validates), but it throws inside a MobX reaction, so the failure is swallowed and preset selection silently does nothing. Malformed entries are now skipped rather than throwing; presets remain repaired-not-dropped, consistent with the direction of [CUS-210](https://linear.app/customermates/issue/CUS-210/saved-filter-presets-are-dropped-instead-of-repaired-when-one-filter-fails-validation).

Selecting "No preset" in the dropdown keeps the current filters rather than clearing them, preserving today's behaviour and keeping Cancel out of preset creation from wiping the view.

## Validation

Gates, all green on this branch: `yarn typecheck`, `yarn lint`, `yarn conventions:check` (41 files, 303 tests), `yarn test` (321 files, 2722 tests), `yarn build`.

Focused tests added: `edit-filters-modal.store.test.ts` (13 fake-timer cases: debounce, flush, incomplete configurations, cleared values, guard re-baselining, preset apply, malformed preset, dismissal flush, submit behaviour), `base-data-view-background-refresh.test.ts` (5 deferred-request cases: no visible state, single-flight coalescing with the newest filters, unchanged-filter no-op, failure toast with prior rows, visible mode unchanged), `filter-popover-actions.test.ts` (3 render cases for the footer in normal, editing and creating modes).

Local browser acceptance against disposable PostgreSQL with seeded synthetic data, English and German, desktop (1280) and mobile (390):

- Popover footer offers only Clear; Save appears only in preset mode. Confirmed in English desktop, German desktop and the German mobile drawer.
- Opening the popover fired zero requests.
- Selecting `contains` with no value fired zero requests; typing then produced results.
- Eight rapid keystrokes produced exactly one request after the pause, with the final value in the URL.
- A select change applied immediately: 30 rows to 4, one request, URL updated, popover stayed open.
- Navigating to a bare `/en/contacts` with no query string restored the auto-applied filters from P13n and rewrote the URL, with Apply never pressed.
- Clear applied immediately with no loading overlay.
- Preset selection from the dropdown applied immediately (30 rows to 4). Editing a filter with that preset selected updated the view while the stored `savedFilterPresets` row stayed byte-identical; pressing Save then persisted both filters.
- Entity activity timeline: `Type in Messages` applied cleanly, no console error, no refresh-error state.
- Navigating away with the popover open and an auto-applied filter produced no unsaved-changes guard, and the navigation stayed client-side.
- Failure path, forced by stopping the database mid-edit: prior rows and the entered value were both preserved, nothing reverted, and the only report was the localized toast ("Etwas ist schiefgelaufen. Bitte versuche es erneut."). The next edit after restarting the database recovered.

One dev-only console warning was observed: a Radix `useId` hydration mismatch in the sidebar collapsibles and tooltips. No file in this diff is involved.

## Impact and rollback

Behavioural change to every `FilterPopover` consumer: the five entity tables, entity activity histories, inbox threads, users, audit logs, webhooks and webhook deliveries. The dashboard widget editor is untouched: it reuses the filter leaves but never mounts the popover or the modal store, and `flushPendingChanges` is an optional member that its form store does not implement, so those inputs no-op.

`setQueryOptions` gains an optional `refreshMode` that defaults to the existing visible path, so chip removal, clear-all, search and sorting are unchanged.

Rollback is a straight revert of this commit. Existing URLs, P13n rows, named presets, records and database schema stay compatible and need no repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)