### PR TITLE
fix(auth): clarify terms and privacy notice

### DIFF
--- a/app/[locale]/(public)/auth/signin/sign-in-form.tsx
+++ b/app/[locale]/(public)/auth/signin/sign-in-form.tsx
@@ -136,7 +136,7 @@ export const SignInForm = observer(({ isInvited, socialProviders }: Props) => {
             </Button>
 
             {appMode === "cloud" && !isInvited ? (
-              <p className="text-x-xs text-subdued text-center mt-2">
+              <p className="text-x-xs text-subdued text-center mt-2 max-w-sm">
                 {t.rich("SignInForm.agreeToTerms", {
                   dataPrivacyLink: (chunks) => (
                     <AppLink inheritSize appearance="inline" href="/privacy" target="_blank">

--- a/app/[locale]/(public)/auth/signup/sign-up-form.tsx
+++ b/app/[locale]/(public)/auth/signup/sign-up-form.tsx
@@ -138,7 +138,7 @@ export const SignUpForm = observer(({ isInvited, socialProviders }: Props) => {
             </Button>
 
             {appMode === "cloud" && !isInvited ? (
-              <p className="text-x-xs text-subdued text-center mt-2">
+              <p className="text-x-xs text-subdued text-center mt-2 max-w-sm">
                 {t.rich("SignUpForm.agreeToTerms", {
                   dataPrivacyLink: (chunks) => (
                     <AppLink inheritSize appearance="inline" href="/privacy" target="_blank">

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1708,7 +1708,7 @@
     "title": "Service"
   },
   "SignInForm": {
-    "agreeToTerms": "Siehe unsere <termsOfServiceLink>AGB</termsOfServiceLink>, unseren <dpaLink>AVV</dpaLink> und unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink>.",
+    "agreeToTerms": "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
     "buttonLabel": "Anmelden mit {provider}",
     "forgotPassword": "Passwort vergessen?",
     "or": "ODER",
@@ -1719,7 +1719,7 @@
   },
   "SignUpForm": {
     "acceptInviteCta": "Einladung annehmen",
-    "agreeToTerms": "Siehe unsere <termsOfServiceLink>AGB</termsOfServiceLink>, unseren <dpaLink>AVV</dpaLink> und unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink>.",
+    "agreeToTerms": "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
     "buttonLabel": "Registrieren mit {provider}",
     "inviteSubtitle": "Du wurdest eingeladen, einem Team auf Customermates beizutreten. Wähle deine Anmeldemethode, um die Einladung anzunehmen.",
     "inviteTitle": "Firmeneinladung annehmen",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1708,7 +1708,7 @@
     "title": "Service"
   },
   "SignInForm": {
-    "agreeToTerms": "See our <termsOfServiceLink>Terms</termsOfServiceLink>, <dpaLink>DPA</dpaLink>, and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+    "agreeToTerms": "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continue with {provider}",
     "forgotPassword": "Forgot password?",
     "or": "OR",
@@ -1719,7 +1719,7 @@
   },
   "SignUpForm": {
     "acceptInviteCta": "Accept invitation",
-    "agreeToTerms": "See our <termsOfServiceLink>Terms</termsOfServiceLink>, <dpaLink>DPA</dpaLink>, and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+    "agreeToTerms": "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Register with {provider}",
     "inviteSubtitle": "You have been invited to join a team on Customermates. Choose your sign-in method to accept the invitation.",
     "inviteTitle": "Accept Company Invitation",

--- a/tests/conventions/legal-unipile-disclosure.test.ts
+++ b/tests/conventions/legal-unipile-disclosure.test.ts
@@ -249,7 +249,7 @@ describe("registration legal copy covers the DPA", () => {
       expect(richTags(de[namespace][key]), `${namespace}.${key} tag mismatch`).toEqual(richTags(en[namespace][key]));
   });
 
-  it.each(CONTENT_LOCALES)("places assent at onboarding rather than sign-in or initial sign-up (%s)", (name) => {
+  it.each(CONTENT_LOCALES)("keeps the auth continuation notice distinct from explicit onboarding assent (%s)", (name) => {
     const messages = locale(name);
     const expected = name === "en"
       ? {
@@ -257,14 +257,16 @@ describe("registration legal copy covers the DPA", () => {
             "I am authorised to act for the business customer and accept the <termsOfServiceLink>Terms</termsOfServiceLink> and <dpaLink>DPA</dpaLink>. I have read the <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
           invited:
             "I agree to comply with the <termsOfServiceLink>Terms</termsOfServiceLink> and have read the <dpaLink>DPA</dpaLink> and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
-          auth: "See our <termsOfServiceLink>Terms</termsOfServiceLink>, <dpaLink>DPA</dpaLink>, and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+          auth:
+            "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
         }
       : {
           onboarding:
             "Ich bin berechtigt, für den Geschäftskunden zu handeln, und stimme den <termsOfServiceLink>AGB</termsOfServiceLink> sowie dem <dpaLink>AVV</dpaLink> zu. Die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> habe ich gelesen.",
           invited:
             "Ich verpflichte mich, die <termsOfServiceLink>AGB</termsOfServiceLink> einzuhalten, und habe den <dpaLink>AVV</dpaLink> sowie die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> gelesen.",
-          auth: "Siehe unsere <termsOfServiceLink>AGB</termsOfServiceLink>, unseren <dpaLink>AVV</dpaLink> und unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink>.",
+          auth:
+            "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
         };
 
     expect(messages.OnboardingForm.agreeToTerms).toBe(expected.onboarding);


### PR DESCRIPTION
## Summary

- replace the passive sign-in and sign-up legal-link note with a short continuation notice in English and German
- distinguish agreement to the Terms from acknowledgement of the Privacy Policy while retaining the DPA/AVV link
- constrain both notices to a balanced 384 px text width and pin the new copy in the legal convention test

## Context

Addresses [CUS-254](https://linear.app/customermates/issue/CUS-254/clarify-the-auth-terms-and-privacy-continuation-notice).

The authentication forms previously only pointed users to the legal documents. The new notice makes the continuation effect explicit while leaving the separate onboarding consent checkbox, its copy, and its enforcement unchanged. This wording is a product-risk improvement and is not a substitute for formal legal review.

## Validation

- `yarn typecheck`
- `yarn lint`
- `yarn test` — 323 files passed, 7 skipped; 2,745 tests passed, 66 skipped
- `yarn build`
- focused legal-disclosure convention suite — 42/42 passed
- locale audit — 1,426 keys per locale; passed with advisories only
- local `APP_MODE=cloud` browser verification — English and German sign-in/sign-up returned 200, retained all three legal links, and rendered without error overlays; final English wrapping verified at 384 px with no console errors
- UI screenshots and the independent no-findings review are attached to CUS-254

## Impact and rollback

User-visible authentication copy and presentation only. There are no schema, data, API, environment, or deployment-configuration changes.

Rollback by reverting this commit, which restores the four locale strings, the matching test expectations, and the two notice-width classes.
