### PR TITLE
fix(auth): align consent copy across locales

### DIFF
--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1708,7 +1708,7 @@
     "title": "Servicio"
   },
   "SignInForm": {
-    "agreeToTerms": "Consulta nuestros <termsOfServiceLink>Términos</termsOfServiceLink>, el <dpaLink>DPA</dpaLink> y nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>.",
+    "agreeToTerms": "Al continuar, aceptas nuestros <termsOfServiceLink>Términos</termsOfServiceLink> y reconoces haber leído nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>. Consulta nuestro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continuar con {provider}",
     "forgotPassword": "¿Has olvidado tu contraseña?",
     "or": "O",
@@ -1719,7 +1719,7 @@
   },
   "SignUpForm": {
     "acceptInviteCta": "Aceptar la invitación",
-    "agreeToTerms": "Consulta nuestros <termsOfServiceLink>Términos</termsOfServiceLink>, el <dpaLink>DPA</dpaLink> y nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>.",
+    "agreeToTerms": "Al continuar, aceptas nuestros <termsOfServiceLink>Términos</termsOfServiceLink> y reconoces haber leído nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>. Consulta nuestro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Regístrate con {provider}",
     "inviteSubtitle": "Te han invitado a unirte a un equipo en Customermates. Elige tu método de inicio de sesión para aceptar la invitación.",
     "inviteTitle": "Aceptar la invitación de la empresa",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1708,7 +1708,7 @@
     "title": "Service"
   },
   "SignInForm": {
-    "agreeToTerms": "Consultez nos <termsOfServiceLink>conditions générales</termsOfServiceLink>, notre <dpaLink>DPA</dpaLink> et notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>.",
+    "agreeToTerms": "En continuant, vous acceptez nos <termsOfServiceLink>conditions générales</termsOfServiceLink> et reconnaissez avoir lu notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>. Consultez notre <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continuer avec {provider}",
     "forgotPassword": "Mot de passe oublié ?",
     "or": "OU",
@@ -1719,7 +1719,7 @@
   },
   "SignUpForm": {
     "acceptInviteCta": "Accepter l'invitation",
-    "agreeToTerms": "Consultez nos <termsOfServiceLink>conditions générales</termsOfServiceLink>, notre <dpaLink>DPA</dpaLink> et notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>.",
+    "agreeToTerms": "En continuant, vous acceptez nos <termsOfServiceLink>conditions générales</termsOfServiceLink> et reconnaissez avoir lu notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>. Consultez notre <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "S'inscrire avec {provider}",
     "inviteSubtitle": "Vous avez été invité à rejoindre une équipe sur Customermates. Choisissez votre méthode de connexion pour accepter l'invitation.",
     "inviteTitle": "Accepter l'invitation de l'entreprise",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1708,7 +1708,7 @@
     "title": "Servizio"
   },
   "SignInForm": {
-    "agreeToTerms": "Consulta i nostri <termsOfServiceLink>Termini</termsOfServiceLink>, il <dpaLink>DPA</dpaLink> e l’<dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>.",
+    "agreeToTerms": "Continuando, accetti i nostri <termsOfServiceLink>Termini</termsOfServiceLink> e dichiari di aver letto la nostra <dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>. Consulta il nostro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continua con {provider}",
     "forgotPassword": "Password dimenticata?",
     "or": "OPPURE",
@@ -1719,7 +1719,7 @@
   },
   "SignUpForm": {
     "acceptInviteCta": "Accetta l'invito",
-    "agreeToTerms": "Consulta i nostri <termsOfServiceLink>Termini</termsOfServiceLink>, il <dpaLink>DPA</dpaLink> e l’<dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>.",
+    "agreeToTerms": "Continuando, accetti i nostri <termsOfServiceLink>Termini</termsOfServiceLink> e dichiari di aver letto la nostra <dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>. Consulta il nostro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Registrati con {provider}",
     "inviteSubtitle": "Hai ricevuto un invito a unirti a un team su Customermates. Scegli il tuo metodo di accesso per accettare l’invito.",
     "inviteTitle": "Accetta l'invito aziendale",

--- a/tests/conventions/legal-unipile-disclosure.test.ts
+++ b/tests/conventions/legal-unipile-disclosure.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { REPO_ROOT, walkFiles } from "./walk";
 
 import { LEGAL_DOCUMENT_VERSIONS } from "@/constants/legal-documents";
-import { CONTENT_LOCALES } from "@/i18n/locale-registry";
+import { APP_LOCALES, CONTENT_LOCALES, type AppLocale, type ContentLocale } from "@/i18n/locale-registry";
 
 // Guards the connected-account disclosure (CUS-56) against one-language drift and
 // against describing processing the product does not perform.
@@ -29,6 +29,29 @@ const EXTERNAL_IMAGE_HOSTS = [
   "startupfa.me",
   "open-launch.com",
 ] as const;
+
+const ONBOARDING_COPY = {
+  en: {
+    onboarding:
+      "I am authorised to act for the business customer and accept the <termsOfServiceLink>Terms</termsOfServiceLink> and <dpaLink>DPA</dpaLink>. I have read the <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+    invited:
+      "I agree to comply with the <termsOfServiceLink>Terms</termsOfServiceLink> and have read the <dpaLink>DPA</dpaLink> and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+  },
+  de: {
+    onboarding:
+      "Ich bin berechtigt, für den Geschäftskunden zu handeln, und stimme den <termsOfServiceLink>AGB</termsOfServiceLink> sowie dem <dpaLink>AVV</dpaLink> zu. Die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> habe ich gelesen.",
+    invited:
+      "Ich verpflichte mich, die <termsOfServiceLink>AGB</termsOfServiceLink> einzuhalten, und habe den <dpaLink>AVV</dpaLink> sowie die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> gelesen.",
+  },
+} satisfies Record<ContentLocale, { onboarding: string; invited: string }>;
+
+const AUTH_CONTINUATION_COPY = {
+  en: "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
+  de: "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
+  fr: "En continuant, vous acceptez nos <termsOfServiceLink>conditions générales</termsOfServiceLink> et reconnaissez avoir lu notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>. Consultez notre <dpaLink>DPA</dpaLink>.",
+  it: "Continuando, accetti i nostri <termsOfServiceLink>Termini</termsOfServiceLink> e dichiari di aver letto la nostra <dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>. Consulta il nostro <dpaLink>DPA</dpaLink>.",
+  es: "Al continuar, aceptas nuestros <termsOfServiceLink>Términos</termsOfServiceLink> y reconoces haber leído nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>. Consulta nuestro <dpaLink>DPA</dpaLink>.",
+} satisfies Record<AppLocale, string>;
 
 function legal(locale: string, slug: string): string {
   return readFileSync(join(REPO_ROOT, "content", "legal", locale, `${slug}.mdx`), "utf8");
@@ -234,45 +257,34 @@ describe("legal document versions stay coupled to the acceptance record", () => 
 });
 
 describe("registration legal copy covers the DPA", () => {
-  it.each(CONTENT_LOCALES)("legal-document messages (%s) link the DPA", (name) => {
+  it.each(APP_LOCALES)("legal-document messages (%s) link the DPA", (name) => {
     const messages = locale(name);
 
     for (const [namespace, key] of LEGAL_COPY_MESSAGES)
       expect(messages[namespace][key], `${namespace}.${key} is missing the DPA link`).toContain("<dpaLink>");
   });
 
-  it("keeps rich-text tags identical across locales", () => {
+  it.each(APP_LOCALES)("keeps rich-text tags identical across locales (%s)", (name) => {
     const en = locale("en");
-    const de = locale("de");
+    const messages = locale(name);
 
     for (const [namespace, key] of LEGAL_COPY_MESSAGES)
-      expect(richTags(de[namespace][key]), `${namespace}.${key} tag mismatch`).toEqual(richTags(en[namespace][key]));
+      expect(richTags(messages[namespace][key]), `${namespace}.${key} tag mismatch`).toEqual(richTags(en[namespace][key]));
   });
 
   it.each(CONTENT_LOCALES)("keeps the auth continuation notice distinct from explicit onboarding assent (%s)", (name) => {
     const messages = locale(name);
-    const expected = name === "en"
-      ? {
-          onboarding:
-            "I am authorised to act for the business customer and accept the <termsOfServiceLink>Terms</termsOfServiceLink> and <dpaLink>DPA</dpaLink>. I have read the <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
-          invited:
-            "I agree to comply with the <termsOfServiceLink>Terms</termsOfServiceLink> and have read the <dpaLink>DPA</dpaLink> and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
-          auth:
-            "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
-        }
-      : {
-          onboarding:
-            "Ich bin berechtigt, für den Geschäftskunden zu handeln, und stimme den <termsOfServiceLink>AGB</termsOfServiceLink> sowie dem <dpaLink>AVV</dpaLink> zu. Die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> habe ich gelesen.",
-          invited:
-            "Ich verpflichte mich, die <termsOfServiceLink>AGB</termsOfServiceLink> einzuhalten, und habe den <dpaLink>AVV</dpaLink> sowie die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> gelesen.",
-          auth:
-            "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
-        };
+    const expected = ONBOARDING_COPY[name];
 
     expect(messages.OnboardingForm.agreeToTerms).toBe(expected.onboarding);
     expect(messages.OnboardingForm.invitedAgreeToTerms).toBe(expected.invited);
-    expect(messages.SignUpForm.agreeToTerms).toBe(expected.auth);
-    expect(messages.SignInForm.agreeToTerms).toBe(expected.auth);
+  });
+
+  it.each(APP_LOCALES)("pins the auth continuation notice in every application locale (%s)", (name) => {
+    const messages = locale(name);
+
+    expect(messages.SignUpForm.agreeToTerms).toBe(AUTH_CONTINUATION_COPY[name]);
+    expect(messages.SignInForm.agreeToTerms).toBe(AUTH_CONTINUATION_COPY[name]);
   });
 
   it("renders a DPA link in every legal-copy surface", () => {


### PR DESCRIPTION
## Summary

- Update the Spanish, French, and Italian sign-in and sign-up continuation notices to agree to Terms, acknowledge that the Privacy Policy was read, and retain the DPA link.
- Drive exact auth-copy, DPA-link, and rich-tag parity assertions from all registered application locales.
- Preserve the merged English and German copy byte-for-byte and leave onboarding assent unchanged.

## Context

CUS-259: https://linear.app/customermates/issue/CUS-259/complete-the-auth-continuation-notice-across-every-application-locale

PR #95 clarified the English and German notices. Spanish, French, and Italian still used the older “consult the documents” meaning. This follow-up completes the same semantic contract across every application-locale JSON catalog.

## Validation

- `yarn vitest run tests/conventions/legal-unipile-disclosure.test.ts` — 54 tests passed
- `yarn i18n:audit` — all five catalogs retain 1,426-key parity
- `yarn typecheck` — passed
- `yarn lint` — passed
- `yarn test` — 323 files / 2,757 tests passed; 7 files / 66 tests skipped
- `yarn build` — passed
- Local `APP_MODE=cloud` browser acceptance with synthetic PostgreSQL 16 fixtures: all ten `/{en,de,es,fr,it}/auth/{signin,signup}` routes returned 200, rendered the exact pinned text and all three links, stayed at the 384 px desktop cap, and had no responsive overflow
- Deployed preview acceptance: all ten routes returned 200 and rendered the exact pinned copy and legal links; desktop notice width 384 px; 384 px viewport notice width 302 px with no overflow; browser console clean
- Independent read-only product review: no high, medium, or low findings

## Impact and rollback

Copy and convention-test only. No schema, data, API, consent-enforcement, environment, migration, dependency, or deployment-configuration changes.

Rollback by reverting this pull request, which restores the prior Spanish, French, and Italian auth strings. Formal legal/native-language review remains an optional product checkpoint.

## Screenshots

Preview verified visually in dark mode with the notice wrapping cleanly beneath the auth form.

- German sign-in: https://fix-auth-consent-all-locales.customermates.com/de/auth/signin
- Spanish sign-in: https://fix-auth-consent-all-locales.customermates.com/es/auth/signin
- French sign-in: https://fix-auth-consent-all-locales.customermates.com/fr/auth/signin
- Italian sign-in: https://fix-auth-consent-all-locales.customermates.com/it/auth/signin
