### PR TITLE
fix(api): reject invalid JSON across REST v1

### DIFF
--- a/app/api/v1/contacts/[id]/route.ts
+++ b/app/api/v1/contacts/[id]/route.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getDeleteContactInteractor, getGetContactByIdInteractor, getUpdateContactInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateContactInteractor().invoke({ ...data, id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/contacts/many/route.ts
+++ b/app/api/v1/contacts/many/route.ts
@@ -9,12 +9,13 @@ import {
   getDeleteManyContactsInteractor,
 } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateManyContactsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -27,7 +28,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateManyContactsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -40,7 +41,7 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getDeleteManyContactsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/contacts/route.ts
+++ b/app/api/v1/contacts/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCreateContactInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateContactInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/contacts/search/route.ts
+++ b/app/api/v1/contacts/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetContactsApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetContactsApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/deals/[id]/route.ts
+++ b/app/api/v1/deals/[id]/route.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getDeleteDealInteractor, getGetDealByIdInteractor, getUpdateDealInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateDealInteractor().invoke({ ...data, id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/deals/many/route.ts
+++ b/app/api/v1/deals/many/route.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 import { getCreateManyDealsInteractor, getUpdateManyDealsInteractor, getDeleteManyDealsInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateManyDealsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -23,7 +24,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateManyDealsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -36,7 +37,7 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getDeleteManyDealsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/deals/route.ts
+++ b/app/api/v1/deals/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCreateDealInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateDealInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/deals/search/route.ts
+++ b/app/api/v1/deals/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetDealsApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetDealsApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/activities/search/__tests__/route.test.ts
+++ b/app/api/v1/messaging/activities/search/__tests__/route.test.ts
@@ -15,7 +15,15 @@ vi.mock("@/core/di", () => ({
 import { POST } from "../route";
 
 function request(payload: unknown): NextRequest {
-  return { json: () => Promise.resolve(payload) } as unknown as NextRequest;
+  return rawRequest(JSON.stringify(payload));
+}
+
+function rawRequest(body: string): NextRequest {
+  return new Request("http://localhost/api/v1/messaging/activities/search", {
+    method: "POST",
+    body,
+    headers: { "content-type": "application/json" },
+  }) as unknown as NextRequest;
 }
 
 describe("activity search route", () => {
@@ -64,5 +72,22 @@ describe("activity search route", () => {
 
     expect(response.status).toBe(400);
     expect(invoke).toHaveBeenCalledExactlyOnceWith({});
+  });
+
+  it.each(["", " \n\t", '{"pagination":', "{not-json}"])(
+    "returns a 400 for absent or malformed JSON without invoking",
+    async (body) => {
+      const response = await POST(rawRequest(body));
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toBe("Invalid JSON body");
+      expect(invoke).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps application syntax errors unexpected", async () => {
+    invoke.mockRejectedValueOnce(new SyntaxError("interactor syntax error"));
+
+    await expect(POST(request({}))).rejects.toThrow("interactor syntax error");
   });
 });

--- a/app/api/v1/messaging/activities/search/route.ts
+++ b/app/api/v1/messaging/activities/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetActivitiesApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetActivitiesApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/calendar-events/search/route.ts
+++ b/app/api/v1/messaging/calendar-events/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetCalendarEventsApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getGetCalendarEventsApiInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/calendars/search/route.ts
+++ b/app/api/v1/messaging/calendars/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetCalendarsApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getGetCalendarsApiInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/lists/browse/route.ts
+++ b/app/api/v1/messaging/sales-navigator/lists/browse/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinBrowseSalesListInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinBrowseSalesListInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/lists/save/route.ts
+++ b/app/api/v1/messaging/sales-navigator/lists/save/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinSaveToSalesListInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinSaveToSalesListInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/lists/search/route.ts
+++ b/app/api/v1/messaging/sales-navigator/lists/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinListSalesListsInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinListSalesListsInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/search/companies/route.ts
+++ b/app/api/v1/messaging/sales-navigator/search/companies/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinSearchSalesCompaniesInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinSearchSalesCompaniesInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/search/parameters/route.ts
+++ b/app/api/v1/messaging/sales-navigator/search/parameters/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinListSalesSearchParametersInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinListSalesSearchParametersInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/search/people/route.ts
+++ b/app/api/v1/messaging/sales-navigator/search/people/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinSearchSalesPeopleInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinSearchSalesPeopleInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/sales-navigator/search/route.ts
+++ b/app/api/v1/messaging/sales-navigator/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getLinkedinSearchSalesNavigatorInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getLinkedinSearchSalesNavigatorInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/send-email/route.ts
+++ b/app/api/v1/messaging/send-email/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getSendEmailInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getSendEmailInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/social-post-engagement/search/route.ts
+++ b/app/api/v1/messaging/social-post-engagement/search/route.ts
@@ -9,10 +9,11 @@ import {
   getListSocialPostReactionsInteractor,
 } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = body?.commentId
       ? await getListSocialCommentReactionsInteractor().invoke(body)
       : body?.kind === "reactions"

--- a/app/api/v1/messaging/social-posts/search/route.ts
+++ b/app/api/v1/messaging/social-posts/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getListSocialPostsInteractor, getGetSocialPostInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = body?.postId
       ? await getGetSocialPostInteractor().invoke(body)
       : await getListSocialPostsInteractor().invoke(body);

--- a/app/api/v1/messaging/social-profiles/search/route.ts
+++ b/app/api/v1/messaging/social-profiles/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetSocialProfileInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getGetSocialProfileInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/social-relations/accept/route.ts
+++ b/app/api/v1/messaging/social-relations/accept/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getAcceptRelationRequestInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getAcceptRelationRequestInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/social-relations/cancel/route.ts
+++ b/app/api/v1/messaging/social-relations/cancel/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCancelRelationRequestInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getCancelRelationRequestInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/social-relations/invite/route.ts
+++ b/app/api/v1/messaging/social-relations/invite/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCreateRelationRequestInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getCreateRelationRequestInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/social-relations/search/route.ts
+++ b/app/api/v1/messaging/social-relations/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getListRelationRequestsInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getListRelationRequestsInteractor().invoke(body);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/start-chat/route.ts
+++ b/app/api/v1/messaging/start-chat/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getStartChatInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getStartChatInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/threads/[id]/drafts/route.ts
+++ b/app/api/v1/messaging/threads/[id]/drafts/route.ts
@@ -5,11 +5,12 @@ import { z } from "zod";
 
 import { getSaveDraftInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const body = await request.json();
+    const body = await request.json().catch(mapRequestJsonError);
     const result = await getSaveDraftInteractor().invoke({ ...body, threadId: id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/threads/[id]/messages/route.ts
+++ b/app/api/v1/messaging/threads/[id]/messages/route.ts
@@ -5,11 +5,12 @@ import { z } from "zod";
 
 import { getSendChatMessageInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getSendChatMessageInteractor().invoke({ ...data, threadId: id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/messaging/threads/search/route.ts
+++ b/app/api/v1/messaging/threads/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetMessagingThreadsInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetMessagingThreadsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/organizations/[id]/route.ts
+++ b/app/api/v1/organizations/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   getUpdateOrganizationInteractor,
 } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateOrganizationInteractor().invoke({ ...data, id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/organizations/many/route.ts
+++ b/app/api/v1/organizations/many/route.ts
@@ -9,12 +9,13 @@ import {
   getDeleteManyOrganizationsInteractor,
 } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateManyOrganizationsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -27,7 +28,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateManyOrganizationsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -40,7 +41,7 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getDeleteManyOrganizationsInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/organizations/route.ts
+++ b/app/api/v1/organizations/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCreateOrganizationInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateOrganizationInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/organizations/search/route.ts
+++ b/app/api/v1/organizations/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetOrganizationsApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetOrganizationsApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/services/[id]/route.ts
+++ b/app/api/v1/services/[id]/route.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getDeleteServiceInteractor, getGetServiceByIdInteractor, getUpdateServiceInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateServiceInteractor().invoke({ ...data, id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/services/many/route.ts
+++ b/app/api/v1/services/many/route.ts
@@ -9,12 +9,13 @@ import {
   getDeleteManyServicesInteractor,
 } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateManyServicesInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -27,7 +28,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateManyServicesInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -40,7 +41,7 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getDeleteManyServicesInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/services/route.ts
+++ b/app/api/v1/services/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCreateServiceInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateServiceInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/services/search/route.ts
+++ b/app/api/v1/services/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetServicesApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetServicesApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/tasks/[id]/route.ts
+++ b/app/api/v1/tasks/[id]/route.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getDeleteTaskInteractor, getGetTaskByIdInteractor, getUpdateTaskInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateTaskInteractor().invoke({ ...data, id });
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/tasks/many/route.ts
+++ b/app/api/v1/tasks/many/route.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 import { getCreateManyTasksInteractor, getUpdateManyTasksInteractor, getDeleteManyTasksInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateManyTasksInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -23,7 +24,7 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpdateManyTasksInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });
@@ -36,7 +37,7 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getDeleteManyTasksInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getCreateTaskInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getCreateTaskInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/tasks/search/route.ts
+++ b/app/api/v1/tasks/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetTasksApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetTasksApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/users/search/route.ts
+++ b/app/api/v1/users/search/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getGetUsersApiInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getGetUsersApiInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/app/api/v1/webhooks/route.ts
+++ b/app/api/v1/webhooks/route.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 
 import { getUpsertWebhookInteractor } from "@/core/di";
 import { handleError } from "@/core/api/interactor-handler";
+import { mapRequestJsonError } from "@/core/api/request-json-error";
 
 export async function POST(request: NextRequest) {
   try {
-    const data = await request.json();
+    const data = await request.json().catch(mapRequestJsonError);
     const result = await getUpsertWebhookInteractor().invoke(data);
 
     if (!result.ok) return NextResponse.json(z.prettifyError(result.error), { status: 400 });

--- a/core/api/__tests__/interactor-handler.test.ts
+++ b/core/api/__tests__/interactor-handler.test.ts
@@ -11,7 +11,7 @@ vi.mock("next/server", () => ({
 
 import { handleError } from "../interactor-handler";
 
-import { AuthError, ForbiddenError, DemoModeError } from "@/core/errors/app-errors";
+import { AuthError, DemoModeError, ForbiddenError, InvalidJsonBodyError } from "@/core/errors/app-errors";
 
 describe("handleError", () => {
   it("returns 401 for AuthError", () => {
@@ -29,6 +29,12 @@ describe("handleError", () => {
   it("returns 403 for DemoModeError", () => {
     const result = handleError(new DemoModeError()) as any;
     expect(result.status).toBe(403);
+  });
+
+  it("returns 400 for InvalidJsonBodyError", () => {
+    const result = handleError(new InvalidJsonBodyError()) as any;
+    expect(result.body).toBe("Invalid JSON body");
+    expect(result.status).toBe(400);
   });
 
   it("maps Prisma P2025 (record not found) to 404", () => {

--- a/core/api/__tests__/request-json-error.test.ts
+++ b/core/api/__tests__/request-json-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import type { InvalidJsonBodyError } from "@/core/errors/app-errors";
+import { mapRequestJsonError } from "../request-json-error";
+
+describe("mapRequestJsonError", () => {
+  it.each(["", " \n\t", '{"truncated":'])("maps invalid request JSON to a client error", async (body) => {
+    const request = new Request("http://localhost/api/v1/test", {
+      method: "POST",
+      body,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(request.json().catch(mapRequestJsonError)).rejects.toEqual(
+      expect.objectContaining<Partial<InvalidJsonBodyError>>({
+        name: "InvalidJsonBodyError",
+        message: "Invalid JSON body",
+        statusCode: 400,
+      }),
+    );
+  });
+
+  it("does not reclassify non-parser failures", async () => {
+    const error = new TypeError("body stream failed");
+
+    await expect(Promise.reject(error).catch(mapRequestJsonError)).rejects.toBe(error);
+  });
+});

--- a/core/api/interactor-handler.ts
+++ b/core/api/interactor-handler.ts
@@ -8,7 +8,7 @@ export const ErrorResponseSchema = z.string();
 
 export const CommonApiResponses = {
   "400": {
-    description: "Bad Request - Validation error",
+    description: "Bad Request",
     content: {
       "application/json": {
         schema: ErrorResponseSchema,

--- a/core/api/request-json-error.ts
+++ b/core/api/request-json-error.ts
@@ -1,0 +1,6 @@
+import { InvalidJsonBodyError } from "@/core/errors/app-errors";
+
+export function mapRequestJsonError(error: unknown): never {
+  if (error instanceof SyntaxError) throw new InvalidJsonBodyError();
+  throw error;
+}

--- a/core/errors/__tests__/app-errors.test.ts
+++ b/core/errors/__tests__/app-errors.test.ts
@@ -5,6 +5,7 @@ import {
   ForbiddenError,
   DemoModeError,
   DEMO_MODE_MESSAGE,
+  InvalidJsonBodyError,
   WebhookExternalFailure,
   WebhookNonRetryableFailure,
   isExpectedError,
@@ -49,6 +50,15 @@ describe("ForbiddenError", () => {
   });
 });
 
+describe("InvalidJsonBodyError", () => {
+  it("uses the public REST bad-request contract", () => {
+    const err = new InvalidJsonBodyError();
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe("Invalid JSON body");
+    expect(err.name).toBe("InvalidJsonBodyError");
+  });
+});
+
 describe("DemoModeError", () => {
   it("defaults to 403 with demo mode message", () => {
     const err = new DemoModeError();
@@ -66,6 +76,7 @@ describe("isExpectedError", () => {
   it("recognizes expected error instances", () => {
     expect(isExpectedError(new AuthError())).toBe(true);
     expect(isExpectedError(new ForbiddenError())).toBe(true);
+    expect(isExpectedError(new InvalidJsonBodyError())).toBe(true);
     expect(isExpectedError(new DemoModeError())).toBe(true);
     expect(isExpectedError(new WebhookExternalFailure(503, "down"))).toBe(true);
     expect(isExpectedError(new WebhookNonRetryableFailure(405, "Method Not Allowed"))).toBe(true);

--- a/core/errors/app-errors.ts
+++ b/core/errors/app-errors.ts
@@ -32,6 +32,12 @@ export class ForbiddenError extends AppError {
   }
 }
 
+export class InvalidJsonBodyError extends AppError {
+  constructor() {
+    super("Invalid JSON body", 400);
+  }
+}
+
 export const DEMO_MODE_MESSAGE = "This action is not available in demo mode. Please sign in to access all features.";
 
 export class DemoModeError extends AppError {

--- a/ee/calendar/get-calendar-events.openapi.ts
+++ b/ee/calendar/get-calendar-events.openapi.ts
@@ -14,6 +14,7 @@ export const getCalendarEventsOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/ee/calendar/get-calendars.openapi.ts
+++ b/ee/calendar/get-calendars.openapi.ts
@@ -14,6 +14,7 @@ export const getCalendarsOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/ee/messaging/activities/get-activities.openapi.ts
+++ b/ee/messaging/activities/get-activities.openapi.ts
@@ -12,6 +12,7 @@ export const getActivitiesOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: ActivitiesApiParamsSchema,

--- a/ee/messaging/inbox/get-messaging-threads.openapi.ts
+++ b/ee/messaging/inbox/get-messaging-threads.openapi.ts
@@ -12,6 +12,7 @@ export const getMessagingThreadsOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/ee/messaging/outbound/save-draft.openapi.ts
+++ b/ee/messaging/outbound/save-draft.openapi.ts
@@ -17,6 +17,7 @@ export const saveDraftOperation: ZodOpenApiOperationObject = {
     path: z.object({ id: z.uuid().describe("The thread id the draft belongs to") }),
   },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: SaveDraftSchema.omit({ threadId: true }),

--- a/ee/messaging/outbound/send-chat-message.openapi.ts
+++ b/ee/messaging/outbound/send-chat-message.openapi.ts
@@ -15,6 +15,7 @@ export const sendChatMessageOperation: ZodOpenApiOperationObject = {
   security: [{ apiKeyAuth: [] }],
   requestParams: { path: z.object({ id: z.uuid() }) },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: BaseSendChatMessageSchema.omit({ threadId: true }),

--- a/ee/messaging/outbound/send-email.openapi.ts
+++ b/ee/messaging/outbound/send-email.openapi.ts
@@ -14,6 +14,7 @@ export const sendEmailOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: SendEmailSchema,

--- a/ee/messaging/outbound/start-chat.openapi.ts
+++ b/ee/messaging/outbound/start-chat.openapi.ts
@@ -13,6 +13,7 @@ export const startChatOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: StartChatInputSchema,

--- a/ee/messaging/posts/accept-relation-request.openapi.ts
+++ b/ee/messaging/posts/accept-relation-request.openapi.ts
@@ -12,6 +12,7 @@ export const acceptRelationRequestOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: AcceptRelationRequestSchema,

--- a/ee/messaging/posts/cancel-relation-request.openapi.ts
+++ b/ee/messaging/posts/cancel-relation-request.openapi.ts
@@ -12,6 +12,7 @@ export const cancelRelationRequestOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CancelRelationRequestSchema,

--- a/ee/messaging/posts/create-relation-request.openapi.ts
+++ b/ee/messaging/posts/create-relation-request.openapi.ts
@@ -12,6 +12,7 @@ export const createRelationRequestOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateRelationRequestSchema,

--- a/ee/messaging/posts/get-social-profile.openapi.ts
+++ b/ee/messaging/posts/get-social-profile.openapi.ts
@@ -12,6 +12,7 @@ export const getSocialProfileOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetSocialProfileSchema,

--- a/ee/messaging/posts/list-relation-requests.openapi.ts
+++ b/ee/messaging/posts/list-relation-requests.openapi.ts
@@ -12,6 +12,7 @@ export const listRelationRequestsOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: ListRelationRequestsSchema,

--- a/ee/messaging/posts/list-social-post-comments.openapi.ts
+++ b/ee/messaging/posts/list-social-post-comments.openapi.ts
@@ -24,6 +24,7 @@ export const getSocialPostEngagementOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: SocialPostEngagementBodySchema,

--- a/ee/messaging/posts/list-social-posts.openapi.ts
+++ b/ee/messaging/posts/list-social-posts.openapi.ts
@@ -18,6 +18,7 @@ export const getSocialPostsOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: SocialPostsBodySchema,

--- a/ee/messaging/sales-navigator/linkedin-browse-sales-list.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-browse-sales-list.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinBrowseSalesListOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinBrowseSalesListSchema,

--- a/ee/messaging/sales-navigator/linkedin-list-sales-lists.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-list-sales-lists.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinListSalesListsOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinListSalesListsSchema,

--- a/ee/messaging/sales-navigator/linkedin-list-sales-search-parameters.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-list-sales-search-parameters.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinListSalesSearchParametersOperation: ZodOpenApiOperationObje
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinListSalesSearchParametersSchema,

--- a/ee/messaging/sales-navigator/linkedin-save-to-sales-list.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-save-to-sales-list.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinSaveToSalesListOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinSaveToSalesListSchema,

--- a/ee/messaging/sales-navigator/linkedin-search-sales-companies.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-search-sales-companies.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinSearchSalesCompaniesOperation: ZodOpenApiOperationObject = 
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinSearchSalesCompaniesSchema,

--- a/ee/messaging/sales-navigator/linkedin-search-sales-navigator.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-search-sales-navigator.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinSearchSalesNavigatorOperation: ZodOpenApiOperationObject = 
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinSearchSalesNavigatorSchema,

--- a/ee/messaging/sales-navigator/linkedin-search-sales-people.openapi.ts
+++ b/ee/messaging/sales-navigator/linkedin-search-sales-people.openapi.ts
@@ -12,6 +12,7 @@ export const linkedinSearchSalesPeopleOperation: ZodOpenApiOperationObject = {
   tags: ["messaging"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: LinkedinSearchSalesPeopleSchema,

--- a/features/contacts/delete/delete-many-contacts.openapi.ts
+++ b/features/contacts/delete/delete-many-contacts.openapi.ts
@@ -13,6 +13,7 @@ export const deleteManyContactsOperation: ZodOpenApiOperationObject = {
   tags: ["contacts"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: DeleteManyContactsSchema,

--- a/features/contacts/get/get-contacts.openapi.ts
+++ b/features/contacts/get/get-contacts.openapi.ts
@@ -14,6 +14,7 @@ export const getContactsOperation: ZodOpenApiOperationObject = {
   tags: ["contacts"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/features/contacts/upsert/create-contact.openapi.ts
+++ b/features/contacts/upsert/create-contact.openapi.ts
@@ -13,6 +13,7 @@ export const createContactOperation: ZodOpenApiOperationObject = {
   tags: ["contacts"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateContactSchema,

--- a/features/contacts/upsert/create-many-contacts.openapi.ts
+++ b/features/contacts/upsert/create-many-contacts.openapi.ts
@@ -14,6 +14,7 @@ export const createManyContactsOperation: ZodOpenApiOperationObject = {
   tags: ["contacts"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateManyContactsSchema,

--- a/features/contacts/upsert/update-contact.openapi.ts
+++ b/features/contacts/upsert/update-contact.openapi.ts
@@ -17,6 +17,7 @@ export const updateContactOperation: ZodOpenApiOperationObject = {
   security: [{ apiKeyAuth: [] }],
   requestParams: { path: z.object({ id: ContactKeySchema }) },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: BaseUpdateContactSchema.omit({ id: true }),

--- a/features/contacts/upsert/update-many-contacts.openapi.ts
+++ b/features/contacts/upsert/update-many-contacts.openapi.ts
@@ -15,6 +15,7 @@ export const updateManyContactsOperation: ZodOpenApiOperationObject = {
   tags: ["contacts"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: UpdateManyContactsSchema,

--- a/features/deals/delete/delete-many-deals.openapi.ts
+++ b/features/deals/delete/delete-many-deals.openapi.ts
@@ -11,6 +11,7 @@ export const deleteManyDealsOperation: ZodOpenApiOperationObject = {
   tags: ["deals"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: DeleteManyDealsSchema,

--- a/features/deals/get/get-deals.openapi.ts
+++ b/features/deals/get/get-deals.openapi.ts
@@ -14,6 +14,7 @@ export const getDealsOperation: ZodOpenApiOperationObject = {
   tags: ["deals"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/features/deals/upsert/create-deal.openapi.ts
+++ b/features/deals/upsert/create-deal.openapi.ts
@@ -13,6 +13,7 @@ export const createDealOperation: ZodOpenApiOperationObject = {
   tags: ["deals"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateDealSchema,

--- a/features/deals/upsert/create-many-deals.openapi.ts
+++ b/features/deals/upsert/create-many-deals.openapi.ts
@@ -14,6 +14,7 @@ export const createManyDealsOperation: ZodOpenApiOperationObject = {
   tags: ["deals"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateManyDealsSchema,

--- a/features/deals/upsert/update-deal.openapi.ts
+++ b/features/deals/upsert/update-deal.openapi.ts
@@ -16,6 +16,7 @@ export const updateDealOperation: ZodOpenApiOperationObject = {
   security: [{ apiKeyAuth: [] }],
   requestParams: { path: z.object({ id: z.uuid() }) },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: BaseUpdateDealSchema.omit({ id: true }),

--- a/features/deals/upsert/update-many-deals.openapi.ts
+++ b/features/deals/upsert/update-many-deals.openapi.ts
@@ -14,6 +14,7 @@ export const updateManyDealsOperation: ZodOpenApiOperationObject = {
   tags: ["deals"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: UpdateManyDealsSchema,

--- a/features/organizations/delete/delete-many-organizations.openapi.ts
+++ b/features/organizations/delete/delete-many-organizations.openapi.ts
@@ -11,6 +11,7 @@ export const deleteManyOrganizationsOperation: ZodOpenApiOperationObject = {
   tags: ["organizations"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: DeleteManyOrganizationsSchema,

--- a/features/organizations/get/get-organizations.openapi.ts
+++ b/features/organizations/get/get-organizations.openapi.ts
@@ -14,6 +14,7 @@ export const getOrganizationsOperation: ZodOpenApiOperationObject = {
   tags: ["organizations"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/features/organizations/upsert/create-many-organizations.openapi.ts
+++ b/features/organizations/upsert/create-many-organizations.openapi.ts
@@ -14,6 +14,7 @@ export const createManyOrganizationsOperation: ZodOpenApiOperationObject = {
   tags: ["organizations"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateManyOrganizationsSchema,

--- a/features/organizations/upsert/create-organization.openapi.ts
+++ b/features/organizations/upsert/create-organization.openapi.ts
@@ -13,6 +13,7 @@ export const createOrganizationOperation: ZodOpenApiOperationObject = {
   tags: ["organizations"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateOrganizationSchema,

--- a/features/organizations/upsert/update-many-organizations.openapi.ts
+++ b/features/organizations/upsert/update-many-organizations.openapi.ts
@@ -14,6 +14,7 @@ export const updateManyOrganizationsOperation: ZodOpenApiOperationObject = {
   tags: ["organizations"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: UpdateManyOrganizationsSchema,

--- a/features/organizations/upsert/update-organization.openapi.ts
+++ b/features/organizations/upsert/update-organization.openapi.ts
@@ -16,6 +16,7 @@ export const updateOrganizationOperation: ZodOpenApiOperationObject = {
   security: [{ apiKeyAuth: [] }],
   requestParams: { path: z.object({ id: z.uuid() }) },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: BaseUpdateOrganizationSchema.omit({ id: true }),

--- a/features/services/delete/delete-many-services.openapi.ts
+++ b/features/services/delete/delete-many-services.openapi.ts
@@ -11,6 +11,7 @@ export const deleteManyServicesOperation: ZodOpenApiOperationObject = {
   tags: ["services"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: DeleteManyServicesSchema,

--- a/features/services/get/get-services.openapi.ts
+++ b/features/services/get/get-services.openapi.ts
@@ -14,6 +14,7 @@ export const getServicesOperation: ZodOpenApiOperationObject = {
   tags: ["services"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/features/services/upsert/create-many-services.openapi.ts
+++ b/features/services/upsert/create-many-services.openapi.ts
@@ -14,6 +14,7 @@ export const createManyServicesOperation: ZodOpenApiOperationObject = {
   tags: ["services"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateManyServicesSchema,

--- a/features/services/upsert/create-service.openapi.ts
+++ b/features/services/upsert/create-service.openapi.ts
@@ -13,6 +13,7 @@ export const createServiceOperation: ZodOpenApiOperationObject = {
   tags: ["services"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateServiceSchema,

--- a/features/services/upsert/update-many-services.openapi.ts
+++ b/features/services/upsert/update-many-services.openapi.ts
@@ -13,6 +13,7 @@ export const updateManyServicesOperation: ZodOpenApiOperationObject = {
   tags: ["services"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: UpdateManyServicesSchema,

--- a/features/services/upsert/update-service.openapi.ts
+++ b/features/services/upsert/update-service.openapi.ts
@@ -16,6 +16,7 @@ export const updateServiceOperation: ZodOpenApiOperationObject = {
   security: [{ apiKeyAuth: [] }],
   requestParams: { path: z.object({ id: z.uuid() }) },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: BaseUpdateServiceSchema.omit({ id: true }),

--- a/features/tasks/delete/delete-many-tasks.openapi.ts
+++ b/features/tasks/delete/delete-many-tasks.openapi.ts
@@ -11,6 +11,7 @@ export const deleteManyTasksOperation: ZodOpenApiOperationObject = {
   tags: ["tasks"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: DeleteManyTasksSchema,

--- a/features/tasks/get/get-tasks.openapi.ts
+++ b/features/tasks/get/get-tasks.openapi.ts
@@ -14,6 +14,7 @@ export const getTasksOperation: ZodOpenApiOperationObject = {
   tags: ["tasks"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/features/tasks/upsert/create-many-tasks.openapi.ts
+++ b/features/tasks/upsert/create-many-tasks.openapi.ts
@@ -13,6 +13,7 @@ export const createManyTasksOperation: ZodOpenApiOperationObject = {
   tags: ["tasks"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateManyTasksSchema,

--- a/features/tasks/upsert/create-task.openapi.ts
+++ b/features/tasks/upsert/create-task.openapi.ts
@@ -13,6 +13,7 @@ export const createTaskOperation: ZodOpenApiOperationObject = {
   tags: ["tasks"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: CreateTaskSchema,

--- a/features/tasks/upsert/update-many-tasks.openapi.ts
+++ b/features/tasks/upsert/update-many-tasks.openapi.ts
@@ -13,6 +13,7 @@ export const updateManyTasksOperation: ZodOpenApiOperationObject = {
   tags: ["tasks"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: UpdateManyTasksSchema,

--- a/features/tasks/upsert/update-task.openapi.ts
+++ b/features/tasks/upsert/update-task.openapi.ts
@@ -16,6 +16,7 @@ export const updateTaskOperation: ZodOpenApiOperationObject = {
   security: [{ apiKeyAuth: [] }],
   requestParams: { path: z.object({ id: z.uuid() }) },
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: BaseUpdateTaskSchema.omit({ id: true }),

--- a/features/user/get/get-users.openapi.ts
+++ b/features/user/get/get-users.openapi.ts
@@ -14,6 +14,7 @@ export const getUsersOperation: ZodOpenApiOperationObject = {
   tags: ["users"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: GetQueryParamsApiSchema,

--- a/features/webhook/create-webhook.openapi.ts
+++ b/features/webhook/create-webhook.openapi.ts
@@ -13,6 +13,7 @@ export const createWebhookOperation: ZodOpenApiOperationObject = {
   tags: ["webhooks"],
   security: [{ apiKeyAuth: [] }],
   requestBody: {
+    required: true,
     content: {
       "application/json": {
         schema: UpsertWebhookSchema,

--- a/public/v1/openapi.json
+++ b/public/v1/openapi.json
@@ -26,6 +26,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -363,6 +364,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -701,6 +703,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1039,6 +1042,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1123,6 +1127,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5060,6 +5065,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5634,6 +5640,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5903,6 +5910,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -6173,6 +6181,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -6443,6 +6452,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -6526,6 +6536,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -10323,6 +10334,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -10778,6 +10790,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -11096,6 +11109,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -11415,6 +11429,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -11734,6 +11749,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -11817,6 +11833,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -15712,6 +15729,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -16244,6 +16262,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -16480,6 +16499,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -16717,6 +16737,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -16954,6 +16975,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -17037,6 +17059,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -20768,6 +20791,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -21179,6 +21203,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -21474,6 +21499,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -21770,6 +21796,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -22066,6 +22093,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -22149,6 +22177,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -25998,6 +26027,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -26494,6 +26524,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -27298,6 +27329,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -27835,6 +27867,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -28406,6 +28439,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -29259,6 +29293,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -29335,6 +29370,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -31199,6 +31235,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -33339,6 +33376,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -34156,6 +34194,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -34264,6 +34303,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -35203,6 +35243,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -36040,6 +36081,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -36789,6 +36831,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -37273,6 +37316,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -37728,6 +37772,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -38715,6 +38760,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -39331,6 +39377,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -39498,6 +39545,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -39698,6 +39746,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -40161,6 +40210,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -40278,6 +40328,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -40674,6 +40725,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -40792,6 +40844,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -40906,6 +40959,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {

--- a/public/v1/openapi.json
+++ b/public/v1/openapi.json
@@ -308,7 +308,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -649,7 +649,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -988,7 +988,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1071,7 +1071,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2977,7 +2977,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -3877,7 +3877,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -4997,7 +4997,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -5505,7 +5505,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -5584,7 +5584,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -5854,7 +5854,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -6127,7 +6127,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -6398,7 +6398,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -6480,7 +6480,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -8318,7 +8318,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -9218,7 +9218,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -10268,7 +10268,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -10657,7 +10657,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -10734,7 +10734,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -11053,7 +11053,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -11375,7 +11375,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -11695,7 +11695,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -11777,7 +11777,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -13664,7 +13664,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -14564,7 +14564,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -15663,7 +15663,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -16129,7 +16129,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -16206,7 +16206,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -16443,7 +16443,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -16683,7 +16683,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -16921,7 +16921,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -17003,7 +17003,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -18808,7 +18808,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -19708,7 +19708,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -20725,7 +20725,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -21070,7 +21070,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -21147,7 +21147,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -21443,7 +21443,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -21742,7 +21742,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -22039,7 +22039,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -22121,7 +22121,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -23985,7 +23985,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -24885,7 +24885,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -25961,7 +25961,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -26391,7 +26391,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -26468,7 +26468,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -26906,7 +26906,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -27273,7 +27273,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -27500,7 +27500,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -27664,7 +27664,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -27741,7 +27741,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -27811,7 +27811,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -28292,7 +28292,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -28371,7 +28371,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -29237,7 +29237,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -29314,7 +29314,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -31026,7 +31026,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -31179,7 +31179,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -33029,7 +33029,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -33320,7 +33320,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -34138,7 +34138,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -34233,7 +34233,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -35090,7 +35090,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -35187,7 +35187,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -36025,7 +36025,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -36775,7 +36775,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -37260,7 +37260,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -37716,7 +37716,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -38704,7 +38704,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -39321,7 +39321,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -39489,7 +39489,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -39690,7 +39690,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -40154,7 +40154,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -40272,7 +40272,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -40669,7 +40669,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -40788,7 +40788,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -40903,7 +40903,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -41018,7 +41018,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - Validation error",
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {

--- a/tests/conventions/rest-openapi-coverage.test.ts
+++ b/tests/conventions/rest-openapi-coverage.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
-
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
 
 import { generateOpenApiSpec } from "@/core/openapi/openapi-spec";
 import { REPO_ROOT, walkFiles } from "./walk";
@@ -10,8 +11,40 @@ const ENFORCED = true;
 
 const SPEC_EXEMPT_PATHS = new Set(["/v1/mcp", "/v1/openapi"]);
 const HTTP_VERBS = new Set(["get", "post", "put", "patch", "delete"]);
+const HTTP_HANDLER_NAMES = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 const BODY_VERBS = new Set(["post", "put", "patch"]);
-const VERB_EXPORT_PATTERN = /export (async )?function (GET|POST|PUT|PATCH|DELETE)/g;
+const BODY_READER_METHODS = new Set(["arrayBuffer", "blob", "bytes", "formData", "json", "text"]);
+const BODY_REQUIRED_DELETE_PATHS = new Set([
+  "/v1/contacts/many",
+  "/v1/deals/many",
+  "/v1/organizations/many",
+  "/v1/services/many",
+  "/v1/tasks/many",
+]);
+
+type JsonReader = {
+  line: number;
+  mapped: boolean;
+};
+
+type InspectionError = {
+  line: number;
+  message: string;
+};
+
+type RouteOperation = {
+  file: string;
+  importsMapper: boolean;
+  jsonReaders: JsonReader[];
+  inspectionErrors: InspectionError[];
+};
+
+type SpecOperation = {
+  requestBody?: {
+    required?: boolean;
+    content?: Record<string, unknown>;
+  };
+};
 
 function toSpecPath(routeFile: string): string {
   return routeFile
@@ -20,29 +53,238 @@ function toSpecPath(routeFile: string): string {
     .replace(/\[([^\]]+)\]/g, "{$1}");
 }
 
-function routeOperations(): Map<string, string> {
-  const operations = new Map<string, string>();
+function isExported(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    Boolean(ts.getModifiers(node)?.some(({ kind }) => kind === ts.SyntaxKind.ExportKeyword))
+  );
+}
+
+function importsRequestJsonMapper(source: ts.SourceFile): boolean {
+  return source.statements.some((statement) => {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) return false;
+    if (statement.moduleSpecifier.text !== "@/core/api/request-json-error") return false;
+
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) return false;
+
+    return bindings.elements.some(
+      ({ name, propertyName }) =>
+        name.text === "mapRequestJsonError" && (propertyName?.text ?? name.text) === "mapRequestJsonError",
+    );
+  });
+}
+
+function bindingContainsName(binding: ts.BindingName, name: string): boolean {
+  if (ts.isIdentifier(binding)) return binding.text === name;
+  return binding.elements.some(
+    (element) => !ts.isOmittedExpression(element) && bindingContainsName(element.name, name),
+  );
+}
+
+function bindingIdentifiers(binding: ts.BindingName): ts.Identifier[] {
+  if (ts.isIdentifier(binding)) return [binding];
+  return binding.elements.flatMap((element) =>
+    ts.isOmittedExpression(element) ? [] : bindingIdentifiers(element.name),
+  );
+}
+
+function zeroArgumentMethodCall(node: ts.Node):
+  | {
+      call: ts.CallExpression;
+      method: string;
+      receiver: ts.Expression;
+      canonicalPropertyAccess: boolean;
+    }
+  | undefined {
+  if (!ts.isCallExpression(node) || node.arguments.length !== 0) return undefined;
+  if (ts.isPropertyAccessExpression(node.expression)) {
+    return {
+      call: node,
+      method: node.expression.name.text,
+      receiver: node.expression.expression,
+      canonicalPropertyAccess: node.expression.questionDotToken === undefined,
+    };
+  }
+  if (
+    ts.isElementAccessExpression(node.expression) &&
+    node.expression.argumentExpression &&
+    ts.isStringLiteral(node.expression.argumentExpression)
+  ) {
+    return {
+      call: node,
+      method: node.expression.argumentExpression.text,
+      receiver: node.expression.expression,
+      canonicalPropertyAccess: false,
+    };
+  }
+  return undefined;
+}
+
+function hasMappedParserFailure(call: ts.CallExpression): boolean {
+  const catchAccess = call.parent;
+  if (
+    !ts.isPropertyAccessExpression(catchAccess) ||
+    catchAccess.expression !== call ||
+    catchAccess.name.text !== "catch"
+  )
+    return false;
+
+  const catchCall = catchAccess.parent;
+  if (!ts.isCallExpression(catchCall) || catchCall.expression !== catchAccess || catchCall.arguments.length !== 1)
+    return false;
+
+  const mapper = catchCall.arguments[0];
+  if (!ts.isIdentifier(mapper) || mapper.text !== "mapRequestJsonError") return false;
+
+  return ts.isAwaitExpression(catchCall.parent) && catchCall.parent.expression === catchCall;
+}
+
+function analyzeJsonReaders(
+  source: ts.SourceFile,
+  body: ts.ConciseBody | undefined,
+  parameters: ts.NodeArray<ts.ParameterDeclaration>,
+): { readers: JsonReader[]; inspectionErrors: InspectionError[] } {
+  if (!body) return { readers: [], inspectionErrors: [] };
+  const requestParameter = parameters[0]?.name;
+  if (!requestParameter || !ts.isIdentifier(requestParameter)) return { readers: [], inspectionErrors: [] };
+
+  const readers: JsonReader[] = [];
+  const inspectionErrors: InspectionError[] = [];
+  const visit = (node: ts.Node) => {
+    if (node !== body && ts.isFunctionLike(node)) return;
+    const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+    if (ts.isVariableDeclaration(node) && bindingContainsName(node.name, requestParameter.text)) {
+      inspectionErrors.push({
+        line,
+        message: `must not shadow the handler request parameter '${requestParameter.text}'`,
+      });
+    }
+
+    const methodCall = zeroArgumentMethodCall(node);
+    if (methodCall && BODY_READER_METHODS.has(methodCall.method)) {
+      const isCanonicalRequestJson =
+        methodCall.method === "json" &&
+        methodCall.canonicalPropertyAccess &&
+        ts.isIdentifier(methodCall.receiver) &&
+        methodCall.receiver.text === requestParameter.text;
+      if (!isCanonicalRequestJson) {
+        inspectionErrors.push({
+          line,
+          message: `must read request JSON only as ${requestParameter.text}.json().catch(mapRequestJsonError)`,
+        });
+      } else {
+        readers.push({
+          line,
+          mapped: hasMappedParserFailure(methodCall.call),
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(body);
+  return { readers, inspectionErrors };
+}
+
+function routeOperations(): Map<string, RouteOperation> {
+  const operations = new Map<string, RouteOperation>();
   const routeFiles = walkFiles(join(REPO_ROOT, "app", "api", "v1"), (path) => path.endsWith("/route.ts"));
-  for (const file of routeFiles) {
-    const specPath = toSpecPath(file);
+
+  for (const path of routeFiles) {
+    const specPath = toSpecPath(path);
     if (SPEC_EXEMPT_PATHS.has(specPath)) continue;
-    const text = readFileSync(file, "utf8");
-    for (const match of text.matchAll(VERB_EXPORT_PATTERN)) {
-      operations.set(`${match[2].toLowerCase()} ${specPath}`, file.slice(REPO_ROOT.length + 1));
+
+    const text = readFileSync(path, "utf8");
+    const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    const file = path.slice(REPO_ROOT.length + 1);
+    const importsMapper = importsRequestJsonMapper(source);
+    const setOperation = (name: string, operation: RouteOperation) => {
+      if (HTTP_HANDLER_NAMES.has(name)) operations.set(`${name.toLowerCase()} ${specPath}`, operation);
+    };
+    const register = (
+      name: string,
+      parameters: ts.NodeArray<ts.ParameterDeclaration>,
+      body: ts.ConciseBody | undefined,
+    ) => {
+      const analysis = analyzeJsonReaders(source, body, parameters);
+      setOperation(name, {
+        file,
+        importsMapper,
+        jsonReaders: analysis.readers,
+        inspectionErrors: analysis.inspectionErrors,
+      });
+    };
+    const registerUnsupported = (name: string, node: ts.Node) => {
+      setOperation(name, {
+        file,
+        importsMapper,
+        jsonReaders: [],
+        inspectionErrors: [
+          {
+            line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+            message: `must export ${name} as a direct function, function expression, or arrow function`,
+          },
+        ],
+      });
+    };
+
+    for (const statement of source.statements) {
+      if (ts.isFunctionDeclaration(statement) && isExported(statement) && statement.name) {
+        if (statement.body) register(statement.name.text, statement.parameters, statement.body);
+        else registerUnsupported(statement.name.text, statement);
+        continue;
+      }
+      if (ts.isVariableStatement(statement) && isExported(statement)) {
+        for (const declaration of statement.declarationList.declarations) {
+          if (!ts.isIdentifier(declaration.name)) {
+            for (const identifier of bindingIdentifiers(declaration.name)) {
+              registerUnsupported(identifier.text, identifier);
+            }
+            continue;
+          }
+          const initializer = declaration.initializer;
+          if (initializer && (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer))) {
+            register(declaration.name.text, initializer.parameters, initializer.body);
+          } else {
+            registerUnsupported(declaration.name.text, declaration);
+          }
+        }
+        continue;
+      }
+      if (ts.isExportDeclaration(statement) && statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) registerUnsupported(element.name.text, element);
+      } else if (
+        ts.isExportDeclaration(statement) &&
+        statement.exportClause &&
+        ts.isNamespaceExport(statement.exportClause)
+      ) {
+        registerUnsupported(statement.exportClause.name.text, statement.exportClause);
+      } else if (ts.isExportDeclaration(statement) && !statement.exportClause) {
+        throw new Error(
+          `${file}:${source.getLineAndCharacterOfPosition(statement.getStart(source)).line + 1} uses export *`,
+        );
+      }
+    }
+  }
+
+  return operations;
+}
+
+function specOperations(): Map<string, SpecOperation> {
+  const spec = generateOpenApiSpec() as {
+    paths?: Record<string, Record<string, SpecOperation>>;
+  };
+  const operations = new Map<string, SpecOperation>();
+  for (const [path, entry] of Object.entries(spec.paths ?? {})) {
+    for (const [verb, operation] of Object.entries(entry)) {
+      if (HTTP_VERBS.has(verb)) operations.set(`${verb} ${path}`, operation);
     }
   }
   return operations;
 }
 
-function specOperations(): Set<string> {
-  const spec = generateOpenApiSpec() as { paths?: Record<string, Record<string, unknown>> };
-  const operations = new Set<string>();
-  for (const [path, entry] of Object.entries(spec.paths ?? {})) {
-    for (const verb of Object.keys(entry)) {
-      if (HTTP_VERBS.has(verb)) operations.add(`${verb} ${path}`);
-    }
-  }
-  return operations;
+function hasJsonRequestBody(operation: SpecOperation | undefined): boolean {
+  return operation?.requestBody?.content?.["application/json"] !== undefined;
 }
 
 describe("v1 REST OpenAPI coverage", () => {
@@ -50,20 +292,22 @@ describe("v1 REST OpenAPI coverage", () => {
     const documented = specOperations();
     const undocumented = [...routeOperations()]
       .filter(([operation]) => !documented.has(operation))
-      .map(([operation, file]) => `${operation} (${file}) has no operation in generateOpenApiSpec()`);
+      .map(([operation, { file }]) => `${operation} (${file}) has no operation in generateOpenApiSpec()`);
     expect(undocumented).toEqual([]);
   });
 
   it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("has a route handler for every spec operation", () => {
     const routes = routeOperations();
     const orphaned = [...specOperations()]
-      .filter((operation) => !routes.has(operation))
-      .map((operation) => `${operation} is in generateOpenApiSpec() but has no route handler under app/api/v1`);
+      .filter(([operation]) => !routes.has(operation))
+      .map(([operation]) => `${operation} is in generateOpenApiSpec() but has no route handler under app/api/v1`);
     expect(orphaned).toEqual([]);
   });
 
   it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("documents a requestBody for every write-verb operation", () => {
-    const spec = generateOpenApiSpec() as { paths?: Record<string, Record<string, { requestBody?: unknown }>> };
+    const spec = generateOpenApiSpec() as {
+      paths?: Record<string, Record<string, { requestBody?: unknown }>>;
+    };
     const missing: string[] = [];
     for (const [path, entry] of Object.entries(spec.paths ?? {})) {
       for (const [verb, operation] of Object.entries(entry)) {
@@ -72,6 +316,56 @@ describe("v1 REST OpenAPI coverage", () => {
         }
       }
     }
+    for (const path of BODY_REQUIRED_DELETE_PATHS) {
+      if (spec.paths?.[path]?.delete?.requestBody === undefined) {
+        missing.push(`delete ${path} has no requestBody in generateOpenApiSpec()`);
+      }
+    }
     expect(missing).toEqual([]);
   });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
+    "keeps REST JSON parsing and required OpenAPI bodies aligned",
+    () => {
+      const routes = routeOperations();
+      const documented = specOperations();
+      const violations: string[] = [];
+
+      for (const [operation, spec] of documented) {
+        if (!hasJsonRequestBody(spec)) continue;
+        if (spec.requestBody?.required !== true) {
+          violations.push(`${operation} must declare its JSON requestBody as required`);
+        }
+
+        const route = routes.get(operation);
+        if (route && route.jsonReaders.length !== 1) {
+          violations.push(
+            `${operation} (${route.file}) must read its documented JSON body exactly once; found ${route.jsonReaders.length}`,
+          );
+        }
+      }
+
+      for (const [operation, route] of routes) {
+        const spec = documented.get(operation);
+        for (const inspectionError of route.inspectionErrors) {
+          violations.push(`${operation} (${route.file}:${inspectionError.line}) ${inspectionError.message}`);
+        }
+        if (route.jsonReaders.length > 0 && !hasJsonRequestBody(spec)) {
+          violations.push(`${operation} (${route.file}) reads JSON without an OpenAPI application/json requestBody`);
+        }
+        if (route.jsonReaders.length > 0 && !route.importsMapper) {
+          violations.push(`${operation} (${route.file}) must import mapRequestJsonError from the shared API boundary`);
+        }
+        for (const reader of route.jsonReaders) {
+          if (!reader.mapped) {
+            violations.push(
+              `${operation} (${route.file}:${reader.line}) must await request.json().catch(mapRequestJsonError)`,
+            );
+          }
+        }
+      }
+
+      expect(violations, violations.join("\n")).toEqual([]);
+    },
+  );
 });

--- a/tests/conventions/rest-openapi-coverage.test.ts
+++ b/tests/conventions/rest-openapi-coverage.test.ts
@@ -10,10 +10,31 @@ import { REPO_ROOT, walkFiles } from "./walk";
 const ENFORCED = true;
 
 const SPEC_EXEMPT_PATHS = new Set(["/v1/mcp", "/v1/openapi"]);
-const HTTP_VERBS = new Set(["get", "post", "put", "patch", "delete"]);
-const HTTP_HANDLER_NAMES = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+const HTTP_VERBS = new Set(["get", "post", "put", "patch", "delete", "head", "options"]);
+const HTTP_HANDLER_NAMES = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
+const ROUTE_MODULE_PATTERN = /\/route\.(?:js|jsx|ts|tsx)$/;
 const BODY_VERBS = new Set(["post", "put", "patch"]);
-const BODY_READER_METHODS = new Set(["arrayBuffer", "blob", "bytes", "formData", "json", "text"]);
+const SAFE_REQUEST_METADATA_MEMBERS = new Set([
+  "bodyUsed",
+  "cache",
+  "cookies",
+  "credentials",
+  "destination",
+  "duplex",
+  "geo",
+  "headers",
+  "integrity",
+  "ip",
+  "keepalive",
+  "method",
+  "mode",
+  "nextUrl",
+  "redirect",
+  "referrer",
+  "referrerPolicy",
+  "signal",
+  "url",
+]);
 const BODY_REQUIRED_DELETE_PATHS = new Set([
   "/v1/contacts/many",
   "/v1/deals/many",
@@ -24,7 +45,6 @@ const BODY_REQUIRED_DELETE_PATHS = new Set([
 
 type JsonReader = {
   line: number;
-  mapped: boolean;
 };
 
 type InspectionError = {
@@ -34,7 +54,8 @@ type InspectionError = {
 
 type RouteOperation = {
   file: string;
-  importsMapper: boolean;
+  hasExactHandleErrorImport: boolean;
+  hasExactMapperImport: boolean;
   jsonReaders: JsonReader[];
   inspectionErrors: InspectionError[];
 };
@@ -44,6 +65,12 @@ type SpecOperation = {
     required?: boolean;
     content?: Record<string, unknown>;
   };
+  responses?: Record<
+    string,
+    {
+      content?: Record<string, unknown>;
+    }
+  >;
 };
 
 function toSpecPath(routeFile: string): string {
@@ -60,26 +87,31 @@ function isExported(node: ts.Node): boolean {
   );
 }
 
-function importsRequestJsonMapper(source: ts.SourceFile): boolean {
-  return source.statements.some((statement) => {
-    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) return false;
-    if (statement.moduleSpecifier.text !== "@/core/api/request-json-error") return false;
-
-    const bindings = statement.importClause?.namedBindings;
-    if (!bindings || !ts.isNamedImports(bindings)) return false;
-
-    return bindings.elements.some(
-      ({ name, propertyName }) =>
-        name.text === "mapRequestJsonError" && (propertyName?.text ?? name.text) === "mapRequestJsonError",
-    );
-  });
+function isDefaultExported(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    Boolean(ts.getModifiers(node)?.some(({ kind }) => kind === ts.SyntaxKind.DefaultKeyword))
+  );
 }
 
-function bindingContainsName(binding: ts.BindingName, name: string): boolean {
-  if (ts.isIdentifier(binding)) return binding.text === name;
-  return binding.elements.some(
-    (element) => !ts.isOmittedExpression(element) && bindingContainsName(element.name, name),
-  );
+function hasExactValueImport(source: ts.SourceFile, moduleName: string, importedName: string): boolean {
+  const matchingSpecifiers = source.statements.flatMap((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== moduleName ||
+      !statement.importClause ||
+      statement.importClause.isTypeOnly ||
+      !statement.importClause.namedBindings ||
+      !ts.isNamedImports(statement.importClause.namedBindings)
+    ) {
+      return [];
+    }
+    return statement.importClause.namedBindings.elements.filter(
+      (specifier) => !specifier.isTypeOnly && !specifier.propertyName && specifier.name.text === importedName,
+    );
+  });
+  return matchingSpecifiers.length === 1;
 }
 
 function bindingIdentifiers(binding: ts.BindingName): ts.Identifier[] {
@@ -89,181 +121,474 @@ function bindingIdentifiers(binding: ts.BindingName): ts.Identifier[] {
   );
 }
 
-function zeroArgumentMethodCall(node: ts.Node):
-  | {
-      call: ts.CallExpression;
-      method: string;
-      receiver: ts.Expression;
-      canonicalPropertyAccess: boolean;
-    }
-  | undefined {
-  if (!ts.isCallExpression(node) || node.arguments.length !== 0) return undefined;
-  if (ts.isPropertyAccessExpression(node.expression)) {
-    return {
-      call: node,
-      method: node.expression.name.text,
-      receiver: node.expression.expression,
-      canonicalPropertyAccess: node.expression.questionDotToken === undefined,
-    };
-  }
+type JsonParserBoundary = {
+  line: number;
+  requestReceiver: ts.Identifier;
+  mapper: ts.Identifier;
+};
+
+type ErrorBoundary = {
+  handler: ts.Identifier;
+};
+
+function exactErrorBoundary(statement: ts.TryStatement): ErrorBoundary | undefined {
+  if (statement.finallyBlock || !statement.catchClause) return undefined;
+
+  const caughtError = statement.catchClause.variableDeclaration?.name;
+  const [catchStatement] = statement.catchClause.block.statements;
   if (
-    ts.isElementAccessExpression(node.expression) &&
-    node.expression.argumentExpression &&
-    ts.isStringLiteral(node.expression.argumentExpression)
+    !caughtError ||
+    !ts.isIdentifier(caughtError) ||
+    statement.catchClause.block.statements.length !== 1 ||
+    !ts.isReturnStatement(catchStatement) ||
+    !catchStatement.expression ||
+    !ts.isCallExpression(catchStatement.expression)
   ) {
-    return {
-      call: node,
-      method: node.expression.argumentExpression.text,
-      receiver: node.expression.expression,
-      canonicalPropertyAccess: false,
-    };
+    return undefined;
   }
-  return undefined;
+
+  const handlerCall = catchStatement.expression;
+  if (
+    handlerCall.questionDotToken ||
+    handlerCall.typeArguments?.length ||
+    handlerCall.arguments.length !== 1 ||
+    !ts.isIdentifier(handlerCall.expression) ||
+    handlerCall.expression.text !== "handleError"
+  ) {
+    return undefined;
+  }
+
+  const [argument] = handlerCall.arguments;
+  if (!ts.isIdentifier(argument) || argument.text !== caughtError.text) return undefined;
+
+  return { handler: handlerCall.expression };
 }
 
-function hasMappedParserFailure(call: ts.CallExpression): boolean {
-  const catchAccess = call.parent;
+function exactJsonParserBoundary(
+  source: ts.SourceFile,
+  statement: ts.Statement,
+  requestParameter: ts.Identifier,
+): JsonParserBoundary | undefined {
+  if (!ts.isVariableStatement(statement)) return undefined;
+  const declarationList = statement.declarationList;
+  if (!(declarationList.flags & ts.NodeFlags.Const) || declarationList.declarations.length !== 1) return undefined;
+
+  const [declaration] = declarationList.declarations;
+  if (
+    !ts.isIdentifier(declaration.name) ||
+    !declaration.initializer ||
+    !ts.isAwaitExpression(declaration.initializer)
+  ) {
+    return undefined;
+  }
+
+  const catchCall = declaration.initializer.expression;
+  if (
+    !ts.isCallExpression(catchCall) ||
+    catchCall.questionDotToken ||
+    catchCall.typeArguments?.length ||
+    catchCall.arguments.length !== 1
+  ) {
+    return undefined;
+  }
+
+  const catchAccess = catchCall.expression;
   if (
     !ts.isPropertyAccessExpression(catchAccess) ||
-    catchAccess.expression !== call ||
-    catchAccess.name.text !== "catch"
-  )
-    return false;
-
-  const catchCall = catchAccess.parent;
-  if (!ts.isCallExpression(catchCall) || catchCall.expression !== catchAccess || catchCall.arguments.length !== 1)
-    return false;
+    catchAccess.questionDotToken ||
+    catchAccess.name.text !== "catch" ||
+    !ts.isCallExpression(catchAccess.expression)
+  ) {
+    return undefined;
+  }
 
   const mapper = catchCall.arguments[0];
-  if (!ts.isIdentifier(mapper) || mapper.text !== "mapRequestJsonError") return false;
+  if (!ts.isIdentifier(mapper) || mapper.text !== "mapRequestJsonError") return undefined;
 
-  return ts.isAwaitExpression(catchCall.parent) && catchCall.parent.expression === catchCall;
+  const jsonCall = catchAccess.expression;
+  if (
+    jsonCall.questionDotToken ||
+    jsonCall.typeArguments?.length ||
+    jsonCall.arguments.length !== 0 ||
+    !ts.isPropertyAccessExpression(jsonCall.expression)
+  ) {
+    return undefined;
+  }
+
+  const jsonAccess = jsonCall.expression;
+  if (
+    jsonAccess.questionDotToken ||
+    jsonAccess.name.text !== "json" ||
+    !ts.isIdentifier(jsonAccess.expression) ||
+    jsonAccess.expression.text !== requestParameter.text
+  ) {
+    return undefined;
+  }
+
+  return {
+    line: lineOf(source, statement),
+    requestReceiver: jsonAccess.expression,
+    mapper,
+  };
 }
 
-function analyzeJsonReaders(
+function lineOf(source: ts.SourceFile, node: ts.Node): number {
+  return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+}
+
+function identifierLines(
   source: ts.SourceFile,
-  body: ts.ConciseBody | undefined,
-  parameters: ts.NodeArray<ts.ParameterDeclaration>,
-): { readers: JsonReader[]; inspectionErrors: InspectionError[] } {
-  if (!body) return { readers: [], inspectionErrors: [] };
-  const requestParameter = parameters[0]?.name;
-  if (!requestParameter || !ts.isIdentifier(requestParameter)) return { readers: [], inspectionErrors: [] };
-
-  const readers: JsonReader[] = [];
-  const inspectionErrors: InspectionError[] = [];
+  body: ts.ConciseBody,
+  name: string,
+  allowed: ReadonlySet<ts.Identifier>,
+): number[] {
+  const lines: number[] = [];
   const visit = (node: ts.Node) => {
-    if (node !== body && ts.isFunctionLike(node)) return;
-    const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
-    if (ts.isVariableDeclaration(node) && bindingContainsName(node.name, requestParameter.text)) {
-      inspectionErrors.push({
-        line,
-        message: `must not shadow the handler request parameter '${requestParameter.text}'`,
-      });
-    }
-
-    const methodCall = zeroArgumentMethodCall(node);
-    if (methodCall && BODY_READER_METHODS.has(methodCall.method)) {
-      const isCanonicalRequestJson =
-        methodCall.method === "json" &&
-        methodCall.canonicalPropertyAccess &&
-        ts.isIdentifier(methodCall.receiver) &&
-        methodCall.receiver.text === requestParameter.text;
-      if (!isCanonicalRequestJson) {
-        inspectionErrors.push({
-          line,
-          message: `must read request JSON only as ${requestParameter.text}.json().catch(mapRequestJsonError)`,
-        });
-      } else {
-        readers.push({
-          line,
-          mapped: hasMappedParserFailure(methodCall.call),
-        });
-      }
+    if (ts.isIdentifier(node) && node.text === name && !allowed.has(node) && !isPropertyName(node)) {
+      lines.push(lineOf(source, node));
     }
     ts.forEachChild(node, visit);
   };
   visit(body);
+  return lines;
+}
+
+function isPropertyName(identifier: ts.Identifier): boolean {
+  const parent = identifier.parent;
+  return (
+    (ts.isPropertyAccessExpression(parent) && parent.name === identifier) ||
+    (ts.isPropertyAssignment(parent) && parent.name === identifier) ||
+    (ts.isBindingElement(parent) && parent.propertyName === identifier) ||
+    (ts.isMethodDeclaration(parent) && parent.name === identifier) ||
+    (ts.isMethodSignature(parent) && parent.name === identifier) ||
+    (ts.isPropertyDeclaration(parent) && parent.name === identifier) ||
+    (ts.isPropertySignature(parent) && parent.name === identifier)
+  );
+}
+
+function unsafeRequestIdentifierLines(
+  source: ts.SourceFile,
+  body: ts.Block,
+  name: string,
+  allowed: ReadonlySet<ts.Identifier>,
+): number[] {
+  const lines: number[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isIdentifier(node) && node.text === name && !allowed.has(node) && !isPropertyName(node)) {
+      const parent = node.parent;
+      const safePropertyAccess =
+        ts.isPropertyAccessExpression(parent) &&
+        parent.expression === node &&
+        SAFE_REQUEST_METADATA_MEMBERS.has(parent.name.text);
+      const safeElementAccess =
+        ts.isElementAccessExpression(parent) &&
+        parent.expression === node &&
+        parent.argumentExpression &&
+        (ts.isStringLiteral(parent.argumentExpression) ||
+          ts.isNoSubstitutionTemplateLiteral(parent.argumentExpression)) &&
+        SAFE_REQUEST_METADATA_MEMBERS.has(parent.argumentExpression.text);
+      if (!safePropertyAccess && !safeElementAccess) lines.push(lineOf(source, node));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(body);
+  return lines;
+}
+
+function analyzeJsonReaders(
+  source: ts.SourceFile,
+  body: ts.Block,
+  parameters: ts.NodeArray<ts.ParameterDeclaration>,
+): { readers: JsonReader[]; inspectionErrors: InspectionError[] } {
+  const readers: JsonReader[] = [];
+  const inspectionErrors: InspectionError[] = [];
+  const firstParameter = parameters[0];
+  const requestParameter = firstParameter?.name;
+  const validRequestParameter =
+    firstParameter &&
+    ts.isIdentifier(requestParameter) &&
+    !firstParameter.dotDotDotToken &&
+    !firstParameter.questionToken &&
+    !firstParameter.initializer;
+  if (!firstParameter) return { readers, inspectionErrors };
+  if (!validRequestParameter) {
+    return {
+      readers,
+      inspectionErrors: [
+        {
+          line: lineOf(source, firstParameter),
+          message: "must declare the request as a plain first parameter",
+        },
+      ],
+    };
+  }
+
+  const allowedMapperIdentifiers = new Set<ts.Identifier>();
+  const allowedRequestIdentifiers = new Set<ts.Identifier>();
+  const allowedErrorHandlerIdentifiers = new Set<ts.Identifier>();
+  if (parameters.length > 2) {
+    inspectionErrors.push({
+      line: lineOf(source, parameters[2]),
+      message: "must declare at most the request and route context parameters",
+    });
+  }
+  const contextParameter = parameters[1];
+  const contextBinding = contextParameter?.name;
+  const contextElement =
+    contextBinding && ts.isObjectBindingPattern(contextBinding) ? contextBinding.elements[0] : undefined;
+  if (
+    contextParameter &&
+    (contextParameter.dotDotDotToken ||
+      contextParameter.questionToken ||
+      contextParameter.initializer ||
+      !contextBinding ||
+      !ts.isObjectBindingPattern(contextBinding) ||
+      contextBinding.elements.length !== 1 ||
+      !contextElement ||
+      contextElement.dotDotDotToken ||
+      contextElement.propertyName ||
+      contextElement.initializer ||
+      !ts.isIdentifier(contextElement.name) ||
+      contextElement.name.text !== "params")
+  ) {
+    inspectionErrors.push({
+      line: lineOf(source, contextParameter),
+      message: "must declare route context exactly as a non-defaulted { params } binding",
+    });
+  }
+  const [onlyStatement] = body.statements;
+  const outerTryCandidate =
+    body.statements.length === 1 && ts.isTryStatement(onlyStatement) ? onlyStatement : undefined;
+  const errorBoundary = outerTryCandidate ? exactErrorBoundary(outerTryCandidate) : undefined;
+  const outerTry = errorBoundary ? outerTryCandidate : undefined;
+
+  if (errorBoundary) allowedErrorHandlerIdentifiers.add(errorBoundary.handler);
+
+  if (outerTry?.catchClause) {
+    for (const [index, statement] of outerTry.tryBlock.statements.entries()) {
+      const boundary = exactJsonParserBoundary(source, statement, requestParameter);
+      if (!boundary) continue;
+
+      const hasOnlyStraightLineDeclarationsBefore = outerTry.tryBlock.statements
+        .slice(0, index)
+        .every(ts.isVariableStatement);
+      if (!hasOnlyStraightLineDeclarationsBefore) continue;
+
+      readers.push({ line: boundary.line });
+      allowedRequestIdentifiers.add(boundary.requestReceiver);
+      allowedMapperIdentifiers.add(boundary.mapper);
+    }
+  }
+
+  const visit = (node: ts.Node) => {
+    if (ts.isIdentifier(node) && node.text === "arguments" && !isPropertyName(node)) {
+      inspectionErrors.push({
+        line: lineOf(source, node),
+        message: "must not access the handler request through arguments",
+      });
+    }
+    if (ts.isIdentifier(node) && node.text === "eval" && !isPropertyName(node)) {
+      inspectionErrors.push({
+        line: lineOf(source, node),
+        message: "must not access the handler request through eval",
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(body);
+
+  for (const line of unsafeRequestIdentifierLines(source, body, requestParameter.text, allowedRequestIdentifiers)) {
+    inspectionErrors.push({
+      line,
+      message: `must not alias '${requestParameter.text}' or access its body outside the one canonical JSON parser`,
+    });
+  }
+  for (const line of identifierLines(source, body, "mapRequestJsonError", allowedMapperIdentifiers)) {
+    inspectionErrors.push({
+      line,
+      message: "must use the imported mapRequestJsonError without shadowing or aliases",
+    });
+  }
+  for (const line of identifierLines(source, body, "handleError", allowedErrorHandlerIdentifiers)) {
+    inspectionErrors.push({
+      line,
+      message: "must return the imported handleError(error) from the outer catch",
+    });
+  }
+  for (const parameter of parameters.slice(1)) {
+    for (const identifier of bindingIdentifiers(parameter.name)) {
+      if (identifier.text === requestParameter.text) {
+        inspectionErrors.push({
+          line: lineOf(source, identifier),
+          message: `must not shadow the handler request parameter '${requestParameter.text}'`,
+        });
+      }
+      if (identifier.text === "mapRequestJsonError") {
+        inspectionErrors.push({
+          line: lineOf(source, identifier),
+          message: "must not shadow mapRequestJsonError with another handler parameter",
+        });
+      }
+      if (identifier.text === "handleError") {
+        inspectionErrors.push({
+          line: lineOf(source, identifier),
+          message: "must not shadow handleError with another handler parameter",
+        });
+      }
+    }
+  }
+  if (requestParameter.text === "mapRequestJsonError") {
+    inspectionErrors.push({
+      line: lineOf(source, requestParameter),
+      message: "must not shadow mapRequestJsonError with the handler request parameter",
+    });
+  }
+  if (requestParameter.text === "handleError") {
+    inspectionErrors.push({
+      line: lineOf(source, requestParameter),
+      message: "must not shadow handleError with the handler request parameter",
+    });
+  }
+
   return { readers, inspectionErrors };
+}
+
+function inspectRouteSource(path: string, text: string): Map<string, RouteOperation> {
+  const operations = new Map<string, RouteOperation>();
+  const allowedHandlerDeclarations = new Set<ts.Identifier>();
+  const specPath = toSpecPath(path);
+  if (SPEC_EXEMPT_PATHS.has(specPath)) return operations;
+
+  const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const file = path.slice(REPO_ROOT.length + 1);
+  const hasExactHandleErrorImport = hasExactValueImport(source, "@/core/api/interactor-handler", "handleError");
+  const hasExactMapperImport = hasExactValueImport(source, "@/core/api/request-json-error", "mapRequestJsonError");
+  const setOperation = (name: string, node: ts.Node, operation: RouteOperation) => {
+    if (!HTTP_HANDLER_NAMES.has(name)) return;
+    const key = `${name.toLowerCase()} ${specPath}`;
+    const existing = operations.get(key);
+    if (existing) {
+      existing.inspectionErrors.push({
+        line: lineOf(source, node),
+        message: `must declare ${name} exactly once`,
+      });
+      return;
+    }
+    operations.set(key, operation);
+  };
+  const register = (statement: ts.FunctionDeclaration & { name: ts.Identifier; body: ts.Block }) => {
+    const name = statement.name.text;
+    allowedHandlerDeclarations.add(statement.name);
+    const analysis = analyzeJsonReaders(source, statement.body, statement.parameters);
+    setOperation(name, statement, {
+      file,
+      hasExactHandleErrorImport,
+      hasExactMapperImport,
+      jsonReaders: analysis.readers,
+      inspectionErrors: analysis.inspectionErrors,
+    });
+  };
+  const registerUnsupported = (name: string, node: ts.Node, message?: string) => {
+    setOperation(name, node, {
+      file,
+      hasExactHandleErrorImport,
+      hasExactMapperImport,
+      jsonReaders: [],
+      inspectionErrors: [
+        {
+          line: lineOf(source, node),
+          message: message ?? `must export ${name} as a direct named function declaration`,
+        },
+      ],
+    });
+  };
+
+  for (const statement of source.statements) {
+    if (ts.isFunctionDeclaration(statement) && isExported(statement) && statement.name) {
+      if (isDefaultExported(statement) || statement.asteriskToken || !statement.body) {
+        registerUnsupported(statement.name.text, statement);
+      } else {
+        register(
+          statement as ts.FunctionDeclaration & {
+            name: ts.Identifier;
+            body: ts.Block;
+          },
+        );
+      }
+      continue;
+    }
+    if (ts.isVariableStatement(statement) && isExported(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) {
+          for (const identifier of bindingIdentifiers(declaration.name)) {
+            registerUnsupported(identifier.text, identifier);
+          }
+          continue;
+        }
+        registerUnsupported(declaration.name.text, declaration);
+      }
+      continue;
+    }
+    if (ts.isExportDeclaration(statement) && statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+      for (const element of statement.exportClause.elements) registerUnsupported(element.name.text, element);
+    } else if (
+      ts.isExportDeclaration(statement) &&
+      statement.exportClause &&
+      ts.isNamespaceExport(statement.exportClause)
+    ) {
+      registerUnsupported(statement.exportClause.name.text, statement.exportClause);
+    } else if (ts.isExportDeclaration(statement) && !statement.exportClause) {
+      throw new Error(`${file}:${lineOf(source, statement)} uses export *`);
+    }
+  }
+
+  const addSourceError = (name: string | undefined, node: ts.Node, message: string) => {
+    const matchingOperation = name ? operations.get(`${name.toLowerCase()} ${specPath}`) : undefined;
+    const targets = matchingOperation ? [matchingOperation] : [...operations.values()];
+    if (targets.length === 0) throw new Error(`${file}:${lineOf(source, node)} ${message}`);
+    for (const operation of targets) {
+      operation.inspectionErrors.push({ line: lineOf(source, node), message });
+    }
+  };
+  const auditSource = (node: ts.Node) => {
+    if (
+      ts.isIdentifier(node) &&
+      HTTP_HANDLER_NAMES.has(node.text) &&
+      !allowedHandlerDeclarations.has(node) &&
+      !isPropertyName(node)
+    ) {
+      addSourceError(
+        node.text,
+        node,
+        `must not reference or replace the exported ${node.text} handler outside its declaration`,
+      );
+    }
+    if (ts.isIdentifier(node) && node.text === "eval" && !isPropertyName(node)) {
+      addSourceError(undefined, node, "must not use eval in a REST route module");
+    }
+    ts.forEachChild(node, auditSource);
+  };
+  auditSource(source);
+
+  return operations;
+}
+
+function inspectRouteModule(path: string, text: string): Map<string, RouteOperation> {
+  if (!path.endsWith("/route.ts")) {
+    throw new Error(`${path.slice(REPO_ROOT.length + 1)} must use the canonical route.ts extension`);
+  }
+  return inspectRouteSource(path, text);
 }
 
 function routeOperations(): Map<string, RouteOperation> {
   const operations = new Map<string, RouteOperation>();
-  const routeFiles = walkFiles(join(REPO_ROOT, "app", "api", "v1"), (path) => path.endsWith("/route.ts"));
+  const routeFiles = walkFiles(join(REPO_ROOT, "app", "api", "v1"), (path) => ROUTE_MODULE_PATTERN.test(path));
 
   for (const path of routeFiles) {
-    const specPath = toSpecPath(path);
-    if (SPEC_EXEMPT_PATHS.has(specPath)) continue;
-
     const text = readFileSync(path, "utf8");
-    const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-    const file = path.slice(REPO_ROOT.length + 1);
-    const importsMapper = importsRequestJsonMapper(source);
-    const setOperation = (name: string, operation: RouteOperation) => {
-      if (HTTP_HANDLER_NAMES.has(name)) operations.set(`${name.toLowerCase()} ${specPath}`, operation);
-    };
-    const register = (
-      name: string,
-      parameters: ts.NodeArray<ts.ParameterDeclaration>,
-      body: ts.ConciseBody | undefined,
-    ) => {
-      const analysis = analyzeJsonReaders(source, body, parameters);
-      setOperation(name, {
-        file,
-        importsMapper,
-        jsonReaders: analysis.readers,
-        inspectionErrors: analysis.inspectionErrors,
-      });
-    };
-    const registerUnsupported = (name: string, node: ts.Node) => {
-      setOperation(name, {
-        file,
-        importsMapper,
-        jsonReaders: [],
-        inspectionErrors: [
-          {
-            line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
-            message: `must export ${name} as a direct function, function expression, or arrow function`,
-          },
-        ],
-      });
-    };
-
-    for (const statement of source.statements) {
-      if (ts.isFunctionDeclaration(statement) && isExported(statement) && statement.name) {
-        if (statement.body) register(statement.name.text, statement.parameters, statement.body);
-        else registerUnsupported(statement.name.text, statement);
-        continue;
-      }
-      if (ts.isVariableStatement(statement) && isExported(statement)) {
-        for (const declaration of statement.declarationList.declarations) {
-          if (!ts.isIdentifier(declaration.name)) {
-            for (const identifier of bindingIdentifiers(declaration.name)) {
-              registerUnsupported(identifier.text, identifier);
-            }
-            continue;
-          }
-          const initializer = declaration.initializer;
-          if (initializer && (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer))) {
-            register(declaration.name.text, initializer.parameters, initializer.body);
-          } else {
-            registerUnsupported(declaration.name.text, declaration);
-          }
-        }
-        continue;
-      }
-      if (ts.isExportDeclaration(statement) && statement.exportClause && ts.isNamedExports(statement.exportClause)) {
-        for (const element of statement.exportClause.elements) registerUnsupported(element.name.text, element);
-      } else if (
-        ts.isExportDeclaration(statement) &&
-        statement.exportClause &&
-        ts.isNamespaceExport(statement.exportClause)
-      ) {
-        registerUnsupported(statement.exportClause.name.text, statement.exportClause);
-      } else if (ts.isExportDeclaration(statement) && !statement.exportClause) {
-        throw new Error(
-          `${file}:${source.getLineAndCharacterOfPosition(statement.getStart(source)).line + 1} uses export *`,
-        );
-      }
+    for (const [operation, route] of inspectRouteModule(path, text)) {
+      if (operations.has(operation)) throw new Error(`duplicate REST route operation: ${operation}`);
+      operations.set(operation, route);
     }
   }
 
@@ -287,20 +612,550 @@ function hasJsonRequestBody(operation: SpecOperation | undefined): boolean {
   return operation?.requestBody?.content?.["application/json"] !== undefined;
 }
 
+function undocumentedRouteViolations(
+  routes: ReadonlyMap<string, RouteOperation>,
+  documented: ReadonlyMap<string, SpecOperation>,
+): string[] {
+  return [...routes]
+    .filter(([operation]) => !documented.has(operation))
+    .map(([operation, { file }]) => `${operation} (${file}) has no operation in generateOpenApiSpec()`);
+}
+
+function orphanedSpecViolations(
+  routes: ReadonlyMap<string, RouteOperation>,
+  documented: ReadonlyMap<string, SpecOperation>,
+): string[] {
+  return [...documented]
+    .filter(([operation]) => !routes.has(operation))
+    .map(([operation]) => `${operation} is in generateOpenApiSpec() but has no route handler under app/api/v1`);
+}
+
+function jsonContractViolations(
+  routes: ReadonlyMap<string, RouteOperation>,
+  documented: ReadonlyMap<string, SpecOperation>,
+): string[] {
+  const violations: string[] = [];
+
+  for (const [operation, spec] of documented) {
+    if (!hasJsonRequestBody(spec)) continue;
+    if (spec.requestBody?.required !== true) {
+      violations.push(`${operation} must declare its JSON requestBody as required`);
+    }
+    if (spec.responses?.["400"]?.content?.["application/json"] === undefined) {
+      violations.push(`${operation} must document its JSON parse failure as an application/json 400 response`);
+    }
+
+    const route = routes.get(operation);
+    if (route && route.jsonReaders.length !== 1) {
+      violations.push(
+        `${operation} (${route.file}) must read its documented JSON body exactly once; found ${route.jsonReaders.length}`,
+      );
+    }
+  }
+
+  for (const [operation, route] of routes) {
+    const spec = documented.get(operation);
+    for (const inspectionError of route.inspectionErrors) {
+      violations.push(`${operation} (${route.file}:${inspectionError.line}) ${inspectionError.message}`);
+    }
+    if (route.jsonReaders.length > 0 && !hasJsonRequestBody(spec)) {
+      violations.push(`${operation} (${route.file}) reads JSON without an OpenAPI application/json requestBody`);
+    }
+    if (route.jsonReaders.length > 0 && !route.hasExactMapperImport) {
+      violations.push(`${operation} (${route.file}) must import mapRequestJsonError from the shared API boundary`);
+    }
+    if (route.jsonReaders.length > 0 && !route.hasExactHandleErrorImport) {
+      violations.push(`${operation} (${route.file}) must import handleError from the shared API boundary`);
+    }
+  }
+
+  return violations;
+}
+
+const SYNTHETIC_ROUTE_FILE = join(REPO_ROOT, "app", "api", "v1", "__route_analyzer_probe__", "route.ts");
+const SYNTHETIC_SPEC_PATH = "/v1/__route_analyzer_probe__";
+const HANDLE_ERROR_IMPORT = `import { handleError } from "@/core/api/interactor-handler";`;
+const MAPPER_IMPORT = `import { mapRequestJsonError } from "@/core/api/request-json-error";`;
+const ROUTE_IMPORTS = `${HANDLE_ERROR_IMPORT}\n${MAPPER_IMPORT}`;
+
+type SyntheticSpecKind = "json" | "json-no-400" | "optional-json" | "none";
+type SyntheticSpecs = Readonly<
+  Partial<Record<"get" | "post" | "put" | "patch" | "delete" | "head" | "options", SyntheticSpecKind>>
+>;
+
+function syntheticSpecOperations(specs: SyntheticSpecs): Map<string, SpecOperation> {
+  return new Map(
+    Object.entries(specs).map(([verb, kind]) => [
+      `${verb} ${SYNTHETIC_SPEC_PATH}`,
+      kind === "none"
+        ? {}
+        : {
+            requestBody: {
+              required: kind !== "optional-json",
+              content: { "application/json": {} },
+            },
+            ...(kind === "json-no-400"
+              ? {}
+              : {
+                  responses: {
+                    "400": { content: { "application/json": {} } },
+                  },
+                }),
+          },
+    ]),
+  );
+}
+
+function syntheticViolations(source: string, specs: SyntheticSpecs): string[] {
+  const routes = inspectRouteSource(SYNTHETIC_ROUTE_FILE, source);
+  const documented = syntheticSpecOperations(specs);
+  return [
+    ...undocumentedRouteViolations(routes, documented),
+    ...orphanedSpecViolations(routes, documented),
+    ...jsonContractViolations(routes, documented),
+  ];
+}
+
+function canonicalHandler(
+  verb: "POST" | "PUT" | "PATCH" | "DELETE",
+  options: { before?: string; after?: string; parameters?: string } = {},
+): string {
+  const { before = "", after = "return data;", parameters = "request: Request" } = options;
+  return `
+export async function ${verb}(${parameters}) {
+  try {
+    ${before}
+    const data = await request.json().catch(mapRequestJsonError);
+    ${after}
+  } catch (error) {
+    return handleError(error);
+  }
+}
+`;
+}
+
+describe("REST route analyzer self-tests", () => {
+  it.each([
+    {
+      name: "the canonical JSON boundary",
+      source: ROUTE_IMPORTS + canonicalHandler("POST"),
+      specs: { post: "json" } as const,
+    },
+    {
+      name: "an exact boundary import grouped with another legitimate export",
+      source:
+        `import { CommonApiResponses, handleError } from "@/core/api/interactor-handler";` +
+        MAPPER_IMPORT +
+        canonicalHandler("POST"),
+      specs: { post: "json" } as const,
+    },
+    {
+      name: "parameter resolution before the canonical boundary",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("PUT", {
+          parameters: "request: Request, { params }: { params: Promise<{ id: string }> }",
+          before: "const { id } = await params;",
+          after: "return { data, id };",
+        }),
+      specs: { put: "json" } as const,
+    },
+    {
+      name: "safe request metadata in a bodyless GET handler",
+      source: `export function GET(request: Request) { return Response.json({ url: request.url, trace: request.headers.get("x-trace-id") }); }`,
+      specs: { get: "none" } as const,
+    },
+    {
+      name: "unrelated properties that share the request parameter's spelling",
+      source: `export function GET(request: Request) { const client = { request: () => "accepted", arguments: "safe" }; const value: { request: string; arguments: string } = { request: client.request(), arguments: client.arguments }; return Response.json(value); }`,
+      specs: { get: "none" } as const,
+    },
+    {
+      name: "multiple canonical handlers in one route file",
+      source: ROUTE_IMPORTS + canonicalHandler("POST") + canonicalHandler("PUT") + canonicalHandler("DELETE"),
+      specs: { post: "json", put: "json", delete: "json" } as const,
+    },
+    {
+      name: "a canonical PATCH handler",
+      source: ROUTE_IMPORTS + canonicalHandler("PATCH"),
+      specs: { patch: "json" } as const,
+    },
+    {
+      name: "bodyless HEAD and OPTIONS handlers",
+      source: `export function HEAD() { return new Response(null); } export function OPTIONS() { return new Response(null); }`,
+      specs: { head: "none", options: "none" } as const,
+    },
+    {
+      name: "an unrelated response.json() call after the request boundary",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          after: `const response = new Response("{}"); const result = await response.json(); return { data, result };`,
+        }),
+      specs: { post: "json" } as const,
+    },
+  ])("accepts $name", ({ source, specs }) => {
+    expect(syntheticViolations(source, specs)).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "a parser without await",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = request.json().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "a parser without the mapper",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await request.json(); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "an aliased mapper import",
+      source:
+        HANDLE_ERROR_IMPORT +
+        `import { mapRequestJsonError as mapper } from "@/core/api/request-json-error";` +
+        canonicalHandler("POST").replace(".catch(mapRequestJsonError)", ".catch(mapper)"),
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "a type-only mapper import",
+      source:
+        HANDLE_ERROR_IMPORT +
+        `import type { mapRequestJsonError } from "@/core/api/request-json-error";` +
+        canonicalHandler("POST"),
+      specs: { post: "json" } as const,
+      expected: "must import mapRequestJsonError from the shared API boundary",
+    },
+    {
+      name: "a mapper import from the wrong module",
+      source: HANDLE_ERROR_IMPORT + `import { mapRequestJsonError } from "./wrong-module";` + canonicalHandler("POST"),
+      specs: { post: "json" } as const,
+      expected: "must import mapRequestJsonError from the shared API boundary",
+    },
+    {
+      name: "a handler-local mapper shadow",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          before: "const mapRequestJsonError = (error: unknown) => error;",
+        }),
+      specs: { post: "json" } as const,
+      expected: "must use the imported mapRequestJsonError without shadowing or aliases",
+    },
+    {
+      name: "a mapper shadow in another handler parameter",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          parameters: "request: Request, mapRequestJsonError: unknown",
+        }),
+      specs: { post: "json" } as const,
+      expected: "must not shadow mapRequestJsonError with another handler parameter",
+    },
+    {
+      name: "a hidden reader in a third default parameter",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          parameters: "request: Request, context: unknown, hidden = request.json()",
+          after: "await hidden; return { context, data };",
+        }),
+      specs: { post: "json" } as const,
+      expected: "must declare at most the request and route context parameters",
+    },
+    {
+      name: "a request alias alongside the canonical parser",
+      source: ROUTE_IMPORTS + canonicalHandler("POST", { before: "const alias = request;" }),
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "an extra nested request read",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          after: "async function extra() { return request.json(); } return { data, extra };",
+        }),
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "two canonical parsers",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          after: "const again = await request.json().catch(mapRequestJsonError); return { data, again };",
+        }),
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 2",
+    },
+    {
+      name: "a parser inside a branch",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { if (ready) { const data = await request.json().catch(mapRequestJsonError); return data; } } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "a parser inside a loop",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { while (ready) { const data = await request.json().catch(mapRequestJsonError); return data; } } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+  ])("rejects $name", ({ source, specs, expected }) => {
+    expect(syntheticViolations(source, specs).join("\n")).toContain(expected);
+  });
+
+  it.each([
+    {
+      name: "request.text()",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await request.text(); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "request.body",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = request.body; return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "computed JSON access",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await request["json"]().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "a JSON call with an argument",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await request.json(undefined).catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "an extracted JSON method",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const parse = request.json.bind(request); const data = await parse().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "a request alias through valueOf()",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          after: "const hidden = request.valueOf(); await hidden.json(); return data;",
+        }),
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "a request alias through computed valueOf()",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          after: `const hidden = request["valueOf"](); await hidden.json(); return data;`,
+        }),
+      specs: { post: "json" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "arguments-based request access",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await arguments[0].json().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must not access the handler request through arguments",
+    },
+    {
+      name: "eval-based request access",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { return eval("request.json()"); } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must not access the handler request through eval",
+    },
+    {
+      name: "parenthesized eval hiding an extra reader",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST", {
+          after: `const hidden = (eval)("request"); await hidden.json(); return data;`,
+        }),
+      specs: { post: "json" } as const,
+      expected: "must not access the handler request through eval",
+    },
+    {
+      name: "a swallowed parser error",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await request.json().catch(mapRequestJsonError); return data; } catch { return new Response(null, { status: 200 }); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "a parser outside the outer try",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { const data = await request.json().catch(mapRequestJsonError); try { return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "a return-overriding finally block",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(request: Request) { try { const data = await request.json().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } finally { return new Response(null, { status: 200 }); } }`,
+      specs: { post: "json" } as const,
+      expected: "must read its documented JSON body exactly once; found 0",
+    },
+    {
+      name: "a handler imported from the wrong error boundary",
+      source: MAPPER_IMPORT + `import { handleError } from "./wrong-module";` + canonicalHandler("POST"),
+      specs: { post: "json" } as const,
+      expected: "must import handleError from the shared API boundary",
+    },
+    {
+      name: "a request parameter that shadows handleError",
+      source:
+        ROUTE_IMPORTS +
+        `export async function POST(handleError: Request) { try { const data = await handleError.json().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } }`,
+      specs: { post: "json" } as const,
+      expected: "must not shadow handleError with the handler request parameter",
+    },
+    {
+      name: "an alias-only reader without a requestBody",
+      source:
+        ROUTE_IMPORTS + `export async function GET(request: Request) { const alias = request; return alias.json(); }`,
+      specs: { get: "none" } as const,
+      expected: "or access its body outside the one canonical JSON parser",
+    },
+    {
+      name: "a default-exported handler",
+      source: ROUTE_IMPORTS + canonicalHandler("POST").replace("export async", "export default async"),
+      specs: { post: "json" } as const,
+      expected: "must export POST as a direct named function declaration",
+    },
+    {
+      name: "an exported arrow handler",
+      source:
+        ROUTE_IMPORTS +
+        `export const POST = async (request: Request) => { try { const data = await request.json().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } };`,
+      specs: { post: "json" } as const,
+      expected: "must export POST as a direct named function declaration",
+    },
+    {
+      name: "an exported function-expression handler",
+      source:
+        ROUTE_IMPORTS +
+        `export const POST = async function (request: Request) { try { const data = await request.json().catch(mapRequestJsonError); return data; } catch (error) { return handleError(error); } };`,
+      specs: { post: "json" } as const,
+      expected: "must export POST as a direct named function declaration",
+    },
+    {
+      name: "a named handler re-export",
+      source: `const handler = () => null; export { handler as POST };`,
+      specs: { post: "json" } as const,
+      expected: "must export POST as a direct named function declaration",
+    },
+    {
+      name: "a generator handler",
+      source: `export function* POST(request: Request) { yield request; }`,
+      specs: { post: "json" } as const,
+      expected: "must export POST as a direct named function declaration",
+    },
+    {
+      name: "duplicate handler exports",
+      source: `export function POST() {} export function POST() {}`,
+      specs: { post: "none" } as const,
+      expected: "must declare POST exactly once",
+    },
+    {
+      name: "a reassigned exported handler",
+      source:
+        ROUTE_IMPORTS +
+        canonicalHandler("POST") +
+        `POST = async function (request: Request) { return request.json(); };`,
+      specs: { post: "json" } as const,
+      expected: "must not reference or replace the exported POST handler outside its declaration",
+    },
+    {
+      name: "top-level eval that can replace an exported handler",
+      source: ROUTE_IMPORTS + canonicalHandler("POST") + `eval("POST = unsafe");`,
+      specs: { post: "json" } as const,
+      expected: "must not use eval in a REST route module",
+    },
+    {
+      name: "a JSON parser without a documented request body",
+      source: ROUTE_IMPORTS + canonicalHandler("POST"),
+      specs: { post: "none" } as const,
+      expected: "reads JSON without an OpenAPI application/json requestBody",
+    },
+    {
+      name: "an optional documented JSON body",
+      source: ROUTE_IMPORTS + canonicalHandler("POST"),
+      specs: { post: "optional-json" } as const,
+      expected: "must declare its JSON requestBody as required",
+    },
+    {
+      name: "a documented JSON body without its parse-failure response",
+      source: ROUTE_IMPORTS + canonicalHandler("POST"),
+      specs: { post: "json-no-400" } as const,
+      expected: "must document its JSON parse failure as an application/json 400 response",
+    },
+  ])("rejects $name", ({ source, specs, expected }) => {
+    expect(syntheticViolations(source, specs).join("\n")).toContain(expected);
+  });
+
+  it("reports an undocumented route operation", () => {
+    expect(syntheticViolations(ROUTE_IMPORTS + canonicalHandler("POST"), {}).join("\n")).toContain(
+      "post /v1/__route_analyzer_probe__ (app/api/v1/__route_analyzer_probe__/route.ts) has no operation",
+    );
+  });
+
+  it("reports an orphaned OpenAPI operation", () => {
+    expect(syntheticViolations("", { post: "json" }).join("\n")).toContain(
+      "post /v1/__route_analyzer_probe__ is in generateOpenApiSpec() but has no route handler",
+    );
+  });
+
+  it("rejects export-star route modules", () => {
+    expect(() => inspectRouteSource(SYNTHETIC_ROUTE_FILE, `export * from "./handler";`)).toThrow("uses export *");
+  });
+
+  it.each(["js", "jsx", "tsx"])("rejects route.%s modules that would bypass the route.ts analyzer", (extension) => {
+    expect(() =>
+      inspectRouteModule(SYNTHETIC_ROUTE_FILE.replace(/\.ts$/, `.${extension}`), "export function GET() {}"),
+    ).toThrow("must use the canonical route.ts extension");
+  });
+});
+
 describe("v1 REST OpenAPI coverage", () => {
   it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("documents every route handler in the OpenAPI spec", () => {
-    const documented = specOperations();
-    const undocumented = [...routeOperations()]
-      .filter(([operation]) => !documented.has(operation))
-      .map(([operation, { file }]) => `${operation} (${file}) has no operation in generateOpenApiSpec()`);
+    const undocumented = undocumentedRouteViolations(routeOperations(), specOperations());
     expect(undocumented).toEqual([]);
   });
 
   it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("has a route handler for every spec operation", () => {
-    const routes = routeOperations();
-    const orphaned = [...specOperations()]
-      .filter(([operation]) => !routes.has(operation))
-      .map(([operation]) => `${operation} is in generateOpenApiSpec() but has no route handler under app/api/v1`);
+    const orphaned = orphanedSpecViolations(routeOperations(), specOperations());
     expect(orphaned).toEqual([]);
   });
 
@@ -327,43 +1182,7 @@ describe("v1 REST OpenAPI coverage", () => {
   it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
     "keeps REST JSON parsing and required OpenAPI bodies aligned",
     () => {
-      const routes = routeOperations();
-      const documented = specOperations();
-      const violations: string[] = [];
-
-      for (const [operation, spec] of documented) {
-        if (!hasJsonRequestBody(spec)) continue;
-        if (spec.requestBody?.required !== true) {
-          violations.push(`${operation} must declare its JSON requestBody as required`);
-        }
-
-        const route = routes.get(operation);
-        if (route && route.jsonReaders.length !== 1) {
-          violations.push(
-            `${operation} (${route.file}) must read its documented JSON body exactly once; found ${route.jsonReaders.length}`,
-          );
-        }
-      }
-
-      for (const [operation, route] of routes) {
-        const spec = documented.get(operation);
-        for (const inspectionError of route.inspectionErrors) {
-          violations.push(`${operation} (${route.file}:${inspectionError.line}) ${inspectionError.message}`);
-        }
-        if (route.jsonReaders.length > 0 && !hasJsonRequestBody(spec)) {
-          violations.push(`${operation} (${route.file}) reads JSON without an OpenAPI application/json requestBody`);
-        }
-        if (route.jsonReaders.length > 0 && !route.importsMapper) {
-          violations.push(`${operation} (${route.file}) must import mapRequestJsonError from the shared API boundary`);
-        }
-        for (const reader of route.jsonReaders) {
-          if (!reader.mapped) {
-            violations.push(
-              `${operation} (${route.file}:${reader.line}) must await request.json().catch(mapRequestJsonError)`,
-            );
-          }
-        }
-      }
+      const violations = jsonContractViolations(routeOperations(), specOperations());
 
       expect(violations, violations.join("\n")).toEqual([]);
     },


### PR DESCRIPTION
## Summary

- Return a controlled HTTP 400 with the existing API error shape, JSON string `"Invalid JSON body"`, for absent, whitespace-only, or malformed JSON across every documented public REST v1 operation with a JSON request body.
- Mark all 54 matching OpenAPI request bodies as explicitly `required: true` and publish the shared 400 response as the accurate generic description `Bad Request`.
- Enforce the parser, error boundary, OpenAPI contract, and route-module shape with a fail-closed AST convention test backed by committed synthetic regression cases.

## Context

Sentry issue `CUSTOMERMATES-5C` grouped native `request.json()` parser failures across 18 transactions. The parser rejected before normal input validation, so malformed bodies surfaced as unexpected server errors. This was a shared API-boundary problem rather than an activity-search-only bug.

### Design

Each documented JSON handler uses the deliberately narrow boundary:

```ts
const data = await request.json().catch(mapRequestJsonError);
```

`mapRequestJsonError` converts only a native parser `SyntaxError` into the expected `InvalidJsonBodyError` (`400`). It rethrows other stream/runtime failures, and errors thrown later by application code are outside this catch and remain observable in Sentry. The handler's outer catch must return the shared `handleError(error)` result; the mapper is not a replacement for that boundary.

The convention guard now proves the supported codebase pattern rather than counting AST sites heuristically. It requires a direct named HTTP function export, a single straight-line mapped parser inside the handler's sole outer try/catch, exact shared imports, a required OpenAPI JSON body, and an explicit JSON 400 response. It rejects aliases, shadowing, alternate body readers, branches/loops, nested or duplicate reads, hidden parameter initializers, `arguments`/lexical `eval`, handler reassignment, unsupported export forms, and alternate Next route-module extensions. Safe metadata access such as `request.url` and `request.headers` remains supported.

### API behavior

This deliberately makes a JSON document required for all 54 documented JSON operations. In particular, the ten search endpoints whose schemas accept an empty object must now receive literal `{}` for the default/no-filter query. An absent or whitespace-only body returns 400 instead of being treated as `{}`. Malformed and truncated JSON also return 400. This does not add new `Content-Type` enforcement.

### Owner-directed Linear exception

The repository owner directed this fix in the current conversation on 2026-08-25. Linear issue creation/claim/receipt is waived because the workspace's free issue limit prevented creating the issue. The bounded outcome is the systemic resolution of `CUSTOMERMATES-5C` across public REST v1 JSON routes, explicit OpenAPI body requirements, and the executable convention guard. The write scope is limited to the 44 affected routes, 54 operation sources, shared API error/mapper and tests, generated v1 OpenAPI, and the REST/OpenAPI convention test. CI, preview verification, Code Owner review, and human merge remain required. This exception expires when this PR is merged or closed; this PR carries the evidence and rollback record.

## Validation

- Disposable PostgreSQL 16 database: full reset/migrations plus deterministic synthetic seed; database switched read-only for the HTTP run and removed afterward.
- Local HTTP sweep: all 54 operations × zero-byte, whitespace-only, and truncated JSON = **162/162 controlled 400 responses**.
- Exact current-head preview deployment [`dpl_EoryaxVpci7LP8d44gxxbv6Tp5m1`](https://customermates-3d6ahly2q-customermates.vercel.app) for `df57d5a4`: READY; root redirected to `/en`; OpenAPI returned 200; 54/54 JSON request bodies were required with explicit JSON 400 responses; **162/162 malformed-body cases** returned HTTP 400 with JSON string `"Invalid JSON body"`; and **54/54 literal `{}` controls** reached authentication with 401. Zero failures across 216 API requests.
- Runtime/OpenAPI inventory: 54 JSON body operations, 54 guarded readers, 54 `required: true` declarations, explicit JSON 400 responses, and no bare REST v1 `request.json()` calls.
- Committed analyzer regression matrix: canonical POST/PUT/PATCH/DELETE and bodyless GET/HEAD/OPTIONS positives; malformed imports, shadows, aliases, loops/branches, nested/duplicate/alternate readers, wrong catches/finally, parameter defaults, export reassignment/forms, route extensions, OpenAPI orphan/bijection/required/400 failures, and false-positive controls.
- Focused boundary/error tests: **71 passed**.
- Full rebased test suite: **3,015 passed, 70 skipped** (**359 files passed, 9 skipped**).
- Typecheck: pass.
- Lint: pass.
- Production build: pass; 60/60 static pages generated.
- OpenAPI/raw-doc generation: pass with no post-generation drift.
- Two independent adversarial reviews: no blocking findings after the reproduced bypasses were converted into regression fixtures.
- All eight current-head GitHub status checks passed, including Tests, Page shipping E2E, CodeQL, repository policy, and the exact Vercel deployment.

## Impact and rollback

The behavior change is limited to public REST v1 JSON request parsing and its published OpenAPI contract. There is no database migration, environment-variable change, or production-data write. The ten default-query search endpoints now require literal `{}` instead of an absent body. The branch push starts one standard isolated Vercel preview build.

Before merge, rollback by closing this pull request and deleting `fix/activity-search-invalid-json`. After a human merge, revert the squash commit through a new pull request; that restores the previous optional-body declarations and unhandled native parser failures. Merge remains a human-only action.
