### PR TITLE
style(homepage): prototype OpenAI-inspired marketing design

### DIFF
--- a/app/[locale]/(static)/components/hero-demo-iframe.tsx
+++ b/app/[locale]/(static)/components/hero-demo-iframe.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ArrowUpRight } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { BrowserFrame } from "@/components/marketing/browser-frame";
@@ -7,10 +8,31 @@ import { BrowserFrame } from "@/components/marketing/browser-frame";
 export function HeroDemoIframe() {
   const locale = useLocale();
   const t = useTranslations();
+  const src = `https://demo.customermates.com/${locale}`;
+  const showLocalFallback = process.env.NODE_ENV === "development";
 
   return (
-    <div className="mt-2 max-w-[1400px] mx-auto w-full">
-      <BrowserFrame src={`https://demo.customermates.com/${locale}`} title={t("BrowserFrame.liveDemoTitle")} />
+    <div className="relative mx-auto mt-2 w-full max-w-[1400px]">
+      <BrowserFrame src={src} title={t("BrowserFrame.liveDemoTitle")} />
+
+      {showLocalFallback ? (
+        <div className="absolute inset-x-px top-[35px] bottom-px flex flex-col items-center justify-center gap-6 rounded-b-[13px] bg-card px-6 text-center">
+          <p className="max-w-lg text-[clamp(1.75rem,4vw,3.5rem)] font-medium leading-tight tracking-[-0.035em] text-balance">
+            {t("BrowserFrame.liveDemoTitle")}
+          </p>
+
+          <a
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-foreground px-6 text-sm font-medium text-background transition-opacity hover:opacity-85"
+            href={src}
+            rel="noreferrer noopener"
+            target="_blank"
+          >
+            {t("BrowserFrame.open")}
+
+            <ArrowUpRight className="size-4" />
+          </a>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/[locale]/(static)/components/homepage-benefits.tsx
+++ b/app/[locale]/(static)/components/homepage-benefits.tsx
@@ -1,56 +1,140 @@
+"use client";
+
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex -- The native horizontal scroll region needs a keyboard focus target. */
+
 import type { Benefits } from "@/core/fumadocs/schemas/homepage";
 
-import { AppCard } from "@/components/card/app-card";
-import { AppCardBody } from "@/components/card/app-card-body";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useRef } from "react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/shared/icon";
 import { ICONS } from "@/components/shared/icons";
-import { SectionBadge } from "@/components/marketing/section-badge";
+import { cn } from "@/core/utils/cn";
 
 type Props = {
   benefitsSection: Benefits;
 };
 
 export function HomepageBenefits({ benefitsSection }: Props) {
+  const t = useTranslations();
+  const shelfRef = useRef<HTMLDivElement>(null);
+
+  function scrollShelf(direction: -1 | 1) {
+    const shelf = shelfRef.current;
+    if (!shelf) return;
+
+    shelf.scrollBy({
+      behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+      left: shelf.clientWidth * 0.85 * direction,
+    });
+  }
+
   return (
-    <section className="relative py-14 md:py-20 w-full max-w-[1200px] px-4 mx-auto" id="benefits">
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(16,185,129,0.10)_1px,transparent_0)] bg-size-[28px_28px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_30%,black,transparent_75%)]" />
+    <section
+      className="w-full border-b border-foreground/15 py-20 sm:py-24 lg:py-32"
+      data-homepage-section="benefits"
+      id="benefits"
+    >
+      <div className="mx-auto w-full max-w-[1440px] px-5 sm:px-8">
+        <div className="grid gap-6 lg:grid-cols-[minmax(180px,0.45fr)_minmax(0,1.55fr)] lg:gap-12">
+          <p className="pt-1 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+            {benefitsSection.badge}
+          </p>
 
-        <div className="absolute -top-12 right-[8%] size-[300px] rounded-full bg-[rgba(18,148,144,0.16)] blur-[90px]" />
+          <div>
+            <h2
+              className="m-0 max-w-[980px] text-[clamp(2.5rem,5.2vw,5.25rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance"
+              id="homepage-benefits-heading"
+            >
+              {benefitsSection.title}
+            </h2>
 
-        <div className="absolute bottom-[8%] left-[6%] size-[320px] rounded-full bg-[rgba(16,185,129,0.13)] blur-[100px]" />
+            <p className="mt-5 max-w-[720px] text-base leading-relaxed text-muted-foreground sm:text-lg">
+              {benefitsSection.subtitle}
+            </p>
+          </div>
+        </div>
 
-        <div className="absolute top-1/3 right-[18%] size-[200px] rounded-full bg-[rgba(245,158,11,0.10)] blur-[80px]" />
-      </div>
+        <div className="mt-8 flex justify-end gap-2 lg:hidden">
+          <Button
+            aria-label={t("OnboardingWizard.back")}
+            className="rounded-full"
+            size="icon"
+            type="button"
+            variant="secondary"
+            onClick={() => scrollShelf(-1)}
+          >
+            <ArrowLeft aria-hidden className="size-4" />
+          </Button>
 
-      <div className="text-center mb-10 md:mb-16">
-        <SectionBadge className="mb-4">{benefitsSection.badge}</SectionBadge>
+          <Button
+            aria-label={t("OnboardingWizard.next")}
+            className="rounded-full"
+            size="icon"
+            type="button"
+            variant="secondary"
+            onClick={() => scrollShelf(1)}
+          >
+            <ArrowRight aria-hidden className="size-4" />
+          </Button>
+        </div>
 
-        <h2 className="text-x-3xl">{benefitsSection.title}</h2>
+        <div
+          ref={shelfRef}
+          aria-labelledby="homepage-benefits-heading"
+          className="-mx-5 mt-4 flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-4 sm:-mx-8 sm:px-8 lg:mx-0 lg:mt-16 lg:grid lg:auto-rows-fr lg:grid-cols-4 lg:overflow-visible lg:px-0 lg:pb-0"
+          role="region"
+          tabIndex={0}
+        >
+          {benefitsSection.benefits.map((benefit, index) => {
+            const IconComponent = ICONS[benefit.icon];
+            const featured = index === 0;
 
-        <p className="mt-4 text-x-xl text-subdued max-w-2xl mx-auto">{benefitsSection.subtitle}</p>
-      </div>
+            return (
+              <article
+                key={benefit.title}
+                aria-posinset={index + 1}
+                aria-setsize={benefitsSection.benefits.length}
+                className={cn(
+                  "flex min-h-[360px] w-[82vw] max-w-[340px] shrink-0 snap-start flex-col justify-between rounded-[20px] bg-muted/45 p-6 sm:w-[42vw] sm:max-w-[420px] sm:p-7 lg:min-h-[230px] lg:w-auto lg:max-w-none lg:shrink lg:snap-none",
+                  featured &&
+                    "min-h-[420px] w-[86vw] max-w-[520px] bg-foreground text-background sm:w-[64vw] sm:max-w-[620px] lg:col-span-2 lg:row-span-2 lg:min-h-[480px] lg:w-auto lg:max-w-none",
+                )}
+              >
+                <div
+                  className={cn(
+                    "flex size-10 items-center justify-center rounded-full border border-foreground/15 text-muted-foreground",
+                    featured && "border-background/25 text-background/75",
+                  )}
+                >
+                  <Icon icon={IconComponent} />
+                </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4">
-        {benefitsSection.benefits.map((benefit, index) => {
-          const IconComponent = ICONS[benefit.icon];
+                <div className="mt-12">
+                  <h3
+                    className={cn(
+                      "text-xl font-medium leading-tight tracking-[-0.025em]",
+                      featured && "max-w-[620px] text-[clamp(2rem,4vw,4.25rem)] leading-[0.98] tracking-[-0.045em]",
+                    )}
+                  >
+                    {benefit.title}
+                  </h3>
 
-          return (
-            <AppCard key={index}>
-              <AppCardBody>
-                <h3 className="font-semibold flex items-center gap-2">
-                  <div className="text-subdued">
-                    <Icon icon={IconComponent} />
-                  </div>
-
-                  {benefit.title}
-                </h3>
-
-                <p className="text-x-sm text-subdued leading-relaxed">{benefit.description}</p>
-              </AppCardBody>
-            </AppCard>
-          );
-        })}
+                  <p
+                    className={cn(
+                      "mt-3 text-sm leading-relaxed text-muted-foreground",
+                      featured && "max-w-[640px] text-base text-background/70 sm:text-lg",
+                    )}
+                  >
+                    {benefit.description}
+                  </p>
+                </div>
+              </article>
+            );
+          })}
+        </div>
       </div>
     </section>
   );

--- a/app/[locale]/(static)/components/homepage-hero.tsx
+++ b/app/[locale]/(static)/components/homepage-hero.tsx
@@ -1,6 +1,6 @@
 import type { Hero } from "@/core/fumadocs/schemas/homepage";
 
-import { ChevronDown } from "lucide-react";
+import { ArrowUpRight, ChevronDown } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -17,88 +17,92 @@ import {
   XTwitter,
 } from "@/components/icons/channel-icon";
 import { AgplGithubBadge } from "@/components/marketing/agpl-github-badge";
-import { WaveDecoration } from "@/components/marketing/wave-decoration";
+import { AppLink } from "@/components/shared/app-link";
 
 import { HeroDemoIframe } from "./hero-demo-iframe";
-
-import { AppLink } from "@/components/shared/app-link";
 
 type Props = {
   heroSection: Hero;
 };
 
+const CHANNELS = [
+  { name: "LinkedIn", mark: <Linkedin size={22} />, status: "supported" },
+  { name: "Instagram", mark: <Instagram size={22} />, status: "supported" },
+  { name: "WhatsApp", mark: <Whatsapp size={22} />, status: "supported" },
+  { name: "Telegram", mark: <Telegram size={22} />, status: "supported" },
+  { name: "Gmail", mark: <Google size={22} />, status: "supported" },
+  { name: "Outlook", mark: <Outlook size={22} />, status: "supported" },
+  { name: "IMAP", mark: <Mail size={22} />, status: "supported" },
+  { name: "Google Calendar", mark: <GoogleCalendar size={22} />, status: "supported" },
+  { name: "Outlook Calendar", mark: <OutlookCalendar size={22} />, status: "supported" },
+  { name: "X / Twitter", mark: <XTwitter size={22} />, status: "concept" },
+  { name: "Messenger", mark: <Messenger size={22} />, status: "concept" },
+] as const;
+
 export function HomepageHero({ heroSection }: Props) {
   return (
-    <section className="relative isolate w-full overflow-hidden pt-16 pb-14 md:pt-24 md:pb-16">
-      <WaveDecoration
-        className="-top-20 -left-40 w-[min(900px,92vw)] md:-top-20 md:-left-40"
-        opacity={0.25}
-        variant="wave-1"
-      />
-
-      <WaveDecoration
-        className="top-5 right-0 hidden w-[min(620px,55vw)] md:block md:-right-20 md:top-5"
-        opacity={0.3}
-        variant="wave-2"
-      />
-
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 z-5 bg-[radial-gradient(ellipse_60%_60%_at_50%_35%,var(--background)_0%,transparent_70%)]"
-      />
-
-      <div className="relative z-10 flex w-full flex-col items-center">
-        <div className="mx-auto flex w-full max-w-[1000px] flex-col items-center px-4 text-center">
+    <section className="w-full border-b border-foreground/15" data-homepage-section="hero">
+      <div className="mx-auto flex min-h-[calc(100svh-4rem)] w-full max-w-[1440px] flex-col px-5 sm:px-8">
+        <div className="flex flex-1 flex-col items-center justify-center py-16 text-center sm:py-24 lg:py-28">
           <AgplGithubBadge />
 
-          <h1 className="m-0 max-w-[900px] bg-[linear-gradient(to_bottom,#171717,#262626_45%,#525252)] bg-clip-text text-[44px] font-extrabold leading-[1.02] tracking-[-0.035em] text-transparent [background-repeat:repeat-y] [background-size:100%_1.02em] sm:text-[58px] md:text-[72px] dark:bg-[linear-gradient(to_bottom,#fafafa,#e5e5e5_45%,#a3a3a3)]">
+          <h1 className="mt-7 max-w-[1120px] text-[clamp(2.75rem,6.6vw,6.25rem)] font-medium leading-[0.94] tracking-[-0.055em] text-balance">
             {/* eslint-disable react/jsx-newline */}
             {heroSection.title}{" "}
             {heroSection.titleAccent ? (
-              <span
-                className="bg-[linear-gradient(110deg,#8b5cf6,#6366f1)] bg-clip-text font-semibold italic text-transparent"
-                style={{ fontFamily: "var(--font-serif)" }}
-              >
-                {heroSection.titleAccent}
-              </span>
+              <span className="font-serif font-normal italic tracking-[-0.035em]">{heroSection.titleAccent}</span>
             ) : null}
             {/* eslint-enable react/jsx-newline */}
           </h1>
 
-          <p className="mx-auto mt-6 max-w-[680px] text-[16px] font-medium leading-normal text-muted-foreground md:text-[18px]">
-            {heroSection.subtitle}
-          </p>
+          <div className="mt-10 w-full max-w-[780px] rounded-[28px] border border-foreground/10 bg-muted/55 p-5 text-left shadow-[0_20px_70px_-48px_rgba(0,0,0,0.8)] sm:p-6">
+            <p className="max-w-[680px] text-[15px] leading-relaxed text-muted-foreground sm:text-base">
+              {heroSection.subtitle}
+            </p>
 
-          <div className="mt-7 flex flex-wrap items-center justify-center gap-4">
-            <Linkedin size={28} />
+            <div className="mt-7 flex items-end justify-between gap-4">
+              <ul aria-hidden className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-2.5">
+                {CHANNELS.map((channel) => (
+                  <li
+                    key={channel.name}
+                    className={`flex size-8 items-center justify-center rounded-full border bg-background sm:size-9 ${
+                      channel.status === "concept"
+                        ? "border-dashed border-foreground/35 opacity-45 grayscale"
+                        : "border-foreground/10"
+                    }`}
+                    data-prototype-status={channel.status}
+                  >
+                    {channel.mark}
+                  </li>
+                ))}
+              </ul>
 
-            <Instagram size={28} />
-
-            <Whatsapp size={28} />
-
-            <Messenger size={28} />
-
-            <Telegram size={28} />
-
-            <XTwitter size={28} />
-
-            <Google size={28} />
-
-            <Outlook size={28} />
-
-            <Mail size={28} />
-
-            <OutlookCalendar size={28} />
-
-            <GoogleCalendar size={28} />
+              <Button
+                asChild
+                className="size-11 shrink-0 rounded-full bg-foreground p-0 text-background hover:bg-foreground/85"
+                size="icon-lg"
+              >
+                <AppLink aria-label={heroSection.buttonLeftText} href={heroSection.buttonLeftHref}>
+                  <ArrowUpRight className="size-5" />
+                </AppLink>
+              </Button>
+            </div>
           </div>
 
-          <div className="my-8 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
-            <Button asChild className="w-full shadow-[0_6px_14px_-4px_rgba(94,74,227,0.45)] sm:w-auto" size="lg">
-              <AppLink href={heroSection.buttonLeftHref}>{heroSection.buttonLeftText}</AppLink>
+          <div className="mt-6 flex w-full max-w-[780px] flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
+            <Button
+              asChild
+              className="h-11 rounded-full bg-foreground px-6 text-background hover:bg-foreground/85"
+              size="lg"
+            >
+              <AppLink href={heroSection.buttonLeftHref}>
+                {heroSection.buttonLeftText}
+
+                <ArrowUpRight className="size-4" />
+              </AppLink>
             </Button>
 
-            <Button asChild className="w-full sm:w-auto" size="lg" variant="secondary">
+            <Button asChild className="h-11 rounded-full bg-transparent px-6" size="lg" variant="secondary">
               {heroSection.buttonRightHref.startsWith("#") ? (
                 <a href={heroSection.buttonRightHref}>
                   {heroSection.buttonRightText}
@@ -113,12 +117,12 @@ export function HomepageHero({ heroSection }: Props) {
             </Button>
           </div>
 
-          <p className="mb-6 text-xs text-muted-foreground">{heroSection.startFree}</p>
+          <p className="mt-5 text-xs leading-relaxed text-muted-foreground">{heroSection.startFree}</p>
         </div>
+      </div>
 
-        <div className="w-full px-4">
-          <HeroDemoIframe />
-        </div>
+      <div className="mx-auto w-full max-w-[1440px] px-5 pb-20 sm:px-8 sm:pb-28">
+        <HeroDemoIframe />
       </div>
     </section>
   );

--- a/app/[locale]/(static)/components/homepage-how-it-works.tsx
+++ b/app/[locale]/(static)/components/homepage-how-it-works.tsx
@@ -2,9 +2,6 @@ import type { ClipTerminal } from "@/core/fumadocs/schemas/homepage";
 
 import { getTranslations } from "next-intl/server";
 
-import { Card, CardContent } from "@/components/ui/card";
-import { WaveDecoration } from "@/components/marketing/wave-decoration";
-
 import { HomepageClipTerminal } from "./homepage-clip-terminal";
 
 type Step = { n: string; title: string; description: string };
@@ -18,73 +15,52 @@ type Props = {
 
 export async function HomepageHowItWorks({ eyebrow, title, steps, clipTerminal }: Props) {
   const t = await getTranslations();
+
   return (
-    <section className="relative w-full overflow-hidden px-4 py-14 md:py-20">
-      <WaveDecoration
-        className="-top-10 right-0 hidden w-[min(560px,40%)] -scale-x-100 opacity-50 md:block"
-        opacity={0.18}
-        variant="wave-2"
-      />
+    <section
+      className="w-full border-b border-foreground/15 py-20 sm:py-24 lg:py-32"
+      data-homepage-section="how-it-works"
+    >
+      <div className="mx-auto w-full max-w-[1440px] px-5 sm:px-8">
+        <div className="grid gap-6 lg:grid-cols-[minmax(180px,0.45fr)_minmax(0,1.55fr)] lg:gap-12">
+          <p className="pt-1 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">{eyebrow}</p>
 
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute -top-12 left-[6%] size-[380px] rounded-full bg-[rgba(6,182,212,0.13)] blur-[110px]" />
-
-        <div className="absolute bottom-[8%] right-[10%] size-[300px] rounded-full bg-[rgba(139,92,246,0.13)] blur-[90px]" />
-
-        <div
-          className="absolute inset-0 opacity-[0.28] bg-[radial-gradient(circle_at_1px_1px,rgba(6,182,212,0.10)_1px,transparent_0)] bg-size-[26px_26px]"
-          style={{
-            maskImage: "radial-gradient(ellipse 70% 60% at 50% 50%, #000 30%, transparent 85%)",
-            WebkitMaskImage: "radial-gradient(ellipse 70% 60% at 50% 50%, #000 30%, transparent 85%)",
-          }}
-        />
-      </div>
-
-      <Card className="relative mx-auto w-full max-w-[1100px] overflow-hidden py-10 md:py-14">
-        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div className="absolute -left-16 top-0 size-[360px] rounded-full bg-[rgba(94,74,227,0.12)] blur-[90px]" />
-
-          <div className="absolute -right-16 bottom-0 size-[340px] rounded-full bg-[rgba(18,148,144,0.10)] blur-[80px]" />
+          <h2 className="m-0 max-w-[980px] text-[clamp(2.5rem,5.2vw,5.25rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance">
+            {title}
+          </h2>
         </div>
 
-        <CardContent>
-          <div className="mb-10 text-center">
-            <span className="mb-3 inline-block rounded-md bg-primary/15 px-3 py-1 text-[13px] font-medium text-primary">
-              {eyebrow}
-            </span>
+        <div className="mt-12 grid gap-12 lg:mt-20 lg:grid-cols-2 lg:items-start lg:gap-16">
+          <ol className="border-t border-foreground/20">
+            {steps.map((step) => (
+              <li
+                key={step.n}
+                className="grid grid-cols-[56px_minmax(0,1fr)] gap-4 border-b border-foreground/20 py-7 sm:grid-cols-[76px_minmax(0,1fr)] sm:gap-6 sm:py-9"
+              >
+                <span className="font-mono text-sm text-muted-foreground">{step.n}</span>
 
-            <h2 className="m-0 text-[28px] font-bold leading-tight tracking-tight md:text-[32px]">{title}</h2>
-          </div>
+                <div>
+                  <h3 className="text-xl font-medium leading-tight tracking-[-0.025em] sm:text-2xl">{step.title}</h3>
 
-          <div className="grid grid-cols-1 items-center gap-14 md:grid-cols-2">
-            <ol className="flex flex-col gap-[18px]">
-              {steps.map((step) => (
-                <li key={step.n} className="flex gap-3.5">
-                  <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 font-mono text-sm font-bold text-primary">
-                    {step.n}
-                  </div>
+                  <p className="mt-3 max-w-[620px] text-sm leading-relaxed text-muted-foreground sm:text-base">
+                    {step.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
 
-                  <div>
-                    <div className="mb-0.5 text-[15px] font-semibold">{step.title}</div>
+          <div className="lg:sticky lg:top-24">
+            <HomepageClipTerminal strings={clipTerminal} />
 
-                    <div className="text-[13px] leading-[1.55] text-muted-foreground">{step.description}</div>
-                  </div>
-                </li>
-              ))}
-            </ol>
+            <div className="mt-3 flex items-center justify-between gap-4 px-1 font-mono text-[11px] text-muted-foreground">
+              <span>{t("HomepageHowItWorks.loopCaption")}</span>
 
-            <div className="relative">
-              <HomepageClipTerminal strings={clipTerminal} />
-
-              <div className="mt-2.5 flex items-center justify-between px-1 font-mono text-[11px] text-muted-foreground">
-                <span>{t("HomepageHowItWorks.loopCaption")}</span>
-
-                <span>{t("HomepageHowItWorks.tailCaption")}</span>
-              </div>
+              <span>{t("HomepageHowItWorks.tailCaption")}</span>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/[locale]/(static)/components/homepage-pricing.tsx
+++ b/app/[locale]/(static)/components/homepage-pricing.tsx
@@ -3,8 +3,8 @@ import { getLocale, getTranslations } from "next-intl/server";
 
 import { Button } from "@/components/ui/button";
 import { AppLink } from "@/components/shared/app-link";
-import { WaveDecoration } from "@/components/marketing/wave-decoration";
 import { formatCommercialAmount, PLAN_CATALOG } from "@/core/commercial/plan-catalog";
+import { cn } from "@/core/utils/cn";
 
 type CardConfig = {
   href: string;
@@ -43,80 +43,68 @@ export async function HomepagePricing() {
   const [t, locale] = await Promise.all([getTranslations(), getLocale()]);
 
   return (
-    <section className="relative isolate w-full overflow-hidden py-20 md:py-28" id="pricing">
-      <WaveDecoration className="-top-10 -left-32 w-[min(560px,70%)] -scale-x-100" opacity={0.4} variant="wave-1" />
-
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute left-[10%] top-[20%] size-[360px] rounded-full bg-[rgba(94,74,227,0.18)] blur-[80px]" />
-
-        <div className="absolute right-[8%] bottom-[10%] size-[320px] rounded-full bg-[rgba(18,148,144,0.15)] blur-[80px]" />
-
-        <div
-          className="absolute inset-0 opacity-[0.35] bg-[radial-gradient(circle_at_1px_1px,rgba(94,74,227,0.12)_1px,transparent_0)] bg-size-[24px_24px]"
-          style={{
-            maskImage: "radial-gradient(ellipse 70% 60% at 50% 50%, #000 30%, transparent 85%)",
-            WebkitMaskImage: "radial-gradient(ellipse 70% 60% at 50% 50%, #000 30%, transparent 85%)",
-          }}
-        />
-      </div>
-
-      <div className="relative mx-auto max-w-[820px] px-4">
-        <div className="relative mb-10 text-center">
-          <span className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 font-mono text-[12px] font-medium uppercase tracking-[0.05em] text-primary">
-            <span className="size-[5px] rounded-full bg-primary" style={{ boxShadow: "0 0 8px var(--primary)" }} />
-
+    <section
+      className="w-full border-b border-foreground/15 py-20 sm:py-24 lg:py-32"
+      data-homepage-section="pricing"
+      id="pricing"
+    >
+      <div className="mx-auto w-full max-w-[1440px] px-5 sm:px-8">
+        <div className="grid gap-6 lg:grid-cols-[minmax(180px,0.45fr)_minmax(0,1.55fr)] lg:gap-12">
+          <p className="pt-1 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
             {t("HomepagePricing.eyebrow")}
-          </span>
+          </p>
 
-          <h2 className="text-x-3xl pb-4">{t("HomepagePricing.title")}</h2>
+          <div>
+            <h2 className="m-0 max-w-[980px] text-[clamp(2.5rem,5.2vw,5.25rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance">
+              {t("HomepagePricing.title")}
+            </h2>
 
-          <p className="mx-auto max-w-[560px] text-x-lg text-subdued">{t("HomepagePricing.subtitle")}</p>
-
-          <svg
-            aria-hidden
-            className="absolute -top-2 left-[calc(50%-220px)] size-4 text-primary opacity-45"
-            fill="none"
-            viewBox="0 0 16 16"
-          >
-            <path d="M8 0v16M0 8h16" stroke="currentColor" strokeWidth="1" />
-          </svg>
-
-          <svg
-            aria-hidden
-            className="absolute -top-2 right-[calc(50%-220px)] size-4 text-primary opacity-45"
-            fill="none"
-            viewBox="0 0 16 16"
-          >
-            <path d="M8 0v16M0 8h16" stroke="currentColor" strokeWidth="1" />
-          </svg>
+            <p className="mt-5 max-w-[680px] text-base leading-relaxed text-muted-foreground sm:text-lg">
+              {t("HomepagePricing.subtitle")}
+            </p>
+          </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="mt-12 grid grid-cols-1 gap-3 md:grid-cols-2 lg:mt-16">
           {CARDS.map((card) => {
             const featured = card.variant === "default";
-            return (
-              <div
-                key={card.titleKey}
-                className={`relative flex flex-col rounded-xl border border-border bg-card p-6 shadow-xs ${
-                  featured ? "border-2 border-primary" : ""
-                }`}
-              >
-                <div className="mb-1 flex items-center justify-between">
-                  <h3 className="m-0 text-[19px] font-semibold">{t(`HomepagePricing.${card.titleKey}.title`)}</h3>
 
-                  {card.badgeKey && (
-                    <span className="rounded-full bg-primary/15 px-2.5 py-0.5 text-[11px] font-medium text-primary">
+            return (
+              <article
+                key={card.titleKey}
+                className={cn(
+                  "flex min-h-[560px] flex-col rounded-[24px] bg-muted/45 p-6 sm:p-8",
+                  featured && "bg-foreground text-background",
+                )}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <h3 className="m-0 text-2xl font-medium tracking-[-0.03em]">
+                    {t(`HomepagePricing.${card.titleKey}.title`)}
+                  </h3>
+
+                  {card.badgeKey ? (
+                    <span
+                      className={cn(
+                        "rounded-full border border-foreground/20 px-3 py-1 text-xs",
+                        featured && "border-background/25",
+                      )}
+                    >
                       {t(`HomepagePricing.${card.titleKey}.${card.badgeKey}`)}
                     </span>
-                  )}
+                  ) : null}
                 </div>
 
-                <p className="m-0 min-h-[40px] text-[13px] leading-[1.55] text-muted-foreground">
+                <p
+                  className={cn(
+                    "mt-3 max-w-[520px] text-sm leading-relaxed text-muted-foreground",
+                    featured && "text-background/65",
+                  )}
+                >
                   {t(`HomepagePricing.${card.titleKey}.tag`)}
                 </p>
 
-                <div className="my-4">
-                  <span className="text-[34px] font-bold tracking-[-0.02em]">
+                <div className="mt-10">
+                  <span className="text-[clamp(3rem,6vw,5.5rem)] font-medium leading-none tracking-[-0.055em]">
                     {card.titleKey === "cloud"
                       ? t("HomepagePricing.cloud.price", {
                           price: formatCommercialAmount(
@@ -128,29 +116,44 @@ export async function HomepagePricing() {
                       : t("HomepagePricing.selfHosted.price")}
                   </span>
 
-                  {card.periodKey && (
-                    <span className="ml-1.5 text-[13px] text-muted-foreground">
+                  {card.periodKey ? (
+                    <span className={cn("ml-2 text-sm text-muted-foreground", featured && "text-background/65")}>
                       {t(`HomepagePricing.${card.titleKey}.${card.periodKey}`)}
                     </span>
-                  )}
+                  ) : null}
                 </div>
 
-                <Button asChild className="w-full" variant={featured ? "default" : "secondary"}>
+                <Button
+                  asChild
+                  className={cn(
+                    "mt-8 h-11 w-full rounded-full bg-foreground text-background hover:bg-foreground/85",
+                    featured && "bg-background text-foreground hover:bg-background/85",
+                  )}
+                >
                   <AppLink external={card.href.startsWith("http")} href={card.href}>
                     {t(`HomepagePricing.${card.titleKey}.ctaText`)}
                   </AppLink>
                 </Button>
 
-                {card.compareHref && card.compareTextKey && (
-                  <AppLink className="mt-3 text-center text-[12px] text-muted-foreground" href={card.compareHref}>
+                {card.compareHref && card.compareTextKey ? (
+                  <AppLink
+                    className={cn(
+                      "mt-3 text-center text-xs text-muted-foreground underline-offset-4 hover:underline",
+                      featured && "text-background/65",
+                    )}
+                    href={card.compareHref}
+                  >
                     {t(`HomepagePricing.${card.titleKey}.${card.compareTextKey}`)}
                   </AppLink>
-                )}
+                ) : null}
 
-                <ul className="m-0 mt-4 flex flex-col gap-2 p-0">
+                <ul className="m-0 mt-8 flex flex-col border-t border-current/20 p-0">
                   {card.featureKeys.map((featureKey) => (
-                    <li key={featureKey} className="flex items-start gap-2 text-[13px] text-foreground">
-                      <Check aria-hidden className="mt-0.5 size-3.5 shrink-0 text-primary" strokeWidth={2.5} />
+                    <li
+                      key={featureKey}
+                      className="flex items-start gap-3 border-b border-current/20 py-3.5 text-sm leading-relaxed last:border-b-0"
+                    >
+                      <Check aria-hidden className="mt-1 size-3.5 shrink-0" strokeWidth={2.5} />
 
                       <span>
                         {t(`HomepagePricing.${card.titleKey}.${featureKey}`, {
@@ -163,21 +166,17 @@ export async function HomepagePricing() {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </article>
             );
           })}
         </div>
 
-        <div className="mx-auto mt-8 flex max-w-[820px] flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] uppercase tracking-[0.04em] text-muted-foreground">
-          {COMPARE_KEYS.map((key, i) => (
-            <span key={key} className="inline-flex items-center gap-1.5">
-              {i > 0 && <span className="opacity-30">|</span>}
+        <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-xs text-muted-foreground">
+          {COMPARE_KEYS.map((key) => (
+            <span key={key} className="inline-flex items-center gap-2">
+              <Check aria-hidden className="size-3.5" />
 
-              <span className="inline-flex items-center gap-1.5">
-                <span className="text-[#34c759]">✓</span>
-
-                {t(`HomepagePricing.compare.${key}`)}
-              </span>
+              {t(`HomepagePricing.compare.${key}`)}
             </span>
           ))}
         </div>

--- a/app/[locale]/(static)/components/homepage-stats-row.tsx
+++ b/app/[locale]/(static)/components/homepage-stats-row.tsx
@@ -15,15 +15,15 @@ const LOGOS: Logo[] = [
     name: "n8n",
     mark: (
       <svg aria-hidden fill="none" height="22" viewBox="0 0 24 24" width="22">
-        <circle cx="5" cy="12" fill="#EA4B71" r="2" />
+        <circle cx="5" cy="12" fill="currentColor" r="2" />
 
-        <circle cx="19" cy="7" fill="#EA4B71" r="2" />
+        <circle cx="19" cy="7" fill="currentColor" r="2" />
 
-        <circle cx="19" cy="17" fill="#EA4B71" r="2" />
+        <circle cx="19" cy="17" fill="currentColor" r="2" />
 
-        <circle cx="12" cy="12" fill="#EA4B71" r="2.5" />
+        <circle cx="12" cy="12" fill="currentColor" r="2.5" />
 
-        <path d="M7 12h3M14 12l3-4M14 12l3 4" stroke="#EA4B71" strokeWidth="1.5" />
+        <path d="M7 12h3M14 12l3-4M14 12l3 4" stroke="currentColor" strokeWidth="1.5" />
       </svg>
     ),
   },
@@ -33,33 +33,26 @@ export async function HomepageStatsRow() {
   const t = await getTranslations();
 
   return (
-    <div className="mx-auto -mt-5 w-full max-w-[1100px] px-4">
-      <div className="relative overflow-hidden rounded-2xl px-6 py-7 text-center">
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 opacity-[0.35] [background:radial-gradient(ellipse_at_15%_50%,rgba(94,74,227,0.10),transparent_55%),radial-gradient(ellipse_at_85%_50%,rgba(18,148,144,0.08),transparent_55%)]"
-        />
+    <section className="w-full border-b border-foreground/15" data-homepage-section="clients">
+      <div className="mx-auto grid w-full max-w-[1440px] gap-8 px-5 py-8 sm:px-8 md:grid-cols-[minmax(220px,0.65fr)_minmax(0,1.35fr)] md:items-center md:py-10">
+        {/* eslint-disable react/jsx-newline */}
+        <p className="max-w-[360px] text-sm leading-relaxed text-muted-foreground">
+          {t("HomepageStatsRow.taglinePre")}{" "}
+          <span className="font-medium text-foreground">{t("HomepageStatsRow.taglineMcp")}</span>
+          {t("HomepageStatsRow.taglinePost")}
+        </p>
+        {/* eslint-enable react/jsx-newline */}
 
-        <div className="relative">
-          {/* eslint-disable react/jsx-newline */}
-          <p className="mb-4 text-xs tracking-wide text-muted-foreground">
-            {t("HomepageStatsRow.taglinePre")}{" "}
-            <span className="font-medium text-foreground">{t("HomepageStatsRow.taglineMcp")}</span>
-            {t("HomepageStatsRow.taglinePost")}
-          </p>
-          {/* eslint-enable react/jsx-newline */}
+        <ul className="flex flex-wrap items-center gap-x-8 gap-y-5 md:justify-end lg:gap-x-12">
+          {LOGOS.map((logo) => (
+            <li key={logo.name} className="flex items-center gap-2.5 text-foreground/80 grayscale">
+              {logo.mark}
 
-          <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-4">
-            {LOGOS.map((logo) => (
-              <div key={logo.name} className="flex items-center gap-2 text-foreground/80">
-                {logo.mark}
-
-                <span className="text-[15px] font-semibold tracking-tight">{logo.name}</span>
-              </div>
-            ))}
-          </div>
-        </div>
+              <span className="text-sm font-medium tracking-[-0.015em]">{logo.name}</span>
+            </li>
+          ))}
+        </ul>
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/[locale]/(static)/components/homepage-walkthrough.tsx
+++ b/app/[locale]/(static)/components/homepage-walkthrough.tsx
@@ -2,8 +2,6 @@ import type { Walkthrough } from "@/core/fumadocs/schemas/homepage";
 
 import { Check } from "lucide-react";
 
-import { WaveDecoration } from "@/components/marketing/wave-decoration";
-
 type Props = {
   walkthrough: Walkthrough;
 };
@@ -12,79 +10,52 @@ export function HomepageWalkthrough({ walkthrough }: Props) {
   const { badge, title, titleAccent, videoSrc, bullets } = walkthrough;
 
   return (
-    <section className="relative w-full overflow-hidden px-4 py-20 md:py-28" id="walkthrough">
-      <WaveDecoration
-        className="-bottom-20 -left-32 hidden w-[min(620px,55%)] md:block"
-        opacity={0.18}
-        variant="wave-1"
-      />
+    <section
+      className="w-full border-b border-foreground/15 py-20 sm:py-24 lg:py-32"
+      data-homepage-section="walkthrough"
+      id="walkthrough"
+    >
+      <div className="mx-auto w-full max-w-[1440px] px-5 sm:px-8">
+        <div className="grid gap-6 lg:grid-cols-[minmax(180px,0.45fr)_minmax(0,1.55fr)] lg:gap-12">
+          <p className="pt-1 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">{badge}</p>
 
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute -top-10 right-[6%] size-[360px] rounded-full bg-[rgba(249,115,22,0.10)] blur-[110px]" />
+          {/* eslint-disable react/jsx-newline */}
+          <h2 className="m-0 max-w-[980px] text-[clamp(2.5rem,5.4vw,5.5rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance">
+            {title} <span className="font-serif font-normal italic tracking-[-0.035em]">{titleAccent}</span>
+          </h2>
+          {/* eslint-enable react/jsx-newline */}
+        </div>
 
-        <div className="absolute bottom-[5%] left-[12%] size-[280px] rounded-full bg-[rgba(236,72,153,0.10)] blur-[90px]" />
-
-        <div
-          className="absolute inset-0 opacity-[0.30] bg-[radial-gradient(circle_at_1px_1px,rgba(249,115,22,0.10)_1px,transparent_0)] bg-size-[28px_28px]"
-          style={{
-            maskImage: "radial-gradient(ellipse 60% 55% at 50% 50%, #000 25%, transparent 85%)",
-            WebkitMaskImage: "radial-gradient(ellipse 60% 55% at 50% 50%, #000 25%, transparent 85%)",
-          }}
-        />
-      </div>
-
-      <div className="mx-auto flex max-w-[1240px] flex-col items-center">
-        <span className="mb-5 inline-flex items-center rounded-md bg-primary/15 px-3 py-1 text-[13px] font-medium text-primary">
-          {badge}
-        </span>
-
-        {/* eslint-disable react/jsx-newline */}
-        <h2 className="m-0 max-w-[900px] text-center text-[34px] font-bold leading-[1.1] tracking-[-0.025em] sm:text-[44px] md:text-[52px]">
-          {title}{" "}
-          <span className="italic text-primary" style={{ fontFamily: "var(--font-serif)" }}>
-            {titleAccent}
-          </span>
-        </h2>
-        {/* eslint-enable react/jsx-newline */}
-
-        <div className="mt-12 grid w-full grid-cols-1 items-center gap-10 md:mt-16 md:grid-cols-[1.55fr_1fr] md:gap-14">
-          <div className="relative">
-            <div
-              aria-hidden
-              className="pointer-events-none absolute -inset-6 -z-10 rounded-[20px] bg-[radial-gradient(circle_at_50%_50%,rgba(94,74,227,0.18),transparent_60%)]"
-            />
-
-            <div className="group relative overflow-hidden rounded-2xl border border-border bg-card shadow-[0_24px_60px_-22px_rgba(0,0,0,0.55)]">
-              <div className="relative aspect-video w-full bg-[#0a0a0f]">
-                {videoSrc && (
-                  <video
-                    autoPlay
-                    controls
-                    loop
-                    muted
-                    playsInline
-                    className="absolute inset-0 size-full object-cover"
-                    preload="metadata"
-                    src={videoSrc}
-                  />
-                )}
-              </div>
-            </div>
+        <div className="mt-12 grid items-stretch gap-5 lg:mt-16 lg:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.55fr)]">
+          <div className="relative min-h-[280px] overflow-hidden rounded-[24px] border border-foreground/10 bg-[#080808] sm:min-h-[420px] lg:min-h-[640px]">
+            {videoSrc ? (
+              <video
+                autoPlay
+                controls
+                loop
+                muted
+                playsInline
+                className="absolute inset-0 size-full object-cover"
+                preload="metadata"
+                src={videoSrc}
+              />
+            ) : null}
           </div>
 
-          <ul className="flex flex-col gap-7">
+          <ul className="flex flex-col rounded-[24px] bg-muted/45 px-5 sm:px-7">
             {bullets.map((bullet) => (
-              <li key={bullet.title} className="flex gap-3">
-                <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
-                  <Check className="size-3.5" strokeWidth={3} />
+              <li
+                key={bullet.title}
+                className="grid flex-1 grid-cols-[auto_1fr] content-center gap-4 border-b border-foreground/15 py-6 last:border-b-0 lg:py-8"
+              >
+                <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full border border-foreground/20">
+                  <Check className="size-3.5" strokeWidth={2.5} />
                 </span>
 
                 <div>
-                  <div className="text-[15px] font-semibold leading-tight md:text-[16px]">{bullet.title}</div>
+                  <h3 className="text-base font-medium leading-tight tracking-[-0.02em]">{bullet.title}</h3>
 
-                  <div className="mt-1 text-[13px] leading-[1.55] text-muted-foreground md:text-[14px]">
-                    {bullet.description}
-                  </div>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{bullet.description}</p>
                 </div>
               </li>
             ))}

--- a/app/[locale]/(static)/page.tsx
+++ b/app/[locale]/(static)/page.tsx
@@ -53,7 +53,7 @@ export default async function HomePage() {
   const { hero, howItWorks, walkthrough, benefits, features, faq, cta } = homepagePage.data;
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex w-full flex-col items-center overflow-x-clip bg-background text-foreground">
       <JsonLd schema={organizationSchema()} />
 
       <JsonLd
@@ -80,13 +80,13 @@ export default async function HomePage() {
 
       <HomepageBenefits benefitsSection={benefits} />
 
-      <FeatureSection {...features} />
+      <FeatureSection {...features} variant="editorial" />
 
       <HomepagePricing />
 
-      <FAQSection {...faq} />
+      <FAQSection {...faq} variant="editorial" />
 
-      <CTASection {...cta} />
+      <CTASection {...cta} variant="editorial" />
 
       <Footer />
     </div>

--- a/app/components/footer-content.tsx
+++ b/app/components/footer-content.tsx
@@ -26,8 +26,8 @@ export function FooterContent({ blogPosts = [], competitors = [], featureLinks =
   return (
     <footer className="bg-muted mt-auto w-full text-x-sm">
       <div className="max-w-[1300px] mx-auto px-6 py-12">
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-8 mb-12">
-          <div className="col-span-2 sm:col-span-3 lg:col-span-1 flex flex-col items-start gap-4">
+        <div className="mb-12 grid grid-cols-1 gap-10 sm:grid-cols-3 sm:gap-8 lg:grid-cols-7">
+          <div className="col-span-1 flex flex-col items-start gap-4 sm:col-span-3 lg:col-span-1">
             <AppLink aria-label={`${t("Common.imageAlt.logo")} ${t("UserAvatar.home")}`} href="/">
               <AppImage alt={t("Common.imageAlt.logo")} height={27} src="customermates.svg" width={156} />
 

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -3,7 +3,7 @@
 import type { AccountState } from "@/features/auth/account-state";
 
 import { LogOut, Menu, X } from "lucide-react";
-import { useState } from "react";
+import { type Ref, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
 
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/sheet";
 import { ThemeSwitcher } from "@/components/shared/theme-switcher";
 import { cn } from "@/core/utils/cn";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { signOutAction } from "@/app/[locale]/actions";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 import { runUserAction } from "@/core/errors/report-application-error";
@@ -35,11 +36,20 @@ type Props = {
   hasValidSession: boolean;
 };
 
+const PUBLIC_NAV_DESKTOP_QUERY = "(min-width: 56rem)";
+
 export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) => {
   const t = useTranslations();
   const { layoutStore } = useRootStore();
   const pathname = usePathname();
+  const isDesktop = useMediaQuery(PUBLIC_NAV_DESKTOP_QUERY);
+  const desktopHomeButtonRef = useRef<HTMLAnchorElement>(null);
+  const firstMobileNavItemRef = useRef<HTMLAnchorElement>(null);
   const [isSigningOut, setIsSigningOut] = useState(false);
+
+  useEffect(() => {
+    if (isDesktop) layoutStore.setIsMenuOpen(false);
+  }, [isDesktop, layoutStore]);
 
   function closeMenu() {
     layoutStore.setIsMenuOpen(false);
@@ -58,12 +68,12 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
 
   const logoAlt = t("Common.imageAlt.logo");
   const homeLabel = t("UserAvatar.home");
-  function renderHomeButton() {
+  function renderHomeButton(ref?: Ref<HTMLAnchorElement>) {
     return (
-      <AppLink aria-label={`${logoAlt} ${homeLabel}`} href="/" onClick={closeMenu}>
+      <AppLink ref={ref} aria-label={`${logoAlt} ${homeLabel}`} href="/" onClick={closeMenu}>
         <AppImage
           alt={logoAlt}
-          className="object-contain select-none"
+          className="h-auto object-contain select-none"
           height={24}
           loading="eager"
           src="customermates.svg"
@@ -89,14 +99,26 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
         : cta?.label === "continueSetup"
           ? t("Common.actions.continueSetup")
           : null;
-  const ctaButton =
-    cta && ctaLabel && pathname !== cta.href ? (
-      <Button asChild size="sm" variant="softPrimary" onClick={closeMenu}>
+  function renderCtaButton(isMobile = false) {
+    if (!cta || !ctaLabel || pathname === cta.href) return null;
+
+    return (
+      <Button
+        asChild
+        className={cn(
+          isMobile &&
+            "h-11 w-full rounded-full bg-sidebar-foreground px-5 text-base text-sidebar shadow-none hover:bg-sidebar-foreground/90 sm:w-auto sm:min-w-40",
+        )}
+        size={isMobile ? "default" : "sm"}
+        variant={isMobile ? "default" : "softPrimary"}
+        onClick={closeMenu}
+      >
         <AppLink appearance="unstyled" href={cta.href}>
           {ctaLabel}
         </AppLink>
       </Button>
-    ) : null;
+    );
+  }
 
   async function handleSignOut() {
     if (isSigningOut) return;
@@ -113,11 +135,19 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
     }
   }
 
-  const signOutButton =
-    actions.signOut !== "hidden" ? (
+  function renderSignOutButton(isMobile = false) {
+    if (actions.signOut === "hidden") return null;
+
+    return (
       <Button
+        className={cn(
+          isMobile && "h-11 w-full rounded-full px-5 text-base shadow-none sm:w-auto sm:min-w-40",
+          isMobile &&
+            actions.signOut !== "setupEscape" &&
+            "border border-sidebar-border bg-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        )}
         disabled={isSigningOut}
-        size="sm"
+        size={isMobile ? "default" : "sm"}
         variant={actions.signOut === "setupEscape" ? "destructiveOutline" : "ghost"}
         onClick={() => runUserAction(handleSignOut)}
       >
@@ -125,83 +155,133 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
 
         {t("UserAvatar.signOut")}
       </Button>
-    ) : null;
+    );
+  }
 
-  const contactButton = actions.showContact ? (
-    <Button asChild size="sm" variant="secondary" onClick={closeMenu}>
-      <IntlLink href="/contact">{t("Common.actions.contact")}</IntlLink>
-    </Button>
-  ) : null;
+  function renderContactButton(isMobile = false) {
+    if (!actions.showContact) return null;
 
-  function renderPreferenceButtons() {
+    return (
+      <Button
+        asChild
+        className={cn(
+          isMobile &&
+            "h-11 w-full rounded-full border-sidebar-border bg-transparent px-5 text-base text-sidebar-foreground shadow-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground sm:w-auto sm:min-w-40",
+        )}
+        size={isMobile ? "default" : "sm"}
+        variant="secondary"
+        onClick={closeMenu}
+      >
+        <IntlLink href="/contact">{t("Common.actions.contact")}</IntlLink>
+      </Button>
+    );
+  }
+
+  function renderPreferenceButtons(isMobile = false) {
     return (
       <div className="flex items-center gap-1">
-        <LanguageSelector />
+        <LanguageSelector className={cn(isMobile && "size-11 rounded-full text-sidebar-foreground")} />
 
-        <ThemeSwitcher />
+        <ThemeSwitcher className={cn(isMobile && "size-11 rounded-full text-sidebar-foreground")} />
       </div>
     );
   }
 
   return (
-    <div className="sticky top-0 z-40 bg-background/80 backdrop-blur">
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
-        <div className="hidden items-center gap-3 md:flex">{renderHomeButton()}</div>
+    <div className="sticky top-0 z-40 border-b border-border/70 bg-background/95 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-[1600px] items-center justify-between px-6 sm:h-16 sm:px-8">
+        <div className="hidden items-center gap-3 min-[56rem]:flex">{renderHomeButton(desktopHomeButtonRef)}</div>
 
-        <nav className="hidden items-center gap-3 md:flex">
+        <nav className="hidden items-center gap-5 min-[56rem]:flex">
           {publicNavItems.map((item) => (
-            <AppLink key={item.href} className={cn(!isNavItemActive(item.href) && "text-subdued")} href={item.href}>
+            <AppLink
+              key={item.href}
+              aria-current={isNavItemActive(item.href) ? "page" : undefined}
+              className={cn(!isNavItemActive(item.href) && "text-subdued")}
+              href={item.href}
+            >
               {item.title}
             </AppLink>
           ))}
         </nav>
 
-        <div className="hidden items-center gap-2 md:flex">
+        <div className="hidden items-center gap-2 min-[56rem]:flex">
           {renderPreferenceButtons()}
 
-          {contactButton}
+          {renderContactButton()}
 
-          {ctaButton}
+          {renderCtaButton()}
 
-          {signOutButton}
+          {renderSignOutButton()}
         </div>
 
-        <div className="flex w-full items-center justify-between md:hidden">
+        <div className="flex w-full items-center justify-between min-[56rem]:hidden">
           {renderHomeButton()}
 
-          <Sheet open={layoutStore.isMenuOpen} onOpenChange={layoutStore.setIsMenuOpen}>
+          <Sheet open={!isDesktop && layoutStore.isMenuOpen} onOpenChange={layoutStore.setIsMenuOpen}>
             <SheetTrigger asChild>
               <Button aria-label={t("Common.sidebar.toggle")} size="icon" variant="ghost">
                 <Icon aria-hidden icon={layoutStore.isMenuOpen ? X : Menu} />
               </Button>
             </SheetTrigger>
 
-            <SheetContent className="w-80 max-w-[85vw] gap-0 bg-sidebar text-sidebar-foreground" side="right">
-              <SheetHeader>
+            <SheetContent
+              className="w-full max-w-none gap-0 border-0 bg-sidebar text-sidebar-foreground shadow-none sm:max-w-none [&>[data-slot=sheet-close]]:size-11"
+              side="right"
+              onCloseAutoFocus={(event) => {
+                if (!isDesktop) return;
+                event.preventDefault();
+                desktopHomeButtonRef.current?.focus();
+              }}
+              onOpenAutoFocus={(event) => {
+                event.preventDefault();
+                firstMobileNavItemRef.current?.focus();
+              }}
+            >
+              <SheetHeader className="min-h-[calc(3.5rem+var(--safe-top))] flex-row items-center border-b border-sidebar-border/70 pt-[var(--safe-top)] pr-[calc(3.75rem+var(--safe-right))] pb-0 pl-[calc(1.5rem+var(--safe-left))] sm:min-h-[calc(4rem+var(--safe-top))] sm:pl-[calc(2rem+var(--safe-left))]">
+                {renderHomeButton()}
+
                 <SheetTitle className="sr-only">{logoAlt}</SheetTitle>
 
                 <SheetDescription className="sr-only">{t("Common.sidebar.description")}</SheetDescription>
               </SheetHeader>
 
-              <SheetBody className="flex flex-col gap-3 pb-6">
-                {publicNavItems.map((item) => (
-                  <AppLink
-                    key={item.href}
-                    className={cn(!isNavItemActive(item.href) && "text-subdued")}
-                    href={item.href}
-                    onClick={closeMenu}
-                  >
-                    {item.title}
-                  </AppLink>
-                ))}
+              <SheetBody className="pt-8 pr-[calc(1.5rem+var(--safe-right))] pb-[calc(1.5rem+var(--safe-bottom))] pl-[calc(1.5rem+var(--safe-left))] sm:pt-10 sm:pr-[calc(2rem+var(--safe-right))] sm:pb-[calc(2rem+var(--safe-bottom))] sm:pl-[calc(2rem+var(--safe-left))]">
+                <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col">
+                  <nav aria-label={t("Common.sidebar.title")} className="flex flex-col gap-3 sm:gap-4">
+                    {publicNavItems.map((item, index) => (
+                      <AppLink
+                        key={item.href}
+                        ref={index === 0 ? firstMobileNavItemRef : undefined}
+                        aria-current={isNavItemActive(item.href) ? "page" : undefined}
+                        className={cn(
+                          "flex min-h-11 w-fit items-center rounded-sm py-1 text-4xl font-medium leading-none tracking-[-0.035em] text-sidebar-foreground/85 transition-colors outline-none hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring/70 focus-visible:ring-offset-4 focus-visible:ring-offset-sidebar sm:text-[2.5rem]",
+                          isNavItemActive(item.href) && "text-sidebar-foreground",
+                        )}
+                        href={item.href}
+                        onClick={closeMenu}
+                      >
+                        {item.title}
+                      </AppLink>
+                    ))}
+                  </nav>
 
-                <div className="my-1 py-3">{renderPreferenceButtons()}</div>
+                  <div className="mt-auto pt-12 sm:pt-16">
+                    <div className="border-t border-sidebar-border/70 pt-5 sm:pt-6">
+                      <div className="inline-flex rounded-full border border-sidebar-border/80 bg-sidebar-accent/50 p-1">
+                        {renderPreferenceButtons(true)}
+                      </div>
 
-                {contactButton}
+                      <div className="mt-5 grid gap-2.5 sm:flex sm:flex-wrap">
+                        {renderCtaButton(true)}
 
-                {ctaButton}
+                        {renderContactButton(true)}
 
-                {signOutButton}
+                        {renderSignOutButton(true)}
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </SheetBody>
             </SheetContent>
           </Sheet>

--- a/components/marketing/cta-section.tsx
+++ b/components/marketing/cta-section.tsx
@@ -13,6 +13,7 @@ type Props = {
   description: string;
   hint: string;
   image?: ReactNode;
+  variant?: "default" | "editorial";
 };
 
 export function CTASection({
@@ -24,7 +25,49 @@ export function CTASection({
   description,
   hint,
   image,
+  variant = "default",
 }: Props) {
+  if (variant === "editorial") {
+    return (
+      <section className="w-full py-5 sm:py-8" data-homepage-section="cta">
+        <div className="mx-auto w-full max-w-[1440px] px-5 sm:px-8">
+          <div className="flex min-h-[420px] flex-col items-center justify-center rounded-[24px] bg-foreground px-6 py-16 text-center text-background sm:min-h-[500px] sm:px-10 sm:py-20">
+            {image ? <div className="mb-8">{image}</div> : null}
+
+            <h2 className="max-w-[900px] text-[clamp(2.5rem,5.3vw,5.5rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance">
+              {action}
+            </h2>
+
+            <p className="mt-6 max-w-[720px] text-sm leading-relaxed text-background/65 sm:text-base">{description}</p>
+
+            <div className="mt-9 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center">
+              <Button
+                asChild
+                className="h-11 rounded-full bg-background px-6 text-foreground hover:bg-background/85"
+                size="lg"
+              >
+                <IntlLink href={buttonLeftHref}>{buttonLeftText}</IntlLink>
+              </Button>
+
+              <Button
+                asChild
+                className="h-11 rounded-full border-background/25 bg-transparent px-6 text-background hover:bg-background/10 hover:text-background"
+                size="lg"
+                variant="secondary"
+              >
+                <IntlLink href={buttonRightHref} target="_blank">
+                  {buttonRightText}
+                </IntlLink>
+              </Button>
+            </div>
+
+            <p className="mt-6 text-xs leading-relaxed text-background/55">{hint}</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="relative w-full overflow-hidden py-14 md:py-20">
       <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">

--- a/components/marketing/faq-section.tsx
+++ b/components/marketing/faq-section.tsx
@@ -12,12 +12,56 @@ type FAQItem = {
 type Props = {
   faqs: FAQItem[];
   title?: string;
+  variant?: "default" | "editorial";
 };
 
-export async function FAQSection({ faqs, title }: Props) {
+export async function FAQSection({ faqs, title, variant = "default" }: Props) {
   if (!faqs.length) return null;
 
   const t = await getTranslations();
+
+  if (variant === "editorial") {
+    return (
+      <section className="w-full border-b border-foreground/15 py-20 sm:py-24 lg:py-32" data-homepage-section="faq">
+        <div className="mx-auto grid w-full max-w-[1440px] gap-12 px-5 sm:px-8 lg:grid-cols-[minmax(260px,0.7fr)_minmax(0,1.3fr)] lg:gap-20">
+          <div>
+            <p className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+              {t("FAQSection.label")}
+            </p>
+
+            {title ? (
+              <h2 className="mt-5 max-w-[560px] text-[clamp(2.5rem,4.8vw,4.75rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance">
+                {title}
+              </h2>
+            ) : null}
+
+            {/* eslint-disable react/jsx-newline */}
+            <p className="mt-6 max-w-[420px] text-sm leading-relaxed text-muted-foreground">
+              {t("FAQSection.contactIntro")}{" "}
+              <AppLink appearance="inline" className="font-medium text-foreground" href="/contact">
+                {t("FAQSection.contactCta")}
+              </AppLink>
+            </p>
+            {/* eslint-enable react/jsx-newline */}
+          </div>
+
+          <Accordion collapsible className="border-t border-foreground/20" defaultValue={faqs[0].id} type="single">
+            {faqs.map((faq) => (
+              <AccordionItem key={faq.id} className="border-b border-foreground/20" value={faq.id}>
+                <AccordionTrigger className="py-6 text-left text-lg font-medium tracking-[-0.02em] sm:py-7 sm:text-xl">
+                  {faq.title}
+                </AccordionTrigger>
+
+                <AccordionContent className="max-w-[760px] pb-7 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                  {faq.content}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="relative isolate mx-auto w-full max-w-[860px] overflow-visible px-4 py-20">

--- a/components/marketing/feature-section.tsx
+++ b/components/marketing/feature-section.tsx
@@ -19,9 +19,70 @@ type Props = {
   features: FeatureItem[];
   subtitle: string;
   title: string;
+  variant?: "default" | "editorial";
 };
 
-export function FeatureSection({ badge, features, subtitle, title }: Props) {
+export function FeatureSection({ badge, features, subtitle, title, variant = "default" }: Props) {
+  if (variant === "editorial") {
+    return (
+      <section
+        className="w-full border-b border-foreground/15 py-20 sm:py-24 lg:py-32"
+        data-homepage-section="features"
+        id="features"
+      >
+        <div className="mx-auto w-full max-w-[1440px] px-5 sm:px-8">
+          <div className="grid gap-6 lg:grid-cols-[minmax(180px,0.45fr)_minmax(0,1.55fr)] lg:gap-12">
+            <p className="pt-1 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">{badge}</p>
+
+            <div>
+              <h2 className="m-0 max-w-[980px] text-[clamp(2.5rem,5.2vw,5.25rem)] font-medium leading-[0.98] tracking-[-0.05em] text-balance">
+                {title}
+              </h2>
+
+              <p className="mt-5 max-w-[720px] text-base leading-relaxed text-muted-foreground sm:text-lg">
+                {subtitle}
+              </p>
+            </div>
+          </div>
+
+          <div className="-mx-5 mt-12 flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-4 sm:-mx-8 sm:px-8 md:mx-0 md:grid md:grid-cols-2 md:overflow-visible md:px-0 md:pb-0 lg:mt-16">
+            {features.map((feature) => {
+              const Icon = ICONS[feature.icon];
+
+              return (
+                <article
+                  key={feature.title}
+                  className="w-[78vw] max-w-[320px] shrink-0 snap-start overflow-hidden rounded-[20px] bg-muted/45 sm:w-[44vw] sm:max-w-[380px] md:w-auto md:max-w-none md:shrink md:snap-none"
+                >
+                  {feature.image ? (
+                    <AppImage
+                      alt={feature.title}
+                      className="aspect-[1.45/1] w-full object-cover object-top"
+                      height={900}
+                      sizes="(max-width: 639px) 78vw, (max-width: 767px) 44vw, 50vw"
+                      src={feature.image}
+                      width={1516}
+                    />
+                  ) : null}
+
+                  <div className="p-6 sm:p-7">
+                    <FeatureIcon icon={Icon} />
+
+                    <h3 className="mt-8 text-2xl font-medium leading-tight tracking-[-0.03em]">{feature.title}</h3>
+
+                    <p className="mt-3 max-w-[560px] text-sm leading-relaxed text-muted-foreground">
+                      {feature.description}
+                    </p>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="relative isolate w-full max-w-6xl px-4 py-14 md:py-20" id="features">
       <WaveDecoration className="-right-40 top-10 hidden w-[min(820px,70%)] md:block" opacity={0.3} variant="wave-2" />

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -12,10 +12,21 @@ describe("public navigation preferences", () => {
 
     expect(navbar.match(/<LanguageSelector/g)).toHaveLength(1);
     expect(navbar.match(/<ThemeSwitcher/g)).toHaveLength(1);
-    expect(navbar.match(/\{renderPreferenceButtons\(\)\}/g)).toHaveLength(2);
-    expect(navbar).toContain('className="hidden items-center gap-2 md:flex"');
-    expect(navbar).toContain('className="flex w-full items-center justify-between md:hidden"');
-    expect(navbar).toContain('className="my-1 py-3"');
+    expect(navbar.match(/\{renderPreferenceButtons\([^}]*\)\}/g)).toHaveLength(2);
+    expect(navbar).toContain('const PUBLIC_NAV_DESKTOP_QUERY = "(min-width: 56rem)"');
+    expect(navbar).toContain("useMediaQuery(PUBLIC_NAV_DESKTOP_QUERY)");
+    expect(navbar).toContain("open={!isDesktop && layoutStore.isMenuOpen}");
+    expect(navbar.match(/min-\[56rem\]:flex/g)).toHaveLength(3);
+    expect(navbar.match(/min-\[56rem\]:hidden/g)).toHaveLength(1);
+    expect(navbar).toContain('className="hidden items-center gap-2 min-[56rem]:flex"');
+    expect(navbar).toContain('className="flex w-full items-center justify-between min-[56rem]:hidden"');
+    expect(navbar).toContain('className="inline-flex rounded-full border border-sidebar-border/80');
+    expect(navbar).toContain('aria-current={isNavItemActive(item.href) ? "page" : undefined}');
+    expect(navbar).toContain('actions.signOut !== "setupEscape" &&');
+    expect(navbar).toContain("ref={index === 0 ? firstMobileNavItemRef : undefined}");
+    expect(navbar).toContain("firstMobileNavItemRef.current?.focus()");
+    expect(navbar).toContain("desktopHomeButtonRef.current?.focus()");
+    expect(navbar).toContain('className="mt-auto pt-12 sm:pt-16"');
     expect(navbar).not.toContain("border-y");
     expect(navbar).not.toContain("github.com/customermates/customermates");
     expect(footer).not.toContain("LanguageSelector");
@@ -25,10 +36,7 @@ describe("public navigation preferences", () => {
   it("shows the locale code with navbar typography and reuses the complete profile country option", () => {
     const languageSelector = readFileSync(join(REPO_ROOT, "components/shared/language-selector.tsx"), "utf8");
     const countrySelector = readFileSync(join(REPO_ROOT, "components/forms/form-autocomplete-country.tsx"), "utf8");
-    const countryItem = readFileSync(
-      join(REPO_ROOT, "components/forms/form-autocomplete-country-item.tsx"),
-      "utf8",
-    );
+    const countryItem = readFileSync(join(REPO_ROOT, "components/forms/form-autocomplete-country-item.tsx"), "utf8");
 
     expect(languageSelector).toContain("currentLocale.toUpperCase()");
     expect(languageSelector).toContain('className={cn("size-8 rounded-md p-0 text-subdued", className)}');
@@ -36,7 +44,9 @@ describe("public navigation preferences", () => {
     expect(languageSelector).toContain("FormAutocompleteItem({");
     expect(countrySelector).toContain("FormAutocompleteItem({");
     expect(languageSelector).toContain("textValue: label");
-    expect(languageSelector).toContain('<FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />');
+    expect(languageSelector).toContain(
+      "<FormAutocompleteCountryItem countryKey={flagCodeFor(locale)} label={label} />",
+    );
     expect(languageSelector).toContain('className={cn(isSelected && "bg-accent")}');
     expect(languageSelector).toContain("data-selected={isSelected}");
     expect(languageSelector).not.toContain("AvatarImage");


### PR DESCRIPTION
## Summary

- Rework the localized homepage into a sparse, media-led OpenAI-inspired prototype.
- Add responsive homepage-only treatments for the hero, product sections, pricing, FAQ, CTA, navbar, and footer.
- Keep the lazy live-demo iframe available and display supported provider icons plus visually muted X and Messenger concept icons.

## Context

This is a bounded temporary prototype requested directly by the product owner to evaluate the design direction in a cloud preview. The owner explicitly waived Linear issue creation for this prototype only; normal review, checks, protected main, and human merge requirements remain.

## Validation

- `yarn typecheck`
- `yarn lint`
- `yarn test` — 345 files passed, 8 skipped; 2,837 tests passed, 69 skipped
- `yarn build`
- Responsive browser checks on English and German homepage routes at mobile, tablet, and desktop breakpoints

## Impact and rollback

No database migration, environment-variable change, or production data impact. This changes public marketing presentation and shared marketing components only through homepage-specific variants. Roll back by closing this draft PR before merge or reverting commit `5935b84f` after merge.