### PR TITLE
fix(inbox): stop thread date separators stacking at the top of the list

### DIFF
--- a/app/[locale]/(protected)/inbox/components/__tests__/thread-panel-day-groups.test.ts
+++ b/app/[locale]/(protected)/inbox/components/__tests__/thread-panel-day-groups.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { groupMessagesByDay } from "../thread-panel";
+
+function message(id: string, sentAt: string) {
+  return { id, sentAt: new Date(sentAt) };
+}
+
+describe("groupMessagesByDay", () => {
+  it("returns no groups for an empty thread", () => {
+    expect(groupMessagesByDay([])).toEqual([]);
+  });
+
+  it("keeps one day in a single group, so only one separator can ever pin for it", () => {
+    const messages = [
+      message("a", "2026-08-20T08:00:00"),
+      message("b", "2026-08-20T13:30:00"),
+      message("c", "2026-08-20T23:59:00"),
+    ];
+
+    const groups = groupMessagesByDay(messages);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].messages).toEqual(messages);
+  });
+
+  it("opens a new group on each calendar-day boundary", () => {
+    const groups = groupMessagesByDay([
+      message("a", "2026-08-20T23:59:00"),
+      message("b", "2026-08-21T00:01:00"),
+      message("c", "2026-08-21T09:00:00"),
+      message("d", "2026-08-22T09:00:00"),
+    ]);
+
+    expect(groups.map((group) => group.messages.map((m) => m.id))).toEqual([["a"], ["b", "c"], ["d"]]);
+  });
+
+  it("dates each group from its own first message", () => {
+    const groups = groupMessagesByDay([message("a", "2026-08-20T23:59:00"), message("b", "2026-08-21T00:01:00")]);
+
+    expect(groups.map((group) => group.date.toISOString())).toEqual([
+      new Date("2026-08-20T23:59:00").toISOString(),
+      new Date("2026-08-21T00:01:00").toISOString(),
+    ]);
+  });
+
+  it("preserves every message exactly once and in order", () => {
+    const messages = [
+      message("a", "2026-08-20T08:00:00"),
+      message("b", "2026-08-21T08:00:00"),
+      message("c", "2026-08-21T09:00:00"),
+      message("d", "2026-08-23T08:00:00"),
+    ];
+
+    const flattened = groupMessagesByDay(messages).flatMap((group) => group.messages);
+
+    expect(flattened).toEqual(messages);
+  });
+
+  it("gives every group a distinct key, including when a day recurs out of order", () => {
+    const groups = groupMessagesByDay([
+      message("a", "2026-08-20T08:00:00"),
+      message("b", "2026-08-21T08:00:00"),
+      message("c", "2026-08-20T09:00:00"),
+    ]);
+
+    expect(groups.map((group) => group.key)).toEqual(["a", "b", "c"]);
+    expect(new Set(groups.map((group) => group.key)).size).toBe(groups.length);
+  });
+
+  it("accepts a serialized sentAt, which is what crosses the server boundary", () => {
+    const groups = groupMessagesByDay([
+      { id: "a", sentAt: "2026-08-20T08:00:00.000Z" },
+      { id: "b", sentAt: "2026-08-20T09:00:00.000Z" },
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].date).toBeInstanceOf(Date);
+  });
+
+  it("re-groups a prepended older page without repeating a day that is already grouped", () => {
+    const loaded = [message("c", "2026-08-21T08:00:00"), message("d", "2026-08-21T09:00:00")];
+    const olderPage = [message("a", "2026-08-19T08:00:00"), message("b", "2026-08-21T07:00:00")];
+
+    const groups = groupMessagesByDay([...olderPage, ...loaded]);
+
+    expect(groups.map((group) => group.messages.map((m) => m.id))).toEqual([["a"], ["b", "c", "d"]]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("does not mutate the messages it is given", () => {
+    const messages = [message("a", "2026-08-20T08:00:00"), message("b", "2026-08-21T08:00:00")];
+    const snapshot = [...messages];
+
+    groupMessagesByDay(messages);
+
+    expect(messages).toEqual(snapshot);
+  });
+});

--- a/app/[locale]/(protected)/inbox/components/message-date-separator.tsx
+++ b/app/[locale]/(protected)/inbox/components/message-date-separator.tsx
@@ -33,8 +33,10 @@ export const MessageDateSeparator = observer(({ date }: { date: Date }) => {
 
   return (
     <div className="sticky top-0 z-10 flex justify-center py-1">
-      <span className="bg-muted text-muted-foreground border-border w-28 rounded-full border py-0.5 text-center text-xs font-medium">
-        {label}
+      <span className="bg-background rounded-full">
+        <span className="bg-muted text-muted-foreground border-border block w-28 rounded-full border py-0.5 text-center text-xs font-medium">
+          {label}
+        </span>
       </span>
     </div>
   );

--- a/app/[locale]/(protected)/inbox/components/thread-panel.tsx
+++ b/app/[locale]/(protected)/inbox/components/thread-panel.tsx
@@ -3,7 +3,7 @@
 import { Loader2, MessageSquare } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
-import { Fragment, useLayoutEffect, type ReactNode } from "react";
+import { useLayoutEffect, type ReactNode } from "react";
 
 import type { ThreadDetail } from "./messaging-thread-detail.store";
 import type { MessagingThread } from "@/ee/messaging/messaging.schema";
@@ -30,6 +30,28 @@ type ThreadPanelPageState =
   | { status: "loading" }
   | { status: "empty" }
   | { status: "content"; thread: MessagingThread };
+
+type MessageDayGroup<T> = { key: string; date: Date; messages: T[] };
+
+export function groupMessagesByDay<T extends { id: string; sentAt: Date | string }>(
+  messages: readonly T[],
+): MessageDayGroup<T>[] {
+  const groups: MessageDayGroup<T>[] = [];
+
+  for (const message of messages) {
+    const date = new Date(message.sentAt);
+    const currentGroup = groups.at(-1);
+
+    if (currentGroup && isSameDay(currentGroup.date, date)) {
+      currentGroup.messages.push(message);
+      continue;
+    }
+
+    groups.push({ key: message.id, date, messages: [message] });
+  }
+
+  return groups;
+}
 
 export function resolveThreadPanelPageState({
   locked,
@@ -106,15 +128,13 @@ export const ThreadPanel = observer(({ threadDetail, locked = false }: Props) =>
                 </div>
               ) : null}
 
-              {messages.map((message, index) => {
-                const previous = messages[index - 1];
-                const showDate = !previous || !isSameDay(new Date(previous.sentAt), new Date(message.sentAt));
+              {groupMessagesByDay(messages).map((group) => (
+                <section key={group.key} className="flex flex-col gap-1">
+                  <MessageDateSeparator date={group.date} />
 
-                return (
-                  <Fragment key={message.id}>
-                    {showDate ? <MessageDateSeparator date={new Date(message.sentAt)} /> : null}
-
+                  {group.messages.map((message) => (
                     <MessageItem
+                      key={message.id}
                       accountOwner={accountOwners[message.connectedAccountId] ?? null}
                       isMine={thread.isOwner}
                       message={message}
@@ -122,9 +142,9 @@ export const ThreadPanel = observer(({ threadDetail, locked = false }: Props) =>
                         message.sender.identifier ? avatarByIdentifier.get(message.sender.identifier) : undefined
                       }
                     />
-                  </Fragment>
-                );
-              })}
+                  ))}
+                </section>
+              ))}
             </div>
           </MessagesScrollContainer>
 


### PR DESCRIPTION
## Summary

Scrolling a chat thread piled every date separator on top of the previous one at the top of the message list. This makes exactly one pill pin at a time, and makes that pill opaque.

Closes CUS-270.

## Context

Every separator was an independent `sticky top-0` element, and all of them were siblings of one `<div className="flex flex-col gap-1">`, so they shared a single containing block. A sticky element only unpins when its containing block scrolls away, so no separator ever did: each one that passed the top stayed pinned there and the next joined it. On a nine-day thread all nine pills ended up at the same pixel.

The visual smear on top of that has its own cause. `--muted` is `rgb(0 0 0 / 5.1%)` and `--border` is `7.5%`, so the pill is almost fully transparent. Nine of them composited their tints and borders into an unreadable blob, and even a single pinned pill let message text scroll straight through it. A sticky overlay has to be opaque.

Two changes:

- `thread-panel.tsx` groups messages into one `<section>` per calendar day, with the separator as that section's sticky child. The outgoing pill is now pushed out by the next day's group, which is what makes only one pin at a time. The grouping is an exported pure function, `groupMessagesByDay`, following the `resolveThreadPanelPageState` precedent in the same file.
- `message-date-separator.tsx` wraps the pill in an opaque `bg-background` underlay. The muted tint and border stay on the inner span, so the resting appearance is byte-identical to today (the pill already sat on `bg-background`); what changes is that content can no longer read through it.

## Validation

Node 24.18.0, disposable local Postgres 16, `APP_MODE=demo`, seeded synthetic fixtures.

Local gates:

- `yarn typecheck` pass
- `yarn lint` pass (0 warnings)
- `yarn test` 2845 passed, 1 failed: `components/emails/__tests__/preview-inventory.test.ts` times out at 15s under full-suite load and passes in 3.6s when run alone. Pre-existing flake, unrelated to this change.
- `yarn build` pass, and the generators left the tree clean

Unit tests: 9 cases for `groupMessagesByDay` covering day boundaries, ordering, key uniqueness, serialized `sentAt`, non-mutation, and the older-page prepend. Verified they discriminate: replacing the day-boundary check with `if (currentGroup)` fails 3 of them.

Browser measurement, since the repository has no Playwright harness. The synthetic seed gives every thread a single calendar day, so it cannot reproduce this at all; a local-only SQL fixture cloned one seeded thread's messages across eight earlier days, giving 54 messages over 9 distinct days and a ~9700px scroll range. The same measurement swept 61 to 601 scroll positions and, at each, measured every separator pill's rect against the scrollport top:

| | `origin/main` | this branch |
| --- | --- | --- |
| sections in the list | 0 | 9 |
| max pills pinned at once | **9** | **1** |
| max overlapping pill pairs | **36** | **0** |
| max pills visible at once | 9 | 2 |

On `origin/main` at scrollTop 9719 all nine labels sat at y=16 simultaneously. On this branch, across 601 positions, 585 have exactly one pill pinned and 0 have more than one; the remaining 16 are the eight ~30px hand-off gaps where the outgoing pill has slid out and the next has not yet arrived, which is ordinary sticky section-header behaviour. The pinned label walks the days in exact DOM order (`Aug 15` through `Today`), and 19 sampled frames caught a pill mid-push-out, confirming the hand-off is a push rather than a jump.

Opacity, measured from computed styles in both themes: the underlay is `rgb(18, 18, 21)` alpha 1 in dark and `rgb(246, 246, 248)` alpha 1 in light, while the inner span keeps its 4.3% / 5% tint and translucent border, and the pill geometry is unchanged at 112x22.

Not covered locally: `loadOlderMessages` returns early in demo mode and needs a real provider sync in any mode, so the network prepend could not be exercised in the sandbox. The regrouping it feeds is covered by the prepend unit test.

## Impact and rollback

User-visible presentation only, in the inbox transcript. No schema, API, interactor, tenancy, or persistence path is touched, and no localized string changes. The `MessagesScrollContainer` contract is unchanged: it still observes the list container's first element child.

Rollback is `git revert` of the single commit.
