### PR TITLE
fix(search): polish first-open empty state

### DIFF
--- a/app/components/global-search-modal.tsx
+++ b/app/components/global-search-modal.tsx
@@ -4,7 +4,7 @@ import type { GlobalSearchResultItem } from "@/features/search/global-search.int
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
-import { Briefcase, Building2, CornerDownLeft, Loader2, Package, Users } from "lucide-react";
+import { Briefcase, Building2, CornerDownLeft, Loader2, Package, Search, Users } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo } from "react";
@@ -127,13 +127,25 @@ export const GlobalSearchModal = observer(() => {
         {showNoResults && <CommandEmpty>{t("GlobalSearch.noResults")}</CommandEmpty>}
 
         {!hasQuery && recentItems.length === 0 && (
-          <CommandEmpty>
-            {t("GlobalSearch.emptyPrompt", {
-              contacts: plural(EntityType.contact),
-              deals: plural(EntityType.deal),
-              organizations: plural(EntityType.organization),
-              services: plural(EntityType.service),
-            })}
+          <CommandEmpty className="px-8 py-12">
+            <div className="mx-auto flex max-w-sm flex-col items-center gap-4 text-center">
+              <div className="flex size-12 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
+                <Search aria-hidden className="size-5" />
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <p className="text-sm font-medium text-foreground">{t("GlobalSearch.emptyTitle")}</p>
+
+                <p className="text-sm leading-6 text-muted-foreground">
+                  {t("GlobalSearch.emptyDescription", {
+                    contacts: plural(EntityType.contact),
+                    deals: plural(EntityType.deal),
+                    organizations: plural(EntityType.organization),
+                    services: plural(EntityType.service),
+                  })}
+                </p>
+              </div>
+            </div>
           </CommandEmpty>
         )}
 

--- a/features/entity-terminology/__tests__/entity-terminology.catalog.test.ts
+++ b/features/entity-terminology/__tests__/entity-terminology.catalog.test.ts
@@ -100,10 +100,10 @@ describe("entity terminology catalogs", () => {
     expect(messages.Dashboard.aggregationTypes.dealValueRelated).toContain("{entity}");
     expect(messages.Dashboard.aggregationTypes.dealValueRelated).toContain("{deal}");
     expect(messages.Dashboard.tabs.dealFilters).toContain("{deals}");
-    expect(messages.GlobalSearch.emptyPrompt).toContain("{contacts}");
-    expect(messages.GlobalSearch.emptyPrompt).toContain("{organizations}");
-    expect(messages.GlobalSearch.emptyPrompt).toContain("{deals}");
-    expect(messages.GlobalSearch.emptyPrompt).toContain("{services}");
+    expect(messages.GlobalSearch.emptyDescription).toContain("{contacts}");
+    expect(messages.GlobalSearch.emptyDescription).toContain("{organizations}");
+    expect(messages.GlobalSearch.emptyDescription).toContain("{deals}");
+    expect(messages.GlobalSearch.emptyDescription).toContain("{services}");
     expect(messages.TasksCard.systemTaskTooltip).toContain("{task}");
   });
 

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1259,7 +1259,8 @@
   },
   "GlobalSearch": {
     "clearRecent": "Leeren",
-    "emptyPrompt": "Tippe los und durchsuche: {contacts}, {organizations}, {deals} und {services}.",
+    "emptyDescription": "Durchsuche {contacts}, {organizations}, {deals} und {services} an einem Ort.",
+    "emptyTitle": "Finde alles in deinem Workspace",
     "groupRecent": "Zuletzt geöffnet",
     "hintNavigate": "Navigieren",
     "hintOpen": "Öffnen",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1259,7 +1259,8 @@
   },
   "GlobalSearch": {
     "clearRecent": "Clear",
-    "emptyPrompt": "Start typing to search across: {contacts}, {organizations}, {deals}, and {services}.",
+    "emptyDescription": "Search {contacts}, {organizations}, {deals}, and {services} from one place.",
+    "emptyTitle": "Find anything in your workspace",
     "groupRecent": "Recently opened",
     "hintNavigate": "Navigate",
     "hintOpen": "Open",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1259,7 +1259,8 @@
   },
   "GlobalSearch": {
     "clearRecent": "Borrar",
-    "emptyPrompt": "Empieza a escribir para buscar entre: {contacts}, {organizations}, {deals} y {services}.",
+    "emptyDescription": "Busca {contacts}, {organizations}, {deals} y {services} en un solo lugar.",
+    "emptyTitle": "Encuentra todo en tu espacio de trabajo",
     "groupRecent": "Abiertos recientemente",
     "hintNavigate": "Navegar",
     "hintOpen": "Abrir",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1259,7 +1259,8 @@
   },
   "GlobalSearch": {
     "clearRecent": "Effacer",
-    "emptyPrompt": "Commencez à saisir pour rechercher dans : {contacts}, {organizations}, {deals} et {services}.",
+    "emptyDescription": "Recherchez {contacts}, {organizations}, {deals} et {services} au même endroit.",
+    "emptyTitle": "Trouvez tout dans votre espace de travail",
     "groupRecent": "Ouverts récemment",
     "hintNavigate": "Naviguer",
     "hintOpen": "Ouvrir",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1259,7 +1259,8 @@
   },
   "GlobalSearch": {
     "clearRecent": "Cancella",
-    "emptyPrompt": "Inizia a digitare per cercare tra: {contacts}, {organizations}, {deals} e {services}.",
+    "emptyDescription": "Cerca {contacts}, {organizations}, {deals} e {services} in un unico posto.",
+    "emptyTitle": "Trova tutto nel tuo spazio di lavoro",
     "groupRecent": "Aperti di recente",
     "hintNavigate": "Naviga",
     "hintOpen": "Apri",


### PR DESCRIPTION
## Summary

- Add balanced padding and a centered visual treatment to the global-search first-open empty state.
- Replace the default prompt with a concise title and terminology-aware description in all five supported locales.
- Keep the existing no-results and recent-items behavior unchanged.

## Context

Opening search before any prior search or recent item left the sidebar modal with an under-padded, text-only state. This change gives that specific state clearer hierarchy and warmer guidance while continuing to use each workspace's configured contact, organization, deal, and service terminology.

Owner-directed Linear exception: Benjamin Wagner authorized this bounded change in the current Codex task after Linear rejected issue creation because the workspace free issue limit was reached. The waiver covers only the Linear issue/claim gate for the global-search first-open empty-state outcome and the seven files in this pull request. It does not waive verification, review, required checks, the human-only merge, or production boundaries. Recorded 2026-08-25T09:34:19Z; it expires when this pull request is merged or closed.

## Validation

- `yarn vitest run features/entity-terminology/__tests__/entity-terminology.catalog.test.ts` — 16 passed.
- `yarn typecheck` — passed.
- `yarn lint` — passed with zero warnings.
- `yarn vitest run tests/conventions` — 323 passed, 1 skipped.
- Browser acceptance on the isolated local system at desktop and 375 x 812: first-open search state rendered without clipping or horizontal overflow.

The full suite and production build are left to CI because this is a copy, markup, and styling-only change; the routed product flow calls for the focused tests, typecheck, lint, conventions, and browser acceptance run above.

## Screenshots

Reviewed interactively in the isolated local Customermates environment; the local review surface remains running for the owner.

## Impact and rollback

Impact is limited to the first-open global-search empty state and its localized copy. There are no schema, API, environment-variable, migration, production-data, or persistent-data changes. The branch push starts one standard isolated Vercel preview build.

Before merge, rollback by closing this pull request and deleting `fix/global-search-empty-state`. After a human merge, revert the squash commit through a new pull request. Merge remains a human-only action.
