### PR TITLE
fix(activities): connect timeline skeleton dividers

### DIFF
--- a/features/messaging/activities/__tests__/activity-timeline-skeleton.test.ts
+++ b/features/messaging/activities/__tests__/activity-timeline-skeleton.test.ts
@@ -36,6 +36,15 @@ describe("ActivityTimelineSkeleton", () => {
     );
   });
 
+  it("connects adjacent rows behind opaque circle backings", () => {
+    const html = renderToStaticMarkup(createElement(ActivityTimelineSkeleton, { rows: 3 }));
+
+    expect(html.match(/data-skeleton-connector="before"/g)).toHaveLength(2);
+    expect(html.match(/data-skeleton-connector="after"/g)).toHaveLength(2);
+    expect(html.match(/data-skeleton-node="true"/g)).toHaveLength(3);
+    expect(html).toContain("bg-background relative z-10");
+  });
+
   it("hides itself from assistive technology", () => {
     expect(renderToStaticMarkup(createElement(ActivityTimelineSkeleton))).toContain('aria-hidden="true"');
   });

--- a/features/messaging/activities/activity-timeline-skeleton.tsx
+++ b/features/messaging/activities/activity-timeline-skeleton.tsx
@@ -15,11 +15,25 @@ export function ActivityTimelineSkeleton({ animated = true, rows = 6 }: Props) {
     >
       {items.map((row) => (
         <div key={row} className="relative flex items-start gap-3 p-2" data-skeleton-group={row % 4}>
-          {row < items.length - 1 && (
-            <span aria-hidden className="absolute left-[23.5px] top-[26px] bottom-0 w-px bg-border" />
+          {row > 0 && (
+            <span
+              aria-hidden
+              className="absolute left-[23.5px] top-0 h-[26px] w-px bg-border"
+              data-skeleton-connector="before"
+            />
           )}
 
-          <Shape animated={animated} breathe={row === 0} className="mt-0.5 size-8 shrink-0 rounded-full" />
+          {row < items.length - 1 && (
+            <span
+              aria-hidden
+              className="absolute left-[23.5px] top-[26px] bottom-0 w-px bg-border"
+              data-skeleton-connector="after"
+            />
+          )}
+
+          <span data-skeleton-node className="bg-background relative z-10 mt-0.5 size-8 shrink-0 rounded-full">
+            <Shape animated={animated} breathe={row === 0} className="size-full rounded-full" />
+          </span>
 
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

- Connect the activity timeline skeleton divider above and below intermediate nodes so the vertical line reaches every circle.
- Put each circle placeholder on an opaque background layer above the divider so the line cannot show through it.
- Cover the connector and node structure with a focused component test.

## Context

The shared activity skeleton only rendered a lower connector segment and used a translucent circle fill. That produced both a visible gap before the next node and a divider that showed through the circle. This fixes the loading and true-empty skeleton used by activity widgets and entity timelines.

Tracks [CUS-276](https://linear.app/customermates/issue/CUS-276/fix-activity-timeline-skeleton-divider-geometry).

## Validation

- `yarn typecheck`
- `yarn lint` (zero warnings)
- `yarn vitest run features/messaging/activities/__tests__/activity-timeline-skeleton.test.ts` (5 passed)
- `yarn vitest run tests/conventions` (323 passed, 1 skipped)
- `git diff --check`
- Staged secret-pattern scan
- Local Docker/browser verification with the synthetic Max Bergmann fixture: prolonged six-row skeleton had five aligned upper and five aligned lower connector segments, six opaque nodes at z-index 10, and no divider pass-through.
- Normal localhost reload completed with activity content visible, no stale skeletons, and zero console errors.
- Isolated Vercel preview: signed in as synthetic Max Bergmann, loaded 25 activity rows, left zero stale skeleton nodes/connectors, and produced zero browser-console errors.

## Impact and rollback

This is a shared skeleton markup and styling change only. It does not change activity data behavior, dependencies, environment variables, database schema, or deployment configuration.

Before merge, close the PR and delete the branch. After merge, revert the squash commit. The branch preview and its synthetic preview database are disposable.

## Screenshots

- Before and after local captures are recorded in the CUS-276 evidence.
- Verified preview: https://customermates-p7jc9id1j-customermates.vercel.app/en/dashboard
