### PR TITLE
fix(lifecycle): isolate legal notice delivery failures

### DIFF
--- a/ee/lifecycle/__tests__/send-legal-document-notices.interactor.test.ts
+++ b/ee/lifecycle/__tests__/send-legal-document-notices.interactor.test.ts
@@ -167,7 +167,6 @@ describe("SendLegalDocumentNoticesInteractor", () => {
   let auditRepo: { findLegalEventsUnscoped: ReturnType<typeof vi.fn> };
   let emailService: { send: ReturnType<typeof vi.fn> };
   let eventService: { publish: ReturnType<typeof vi.fn> };
-  let warningSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -186,7 +185,6 @@ describe("SendLegalDocumentNoticesInteractor", () => {
       ),
     };
     emailService = { send: vi.fn(() => Promise.resolve(true)) };
-    warningSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     eventService = {
       publish: vi.fn((event, data, options) => {
         records.push(
@@ -205,7 +203,6 @@ describe("SendLegalDocumentNoticesInteractor", () => {
   });
 
   afterEach(() => {
-    warningSpy.mockRestore();
     vi.useRealTimers();
   });
 
@@ -571,10 +568,6 @@ describe("SendLegalDocumentNoticesInteractor", () => {
       systemCompanyId: "company-2",
       systemUserId: "admin-2",
     });
-    expect(warningSpy).toHaveBeenCalledWith(
-      "[SendLegalDocumentNoticesInteractor] Email provider rejected legal notice",
-      { companyId: "company-1", recipientId: "admin-1" },
-    );
   });
 
   it("processes administrators before members and continues after an administrator delivery fails", async () => {

--- a/ee/lifecycle/__tests__/send-legal-document-notices.interactor.test.ts
+++ b/ee/lifecycle/__tests__/send-legal-document-notices.interactor.test.ts
@@ -167,6 +167,7 @@ describe("SendLegalDocumentNoticesInteractor", () => {
   let auditRepo: { findLegalEventsUnscoped: ReturnType<typeof vi.fn> };
   let emailService: { send: ReturnType<typeof vi.fn> };
   let eventService: { publish: ReturnType<typeof vi.fn> };
+  let warningSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -184,7 +185,8 @@ describe("SendLegalDocumentNoticesInteractor", () => {
         Promise.resolve(records.filter((record) => record.companyId === companyId)),
       ),
     };
-    emailService = { send: vi.fn(() => Promise.resolve()) };
+    emailService = { send: vi.fn(() => Promise.resolve(true)) };
+    warningSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     eventService = {
       publish: vi.fn((event, data, options) => {
         records.push(
@@ -203,6 +205,7 @@ describe("SendLegalDocumentNoticesInteractor", () => {
   });
 
   afterEach(() => {
+    warningSpy.mockRestore();
     vi.useRealTimers();
   });
 
@@ -274,14 +277,14 @@ describe("SendLegalDocumentNoticesInteractor", () => {
 
   it("preserves a separate supplier deadline for a combined notice retried on the next run", async () => {
     recipients = [recipient("admin-1", true), recipient("admin-2", true)];
-    emailService.send.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("recipient rejected"));
+    emailService.send.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     const supplierDeadline = "2026-08-12T10:00:00.000Z";
     mockSupplierDeadline.value = supplierDeadline;
 
-    await expect(invoke()).rejects.toThrow("recipient rejected");
+    await invoke();
     expect(records).toHaveLength(1);
 
-    emailService.send.mockReset().mockResolvedValue(undefined);
+    emailService.send.mockReset().mockResolvedValue(true);
     mockLegalDocumentNotice.mockClear();
     mockLegalDocumentNoticeInformation.mockClear();
     await invoke();
@@ -301,9 +304,7 @@ describe("SendLegalDocumentNoticesInteractor", () => {
     await invoke();
 
     expect(emailService.send).toHaveBeenCalledTimes(3);
-    expect(emailService.send).toHaveBeenCalledWith(expect.anything(), {
-      throwOnProviderError: true,
-    });
+    expect(emailService.send.mock.calls.every((call) => call.length === 1)).toBe(true);
     expect(documentNames(emailService.send.mock.calls[0][0])).toEqual([
       "Terms and Conditions",
       "Data Processing Agreement",
@@ -553,44 +554,82 @@ describe("SendLegalDocumentNoticesInteractor", () => {
     ]);
   });
 
-  it("processes administrators before members even when repository order is member-first", async () => {
-    recipients = [recipient("member-1", false), recipient("admin-1", true)];
-    emailService.send.mockRejectedValueOnce(new Error("provider unavailable"));
+  it("continues with later companies after one company's recipient delivery fails", async () => {
+    recipients = [recipient("admin-1", true), recipient("admin-2", true, { companyId: "company-2" })];
+    emailService.send.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
-    await expect(invoke()).rejects.toThrow("provider unavailable");
+    await invoke();
 
-    expect(emailService.send).toHaveBeenCalledOnce();
-    expect(emailService.send.mock.calls[0][0].to).toBe("admin-1@example.com");
-    expect(eventService.publish).not.toHaveBeenCalled();
+    expect(auditRepo.findLegalEventsUnscoped.mock.calls).toEqual([["company-1"], ["company-2"]]);
+    expect(emailService.send.mock.calls.map(([email]) => email.to)).toEqual([
+      "admin-1@example.com",
+      "admin-2@example.com",
+    ]);
+    expect(eventService.publish).toHaveBeenCalledOnce();
+    expect(eventService.publish.mock.calls[0][1].entityId).toBe("admin-2");
+    expect(eventService.publish.mock.calls[0][2]).toEqual({
+      systemCompanyId: "company-2",
+      systemUserId: "admin-2",
+    });
+    expect(warningSpy).toHaveBeenCalledWith(
+      "[SendLegalDocumentNoticesInteractor] Email provider rejected legal notice",
+      { companyId: "company-1", recipientId: "admin-1" },
+    );
   });
 
-  it("fails fast, preserves earlier success, and retries only missing recipients", async () => {
-    emailService.send.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("invalid recipient"));
+  it("processes administrators before members and continues after an administrator delivery fails", async () => {
+    recipients = [recipient("member-1", false), recipient("admin-1", true)];
+    emailService.send.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
-    await expect(invoke()).rejects.toThrow("invalid recipient");
-    expect(emailService.send).toHaveBeenCalledTimes(2);
+    await invoke();
+
+    expect(emailService.send.mock.calls.map(([email]) => email.to)).toEqual([
+      "admin-1@example.com",
+      "member-1@example.com",
+    ]);
     expect(eventService.publish).toHaveBeenCalledOnce();
-    expect(eventService.publish.mock.calls[0][1].entityId).toBe("admin-1");
+    expect(eventService.publish.mock.calls[0][1].entityId).toBe("member-1");
+  });
+
+  it("preserves surrounding successes and retries only the failed recipient", async () => {
+    emailService.send.mockResolvedValueOnce(true).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await invoke();
+    expect(emailService.send).toHaveBeenCalledTimes(3);
+    expect(eventService.publish).toHaveBeenCalledTimes(2);
+    expect(eventService.publish.mock.calls.map(([, data]) => data.entityId)).toEqual(["admin-1", "member-1"]);
 
     emailService.send.mockClear();
     eventService.publish.mockClear();
-    emailService.send.mockResolvedValue(undefined);
+    emailService.send.mockResolvedValue(true);
     await invoke(new Date("2026-08-08T09:00:00.000Z"));
 
-    expect(emailService.send).toHaveBeenCalledTimes(2);
-    expect(emailService.send.mock.calls.map(([email]) => email.to)).toEqual([
-      "admin-2@example.com",
-      "member-1@example.com",
-    ]);
-    expect(eventService.publish).toHaveBeenCalledTimes(2);
+    expect(emailService.send).toHaveBeenCalledOnce();
+    expect(emailService.send.mock.calls[0][0].to).toBe("admin-2@example.com");
+    expect(eventService.publish).toHaveBeenCalledOnce();
+    expect(eventService.publish.mock.calls[0][1].entityId).toBe("admin-2");
   });
 
-  it("stops on the first recipient error before recording any success", async () => {
-    emailService.send.mockRejectedValue(new Error("provider unavailable"));
+  it("propagates unexpected email failures unchanged without attempting later recipients", async () => {
+    const deliveryFailure = new TypeError("email rendering failed");
+    emailService.send.mockRejectedValueOnce(deliveryFailure);
 
-    await expect(invoke()).rejects.toThrow("provider unavailable");
+    const error = await invoke().catch((cause: unknown) => cause);
+
+    expect(error).toBe(deliveryFailure);
     expect(emailService.send).toHaveBeenCalledOnce();
     expect(eventService.publish).not.toHaveBeenCalled();
+  });
+
+  it("fails immediately when audit publication fails after a successful delivery", async () => {
+    const auditFailure = new Error("audit persistence unavailable");
+    eventService.publish.mockRejectedValueOnce(auditFailure);
+
+    const error = await invoke().catch((cause: unknown) => cause);
+
+    expect(error).toBe(auditFailure);
+    expect(emailService.send).toHaveBeenCalledOnce();
+    expect(eventService.publish).toHaveBeenCalledOnce();
   });
 
   it("is a no-op outside managed cloud mode", async () => {

--- a/ee/lifecycle/send-legal-document-notices.interactor.ts
+++ b/ee/lifecycle/send-legal-document-notices.interactor.ts
@@ -148,13 +148,7 @@ export class SendLegalDocumentNoticesInteractor {
     const email = await this.buildEmail(plan, locale, formattingTag);
 
     const accepted = await this.emailService.send(email);
-    if (!accepted) {
-      console.warn("[SendLegalDocumentNoticesInteractor] Email provider rejected legal notice", {
-        companyId: plan.companyId,
-        recipientId: plan.recipient.id,
-      });
-      return;
-    }
+    if (!accepted) return;
 
     await this.eventService.publish(
       DomainEvent.LEGAL_NOTICE_SENT,

--- a/ee/lifecycle/send-legal-document-notices.interactor.ts
+++ b/ee/lifecycle/send-legal-document-notices.interactor.ts
@@ -147,7 +147,14 @@ export class SendLegalDocumentNoticesInteractor {
     const formattingTag = resolveUserFormattingTag(plan.recipient, locale);
     const email = await this.buildEmail(plan, locale, formattingTag);
 
-    await this.emailService.send(email, { throwOnProviderError: true });
+    const accepted = await this.emailService.send(email);
+    if (!accepted) {
+      console.warn("[SendLegalDocumentNoticesInteractor] Email provider rejected legal notice", {
+        companyId: plan.companyId,
+        recipientId: plan.recipient.id,
+      });
+      return;
+    }
 
     await this.eventService.publish(
       DomainEvent.LEGAL_NOTICE_SENT,

--- a/features/email/__tests__/email.service.test.ts
+++ b/features/email/__tests__/email.service.test.ts
@@ -36,10 +36,10 @@ describe("EmailService", () => {
     mockEnv.RESEND_API_KEY = "test-key";
   });
 
-  it("resolves without exposing provider metadata", async () => {
+  it("returns true when the provider accepts the email without exposing provider metadata", async () => {
     resendSend.mockResolvedValue({ data: { id: "message-123" }, error: null });
 
-    await expect(new EmailService().send(email)).resolves.toBeUndefined();
+    await expect(new EmailService().send(email)).resolves.toBe(true);
     expect(resendConstructor).toHaveBeenCalledWith("test-key");
     expect(resendSend).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -51,37 +51,26 @@ describe("EmailService", () => {
     );
   });
 
-  it("throws when strict provider-error handling is requested", async () => {
+  it("returns false when the provider rejects the email", async () => {
     resendSend.mockResolvedValue({
       data: null,
       error: { message: "provider rejected request" },
     });
 
-    await expect(new EmailService().send(email, { throwOnProviderError: true })).rejects.toThrow(
-      "Resend rejected the email: provider rejected request",
-    );
-  });
-
-  it("preserves best-effort delivery for existing callers", async () => {
-    resendSend.mockResolvedValue({
-      data: null,
-      error: { message: "provider rejected request" },
-    });
-
-    await expect(new EmailService().send(email)).resolves.toBeUndefined();
+    await expect(new EmailService().send(email)).resolves.toBe(false);
   });
 
   it("does not require a provider message ID", async () => {
     resendSend.mockResolvedValue({ data: {}, error: null });
 
-    await expect(new EmailService().send(email)).resolves.toBeUndefined();
+    await expect(new EmailService().send(email)).resolves.toBe(true);
   });
 
-  it("resolves locally without calling Resend", async () => {
+  it("returns simulated acceptance locally without calling Resend", async () => {
     mockEnv.NODE_ENV = "test";
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    await expect(new EmailService().send(email)).resolves.toBeUndefined();
+    await expect(new EmailService().send(email)).resolves.toBe(true);
     expect(resendSend).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
@@ -91,5 +80,12 @@ describe("EmailService", () => {
 
     await expect(new EmailService().send(email)).rejects.toThrow("RESEND_API_KEY is not configured");
     expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  it("preserves unexpected provider exceptions", async () => {
+    const failure = new TypeError("email rendering failed");
+    resendSend.mockRejectedValue(failure);
+
+    await expect(new EmailService().send(email)).rejects.toBe(failure);
   });
 });

--- a/features/email/email.service.ts
+++ b/features/email/email.service.ts
@@ -11,14 +11,10 @@ type SendArgs = {
   from?: string;
 };
 
-type SendOptions = {
-  throwOnProviderError?: boolean;
-};
-
 const defaultSender = `Customermates <${env.RESEND_OPERATOR_EMAIL}>`;
 
 export class EmailService {
-  async send(args: SendArgs, options: SendOptions = {}): Promise<void> {
+  async send(args: SendArgs): Promise<boolean> {
     if (env.NODE_ENV !== "production") {
       console.log("[EmailService] EMAIL (local only)", {
         from: args.from ?? defaultSender,
@@ -27,7 +23,7 @@ export class EmailService {
         props: args.react.props,
       });
 
-      return;
+      return true;
     }
 
     if (!env.RESEND_API_KEY) throw new Error("RESEND_API_KEY is not configured");
@@ -41,6 +37,6 @@ export class EmailService {
       react: args.react,
     });
 
-    if (options.throwOnProviderError && error) throw new Error(`Resend rejected the email: ${error.message}`);
+    return error === null;
   }
 }

--- a/tests/conventions/runtime-console.test.ts
+++ b/tests/conventions/runtime-console.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs";
+import { relative } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT, walkFiles } from "./walk";
+
+const ALLOWED_CALLS = new Map<string, string[]>([
+  ["features/email/email.service.ts", ["log"]],
+  ["features/event/event.service.ts", ["log"]],
+  ["instrumentation-client.ts", ["error"]],
+  ["instrumentation.ts", ["error", "error"]],
+  ["workflows/capture-failure.ts", ["error", "error", "warn", "error"]],
+]);
+
+type ConsoleCall = { method: string; line: number };
+
+function unwrap(expression: ts.Expression): ts.Expression {
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  )
+    return unwrap(expression.expression);
+  return expression;
+}
+
+function propertyName(expression: ts.PropertyAccessExpression | ts.ElementAccessExpression): string {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  const argument = expression.argumentExpression;
+  return argument && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))
+    ? argument.text
+    : "<dynamic>";
+}
+
+function isConsoleObject(expression: ts.Expression): boolean {
+  const target = unwrap(expression);
+  if (ts.isIdentifier(target)) return target.text === "console";
+  if (!ts.isPropertyAccessExpression(target) && !ts.isElementAccessExpression(target)) return false;
+
+  const owner = unwrap(target.expression);
+  return (
+    ts.isIdentifier(owner) &&
+    ["global", "globalThis", "self", "window"].includes(owner.text) &&
+    propertyName(target) === "console"
+  );
+}
+
+function consoleCalls(source: ts.SourceFile): ConsoleCall[] {
+  const calls: ConsoleCall[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
+      isConsoleObject(node.expression)
+    ) {
+      calls.push({
+        method: propertyName(node),
+        line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return calls;
+}
+
+function consoleCallsIn(path: string): ConsoleCall[] {
+  const text = readFileSync(path, "utf8");
+  const kind = path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  return consoleCalls(ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, kind));
+}
+
+function excluded(file: string): boolean {
+  return (
+    file.startsWith(".source/") ||
+    file.startsWith("tests/") ||
+    file.startsWith("scripts/") ||
+    file.startsWith("ee/scripts/") ||
+    file === "next-env.d.ts" ||
+    file === "prisma/seed.ts" ||
+    file.includes("/__tests__/") ||
+    /\.(spec|test)\.tsx?$/.test(file)
+  );
+}
+
+function runtimeFiles(): string[] {
+  return walkFiles(REPO_ROOT, (path) => {
+    if (!/\.tsx?$/.test(path)) return false;
+    const file = relative(REPO_ROOT, path).replaceAll("\\", "/");
+    return !excluded(file);
+  });
+}
+
+describe("runtime console boundary", () => {
+  it("keeps console calls inside the approved runtime boundaries", () => {
+    const mismatches: string[] = [];
+    const seen = new Set<string>();
+
+    for (const path of runtimeFiles()) {
+      const file = relative(REPO_ROOT, path).replaceAll("\\", "/");
+      const calls = consoleCallsIn(path);
+      const expected = ALLOWED_CALLS.get(file) ?? [];
+      if (calls.length === 0 && expected.length === 0) continue;
+      seen.add(file);
+
+      const methods = calls.map((call) => call.method);
+      if (methods.join(",") === expected.join(",")) continue;
+      mismatches.push(
+        `${file}: expected [${expected.join(", ")}], found [${calls.map((call) => `${call.method}:${call.line}`).join(", ")}]`,
+      );
+    }
+
+    for (const file of ALLOWED_CALLS.keys()) {
+      if (!seen.has(file)) mismatches.push(`${file}: expected an explicit console-call boundary, found none`);
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  });
+
+  it("detects direct and qualified console access in a synthetic runtime source", () => {
+    const source = ts.createSourceFile(
+      "probe.ts",
+      [
+        'console.warn("direct");',
+        'globalThis.console["error"]("qualified");',
+        'console.log.call(console, "aliased call");',
+        'const warning = (window.console.warn);',
+      ].join("\n"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    expect(consoleCalls(source)).toEqual([
+      { method: "warn", line: 1 },
+      { method: "error", line: 2 },
+      { method: "log", line: 3 },
+      { method: "warn", line: 4 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Represent Resend provider rejection as an explicit `EmailService.send()` boolean outcome instead of an optional throw mode. Legal-document notices now audit only provider-accepted requests and continue with later recipients and companies after a rejection without producing an ad hoc runtime console warning.

Add a convention test that limits direct `console.*` access in application runtime TypeScript to the repository's exact existing local-diagnostic, instrumentation-startup, and reporting boundaries.

Unexpected configuration, rendering, SDK, and audit-persistence exceptions still propagate unchanged and fail fast.

## Context

Sentry issue `CUSTOMERMATES-4K` showed that one provider-returned email error aborted the legal-notice batch, so every later eligible recipient and company was skipped.

The first version of this pull request caught every send exception and raised a custom aggregate error after processing. Review established that this did not match the repository's error model: it could reclassify unexpected faults, still failed the complete lifecycle cron, and could create a replacement Sentry issue.

This revision removes `throwOnProviderError`. `EmailService.send()` returns `true` when Resend accepts the request and `false` when Resend returns its documented error result. On `false`, the legal-notice interactor skips `LEGAL_NOTICE_SENT`, continues sequential administrator-first processing, and naturally retries the missing recipient on the next daily run.

The repository-wide console audit found that the warning added during review was the only unconditional direct console call in production business logic. Existing runtime calls are limited to local development, centralized instrumentation startup, or Sentry-reporting fallbacks. The warning added no control-flow value and was removed without replacement.

The durable rule is documented in [knowledge-base PR #87](https://github.com/customermates/knowledge-base/pull/87), which must merge only after this product pull request.

## Validation

- Pinned dependency proof against the installed Resend 6.3.0 package: a synthetic HTTP 422 and a synthetic fetch failure both returned `{ data: null, error }` rather than throwing.
- Focused EmailService, legal-notice, and runtime-console convention suites: 30 tests passed on final head `03ed462b`.
- `yarn typecheck`: passed on Node 24.18.0.
- `yarn lint`: passed with zero warnings.
- `yarn vitest run tests/conventions`: 325 passed, 1 skipped.
- Full `yarn test`: 2,872 passed, 69 skipped.
- `yarn build`: passed with synthetic local environment values.
- OpenAPI and raw-docs regeneration left no tracked diff.
- `git diff --check`: passed.
- Three independent read-only reviews found no unresolved high- or medium-severity findings.

## Impact and rollback

A known Resend rejection no longer throws. It creates no false legal-delivery audit, later recipients and companies are still attempted, unrelated lifecycle cleanup still runs, and the missing recipient is retried by the next daily invocation. The expected `false` path has no console or Sentry side effect.

This intentionally leaves persistent provider rejection silent while the daily retry remains pending. The boolean does not distinguish authentication, outage, rate-limit, validation, or recipient failures, so actionable monitoring would require a separate aggregated Sentry signal or persisted attempt state with a threshold; a per-recipient console warning is not that solution.

Other existing EmailService callers continue their previous best-effort behavior because they ignore the returned boolean. There are no migrations, environment changes, public API-contract changes, production-data changes, or visible UI changes. A provider-accepted request followed by audit-publication failure retains the pre-existing duplicate-on-retry risk because email acceptance and audit persistence are not atomic; an outbox or provider idempotency boundary remains outside this change.

Before merge, rollback the complete outcome by closing this pull request; revert only the console-boundary refinement with `03ed462b` if needed. After release, revert the squash commit through a new protected pull request.

## Owner-directed Linear exception

- Issuer: Customermates owner directing the current task.
- Instruction source: current uninterrupted Codex conversation.
- Instruction timestamp: 2026-08-25T14:53:39Z.
- Bounded outcome: resolve `CUSTOMERMATES-4K` with an explicit provider-result contract, remove the ad hoc runtime warning, enforce the existing runtime-console boundary, and record that boundary in the linked knowledge-base change.
- Named waiver: Linear issue creation, claim, connection proof, and duplicate-aware receipt for this bounded two-repository outcome.
- Exact product scope: `features/email/email.service.ts`, `features/email/__tests__/email.service.test.ts`, `ee/lifecycle/send-legal-document-notices.interactor.ts`, `ee/lifecycle/__tests__/send-legal-document-notices.interactor.test.ts`, and `tests/conventions/runtime-console.test.ts` on `fix/legal-notice-batch-isolation`.
- Exact knowledge-base scope: `product/conventions.md` on `docs/override-runtime-console-convention` in [knowledge-base PR #87](https://github.com/customermates/knowledge-base/pull/87), merged only after this product change.
- Remaining constraints: isolated single-writer branches, secret and production-data protections, full verification, independent review, required checks, preview acceptance, current base, Code Owner approval, and human-only merges remain required.
- Material consequence and rollback: known provider rejection becomes a silent retriable non-throwing result and direct runtime console access gains an exact allowlist; close the unmerged pull requests or revert their resulting squash commits through protected pull requests.
- Acceptance and expiry: accepted when required checks pass and humans merge this product pull request followed by the dependent knowledge-base pull request; otherwise expires when both pull requests are closed.
- Evidence location: this pull request's Validation section, linked knowledge-base pull request, review conversations, preview evidence, and required checks.
