### PR TITLE
refactor(mcp): hold every tool description to the reference-path standard

### DIFF
--- a/features/mcp-tools/admin.mcp-tools.ts
+++ b/features/mcp-tools/admin.mcp-tools.ts
@@ -139,7 +139,7 @@ export const manageTeamTool = {
   description:
     "Use this when administering team members. " +
     "action invite SENDS REAL INVITATION EMAILS to the given addresses (up to 20 per call). " +
-    "action update_member changes an existing member's role or status: pass userId from list_users plus roleId and/or status, omitted fields keep their current values; " +
+    "action update_member changes an existing member's role or status: pass userId from list_users.items[].id plus roleId from get_workspace_context.roles[].id and/or status, omitted fields keep their current values; " +
     "a member who has no role assigned yet (e.g. a still pending invite) has no role to keep, so you must pass roleId together with the change or the call is rejected. " +
     "last-admin protection is enforced server-side, the workspace can never lose its last active admin. " +
     "Needs users admin rights.",

--- a/features/mcp-tools/entity-generic.mcp-tools.ts
+++ b/features/mcp-tools/entity-generic.mcp-tools.ts
@@ -459,7 +459,7 @@ export const deleteRecordsTool = {
     "Use this when records must be permanently deleted. IRREVERSIBLE. " +
     "Deletes up to 100 records by id for a single entity type. " +
     "Required: entity, ids (for contacts, each id may be a UUID or an email/phone/'provider:handle' channel key). " +
-    "This cannot be undone. Consider exporting first. Idempotent on repeat (missing ids are reported as errors).",
+    "This cannot be undone. Consider exporting first. Repeating a delete leaves state unchanged, but ids that no longer exist come back as per-id errors.",
   annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: true, openWorldHint: false },
   inputSchema: DeleteRecordsSchema,
   execute: ({ entity, ids }: z.infer<typeof DeleteRecordsSchema>) =>

--- a/features/mcp-tools/messaging.mcp-tools.ts
+++ b/features/mcp-tools/messaging.mcp-tools.ts
@@ -348,7 +348,7 @@ export const sendChatMessageTool = {
   description:
     "Use this when sending a real chat message (LinkedIn, WhatsApp, and other connected chat accounts). SIDE EFFECT: delivers a real message. " +
     "Exactly one mode: pass threadId to send text into that existing thread (optional draftMessageId converts a saved draft on send), " +
-    "or omit threadId to start a new chat, which requires connectedAccountId (see get_workspace_context) and attendeeIdentifiers " +
+    "or omit threadId to start a new chat, which requires connectedAccountId from get_workspace_context.connectedAccounts[].id (check its status is ok) and attendeeIdentifiers " +
     "(the recipients' provider handles, i.e. the value of a contact's messaging channel) plus optional chatName to name the group. " +
     "New LinkedIn chats default to the Classic product; set linkedinProduct to sales_navigator or recruiter to send an InMail from that product's inbox " +
     "(requires inmailSubject; recruiter also inmailSignature), or set inmail true on classic to InMail someone outside the network. " +
@@ -386,7 +386,7 @@ export const sendEmailTool = {
     "Required: to, subject, body, and at least one of threadId (reply; takes precedence if both given) or connectedAccountId (new email). " +
     "Optional: cc, bcc. cc/bcc are plain email strings (not the {identifier} object form used by to). " +
     "When replying into a thread, an identical body sent to that thread within about a minute is rejected as a duplicate. " +
-    "Get account ids from get_workspace_context and thread ids from get_messaging_threads.",
+    "connectedAccountId is get_workspace_context.connectedAccounts[].id (check its status is ok first); threadId is get_messaging_threads.items[].id.",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,
@@ -431,8 +431,8 @@ export const discardMessageDraftTool = {
   title: "Discard message draft",
   description:
     "Use this when a prepared draft is no longer wanted: permanently deletes it. " +
-    "messageId is a DRAFT message id, taken from save_message_draft's response or from the thread detail of " +
-    "get_messaging_threads (messages flagged isDraft). Only drafts can be discarded; sent and received messages are never affected. " +
+    "messageId is a DRAFT message id: save_message_draft.draftMessageId, or the id of a message flagged isDraft in " +
+    "get_messaging_threads thread detail. Only drafts can be discarded; sent and received messages are never affected. " +
     "Discarding an id that is not a draft is a safe no-op that reports no draft found.",
   annotations: {
     readOnlyHint: false,
@@ -456,8 +456,11 @@ export const updateMessagingThreadTool = {
   name: "update_messaging_thread",
   title: "Update messaging thread",
   description:
-    "Use this when triaging the inbox: sets a thread's state. state is one of unread, open, closed, or spam. " +
-    "threadId comes from get_messaging_threads. Setting the state a thread already has is a harmless no-op.",
+    "Use this when triaging the inbox: sets a thread's state inside the Customermates inbox only, never at the provider. " +
+    "Required: threadId from get_messaging_threads.items[].id, state. " +
+    "state is one of unread, open, closed, or spam; the state shows as a badge on the thread and is filterable in the inbox, it never hides or deletes anything. " +
+    "Setting the state a thread already has is a harmless no-op, so triage in bulk without reading each state first. " +
+    "The provider mailbox, the messages themselves, and any linked CRM records stay untouched.",
   annotations: {
     readOnlyHint: false,
     idempotentHint: true,

--- a/features/mcp-tools/sales-navigator.mcp-tools.ts
+++ b/features/mcp-tools/sales-navigator.mcp-tools.ts
@@ -265,6 +265,7 @@ export const getSalesSearchParametersTool = {
     "Pass a type (LOCATION, INDUSTRY, JOB_TITLE, JOB_FUNCTION, COMPANY, SCHOOL, GROUP, RELATION, PERSONA, PROFILE_LANGUAGE, POSTAL_CODE, " +
     "LEAD_LIST, ACCOUNT_LIST, SAVED_PEOPLE_SEARCH, SAVED_COMPANY_SEARCH, RECENT_SEARCH) plus keywords and get back matching ids with display names. " +
     "LEAD_LIST and ACCOUNT_LIST also find existing Sales Navigator lists by name; use linkedin_get_sales_search_parameters.items[].id as linkedin_manage_sales_lists.listId. " +
+    "Paginate with offset plus limit when a type has more matches than one page. " +
     "Requires a connected LinkedIn account with an active Sales Navigator subscription.",
   annotations: { readOnlyHint: true, idempotentHint: true, destructiveHint: false, openWorldHint: true },
   inputSchema: GetSalesSearchParametersToolSchema,
@@ -296,6 +297,7 @@ export const manageSalesListsTool = {
     "action list enumerates the existing lists (kind leads for people, accounts for companies) with linkedin_manage_sales_lists.items[].id, name and item count. " +
     "action browse returns the members of one list using listId from linkedin_manage_sales_lists.items[].id; lead rows include items[].current_positions[] (company, role, company_id, company_url), and linkedin_manage_sales_lists.items[].current_positions[].company_id resolves via get_social_profile with profileType=company. " +
     "action save ADDS a person or company to an existing list: for kind leads, pass providerId from linkedin_search_sales_leads.items[].id or get_social_profile.id. For get_messaging_threads.items[].participants[].identifier or get_messaging_threads.thread.participants[].identifier, call get_social_profile first and use get_social_profile.id. For kind accounts, pass linkedin_search_sales_companies.items[].id, linkedin_search_sales_leads.items[].current_positions[].company_id, linkedin_manage_sales_lists.items[].current_positions[].company_id from action=browse, or get_social_profile.current_positions[].company_id. The hosted Assistant verifies the person or company and the list from LinkedIn immediately before asking for approval. " +
+    "Paginate list and browse with offset plus limit, repeating the same kind and listId while increasing offset. " +
     "New lists cannot be created via the API; the user creates them in Sales Navigator first. " +
     "Requires a connected LinkedIn account with an active Sales Navigator subscription.",
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },

--- a/features/mcp-tools/support.mcp-tools.ts
+++ b/features/mcp-tools/support.mcp-tools.ts
@@ -13,7 +13,7 @@ export const requestSupportTool = {
   name: "request_support",
   title: "Request support",
   description:
-    "Email a support request to the Customermates team. " +
+    "Email a support request to the Customermates team. SIDE EFFECT: sends a real email. " +
     "Use when the user has a question, bug report, or request that needs a human. " +
     "Include all relevant context in the description. The Customermates team replies to the email address " +
     "on the user's account. Returns confirmation only after the email provider accepts the request.",

--- a/features/mcp-tools/workspace.mcp-tools.ts
+++ b/features/mcp-tools/workspace.mcp-tools.ts
@@ -82,7 +82,7 @@ export const listUsersTool = {
   description:
     "Use this when you need the workspace members: returns { id, firstName, lastName, email, roleId, status } per user. " +
     "Optional: searchTerm (matches firstName/lastName), filters, sortDescriptor, page, pageSize. " +
-    "Use the id as userId for manage_team update_member and for userIds in record tools; resolve roleId via get_workspace_context.",
+    "Use list_users.items[].id as userId for manage_team update_member and for userIds in record tools; match roleId against get_workspace_context.roles[].id for the role name and permissions.",
   annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   inputSchema: ListUsersSchema,
   execute: (params: z.infer<typeof ListUsersSchema>) =>

--- a/tests/conventions/mcp-docs-fidelity.test.ts
+++ b/tests/conventions/mcp-docs-fidelity.test.ts
@@ -68,6 +68,52 @@ function catalogText(locale: string): string {
   return readFileSync(join(REPO_ROOT, catalogPath(locale)), "utf8");
 }
 
+
+describe("MCP tool description quality", () => {
+  const loadRegistry = async () => (await import("@/features/mcp-tools/tool-registry")).ALL_MCP_TOOLS;
+  const CONNECTOR_MINIMUM_TOOLS = new Set(["search", "fetch"]);
+  const REAL_SEND_TOOLS = new Set(["send_email", "send_chat_message", "manage_social_relations", "manage_team", "request_support"]);
+  const PAGINATION_ARGS = new Set(["page", "cursor", "offset"]);
+  const PAGINATION_WORDS = /pagin|cursor|offset|page/i;
+  const shapeOf = (schema: unknown): Record<string, unknown> => {
+    const candidate = schema as { shape?: Record<string, unknown> };
+    return candidate?.shape ?? {};
+  };
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("keeps every description above the floor and every connector stub pointing at the real tool", async () => {
+    const violations: string[] = [];
+    for (const tool of await loadRegistry()) {
+      if (CONNECTOR_MINIMUM_TOOLS.has(tool.name)) {
+        if (!/prefer [a-z_]+/.test(tool.description)) violations.push(`${tool.name}: connector stub must point interactive agents at the preferred tool`);
+        continue;
+      }
+      if (tool.description.length < 200) violations.push(`${tool.name}: description is ${tool.description.length} chars; the floor is 200`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("explains continuation on every paginated tool", async () => {
+    const violations: string[] = [];
+    for (const tool of await loadRegistry()) {
+      const argNames = Object.keys(shapeOf(tool.inputSchema));
+      if (!argNames.some((name) => PAGINATION_ARGS.has(name))) continue;
+      if (!PAGINATION_WORDS.test(tool.description)) violations.push(`${tool.name}: has ${argNames.filter((name) => PAGINATION_ARGS.has(name)).join("/")} but the description never mentions pagination`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)("marks destructive and real-send behavior in the description itself", async () => {
+    const violations: string[] = [];
+    for (const tool of await loadRegistry()) {
+      if (tool.annotations?.destructiveHint && !/IRREVERSIBLE|permanently/.test(tool.description))
+        violations.push(`${tool.name}: destructiveHint without IRREVERSIBLE/permanently in the description`);
+      if (REAL_SEND_TOOLS.has(tool.name) && !/SIDE EFFECT|SENDS? (A )?REAL/.test(tool.description))
+        violations.push(`${tool.name}: sends something real but the description carries no SIDE EFFECT marker`);
+    }
+    expect(violations).toEqual([]);
+  });
+});
+
 describe("MCP tool catalog fidelity", () => {
   it.skipIf(!ENFORCED && !process.env.AUDIT_REPORT)(
     "extracts one name and title per exported tool",

--- a/tests/conventions/mcp-docs-fidelity.test.ts
+++ b/tests/conventions/mcp-docs-fidelity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -70,7 +70,11 @@ function catalogText(locale: string): string {
 
 
 describe("MCP tool description quality", () => {
-  const loadRegistry = async () => (await import("@/features/mcp-tools/tool-registry")).ALL_MCP_TOOLS;
+  let registry: typeof import("@/features/mcp-tools/tool-registry").ALL_MCP_TOOLS;
+  beforeAll(async () => {
+    registry = (await import("@/features/mcp-tools/tool-registry")).ALL_MCP_TOOLS;
+  }, 120_000);
+  const loadRegistry = async () => registry;
   const CONNECTOR_MINIMUM_TOOLS = new Set(["search", "fetch"]);
   const REAL_SEND_TOOLS = new Set(["send_email", "send_chat_message", "manage_social_relations", "manage_team", "request_support"]);
   const PAGINATION_ARGS = new Set(["page", "cursor", "offset"]);


### PR DESCRIPTION
## Summary

First PR of the agent-documentation audit. All 46 rendered tool descriptions were audited against the reference-path standard the social family established; the surface was already strong, and this closes the gaps the audit found. A description-quality gate in `mcp-docs-fidelity.test.ts` makes the standard enforceable so it cannot rot.

## Context

The audit dumped every rendered description from `ALL_MCP_TOOLS` (not the source literals, which undercount composed strings) and reviewed each against the standard: when-to-use, exact arg sourcing as reference paths (`get_workspace_context.connectedAccounts[].id`), continuation rules on paginated tools, and honest side-effect language. Findings, all fixed here:

- `update_messaging_thread` was the one genuinely thin description (206 chars). It now explains that state is a workspace-local triage badge that never touches the provider, the messages, or linked CRM records, and sources its threadId as `get_messaging_threads.items[].id`. (While verifying, an earlier draft claimed closed/spam threads leave the default inbox view; the code shows states are badges and filter values only, so the shipped text says exactly that.)
- `send_email`, `send_chat_message`, `discard_message_draft`, `list_users`, `manage_team` now name their id sources as exact paths instead of loose prose ("from get_workspace_context" became `get_workspace_context.connectedAccounts[].id`, with the status check).
- `linkedin_get_sales_search_parameters` and `linkedin_manage_sales_lists` never explained continuation despite taking `offset`; the new gate's pagination rule caught both on its first run.
- `request_support` carries the same explicit side-effect marker as the other real-send tools.
- `delete_records` no longer calls a repeat that reports per-id errors "idempotent".

The gate enforces: a 200-character floor (the two ChatGPT connector stubs are exempt but must point at the preferred interactive tool), a continuation explanation on every tool with page/cursor/offset args, IRREVERSIBLE/permanently prose on destructive-hinted tools, and a side-effect marker on the real-send set. It runs against the rendered registry, so composed descriptions are measured as models see them.

Out of scope, deliberately: `UpdateThreadInteractor` supports `sharedToCrm` but the MCP tool exposes only `state`; sharing a private thread to the team from an agent looks privacy-sensitive, so this PR leaves it unexposed and flags the question. Follow-up PRs cover outputSchema rollout and the generated docs catalog.

## Validation

- Rendered-registry audit of all 46 descriptions (median 531 chars; the two connector stubs are minimal by design)
- `tests/conventions/mcp-docs-fidelity.test.ts` 7/7, including the three new gate rules
- Full suite: 3,830 passed, typecheck clean, zero-warning lint, `next build` compiled

## Impact and rollback

Model-facing description strings and a convention test only; no runtime behavior, schema, or API change. Revert the single commit to roll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)