### PR TITLE
fix(dashboard): inherit chart font

### DIFF
--- a/app/[locale]/(protected)/dashboard/components/horizontal-bar-chart-with-labels.tsx
+++ b/app/[locale]/(protected)/dashboard/components/horizontal-bar-chart-with-labels.tsx
@@ -77,7 +77,6 @@ export const HorizontalBarChartWithLabels = observer(
                   <text
                     dominantBaseline="middle"
                     fill={entry.labelColor}
-                    fontFamily="Inter"
                     fontSize={12}
                     textAnchor="start"
                     x={Number(x) + LABEL_PADDING_LEFT}
@@ -102,7 +101,6 @@ export const HorizontalBarChartWithLabels = observer(
               style={{
                 fill: textColor,
                 fontSize: 12,
-                fontFamily: "Inter",
               }}
             />
           </Bar>

--- a/app/[locale]/(protected)/dashboard/components/horizontal-bar-chart.tsx
+++ b/app/[locale]/(protected)/dashboard/components/horizontal-bar-chart.tsx
@@ -37,7 +37,6 @@ export const HorizontalBarChart = observer(
             tick={{
               fill: textColor,
               fontSize: 12,
-              fontFamily: "Inter",
             }}
             tickFormatter={(value) =>
               isCurrencyAggregation(aggregationType) ? intlStore.formatCurrency(value) : intlStore.formatNumber(value)
@@ -52,7 +51,6 @@ export const HorizontalBarChart = observer(
             tick={{
               fill: textColor,
               fontSize: 12,
-              fontFamily: "Inter",
             }}
             type="category"
             width="auto"

--- a/app/[locale]/(protected)/dashboard/components/radar-chart.tsx
+++ b/app/[locale]/(protected)/dashboard/components/radar-chart.tsx
@@ -24,7 +24,7 @@ export const RadarChartComponent = observer(({ aggregationType, chartData, color
       <RadarChart data={chartData}>
         <ChartTooltip aggregationType={aggregationType} />
 
-        <PolarAngleAxis dataKey="label" tick={{ fill: textColor, fontSize: 12, fontFamily: "Inter" }} />
+        <PolarAngleAxis dataKey="label" tick={{ fill: textColor, fontSize: 12 }} />
 
         <PolarGrid opacity={0.2} stroke={textColor} />
 

--- a/app/[locale]/(protected)/dashboard/components/vertical-bar-chart-with-labels.tsx
+++ b/app/[locale]/(protected)/dashboard/components/vertical-bar-chart-with-labels.tsx
@@ -57,7 +57,6 @@ export const VerticalBarChartWithLabels = observer(
                   <text
                     dominantBaseline="middle"
                     fill={entry.labelColor}
-                    fontFamily="Inter"
                     fontSize={12}
                     textAnchor="middle"
                     x={Number(x) + Number(width) / 2}
@@ -79,7 +78,7 @@ export const VerticalBarChartWithLabels = observer(
                   : intlStore.formatNumber(numValue);
               }}
               position="top"
-              style={{ fill: textColor, fontSize: 12, fontFamily: "Inter" }}
+              style={{ fill: textColor, fontSize: 12 }}
             />
           </Bar>
         </BarChart>

--- a/app/[locale]/(protected)/dashboard/components/vertical-bar-chart.tsx
+++ b/app/[locale]/(protected)/dashboard/components/vertical-bar-chart.tsx
@@ -33,7 +33,7 @@ export const VerticalBarChart = observer(
             dataKey="label"
             reversed={Boolean(reverseXAxis)}
             stroke={gridColor}
-            tick={{ fill: textColor, fontSize: 12, fontFamily: "Inter" }}
+            tick={{ fill: textColor, fontSize: 12 }}
             type="category"
           />
 
@@ -42,7 +42,7 @@ export const VerticalBarChart = observer(
             padding={{ top: 1, bottom: 1 }}
             reversed={Boolean(reverseYAxis)}
             stroke={gridColor}
-            tick={{ fill: textColor, fontSize: 12, fontFamily: "Inter" }}
+            tick={{ fill: textColor, fontSize: 12 }}
             tickFormatter={(value) =>
               isCurrencyAggregation(aggregationType) ? intlStore.formatCurrency(value) : intlStore.formatNumber(value)
             }


### PR DESCRIPTION
## Summary

- Remove nine redundant `Inter` overrides from the dashboard SVG chart labels.
- Let horizontal, vertical, labeled, and radar charts inherit the application font already established by the root layout.
- Add no replacement abstraction, token, dependency, or styling layer.

## Context

Dashboard chart labels resolved to the literal family `Inter`, while Next.js registers the local application font under its generated `latin` family. Because the literal family was unavailable, SVG text fell back to a serif face. The mismatch was most visible in “Deal Value By Organizations” but affected the bar and radar chart implementations generally.

Owner-directed Linear exception: Benjamin Wagner authorized this bounded dashboard-chart typography cleanup in the current Codex task after the Linear free issue limit blocked the normal issue path. The waiver covers only the Linear issue/claim gate and these five chart component files. It does not waive verification, review, required checks, preview acceptance, the human-only merge, or production boundaries. Recorded 2026-08-25T10:05:08Z; it expires when this pull request is merged or closed.

## Validation

- `yarn vitest run 'app/[locale]/(protected)/dashboard/components/__tests__/widget-chart.test.ts'` — 15 passed.
- `yarn typecheck` — passed.
- `yarn lint` — passed with zero warnings.
- `yarn vitest run tests/conventions` — 323 passed, 1 skipped.
- Isolated local browser acceptance at `http://customermates-chart-font.localhost:4004/en/dashboard`: all 23 rendered SVG text nodes had no font override and computed to `latin, "latin Fallback"`, matching the “Deal Value By Organizations” heading. The corrected dashboard was visually reviewed with no chart layout shift.

The full suite and production build are left to the required PR checks because this is a styling-only deletion with no logic, data, dependency, or prop-contract change.

## Screenshots

The corrected dashboard was reviewed in the isolated local browser. The branch preview provides the final shared review surface once Vercel finishes.

## Impact and rollback

Impact is limited to dashboard SVG chart typography. Colors, sizes, positions, truncation, formatting, data, and interaction behavior are unchanged. There are no schema, migration, API, environment-variable, production-data, or persistent-data changes. This branch push starts one standard isolated Vercel preview build.

Before merge, rollback by closing this pull request and deleting `fix/dashboard-chart-font`. After a human merge, revert the squash commit through a new pull request. Merge remains a human-only action.
