### PR TITLE
chore(seed): diversify dashboard timeline fixtures

### DIFF
--- a/components/marketing/visuals/demo-visual-catalog.ts
+++ b/components/marketing/visuals/demo-visual-catalog.ts
@@ -342,6 +342,9 @@ export const DEMO_VISUAL_CONVERSATIONS = {
 
 export const DEMO_VISUAL_PROVIDER_PERSON_PAIRINGS = {
   gmail: ["anna-mueller", "amin-hassan", "clara-neumann", "yasmin-farouk"],
+  instagram: ["yasmin-farouk"],
   linkedin: ["leon-becker", "rashid-malik"],
+  outlook: ["amin-hassan"],
+  telegram: ["jonas-weber"],
   whatsapp: ["sophie-wagner", "jonas-weber", "marco-silva"],
 } as const satisfies Record<string, readonly (keyof typeof DEMO_VISUAL_PEOPLE)[]>;

--- a/prisma/__tests__/demo-messaging-fixtures.test.ts
+++ b/prisma/__tests__/demo-messaging-fixtures.test.ts
@@ -5,7 +5,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SYNTHETIC_COMPANY_USERS } from "@/core/config/synthetic-seed-user";
 
 import { seedDemoMessagingFixtures } from "../seeds/messaging/seed";
-import { people, threads as threadFixtures } from "../seeds/messaging/fixtures";
+import {
+  accountActivityFixtures,
+  calendarFixture,
+  people,
+  threads as threadFixtures,
+} from "../seeds/messaging/fixtures";
 import { SYNTHETIC_CONTACT_EMAIL_ADDRESSES, SYNTHETIC_CONTACT_NAMES } from "../seeds/contacts";
 import { fixtureId } from "../seeds/helpers";
 import { SYNTHETIC_SEED_TIMELINE } from "../seeds/timeline";
@@ -165,13 +170,16 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     const participants = createdRows(records.participants);
     const threads = createdRows(records.threads);
 
-    expect(accounts).toHaveLength(3);
-    expect(accountActivities).toHaveLength(1);
-    expect(calendarEvents).toHaveLength(1);
+    expect(accounts).toHaveLength(6);
+    expect(accountActivities).toHaveLength(2);
+    expect(calendarEvents).toHaveLength(5);
     expect(calendars).toHaveLength(1);
     expect(stringsByCount(accounts, "provider")).toEqual({
       google: 1,
+      instagram: 1,
       linkedin: 1,
+      outlook: 1,
+      telegram: 1,
       whatsapp: 1,
     });
     expect(accounts).toEqual(
@@ -196,11 +204,33 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
           hasMessaging: true,
           provider: "whatsapp",
         }),
+        expect.objectContaining({
+          displayName: "Max Bergmann · Instagram",
+          hasCalendar: false,
+          hasMessaging: true,
+          provider: "instagram",
+        }),
+        expect.objectContaining({
+          displayName: "Max Bergmann · Telegram",
+          hasCalendar: false,
+          hasMessaging: true,
+          provider: "telegram",
+        }),
+        expect.objectContaining({
+          displayName: "Max Bergmann · Outlook",
+          emailAddress: context.seedUserEmail,
+          hasCalendar: true,
+          hasMessaging: true,
+          provider: "outlook",
+        }),
       ]),
     );
     expectCanonicalUpdates(records.connectedAccounts, ["id", "unipileAccountId"]);
-    for (const call of records.connectedAccounts)
-      expect(call.where).toEqual({ unipileAccountId: call.create.unipileAccountId });
+    for (const call of records.connectedAccounts) {
+      expect(call.where).toEqual({
+        unipileAccountId: call.create.unipileAccountId,
+      });
+    }
     for (const call of records.contactIdentifiers) {
       expect(call.where).toEqual({
         companyId_channelClass_value: {
@@ -238,73 +268,104 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     });
     expectCanonicalUpdates(records.calendars, ["id", "unipileCalendarId"]);
 
-    expect(calendarEvents[0]).toMatchObject({
-      allDay: false,
-      attendeeEmails: ["anna.mueller@roche.example", "amin.hassan@tui.example", context.seedUserEmail.toLowerCase()],
-      calendarId: calendars[0]?.id,
-      companyId: context.companyId,
-      conferenceUrl: null,
-      connectedAccountId: accounts[0]?.id,
-      status: "confirmed",
-      title: "Customer operations planning",
-      unipileEventId: "demo-fixture-calendar-event-1",
-    });
-    expect((calendarEvents[0]?.endsAt as Date).getTime() - (calendarEvents[0]?.startsAt as Date).getTime()).toBe(
-      45 * 60_000,
-    );
-    expect(calendarEvents[0]?.attendees).toEqual([
-      expect.objectContaining({
-        displayName: "Anna Müller",
-        responseStatus: "yes",
-      }),
-      expect.objectContaining({
-        displayName: "Amin Hassan",
-        responseStatus: "maybe",
-      }),
-    ]);
-    expect(calendarEvents[0]?.organizer).toEqual(
-      expect.objectContaining({
-        displayName: "Max Bergmann",
-        isOrganizer: true,
-      }),
-    );
-    expect(records.calendarEvents[0]?.where).toEqual({
-      connectedAccountId_unipileEventId: {
+    const calendarAnchor = new Date((accounts[0]?.lastSyncedAt as Date).getTime() + 5 * 60_000);
+    for (const [index, fixture] of calendarFixture.events.entries()) {
+      const event = calendarEvents[index];
+      expect(event).toMatchObject({
+        allDay: false,
+        attendeeEmails: [
+          ...fixture.attendees.map(({ person }) => people[person].email?.toLowerCase()),
+          context.seedUserEmail.toLowerCase(),
+        ],
+        calendarId: calendars[0]?.id,
+        companyId: context.companyId,
+        conferenceUrl: null,
         connectedAccountId: accounts[0]?.id,
-        unipileEventId: "demo-fixture-calendar-event-1",
-      },
-    });
+        status: "confirmed",
+        title: fixture.title,
+        unipileEventId: fixture.unipileEventId,
+      });
+      expect(event?.startsAt).toEqual(new Date(calendarAnchor.getTime() - fixture.startsMinutesAgo * 60_000));
+      expect((event?.endsAt as Date).getTime() - (event?.startsAt as Date).getTime()).toBe(
+        fixture.durationMinutes * 60_000,
+      );
+      expect(event?.attendees).toEqual(
+        fixture.attendees.map(({ person, responseStatus }) =>
+          expect.objectContaining({
+            displayName: people[person].displayName,
+            responseStatus,
+          }),
+        ),
+      );
+      expect(event?.organizer).toEqual(
+        expect.objectContaining({
+          displayName: "Max Bergmann",
+          email: context.seedUserEmail,
+          isOrganizer: true,
+        }),
+      );
+      expect(records.calendarEvents[index]?.where).toEqual({
+        connectedAccountId_unipileEventId: {
+          connectedAccountId: accounts[0]?.id,
+          unipileEventId: fixture.unipileEventId,
+        },
+      });
+    }
     expectCanonicalUpdates(records.calendarEvents, ["id", "unipileEventId"]);
 
-    expect(accountActivities[0]).toMatchObject({
-      companyId: context.companyId,
-      connectedAccountId: accounts[1]?.id,
-      identifier: "demo-linkedin-leon",
-      kind: "linkedin_connection_accepted",
-      payload: expect.objectContaining({ fullName: "Leon Becker" }),
-    });
-    expect(records.accountActivities[0]?.where).toEqual({
-      connectedAccountId_kind_identifier: {
+    for (const [index, fixture] of accountActivityFixtures.entries()) {
+      const activity = accountActivities[index];
+      expect(activity).toMatchObject({
+        companyId: context.companyId,
         connectedAccountId: accounts[1]?.id,
-        identifier: "demo-linkedin-leon",
-        kind: "linkedin_connection_accepted",
-      },
-    });
+        id: fixtureId("26000000", index + 1),
+        identifier: fixture.identifier,
+        kind: fixture.kind,
+        payload: expect.objectContaining({ fullName: people[fixture.person].displayName }),
+      });
+      expect(activity?.occurredAt).toEqual(new Date(calendarAnchor.getTime() - fixture.occurredMinutesAgo * 60_000));
+      expect(records.accountActivities[index]?.where).toEqual({
+        connectedAccountId_kind_identifier: {
+          connectedAccountId: accounts[1]?.id,
+          identifier: fixture.identifier,
+          kind: fixture.kind,
+        },
+      });
+    }
+    const newestEventRows = [
+      ...accountActivities.map((activity) => ({
+        at: activity.occurredAt as Date,
+        identifier: activity.identifier,
+        kind: "activity" as const,
+      })),
+      ...calendarEvents.map((event) => ({
+        at: event.startsAt as Date,
+        identifier: event.unipileEventId,
+        kind: "calendar" as const,
+      })),
+    ].toSorted((left, right) => right.at.getTime() - left.at.getTime());
+    expect(newestEventRows.slice(0, 3)).toEqual([
+      expect.objectContaining({ identifier: "demo-linkedin-leon", kind: "activity" }),
+      expect.objectContaining({ identifier: "demo-linkedin-rashid", kind: "activity" }),
+      expect.objectContaining({ identifier: "demo-fixture-calendar-event-1", kind: "calendar" }),
+    ]);
     expectCanonicalUpdates(records.accountActivities, ["id", "identifier", "kind"]);
 
-    expect(identifiers).toHaveLength(4);
+    expect(identifiers).toHaveLength(6);
     expect(identifiers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           channelClass: "linkedin",
           contactId: "contact-0",
           displayName: "Leon Becker",
+          messagingId: "demo-linkedin-leon",
           provider: "linkedin",
         }),
         expect.objectContaining({
           channelClass: "linkedin",
           contactId: "contact-26",
           displayName: "Rashid Malik",
+          messagingId: "demo-linkedin-rashid",
           provider: "linkedin",
         }),
         expect.objectContaining({
@@ -319,10 +380,22 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
           displayName: "Jonas Weber",
           provider: "whatsapp",
         }),
+        expect.objectContaining({
+          channelClass: "instagram",
+          contactId: "contact-23",
+          displayName: "Yasmin Farouk",
+          provider: "instagram",
+        }),
+        expect.objectContaining({
+          channelClass: "telegram",
+          contactId: "contact-6",
+          displayName: "Jonas Weber",
+          provider: "telegram",
+        }),
       ]),
     );
 
-    expect(threads).toHaveLength(25);
+    expect(threads).toHaveLength(28);
     expectCanonicalUpdates(records.threads);
     for (const call of records.threads) {
       expect(call.where).toEqual({
@@ -334,14 +407,17 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     }
     expect(stringsByCount(threads, "provider")).toEqual({
       google: 10,
+      instagram: 1,
       linkedin: 8,
+      outlook: 1,
+      telegram: 1,
       whatsapp: 7,
     });
     expect(stringsByCount(threads, "state")).toEqual({
-      open: 15,
-      unread: 10,
+      open: 17,
+      unread: 11,
     });
-    expect(stringsByCount(threads, "type")).toEqual({ group: 6, single: 19 });
+    expect(stringsByCount(threads, "type")).toEqual({ group: 6, single: 22 });
     expect(
       threads.map(({ name, provider, subject }) => ({
         name,
@@ -388,11 +464,18 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
           provider: "whatsapp",
           subject: null,
         },
+        { name: "Yasmin Farouk", provider: "instagram", subject: null },
+        { name: "Jonas Weber", provider: "telegram", subject: null },
+        {
+          name: null,
+          provider: "outlook",
+          subject: "TUI service journey baseline",
+        },
       ]),
     );
     expect(threads.every((thread) => thread.companyId === context.companyId && thread.sharedToCrm === true)).toBe(true);
 
-    expect(participants).toHaveLength(59);
+    expect(participants).toHaveLength(65);
     const participantsByThread = Map.groupBy(participants, (participant) => String(participant.messagingThreadId));
     for (const thread of threads) {
       const threadParticipants = participantsByThread.get(String(thread.id)) ?? [];
@@ -416,7 +499,7 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
       ]),
     );
     const counterpartNamesByProvider = Object.fromEntries(
-      ["google", "linkedin", "whatsapp"].map((provider) => [
+      ["google", "instagram", "linkedin", "outlook", "telegram", "whatsapp"].map((provider) => [
         provider,
         [
           ...new Set(
@@ -429,7 +512,10 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     );
     expect(counterpartNamesByProvider).toEqual({
       google: ["Amin Hassan", "Anna Müller", "Clara Neumann", "Yasmin Farouk"],
+      instagram: ["Yasmin Farouk"],
       linkedin: ["Leon Becker", "Rashid Malik"],
+      outlook: ["Amin Hassan"],
+      telegram: ["Jonas Weber"],
       whatsapp: ["Jonas Weber", "Marco Silva", "Sophie Wagner"],
     });
 
@@ -478,9 +564,17 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
         if (contactIndex === null) return false;
         if (!syntheticContactAuditIds.has(fixtureId("60000000", contactIndex + 1))) return false;
 
-        if (fixture.account === "google") return person.email === SYNTHETIC_CONTACT_EMAIL_ADDRESSES[contactIndex];
+        if (fixture.account === "google" || fixture.account === "outlook")
+          return person.email === SYNTHETIC_CONTACT_EMAIL_ADDRESSES[contactIndex];
 
-        const expectedValue = fixture.account === "linkedin" ? person.linkedin : person.phone;
+        const expectedValue =
+          fixture.account === "linkedin"
+            ? person.linkedin
+            : fixture.account === "whatsapp"
+              ? person.phone
+              : fixture.account === "instagram"
+                ? person.instagram
+                : person.telegram;
         return identifiers.some(
           (identifier) =>
             identifier.contactId === context.contactIds[contactIndex] &&
@@ -523,12 +617,29 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     }
     expectCanonicalUpdates(records.participants);
 
-    expect(messages).toHaveLength(126);
+    expect(messages).toHaveLength(141);
     expect(stringsByCount(messages, "provider")).toEqual({
       google: 51,
+      instagram: 5,
       linkedin: 40,
+      outlook: 5,
+      telegram: 5,
       whatsapp: 35,
     });
+    const newestMessages = messages
+      .toSorted((left, right) => (right.sentAt as Date).getTime() - (left.sentAt as Date).getTime())
+      .slice(0, 6);
+    expect(newestMessages.map(({ provider }) => provider)).toEqual([
+      "google",
+      "whatsapp",
+      "instagram",
+      "linkedin",
+      "telegram",
+      "outlook",
+    ]);
+    expect(
+      newestMessages.map(({ sentAt }) => (calendarAnchor.getTime() - (sentAt as Date).getTime()) / 60_000),
+    ).toEqual([7, 14, 21, 28, 35, 42]);
     expect(new Set(messages.map(({ direction }) => direction))).toEqual(new Set(["inbound", "outbound"]));
     expectCanonicalUpdates(records.messages);
     for (const call of records.messages) {
@@ -566,10 +677,11 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
         `https://customermates.com/demo/avatars/photos/${expectedAvatarByName[senderName]}`,
       );
 
-      if (message.provider === "google") {
+      if (message.provider === "google" || message.provider === "outlook") {
+        const folderPrefix = message.provider === "google" ? "google" : "outlook";
         expect(String(message.bodyHtml)).toContain("<p>");
         expect(message.folderIds).toEqual(
-          message.direction === "outbound" ? ["demo-google-sent"] : ["demo-google-inbox"],
+          message.direction === "outbound" ? [`demo-${folderPrefix}-sent`] : [`demo-${folderPrefix}-inbox`],
         );
       } else {
         expect(message.bodyHtml).toBeNull();
@@ -578,7 +690,7 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     }
 
     const expectedMessageCounts = threadFixtures.map((thread) => thread.messages.length);
-    expect(expectedMessageCounts).toHaveLength(25);
+    expect(expectedMessageCounts).toHaveLength(28);
     expect(expectedMessageCounts.every((count) => count >= 5)).toBe(true);
     for (const [threadIndex, thread] of threads.entries()) {
       const threadMessages = messagesByThread.get(String(thread.id)) ?? [];
@@ -667,11 +779,11 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     vi.setSystemTime(new Date("2026-07-18T12:47:00.000Z"));
     await seedDemoMessagingFixtures(prisma, context);
 
-    const secondAccounts = createdRows(records.connectedAccounts).slice(3);
-    const secondThreads = createdRows(records.threads).slice(25);
-    const secondMessages = createdRows(records.messages).slice(126);
-    const secondCalendarEvents = createdRows(records.calendarEvents).slice(1);
-    const secondAccountActivities = createdRows(records.accountActivities).slice(1);
+    const secondAccounts = createdRows(records.connectedAccounts).slice(6);
+    const secondThreads = createdRows(records.threads).slice(28);
+    const secondMessages = createdRows(records.messages).slice(141);
+    const secondCalendarEvents = createdRows(records.calendarEvents).slice(5);
+    const secondAccountActivities = createdRows(records.accountActivities).slice(2);
 
     expect(secondAccounts[0]?.createdAt).toEqual(firstAccountCreatedAt);
     expect(secondThreads.map(({ createdAt }) => createdAt)).toEqual(firstThreadCreatedAt);
@@ -686,7 +798,7 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
     ).toEqual(firstCalendarEventTimes);
     expect(secondAccountActivities.map(({ occurredAt }) => occurredAt)).toEqual(firstAccountActivityTimes);
     for (const [index, { create, update }] of records.connectedAccounts.entries()) {
-      expect(update).toMatchObject(SYNTHETIC_SEED_TIMELINE.connectedAccount(index % 3));
+      expect(update).toMatchObject(SYNTHETIC_SEED_TIMELINE.connectedAccount(index % 6));
       expect(update.lastSyncedAt).toEqual(create.lastSyncedAt);
     }
     for (const { create, update } of records.threads) {
@@ -746,7 +858,9 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
         ),
     ).toBe(true);
 
-    const accountCleanup = records.connectedAccountDeletes[0]?.where.id as { notIn: string[] };
+    const accountCleanup = records.connectedAccountDeletes[0]?.where.id as {
+      notIn: string[];
+    };
     expect(accountCleanup.notIn).toContain(existingAccountId);
     expect(accountCleanup.notIn).toContain(existingLinkedinAccountId);
     expect(accountCleanup.notIn).not.toContain(records.connectedAccounts[0]?.create.id);
@@ -892,8 +1006,8 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
 
     await expect(seedDemoMessagingFixtures(prisma, context)).resolves.toBeUndefined();
 
-    const secondSeedCreates = records.contactIdentifiers.slice(4).map(({ create }) => create);
-    expect(secondSeedCreates).toHaveLength(3);
+    const secondSeedCreates = records.contactIdentifiers.slice(6).map(({ create }) => create);
+    expect(secondSeedCreates).toHaveLength(5);
     expect(secondSeedCreates.some(({ value }) => value === "leon-becker.linkedin.example")).toBe(false);
     expect(records.contactIdentifierUpdates).toEqual([
       {

--- a/prisma/__tests__/synthetic-audit-log-fixtures.test.ts
+++ b/prisma/__tests__/synthetic-audit-log-fixtures.test.ts
@@ -13,6 +13,7 @@ import {
   SYNTHETIC_CONTACT_UPDATE_INDEXES,
   SYNTHETIC_DEAL_UPDATE_INDEXES,
   SYNTHETIC_ORGANIZATION_UPDATE_INDEXES,
+  SYNTHETIC_RECENT_TASK_AUDIT_OFFSETS_MINUTES,
   SYNTHETIC_TASK_UPDATE_INDEXES,
   type SyntheticAuditFixture,
   type SyntheticAuditSnapshot,
@@ -32,6 +33,7 @@ const primaryUserReference = {
   lastName: SYNTHETIC_COMPANY_USERS.maxBergmann.lastName,
   avatarUrl: "https://customermates.com/demo/avatars/photos/max-bergmann.png",
 };
+const messagingSyncAt = new Date("2026-08-06T00:00:00.000Z");
 
 function syntheticSnapshot(): SyntheticAuditSnapshot {
   const users = [
@@ -172,6 +174,7 @@ function syntheticSnapshot(): SyntheticAuditSnapshot {
       displayName: `Max Bergmann · ${provider}`,
       emailAddress: provider === "google" ? primaryUserReference.email : null,
       createdAt: SYNTHETIC_SEED_TIMELINE.connectedAccount(index).createdAt,
+      lastSyncedAt: messagingSyncAt,
     })),
     users,
     roles: SYNTHETIC_CUSTOM_ROLES.map(({ companyId: _companyId, permissions, ...role }, index) => ({
@@ -353,6 +356,84 @@ describe("synthetic audit-log fixtures", () => {
         roleId: SEED_IDS.customerSuccessRole,
       },
     );
+  });
+
+  it("rotates task actors across the existing team and keeps recent changes beside the messaging window", () => {
+    const snapshot = syntheticSnapshot();
+    const fixtures = buildFixtures(snapshot);
+    const taskActorIds = [SEED_IDS.user, SEED_IDS.sofiaRossiUser, SEED_IDS.elenaHoffmannUser];
+
+    for (const [taskIndex, task] of snapshot.tasks.entries()) {
+      if (task.type !== "custom") continue;
+
+      expect(fixtureForEntity(fixtures, DomainEvent.TASK_CREATED, task.id).userId).toBe(
+        taskActorIds[taskIndex % taskActorIds.length],
+      );
+    }
+
+    for (const taskIndex of SYNTHETIC_TASK_UPDATE_INDEXES) {
+      const task = snapshot.tasks[taskIndex];
+      expect(fixtureForEntity(fixtures, DomainEvent.TASK_UPDATED, task.id).userId).toBe(
+        taskActorIds[taskIndex % taskActorIds.length],
+      );
+    }
+
+    const recentTaskChanges = fixtures
+      .filter(
+        ({ createdAt, event }) =>
+          (event === DomainEvent.TASK_CREATED || event === DomainEvent.TASK_UPDATED) &&
+          createdAt.getTime() > messagingSyncAt.getTime() - 3 * 60 * 60_000,
+      )
+      .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+
+    expect(recentTaskChanges.map(({ event, entityId, userId }) => ({ event, entityId, userId }))).toEqual([
+      {
+        event: DomainEvent.TASK_CREATED,
+        entityId: snapshot.tasks[14].id,
+        userId: SEED_IDS.elenaHoffmannUser,
+      },
+      {
+        event: DomainEvent.TASK_UPDATED,
+        entityId: snapshot.tasks[13].id,
+        userId: SEED_IDS.sofiaRossiUser,
+      },
+      {
+        event: DomainEvent.TASK_CREATED,
+        entityId: snapshot.tasks[12].id,
+        userId: SEED_IDS.user,
+      },
+      {
+        event: DomainEvent.TASK_CREATED,
+        entityId: snapshot.tasks[13].id,
+        userId: SEED_IDS.sofiaRossiUser,
+      },
+      {
+        event: DomainEvent.TASK_CREATED,
+        entityId: snapshot.tasks[11].id,
+        userId: SEED_IDS.elenaHoffmannUser,
+      },
+      {
+        event: DomainEvent.TASK_CREATED,
+        entityId: snapshot.tasks[10].id,
+        userId: SEED_IDS.sofiaRossiUser,
+      },
+    ]);
+    expect(recentTaskChanges.slice(0, 3).map(({ userId }) => userId)).toEqual([
+      SEED_IDS.elenaHoffmannUser,
+      SEED_IDS.sofiaRossiUser,
+      SEED_IDS.user,
+    ]);
+
+    for (const [taskIndex, offsetMinutes] of SYNTHETIC_RECENT_TASK_AUDIT_OFFSETS_MINUTES.created) {
+      expect(fixtureForEntity(fixtures, DomainEvent.TASK_CREATED, snapshot.tasks[taskIndex].id).createdAt).toEqual(
+        new Date(messagingSyncAt.getTime() - offsetMinutes * 60_000),
+      );
+    }
+    for (const [taskIndex, offsetMinutes] of SYNTHETIC_RECENT_TASK_AUDIT_OFFSETS_MINUTES.updated) {
+      expect(fixtureForEntity(fixtures, DomainEvent.TASK_UPDATED, snapshot.tasks[taskIndex].id).createdAt).toEqual(
+        new Date(messagingSyncAt.getTime() - offsetMinutes * 60_000),
+      );
+    }
   });
 
   it("never references an entity before creation and keeps deal totals coherent", () => {

--- a/prisma/__tests__/synthetic-crm-fixtures.test.ts
+++ b/prisma/__tests__/synthetic-crm-fixtures.test.ts
@@ -392,13 +392,13 @@ Loop in legal team
       "service:Pricing model:singleSelect:Fixed,Monthly,Daily",
     ]);
     expect(SYNTHETIC_WIDGET_NAMES).toEqual([
-      "Sold Hardware",
       "Deal Value By Organizations",
       "Sales Pipeline",
       "Total Deal Value",
       "Deal Overview",
-      "Organizations",
-      "Latest Activities",
+      "Recent Changes",
+      "Messages",
+      "Events",
     ]);
   });
 

--- a/prisma/__tests__/synthetic-widget-filters.test.ts
+++ b/prisma/__tests__/synthetic-widget-filters.test.ts
@@ -13,8 +13,11 @@ import { seedWidgets, SYNTHETIC_WIDGET_NAMES } from "../seeds/widgets";
 type SeedLayoutItem = { h: number; i: string; w: number; x: number; y: number };
 
 describe("synthetic widget filters", () => {
-  it("restores the three legacy option filters with deterministic current IDs", async () => {
-    const calls: Array<{ create: Record<string, unknown>; update: Record<string, unknown> }> = [];
+  it("restores the canonical seven-widget dashboard with deterministic IDs and layouts", async () => {
+    const calls: Array<{
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }> = [];
     const deleteMany = vi.fn().mockResolvedValue({ count: 0 });
     const prisma = {
       widget: {
@@ -38,27 +41,27 @@ describe("synthetic widget filters", () => {
     });
 
     const widgets = calls.map(({ create }) => create);
+    const widgetIds = widgets.map(({ id }) => id);
     expect(widgets).toHaveLength(7);
     expect(widgets.map(({ name }) => name)).toEqual(SYNTHETIC_WIDGET_NAMES);
-    expect(deleteMany).toHaveBeenCalledOnce();
+    expect(widgetIds).toEqual([
+      "15000000-0000-4000-8000-000000000002",
+      "15000000-0000-4000-8000-000000000003",
+      "15000000-0000-4000-8000-000000000004",
+      "15000000-0000-4000-8000-000000000005",
+      "15000000-0000-4000-8000-000000000007",
+      "15000000-0000-4000-8000-000000000008",
+      "15000000-0000-4000-8000-000000000009",
+    ]);
+    expect(deleteMany).toHaveBeenCalledTimes(1);
     expect(calls.every(({ create, update }) => JSON.stringify(create) === JSON.stringify(update))).toBe(true);
     expect(deleteMany).toHaveBeenCalledWith({
       where: {
         companyId: SEED_IDS.company,
-        id: {
-          startsWith: "15000000-",
-          notIn: widgets.map(({ id }) => id),
-        },
+        id: { startsWith: "15000000-", notIn: widgetIds },
       },
     });
     expect(widgets.map(({ entityFilters }) => entityFilters)).toEqual([
-      [
-        {
-          field: SYNTHETIC_CUSTOM_COLUMN_IDS.serviceType,
-          operator: "in",
-          value: [SYNTHETIC_CUSTOM_OPTION_IDS.serviceType.hardware],
-        },
-      ],
       [],
       [],
       [
@@ -75,27 +78,258 @@ describe("synthetic widget filters", () => {
           value: [SYNTHETIC_CUSTOM_OPTION_IDS.dealStatus.abandoned],
         },
       ],
-      [],
+      Prisma.DbNull,
+      Prisma.DbNull,
       Prisma.DbNull,
     ]);
-    expect(widgets.map(({ timelineFilters }) => timelineFilters).slice(0, -1)).toEqual(
-      Array.from({ length: 6 }, () => Prisma.DbNull),
-    );
+    expect(widgets.map(({ timelineFilters }) => timelineFilters)).toEqual([
+      Prisma.DbNull,
+      Prisma.DbNull,
+      Prisma.DbNull,
+      Prisma.DbNull,
+      [{ field: "timelineKind", operator: "in", value: ["changes"] }],
+      [{ field: "timelineKind", operator: "in", value: ["messages"] }],
+      [{ field: "timelineKind", operator: "in", value: ["activities"] }],
+    ]);
     expect(widgets.map(({ kind }) => kind)).toEqual([
-      ...Array.from({ length: 6 }, () => WidgetKind.chart),
+      WidgetKind.chart,
+      WidgetKind.chart,
+      WidgetKind.chart,
+      WidgetKind.chart,
+      WidgetKind.activityTimeline,
+      WidgetKind.activityTimeline,
       WidgetKind.activityTimeline,
     ]);
-    expect(widgets.slice(-1).map(({ timelineFilters }) => timelineFilters)).toEqual([
-      [{ field: "timelineKind", operator: "in", value: ["changes", "messages"] }],
-    ]);
-    expect(widgets.slice(-1).map(({ id, layout }) => ({ id, layout }))).toEqual([
+    expect(widgets.map(({ id, layout }) => ({ id, layout }))).toEqual([
+      {
+        id: "15000000-0000-4000-8000-000000000002",
+        layout: {
+          lg: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000002",
+            w: 3,
+            x: 0,
+            y: 0,
+          },
+          md: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000002",
+            w: 2,
+            x: 0,
+            y: 0,
+          },
+          sm: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000002",
+            w: 2,
+            x: 0,
+            y: 0,
+          },
+          xs: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000002",
+            w: 1,
+            x: 0,
+            y: 0,
+          },
+        },
+      },
+      {
+        id: "15000000-0000-4000-8000-000000000003",
+        layout: {
+          lg: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000003",
+            w: 3,
+            x: 3,
+            y: 0,
+          },
+          md: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000003",
+            w: 2,
+            x: 2,
+            y: 0,
+          },
+          sm: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000003",
+            w: 2,
+            x: 2,
+            y: 0,
+          },
+          xs: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000003",
+            w: 1,
+            x: 1,
+            y: 0,
+          },
+        },
+      },
+      {
+        id: "15000000-0000-4000-8000-000000000004",
+        layout: {
+          lg: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000004",
+            w: 3,
+            x: 9,
+            y: 0,
+          },
+          md: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000004",
+            w: 2,
+            x: 6,
+            y: 0,
+          },
+          sm: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000004",
+            w: 2,
+            x: 2,
+            y: 2,
+          },
+          xs: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000004",
+            w: 1,
+            x: 1,
+            y: 2,
+          },
+        },
+      },
+      {
+        id: "15000000-0000-4000-8000-000000000005",
+        layout: {
+          lg: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000005",
+            w: 3,
+            x: 6,
+            y: 0,
+          },
+          md: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000005",
+            w: 2,
+            x: 4,
+            y: 0,
+          },
+          sm: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000005",
+            w: 2,
+            x: 0,
+            y: 2,
+          },
+          xs: {
+            h: 2,
+            i: "15000000-0000-4000-8000-000000000005",
+            w: 1,
+            x: 0,
+            y: 2,
+          },
+        },
+      },
       {
         id: "15000000-0000-4000-8000-000000000007",
         layout: {
-          lg: { h: 3, i: "15000000-0000-4000-8000-000000000007", w: 4, x: 8, y: 2 },
-          md: { h: 4, i: "15000000-0000-4000-8000-000000000007", w: 4, x: 4, y: 3 },
-          sm: { h: 4, i: "15000000-0000-4000-8000-000000000007", w: 2, x: 2, y: 3 },
-          xs: { h: 4, i: "15000000-0000-4000-8000-000000000007", w: 2, x: 0, y: 9 },
+          lg: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000007",
+            w: 4,
+            x: 0,
+            y: 2,
+          },
+          md: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000007",
+            w: 4,
+            x: 0,
+            y: 2,
+          },
+          sm: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000007",
+            w: 4,
+            x: 0,
+            y: 7,
+          },
+          xs: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000007",
+            w: 2,
+            x: 0,
+            y: 4,
+          },
+        },
+      },
+      {
+        id: "15000000-0000-4000-8000-000000000008",
+        layout: {
+          lg: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000008",
+            w: 4,
+            x: 4,
+            y: 2,
+          },
+          md: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000008",
+            w: 4,
+            x: 4,
+            y: 2,
+          },
+          sm: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000008",
+            w: 4,
+            x: 0,
+            y: 4,
+          },
+          xs: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000008",
+            w: 2,
+            x: 0,
+            y: 7,
+          },
+        },
+      },
+      {
+        id: "15000000-0000-4000-8000-000000000009",
+        layout: {
+          lg: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000009",
+            w: 4,
+            x: 8,
+            y: 2,
+          },
+          md: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000009",
+            w: 8,
+            x: 0,
+            y: 5,
+          },
+          sm: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000009",
+            w: 4,
+            x: 0,
+            y: 10,
+          },
+          xs: {
+            h: 3,
+            i: "15000000-0000-4000-8000-000000000009",
+            w: 2,
+            x: 0,
+            y: 10,
+          },
         },
       },
     ]);

--- a/prisma/seeds/audit-logs.ts
+++ b/prisma/seeds/audit-logs.ts
@@ -66,6 +66,7 @@ type ConnectedAccountSnapshot = {
   displayName: string | null;
   emailAddress: string | null;
   id: string;
+  lastSyncedAt: Date | null;
   provider: DomainEventMap[DomainEvent.CONNECTED_ACCOUNT_CREATED]["payload"]["provider"];
 };
 
@@ -151,6 +152,28 @@ export const SYNTHETIC_PREVIOUS_TASK_NAMES = new Map<number, string>([
   [13, "Review notes from the Roche demo"],
 ]);
 
+export const SYNTHETIC_RECENT_TASK_AUDIT_OFFSETS_MINUTES = {
+  created: new Map<number, number>([
+    [10, 156],
+    [11, 126],
+    [12, 66],
+    [13, 96],
+    [14, 12],
+  ]),
+  updated: new Map<number, number>([[13, 38]]),
+} as const;
+
+// Connected-account sync time is stable across reseeds, unlike Date.now(), and keeps these rows among recent messages.
+function recentTaskAuditTime(
+  messagingSyncAt: Date,
+  phase: keyof typeof SYNTHETIC_RECENT_TASK_AUDIT_OFFSETS_MINUTES,
+  taskIndex: number,
+  fallback: Date,
+): Date {
+  const offsetMinutes = SYNTHETIC_RECENT_TASK_AUDIT_OFFSETS_MINUTES[phase].get(taskIndex);
+  return offsetMinutes === undefined ? fallback : new Date(messagingSyncAt.getTime() - offsetMinutes * 60_000);
+}
+
 function auditFixture<E extends DomainEvent>(args: {
   companyId: string;
   createdAt: Date;
@@ -234,6 +257,19 @@ export function buildSyntheticAuditLogFixtures(args: {
 
   const primaryUser = snapshot.users.find(({ id }) => id === primaryUserId);
   if (!primaryUser) throw new Error(`Missing primary synthetic user ${primaryUserId}`);
+  const taskActorIds = [
+    primaryUserId,
+    ...snapshot.users
+      .filter(({ id }) => id !== primaryUserId)
+      .map(({ id }) => id)
+      .sort(),
+  ];
+  const messagingSyncTimes = snapshot.connectedAccounts.flatMap(({ lastSyncedAt }) =>
+    lastSyncedAt ? [lastSyncedAt.getTime()] : [],
+  );
+  if (messagingSyncTimes.length === 0) throw new Error("Missing synthetic messaging sync anchor for recent audit logs");
+  const messagingSyncAt = new Date(Math.max(...messagingSyncTimes));
+  const taskActorId = (taskIndex: number) => taskActorIds[taskIndex % taskActorIds.length];
 
   push(
     DomainEvent.USER_REGISTERED,
@@ -402,7 +438,13 @@ export function buildSyntheticAuditLogFixtures(args: {
   for (const [taskIndex, task] of snapshot.tasks.entries()) {
     if (task.type !== "custom") continue;
     const initialTask = creationState(task, { name: SYNTHETIC_PREVIOUS_TASK_NAMES.get(taskIndex) ?? task.name });
-    push(DomainEvent.TASK_CREATED, task.id, initialTask, initialTask.createdAt);
+    push(
+      DomainEvent.TASK_CREATED,
+      task.id,
+      initialTask,
+      recentTaskAuditTime(messagingSyncAt, "created", taskIndex, initialTask.createdAt),
+      taskActorId(taskIndex),
+    );
   }
 
   for (const taskIndex of SYNTHETIC_TASK_UPDATE_INDEXES) {
@@ -422,7 +464,8 @@ export function buildSyntheticAuditLogFixtures(args: {
           },
         },
       },
-      updatedTask.updatedAt,
+      recentTaskAuditTime(messagingSyncAt, "updated", taskIndex, updatedTask.updatedAt),
+      taskActorId(taskIndex),
     );
   }
 
@@ -679,6 +722,7 @@ async function loadSyntheticAuditSnapshot(
         displayName: true,
         emailAddress: true,
         createdAt: true,
+        lastSyncedAt: true,
       },
     }),
     prisma.webhook.findUniqueOrThrow({

--- a/prisma/seeds/messaging/fixtures.ts
+++ b/prisma/seeds/messaging/fixtures.ts
@@ -11,7 +11,7 @@ export type MessageFixture = {
 };
 
 export type ThreadFixture = {
-  account: "google" | "linkedin" | "whatsapp";
+  account: "google" | "instagram" | "linkedin" | "outlook" | "telegram" | "whatsapp";
   latestMinutesAgo: number;
   messages: MessageFixture[];
   name: string | null;
@@ -29,10 +29,14 @@ export const people: Record<
     displayName: string;
     email?: string;
     headline?: string;
+    instagram?: string;
+    instagramProfileUrl?: string;
     linkedin?: string;
     occupation?: string;
     phone?: string;
     profileUrl?: string;
+    telegram?: string;
+    telegramProfileUrl?: string;
   }
 > = {
   anna: {
@@ -60,6 +64,7 @@ export const people: Record<
     avatarPath: SYNTHETIC_AVATAR_URLS.leonBecker,
     contactIndex: 0,
     displayName: "Leon Becker",
+    email: "leon.becker@bmw.example",
     headline: "Leading practical IT transformation",
     linkedin: "leon-becker.linkedin.example",
     occupation: "IT Transformation Lead at BMW",
@@ -69,6 +74,7 @@ export const people: Record<
     avatarPath: SYNTHETIC_AVATAR_URLS.sophieWagner,
     contactIndex: 19,
     displayName: "Sophie Wagner",
+    email: "sophie.wagner@bmw.example",
     occupation: "Sales Operations Manager at BMW",
     phone: "+12025550119",
   },
@@ -76,8 +82,11 @@ export const people: Record<
     avatarPath: SYNTHETIC_AVATAR_URLS.jonasWeber,
     contactIndex: 6,
     displayName: "Jonas Weber",
+    email: "jonas.weber@continental.example",
     occupation: "Product Lead at Continental",
     phone: "+12025550106",
+    telegram: "jonas_weber",
+    telegramProfileUrl: "https://telegram.example/jonas-weber",
   },
   marco: {
     avatarPath: SYNTHETIC_AVATAR_URLS.marcoSilva,
@@ -90,6 +99,7 @@ export const people: Record<
     avatarPath: SYNTHETIC_AVATAR_URLS.rashidMalik,
     contactIndex: 26,
     displayName: "Rashid Malik",
+    email: "rashid.malik@kpmg.example",
     headline: "Turning digital strategy into measurable change",
     linkedin: "rashid-malik.linkedin.example",
     occupation: "Digital Strategy Manager at KPMG",
@@ -100,29 +110,92 @@ export const people: Record<
     contactIndex: 23,
     displayName: "Yasmin Farouk",
     email: "yasmin.farouk@asml.example",
+    instagram: "yasmin.farouk",
+    instagramProfileUrl: "https://instagram.example/yasmin-farouk",
     occupation: "Partner Manager at ASML",
   },
 };
 
 export const calendarFixture = {
-  attendees: [
-    { person: "anna", responseStatus: "yes" },
-    { person: "amin", responseStatus: "maybe" },
-  ],
+  events: [
+    {
+      attendees: [
+        { person: "anna", responseStatus: "yes" },
+        { person: "amin", responseStatus: "maybe" },
+      ],
+      durationMinutes: 45,
+      startsMinutesAgo: 90,
+      title: "Customer operations planning",
+      unipileEventId: "demo-fixture-calendar-event-1",
+    },
+    {
+      attendees: [
+        { person: "leon", responseStatus: "yes" },
+        { person: "sophie", responseStatus: "yes" },
+      ],
+      durationMinutes: 60,
+      startsMinutesAgo: 6 * 60,
+      title: "BMW rollout checkpoint",
+      unipileEventId: "demo-fixture-calendar-event-2",
+    },
+    {
+      attendees: [
+        { person: "amin", responseStatus: "yes" },
+        { person: "jonas", responseStatus: "maybe" },
+      ],
+      durationMinutes: 45,
+      startsMinutesAgo: 24 * 60,
+      title: "Customer journey review",
+      unipileEventId: "demo-fixture-calendar-event-3",
+    },
+    {
+      attendees: [
+        { person: "yasmin", responseStatus: "yes" },
+        { person: "anna", responseStatus: "yes" },
+      ],
+      durationMinutes: 60,
+      startsMinutesAgo: 2 * 24 * 60,
+      title: "Partner enablement kickoff",
+      unipileEventId: "demo-fixture-calendar-event-4",
+    },
+    {
+      attendees: [
+        { person: "rashid", responseStatus: "yes" },
+        { person: "leon", responseStatus: "maybe" },
+      ],
+      durationMinutes: 45,
+      startsMinutesAgo: 3 * 24 * 60,
+      title: "Transformation steering review",
+      unipileEventId: "demo-fixture-calendar-event-5",
+    },
+  ] satisfies Array<{
+    attendees: Array<{ person: PersonKey; responseStatus: "maybe" | "yes" }>;
+    durationMinutes: number;
+    startsMinutesAgo: number;
+    title: string;
+    unipileEventId: string;
+  }>,
   name: "Customer meetings",
   timezone: "Europe/Berlin",
-  title: "Customer operations planning",
   unipileCalendarId: "demo-fixture-google-calendar",
-  unipileEventId: "demo-fixture-calendar-event-1",
 } as const;
 
-export const accountActivityFixture = {
-  identifier: "demo-linkedin-leon",
-  kind: "linkedin_connection_accepted",
-  person: "leon",
-} as const;
+export const accountActivityFixtures = [
+  {
+    identifier: "demo-linkedin-leon",
+    kind: "linkedin_connection_accepted",
+    occurredMinutesAgo: 30,
+    person: "leon",
+  },
+  {
+    identifier: "demo-linkedin-rashid",
+    kind: "linkedin_connection_accepted",
+    occurredMinutesAgo: 60,
+    person: "rashid",
+  },
+] as const;
 
-export const threads: ThreadFixture[] = [
+const threadFixtures: ThreadFixture[] = [
   {
     account: "google",
     latestMinutesAgo: 7,
@@ -156,7 +229,7 @@ export const threads: ThreadFixture[] = [
   },
   {
     account: "google",
-    latestMinutesAgo: 32,
+    latestMinutesAgo: 90,
     messages: [
       {
         sender: "self",
@@ -222,7 +295,7 @@ export const threads: ThreadFixture[] = [
   },
   {
     account: "linkedin",
-    latestMinutesAgo: 180,
+    latestMinutesAgo: 28,
     messages: [
       {
         sender: "leon",
@@ -285,7 +358,7 @@ export const threads: ThreadFixture[] = [
   },
   {
     account: "whatsapp",
-    latestMinutesAgo: 3 * 24 * 60,
+    latestMinutesAgo: 14,
     messages: [
       {
         sender: "sophie",
@@ -905,4 +978,99 @@ export const threads: ThreadFixture[] = [
     subject: null,
     type: "single",
   },
+  {
+    account: "instagram",
+    latestMinutesAgo: 21,
+    messages: [
+      {
+        sender: "yasmin",
+        text: "Hi Max, the customer operations checklist you shared is exactly the format our partner team needed.",
+      },
+      {
+        sender: "self",
+        text: "Glad it helps. I can tailor the examples to partner qualification, handoff, and the first quarterly review.",
+      },
+      {
+        sender: "yasmin",
+        text: "Those three moments cover the full journey. A short handoff example would make the post especially useful.",
+      },
+      {
+        sender: "self",
+        text: "Done. I added one practical handoff scenario and kept the full checklist linked for anyone who wants the detail.",
+      },
+      {
+        sender: "yasmin",
+        text: "Perfect, I have shared it with the partner leads and the first responses are already coming in.",
+      },
+    ],
+    name: "Yasmin Farouk",
+    participants: ["yasmin"],
+    state: "open",
+    subject: null,
+    type: "single",
+  },
+  {
+    account: "telegram",
+    latestMinutesAgo: 35,
+    messages: [
+      {
+        sender: "jonas",
+        text: "The test cohort finished onboarding and the only issue was one missing browser permission.",
+      },
+      {
+        sender: "self",
+        text: "That is a clean result. I will add the permission check before the next cohort starts.",
+      },
+      {
+        sender: "jonas",
+        text: "Great. The sample workflow itself was clear and everyone completed it faster than expected.",
+      },
+      {
+        sender: "self",
+        text: "Let us keep that workflow unchanged so the comparison with cohort two stays meaningful.",
+      },
+      {
+        sender: "jonas",
+        text: "Agreed. Cohort two is confirmed for Monday with the new permission step in place.",
+      },
+    ],
+    name: "Jonas Weber",
+    participants: ["jonas"],
+    state: "unread",
+    subject: null,
+    type: "single",
+  },
+  {
+    account: "outlook",
+    latestMinutesAgo: 42,
+    messages: [
+      {
+        sender: "amin",
+        text: "Hi Max, I reviewed the service journey baseline and the regional split is much more useful than the overall average.",
+      },
+      {
+        sender: "self",
+        text: "Agreed. I moved the regional comparison to the opening section and kept the overall figure as leadership context.",
+      },
+      {
+        sender: "amin",
+        text: "Could you also separate partner escalations? They are a small share of volume but drive most of the long tail.",
+      },
+      {
+        sender: "self",
+        text: "Yes. The revised view has a partner segment and shows exactly where ownership changes during escalation.",
+      },
+      {
+        sender: "amin",
+        text: "Excellent. That gives us a complete baseline for Friday's customer experience review.",
+      },
+    ],
+    name: null,
+    participants: ["amin"],
+    state: "open",
+    subject: "TUI service journey baseline",
+    type: "single",
+  },
 ];
+
+export const threads = threadFixtures.toSorted((left, right) => left.latestMinutesAgo - right.latestMinutesAgo);

--- a/prisma/seeds/messaging/seed.ts
+++ b/prisma/seeds/messaging/seed.ts
@@ -6,7 +6,7 @@ import { SYNTHETIC_AVATAR_URLS } from "../avatars";
 import { fixtureId } from "../helpers";
 import { SYNTHETIC_SEED_TIMELINE } from "../timeline";
 import {
-  accountActivityFixture,
+  accountActivityFixtures,
   calendarFixture,
   people,
   threads,
@@ -33,7 +33,16 @@ type DemoAttendee = {
 };
 
 const MINUTE = 60_000;
-const DAY = 24 * 60 * MINUTE;
+const EMAIL_FOLDER_IDS = {
+  google: { inbox: "demo-google-inbox", sent: "demo-google-sent" },
+  outlook: { inbox: "demo-outlook-inbox", sent: "demo-outlook-sent" },
+} as const;
+
+type EmailFixtureProvider = keyof typeof EMAIL_FOLDER_IDS;
+
+function isEmailFixtureProvider(provider: MessagingProvider): provider is EmailFixtureProvider {
+  return provider === "google" || provider === "outlook";
+}
 
 function emailHtml(text: string): string {
   const escaped = text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
@@ -43,19 +52,29 @@ function emailHtml(text: string): string {
     .join("");
 }
 
-function providerFor(account: ThreadFixture["account"]): MessagingProvider {
+function providerFor(account: ThreadFixture["account"]): ThreadFixture["account"] {
   return account;
 }
 
-function personAttendee(personKey: PersonKey, provider: MessagingProvider): DemoAttendee {
+function personAttendee(personKey: PersonKey, provider: ThreadFixture["account"]): DemoAttendee {
   const person = people[personKey];
   const identifier =
-    provider === "google"
+    provider === "google" || provider === "outlook"
       ? person.email
       : provider === "linkedin"
         ? person.linkedin
         : provider === "whatsapp"
           ? person.phone
+          : provider === "instagram"
+            ? person.instagram
+            : person.telegram;
+  const profileUrl =
+    provider === "linkedin"
+      ? person.profileUrl
+      : provider === "instagram"
+        ? person.instagramProfileUrl
+        : provider === "telegram"
+          ? person.telegramProfileUrl
           : undefined;
 
   if (!identifier) throw new Error(`Missing ${provider} demo identifier for ${personKey}`);
@@ -68,23 +87,45 @@ function personAttendee(personKey: PersonKey, provider: MessagingProvider): Demo
     headline: person.headline,
     occupation: person.occupation,
     pictureUrl: person.avatarPath,
-    profileUrl: person.profileUrl,
+    profileUrl,
   };
 }
 
-function selfAttendee(provider: MessagingProvider, seedUserEmail: string): DemoAttendee {
-  const identifier =
-    provider === "google" ? seedUserEmail : provider === "linkedin" ? "max-bergmann.linkedin.example" : "+12025550199";
+function selfAttendee(provider: ThreadFixture["account"], seedUserEmail: string): DemoAttendee {
+  const identities: Record<ThreadFixture["account"], { identifier: string; profileUrl?: string }> = {
+    google: { identifier: seedUserEmail },
+    instagram: {
+      identifier: "max.bergmann",
+      profileUrl: "https://instagram.example/max-bergmann",
+    },
+    linkedin: {
+      identifier: "max-bergmann.linkedin.example",
+      profileUrl: "https://linkedin.example/in/max-bergmann",
+    },
+    outlook: { identifier: seedUserEmail },
+    telegram: {
+      identifier: "max_bergmann",
+      profileUrl: "https://telegram.example/max-bergmann",
+    },
+    whatsapp: { identifier: "+12025550199" },
+  };
+  const identity = identities[provider];
 
   return {
     attendeeId: `demo-${provider}-self`,
     displayName: SYNTHETIC_COMPANY_USERS.maxBergmann.name,
-    identifier,
+    identifier: identity.identifier,
     isSelf: true,
     occupation: "Account Manager at Customermates",
     pictureUrl: SYNTHETIC_AVATAR_URLS.maxBergmann,
-    profileUrl: provider === "linkedin" ? "https://linkedin.example/in/max-bergmann" : undefined,
+    profileUrl: identity.profileUrl,
   };
+}
+
+function emailFolderIds(provider: MessagingProvider, senderIsSelf: boolean): string[] {
+  if (!isEmailFixtureProvider(provider)) return [];
+  const folders = EMAIL_FOLDER_IDS[provider];
+  return [senderIsSelf ? folders.sent : folders.inbox];
 }
 
 function inputJson(value: unknown): Prisma.InputJsonValue {
@@ -96,14 +137,26 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
     google: fixtureId("16000000", 1),
     linkedin: fixtureId("16000000", 2),
     whatsapp: fixtureId("16000000", 3),
+    instagram: fixtureId("16000000", 4),
+    telegram: fixtureId("16000000", 5),
+    outlook: fixtureId("16000000", 6),
   } as const;
-  const seededAccountIds: Record<keyof typeof accountIds, string> = { ...accountIds };
+  const seededAccountIds: Record<keyof typeof accountIds, string> = {
+    ...accountIds,
+  };
   const desiredAccountIds: string[] = [];
   const persistedAnchor = await prisma.connectedAccount.findFirst({
     where: {
       companyId: context.companyId,
       unipileAccountId: {
-        in: ["demo-fixture-google-account", "demo-fixture-linkedin-account", "demo-fixture-whatsapp-account"],
+        in: [
+          "demo-fixture-google-account",
+          "demo-fixture-linkedin-account",
+          "demo-fixture-whatsapp-account",
+          "demo-fixture-instagram-account",
+          "demo-fixture-telegram-account",
+          "demo-fixture-outlook-account",
+        ],
       },
       lastSyncedAt: { not: null },
     },
@@ -120,6 +173,15 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
     0,
   );
   const googleSentCount = googleThreads.reduce(
+    (count, thread) => count + thread.messages.filter((message) => message.sender === "self").length,
+    0,
+  );
+  const outlookThreads = threads.filter((thread) => thread.account === "outlook");
+  const outlookInboundCount = outlookThreads.reduce(
+    (count, thread) => count + thread.messages.filter((message) => message.sender !== "self").length,
+    0,
+  );
+  const outlookSentCount = outlookThreads.reduce(
     (count, thread) => count + thread.messages.filter((message) => message.sender === "self").length,
     0,
   );
@@ -176,6 +238,57 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
       sentFolderIds: [] as string[],
       linkedinProducts: [] as string[],
     },
+    {
+      id: accountIds.instagram,
+      unipileAccountId: "demo-fixture-instagram-account",
+      provider: "instagram" as const,
+      emailAddress: null,
+      displayName: `${SYNTHETIC_COMPANY_USERS.maxBergmann.name} · Instagram`,
+      hasCalendar: false,
+      folders: [],
+      selectedFolderIds: [] as string[],
+      sentFolderIds: [] as string[],
+      linkedinProducts: [] as string[],
+    },
+    {
+      id: accountIds.telegram,
+      unipileAccountId: "demo-fixture-telegram-account",
+      provider: "telegram" as const,
+      emailAddress: null,
+      displayName: `${SYNTHETIC_COMPANY_USERS.maxBergmann.name} · Telegram`,
+      hasCalendar: false,
+      folders: [],
+      selectedFolderIds: [] as string[],
+      sentFolderIds: [] as string[],
+      linkedinProducts: [] as string[],
+    },
+    {
+      id: accountIds.outlook,
+      unipileAccountId: "demo-fixture-outlook-account",
+      provider: "outlook" as const,
+      emailAddress: context.seedUserEmail,
+      displayName: `${SYNTHETIC_COMPANY_USERS.maxBergmann.name} · Outlook`,
+      hasCalendar: true,
+      folders: [
+        {
+          id: EMAIL_FOLDER_IDS.outlook.inbox,
+          name: "Inbox",
+          role: "INBOX",
+          totalCount: outlookInboundCount,
+          unreadCount: outlookThreads.filter((thread) => thread.state === "unread").length,
+        },
+        {
+          id: EMAIL_FOLDER_IDS.outlook.sent,
+          name: "Sent",
+          role: "SENT",
+          totalCount: outlookSentCount,
+          unreadCount: 0,
+        },
+      ],
+      selectedFolderIds: [EMAIL_FOLDER_IDS.outlook.inbox, EMAIL_FOLDER_IDS.outlook.sent],
+      sentFolderIds: [EMAIL_FOLDER_IDS.outlook.sent],
+      linkedinProducts: [] as string[],
+    },
   ];
 
   for (const [index, account] of accounts.entries()) {
@@ -192,7 +305,7 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
       sentFolderIds: account.sentFolderIds,
       folders: inputJson(account.folders),
       selectedFolderIds: account.selectedFolderIds,
-      foldersSyncedAt: account.provider === "google" ? new Date(anchor.getTime() - 5 * MINUTE) : null,
+      foldersSyncedAt: isEmailFixtureProvider(account.provider) ? new Date(anchor.getTime() - 5 * MINUTE) : null,
       linkedinProducts: account.linkedinProducts,
       shared: false,
       syncing: false,
@@ -254,81 +367,87 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
     },
   });
 
-  const attendees = calendarFixture.attendees.map(({ person, responseStatus }) => ({
-    email: people[person].email?.toLowerCase() ?? "",
-    displayName: people[person].displayName,
-    responseStatus,
-    isOrganizer: false,
-  }));
-  if (attendees.some(({ email }) => !email)) throw new Error("Missing demo calendar attendee email");
   const organizer = {
     email: context.seedUserEmail.toLowerCase(),
     displayName: SYNTHETIC_COMPANY_USERS.maxBergmann.name,
     responseStatus: "yes",
     isOrganizer: true,
   };
-  const eventData = {
-    companyId: context.companyId,
-    connectedAccountId: seededAccountIds.google,
-    calendarId: seededCalendar.id,
-    title: calendarFixture.title,
-    description: null,
-    location: null,
-    conferenceUrl: null,
-    startsAt: new Date(anchor.getTime() - 2 * DAY),
-    endsAt: new Date(anchor.getTime() - 2 * DAY + 45 * MINUTE),
-    allDay: false,
-    timezone: calendarFixture.timezone,
-    recurrenceRule: null,
-    status: "confirmed" as const,
-    visibility: null,
-    attendees: inputJson(attendees),
-    organizer: inputJson(organizer),
-    attendeeEmails: [...new Set([...attendees.map(({ email }) => email), organizer.email])],
-  };
-  await prisma.calendarEvent.upsert({
-    where: {
-      connectedAccountId_unipileEventId: {
-        connectedAccountId: seededAccountIds.google,
-        unipileEventId: calendarFixture.unipileEventId,
-      },
-    },
-    update: eventData,
-    create: {
-      ...eventData,
-      id: fixtureId("25000000", 1),
-      unipileEventId: calendarFixture.unipileEventId,
-    },
-  });
+  for (const [index, fixture] of calendarFixture.events.entries()) {
+    const attendees = fixture.attendees.map(({ person, responseStatus }) => ({
+      email: people[person].email?.toLowerCase() ?? "",
+      displayName: people[person].displayName,
+      responseStatus,
+      isOrganizer: false,
+    }));
+    if (attendees.some(({ email }) => !email)) throw new Error("Missing demo calendar attendee email");
 
-  const activityPerson = people[accountActivityFixture.person];
-  const activityData = {
-    companyId: context.companyId,
-    connectedAccountId: seededAccountIds.linkedin,
-    payload: inputJson({
-      fullName: activityPerson.displayName,
-      headline: activityPerson.headline,
-      profileUrl: activityPerson.profileUrl,
-      pictureUrl: activityPerson.avatarPath,
-    }),
-    occurredAt: new Date(anchor.getTime() - 8 * DAY),
-  };
-  await prisma.accountActivity.upsert({
-    where: {
-      connectedAccountId_kind_identifier: {
-        connectedAccountId: seededAccountIds.linkedin,
-        kind: accountActivityFixture.kind,
-        identifier: accountActivityFixture.identifier,
+    const startsAt = new Date(anchor.getTime() - fixture.startsMinutesAgo * MINUTE);
+    const eventData = {
+      companyId: context.companyId,
+      connectedAccountId: seededAccountIds.google,
+      calendarId: seededCalendar.id,
+      title: fixture.title,
+      description: null,
+      location: null,
+      conferenceUrl: null,
+      startsAt,
+      endsAt: new Date(startsAt.getTime() + fixture.durationMinutes * MINUTE),
+      allDay: false,
+      timezone: calendarFixture.timezone,
+      recurrenceRule: null,
+      status: "confirmed" as const,
+      visibility: null,
+      attendees: inputJson(attendees),
+      organizer: inputJson(organizer),
+      attendeeEmails: [...new Set([...attendees.map(({ email }) => email), organizer.email])],
+    };
+    await prisma.calendarEvent.upsert({
+      where: {
+        connectedAccountId_unipileEventId: {
+          connectedAccountId: seededAccountIds.google,
+          unipileEventId: fixture.unipileEventId,
+        },
       },
-    },
-    update: activityData,
-    create: {
-      ...activityData,
-      id: fixtureId("26000000", 1),
-      identifier: accountActivityFixture.identifier,
-      kind: accountActivityFixture.kind,
-    },
-  });
+      update: eventData,
+      create: {
+        ...eventData,
+        id: fixtureId("25000000", index + 1),
+        unipileEventId: fixture.unipileEventId,
+      },
+    });
+  }
+
+  for (const [index, fixture] of accountActivityFixtures.entries()) {
+    const activityPerson = people[fixture.person];
+    const activityData = {
+      companyId: context.companyId,
+      connectedAccountId: seededAccountIds.linkedin,
+      payload: inputJson({
+        fullName: activityPerson.displayName,
+        headline: activityPerson.headline,
+        profileUrl: activityPerson.profileUrl,
+        pictureUrl: activityPerson.avatarPath,
+      }),
+      occurredAt: new Date(anchor.getTime() - fixture.occurredMinutesAgo * MINUTE),
+    };
+    await prisma.accountActivity.upsert({
+      where: {
+        connectedAccountId_kind_identifier: {
+          connectedAccountId: seededAccountIds.linkedin,
+          kind: fixture.kind,
+          identifier: fixture.identifier,
+        },
+      },
+      update: activityData,
+      create: {
+        ...activityData,
+        id: fixtureId("26000000", index + 1),
+        identifier: fixture.identifier,
+        kind: fixture.kind,
+      },
+    });
+  }
 
   // Positional fixture IDs can point at different natural keys after fixtures are
   // inserted or reordered. Rebuild only rows in the reserved synthetic namespaces
@@ -353,12 +472,14 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
 
   const channelPeople: Array<{
     key: PersonKey;
-    provider: "linkedin" | "whatsapp";
+    provider: "instagram" | "linkedin" | "telegram" | "whatsapp";
   }> = [
     { key: "leon", provider: "linkedin" },
     { key: "rashid", provider: "linkedin" },
     { key: "sophie", provider: "whatsapp" },
     { key: "jonas", provider: "whatsapp" },
+    { key: "yasmin", provider: "instagram" },
+    { key: "jonas", provider: "telegram" },
   ];
 
   for (const [index, channel] of channelPeople.entries()) {
@@ -370,9 +491,9 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
       companyId: context.companyId,
       contactId: context.contactIds[person.contactIndex],
       provider: channel.provider,
-      channelClass: channel.provider === "whatsapp" ? "phone" : "linkedin",
+      channelClass: channel.provider === "whatsapp" ? "phone" : channel.provider,
       value: attendee.identifier,
-      messagingId: channel.provider === "linkedin" ? attendee.attendeeId : null,
+      messagingId: channel.provider === "whatsapp" ? null : attendee.attendeeId,
       displayName: attendee.displayName,
       profileUrl: attendee.profileUrl ?? null,
     };
@@ -532,7 +653,7 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
         connectedAccountId,
         messagingThreadId: seededThread.id,
         provider,
-        providerMessageId: provider === "google" ? `demo-provider-message-${messageIndex}` : null,
+        providerMessageId: isEmailFixtureProvider(provider) ? `demo-provider-message-${messageIndex}` : null,
         direction: message.sender === "self" ? ("outbound" as const) : ("inbound" as const),
         origin: "external" as const,
         sender: inputJson(sender),
@@ -552,10 +673,9 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
         ),
         subject: fixture.subject,
         bodyText: message.text,
-        bodyHtml: provider === "google" ? emailHtml(message.text) : null,
+        bodyHtml: isEmailFixtureProvider(provider) ? emailHtml(message.text) : null,
         attachmentsMeta: inputJson([]),
-        folderIds:
-          provider === "google" ? (message.sender === "self" ? ["demo-google-sent"] : ["demo-google-inbox"]) : [],
+        folderIds: emailFolderIds(provider, message.sender === "self"),
         isEvent: false,
         isDeleted: false,
         isHidden: false,

--- a/prisma/seeds/widgets.ts
+++ b/prisma/seeds/widgets.ts
@@ -6,215 +6,228 @@ import type { CustomFieldSeedData } from "./custom-fields";
 import { fixtureId, upsertFixturesById } from "./helpers";
 
 export const SYNTHETIC_WIDGET_NAMES = [
-  "Sold Hardware",
   "Deal Value By Organizations",
   "Sales Pipeline",
   "Total Deal Value",
   "Deal Overview",
-  "Organizations",
-  "Latest Activities",
+  "Recent Changes",
+  "Messages",
+  "Events",
 ] as const;
 
-function widgetLayout(id: string, index: number) {
-  const layouts = [
-    {
-      lg: { h: 2, w: 3, x: 3, y: 0 },
-      md: { h: 2, w: 2, x: 2, y: 2 },
-      sm: { h: 2, w: 1, x: 1, y: 2 },
-      xs: { h: 2, w: 1, x: 1, y: 7 },
-    },
-    {
-      lg: { h: 3, w: 4, x: 0, y: 2 },
-      md: { h: 3, w: 4, x: 4, y: 0 },
-      sm: { h: 3, w: 2, x: 2, y: 0 },
-      xs: { h: 3, w: 2, x: 0, y: 2 },
-    },
-    {
-      lg: { h: 3, w: 4, x: 4, y: 2 },
-      md: { h: 3, w: 4, x: 0, y: 4 },
-      sm: { h: 3, w: 2, x: 0, y: 4 },
-      xs: { h: 2, w: 2, x: 0, y: 5 },
-    },
-    {
-      lg: { h: 2, w: 3, x: 6, y: 0 },
-      md: { h: 2, w: 2, x: 0, y: 0 },
-      sm: { h: 2, w: 1, x: 1, y: 0 },
-      xs: { h: 2, w: 1, x: 1, y: 0 },
-    },
-    {
-      lg: { h: 2, w: 3, x: 9, y: 0 },
-      md: { h: 2, w: 2, x: 2, y: 0 },
-      sm: { h: 2, w: 1, x: 0, y: 0 },
-      xs: { h: 2, w: 1, x: 0, y: 0 },
-    },
-    {
-      lg: { h: 2, w: 3, x: 0, y: 0 },
-      md: { h: 2, w: 2, x: 0, y: 2 },
-      sm: { h: 2, w: 1, x: 0, y: 2 },
-      xs: { h: 2, w: 1, x: 0, y: 7 },
-    },
-  ] as const;
-  const layout = layouts[index];
-  return {
-    lg: { i: id, ...layout.lg },
-    md: { i: id, ...layout.md },
-    sm: { i: id, ...layout.sm },
-    xs: { i: id, ...layout.xs },
-  };
-}
+type LayoutGeometry = {
+  h: number;
+  w: number;
+  x: number;
+  y: number;
+};
 
-function activityWidgetLayout(id: string) {
+type LayoutGeometryByBreakpoint = {
+  lg: LayoutGeometry;
+  md: LayoutGeometry;
+  sm: LayoutGeometry;
+  xs: LayoutGeometry;
+};
+
+function widgetLayout(id: string, geometry: LayoutGeometryByBreakpoint) {
   return {
-    lg: { i: id, h: 3, w: 4, x: 8, y: 2 },
-    md: { i: id, h: 4, w: 4, x: 4, y: 3 },
-    sm: { i: id, h: 4, w: 2, x: 2, y: 3 },
-    xs: { i: id, h: 4, w: 2, x: 0, y: 9 },
+    lg: { i: id, ...geometry.lg },
+    md: { i: id, ...geometry.md },
+    sm: { i: id, ...geometry.sm },
+    xs: { i: id, ...geometry.xs },
   };
 }
 
 export async function seedWidgets(context: SeedContext, customFields: CustomFieldSeedData): Promise<void> {
   const { prisma, ids } = context;
   const { customColumnIds, customOptionIds } = customFields;
-  const entityFilters = [
-    [
-      {
-        field: customColumnIds.serviceType,
-        operator: "in",
-        value: [customOptionIds.serviceType.hardware],
-      },
-    ],
-    [],
-    [],
-    [
-      {
-        field: customColumnIds.dealStatus,
-        operator: "notIn",
-        value: [customOptionIds.dealStatus.abandoned],
-      },
-    ],
-    [
-      {
-        field: customColumnIds.dealStatus,
-        operator: "notIn",
-        value: [customOptionIds.dealStatus.abandoned],
-      },
-    ],
-    [],
-  ] as const;
-  const definitions = [
-    [SYNTHETIC_WIDGET_NAMES[0], "service", "dealQuantity", "none", null, "doughnutChart", ["secondary1"], true],
-    [
-      SYNTHETIC_WIDGET_NAMES[1],
-      "organization",
-      "dealValue",
-      "organization",
-      null,
-      "horizontalBarChartWithLabels",
-      ["primary1", "primary2", "primary3"],
-      true,
-    ],
-    [
-      SYNTHETIC_WIDGET_NAMES[2],
-      "contact",
-      "count",
-      "customColumn",
-      customColumnIds.contactSalesPipeline,
-      "doughnutChart",
-      ["default1", "default2", "primary1", "primary2", "secondary1", "secondary2"],
-      false,
-    ],
-    [
-      SYNTHETIC_WIDGET_NAMES[3],
-      "deal",
-      "dealValue",
-      "customColumn",
-      customColumnIds.dealStatus,
-      "doughnutChart",
-      ["success1", "warning1", "danger1"],
-      true,
-    ],
-    [
-      SYNTHETIC_WIDGET_NAMES[4],
-      "deal",
-      "count",
-      "customColumn",
-      customColumnIds.dealStatus,
-      "verticalBarChart",
-      ["success1", "warning1", "danger1"],
-      true,
-    ],
-    [
-      SYNTHETIC_WIDGET_NAMES[5],
-      "organization",
-      "count",
-      "customColumn",
-      customColumnIds.organizationType,
-      "doughnutChart",
-      ["primary1", "secondary1"],
-      true,
-    ],
-  ] as const;
-
-  const widgets = definitions.map(
-    (
-      [name, entityType, aggregationType, groupByType, groupByCustomColumnId, displayType, barColors, useGroupColors],
-      index,
-    ) => {
-      const id = fixtureId("15000000", index + 1);
-      return {
-        id,
-        kind: WidgetKind.chart,
-        aggregationType,
-        companyId: ids.company,
-        dealFilters: [],
-        displayOptions: {
-          barColors,
-          displayType,
-          reverseXAxis: false,
-          reverseYAxis: false,
-          showFilters: true,
-          showLegend: true,
-          useGroupColors,
-        },
-        entityFilters: entityFilters[index],
-        entityType,
-        groupByCustomColumnId,
-        groupByType,
-        timelineFilters: Prisma.DbNull,
-        isTemplate: false,
-        layout: widgetLayout(id, index),
-        name,
-        userId: ids.user,
-      } satisfies Prisma.WidgetCreateManyInput;
+  const dealStatusFilter = [
+    {
+      field: customColumnIds.dealStatus,
+      operator: "notIn",
+      value: [customOptionIds.dealStatus.abandoned],
     },
-  );
-
-  const activityWidgetId = fixtureId("15000000", widgets.length + 1);
-  const activityWidget = {
-    id: activityWidgetId,
-    companyId: ids.company,
-    kind: WidgetKind.activityTimeline,
-    name: SYNTHETIC_WIDGET_NAMES[widgets.length],
-    entityType: null,
-    entityFilters: Prisma.DbNull,
-    dealFilters: Prisma.DbNull,
-    groupByType: null,
-    groupByCustomColumnId: null,
-    aggregationType: null,
-    displayOptions: { showFilters: true },
-    timelineFilters: [
-      {
-        field: "timelineKind",
-        operator: "in",
-        value: ["changes", "messages"],
+  ] as const;
+  const chartDefinitions = [
+    {
+      aggregationType: "dealValue",
+      barColors: ["primary1", "primary2", "primary3"],
+      displayType: "horizontalBarChartWithLabels",
+      entityFilters: [],
+      entityType: "organization",
+      groupByCustomColumnId: null,
+      groupByType: "organization",
+      idSuffix: 2,
+      layout: {
+        lg: { h: 2, w: 3, x: 0, y: 0 },
+        md: { h: 2, w: 2, x: 0, y: 0 },
+        sm: { h: 2, w: 2, x: 0, y: 0 },
+        xs: { h: 2, w: 1, x: 0, y: 0 },
       },
-    ],
-    isTemplate: false,
-    layout: activityWidgetLayout(activityWidgetId),
-    userId: ids.user,
-  } satisfies Prisma.WidgetCreateManyInput;
+      name: SYNTHETIC_WIDGET_NAMES[0],
+      useGroupColors: true,
+    },
+    {
+      aggregationType: "count",
+      barColors: ["default1", "default2", "primary1", "primary2", "secondary1", "secondary2"],
+      displayType: "doughnutChart",
+      entityFilters: [],
+      entityType: "contact",
+      groupByCustomColumnId: customColumnIds.contactSalesPipeline,
+      groupByType: "customColumn",
+      idSuffix: 3,
+      layout: {
+        lg: { h: 2, w: 3, x: 3, y: 0 },
+        md: { h: 2, w: 2, x: 2, y: 0 },
+        sm: { h: 2, w: 2, x: 2, y: 0 },
+        xs: { h: 2, w: 1, x: 1, y: 0 },
+      },
+      name: SYNTHETIC_WIDGET_NAMES[1],
+      useGroupColors: false,
+    },
+    {
+      aggregationType: "dealValue",
+      barColors: ["success1", "warning1", "danger1"],
+      displayType: "doughnutChart",
+      entityFilters: dealStatusFilter,
+      entityType: "deal",
+      groupByCustomColumnId: customColumnIds.dealStatus,
+      groupByType: "customColumn",
+      idSuffix: 4,
+      layout: {
+        lg: { h: 2, w: 3, x: 9, y: 0 },
+        md: { h: 2, w: 2, x: 6, y: 0 },
+        sm: { h: 2, w: 2, x: 2, y: 2 },
+        xs: { h: 2, w: 1, x: 1, y: 2 },
+      },
+      name: SYNTHETIC_WIDGET_NAMES[2],
+      useGroupColors: true,
+    },
+    {
+      aggregationType: "count",
+      barColors: ["success1", "warning1", "danger1"],
+      displayType: "verticalBarChart",
+      entityFilters: dealStatusFilter,
+      entityType: "deal",
+      groupByCustomColumnId: customColumnIds.dealStatus,
+      groupByType: "customColumn",
+      idSuffix: 5,
+      layout: {
+        lg: { h: 2, w: 3, x: 6, y: 0 },
+        md: { h: 2, w: 2, x: 4, y: 0 },
+        sm: { h: 2, w: 2, x: 0, y: 2 },
+        xs: { h: 2, w: 1, x: 0, y: 2 },
+      },
+      name: SYNTHETIC_WIDGET_NAMES[3],
+      useGroupColors: true,
+    },
+  ] as const satisfies ReadonlyArray<{
+    aggregationType: string;
+    barColors: readonly string[];
+    displayType: string;
+    entityFilters: readonly unknown[];
+    entityType: string;
+    groupByCustomColumnId: string | null;
+    groupByType: string;
+    idSuffix: number;
+    layout: LayoutGeometryByBreakpoint;
+    name: string;
+    useGroupColors: boolean;
+  }>;
 
-  const allWidgets = [...widgets, activityWidget];
+  const chartWidgets = chartDefinitions.map((definition) => {
+    const id = fixtureId("15000000", definition.idSuffix);
+    return {
+      id,
+      kind: WidgetKind.chart,
+      aggregationType: definition.aggregationType,
+      companyId: ids.company,
+      dealFilters: [],
+      displayOptions: {
+        barColors: definition.barColors,
+        displayType: definition.displayType,
+        reverseXAxis: false,
+        reverseYAxis: false,
+        showFilters: true,
+        showLegend: true,
+        useGroupColors: definition.useGroupColors,
+      },
+      entityFilters: definition.entityFilters,
+      entityType: definition.entityType,
+      groupByCustomColumnId: definition.groupByCustomColumnId,
+      groupByType: definition.groupByType,
+      timelineFilters: Prisma.DbNull,
+      isTemplate: false,
+      layout: widgetLayout(id, definition.layout),
+      name: definition.name,
+      userId: ids.user,
+    } satisfies Prisma.WidgetCreateManyInput;
+  });
+
+  const activityDefinitions = [
+    {
+      filterValue: "changes",
+      idSuffix: 7,
+      layout: {
+        lg: { h: 3, w: 4, x: 0, y: 2 },
+        md: { h: 3, w: 4, x: 0, y: 2 },
+        sm: { h: 3, w: 4, x: 0, y: 7 },
+        xs: { h: 3, w: 2, x: 0, y: 4 },
+      },
+      name: SYNTHETIC_WIDGET_NAMES[4],
+    },
+    {
+      filterValue: "messages",
+      idSuffix: 8,
+      layout: {
+        lg: { h: 3, w: 4, x: 4, y: 2 },
+        md: { h: 3, w: 4, x: 4, y: 2 },
+        sm: { h: 3, w: 4, x: 0, y: 4 },
+        xs: { h: 3, w: 2, x: 0, y: 7 },
+      },
+      name: SYNTHETIC_WIDGET_NAMES[5],
+    },
+    {
+      filterValue: "activities",
+      idSuffix: 9,
+      layout: {
+        lg: { h: 3, w: 4, x: 8, y: 2 },
+        md: { h: 3, w: 8, x: 0, y: 5 },
+        sm: { h: 3, w: 4, x: 0, y: 10 },
+        xs: { h: 3, w: 2, x: 0, y: 10 },
+      },
+      name: SYNTHETIC_WIDGET_NAMES[6],
+    },
+  ] as const;
+
+  const activityWidgets = activityDefinitions.map((definition) => {
+    const id = fixtureId("15000000", definition.idSuffix);
+    return {
+      id,
+      companyId: ids.company,
+      kind: WidgetKind.activityTimeline,
+      name: definition.name,
+      entityType: null,
+      entityFilters: Prisma.DbNull,
+      dealFilters: Prisma.DbNull,
+      groupByType: null,
+      groupByCustomColumnId: null,
+      aggregationType: null,
+      displayOptions: { showFilters: true },
+      timelineFilters: [
+        {
+          field: "timelineKind",
+          operator: "in",
+          value: [definition.filterValue],
+        },
+      ],
+      isTemplate: false,
+      layout: widgetLayout(id, definition.layout),
+      userId: ids.user,
+    } satisfies Prisma.WidgetCreateManyInput;
+  });
+
+  const allWidgets = [...chartWidgets, ...activityWidgets];
 
   await upsertFixturesById(allWidgets, (widget) =>
     prisma.widget.upsert({
@@ -226,7 +239,10 @@ export async function seedWidgets(context: SeedContext, customFields: CustomFiel
   await prisma.widget.deleteMany({
     where: {
       companyId: ids.company,
-      id: { startsWith: "15000000-", notIn: allWidgets.map(({ id }) => id) },
+      id: {
+        startsWith: "15000000-",
+        notIn: allWidgets.map(({ id }) => id),
+      },
     },
   });
 }

--- a/tests/conventions/marketing-visual-fixture-catalog.test.ts
+++ b/tests/conventions/marketing-visual-fixture-catalog.test.ts
@@ -127,7 +127,10 @@ describe("marketing visual fixture catalog", () => {
   it("derives every safe channel-person pairing from seeded messaging participants", () => {
     const providerIds = {
       google: "gmail",
+      instagram: "instagram",
       linkedin: "linkedin",
+      outlook: "outlook",
+      telegram: "telegram",
       whatsapp: "whatsapp",
     } as const;
     const sourcePairings = new Set<string>();
@@ -152,7 +155,9 @@ describe("marketing visual fixture catalog", () => {
       "anna-mueller",
       "yasmin-farouk",
     ]);
-    expect(listVisualPeople({ provider: "outlook" })).toEqual([]);
+    expect(listVisualPeople({ provider: "instagram" }).map(({ id }) => id)).toEqual(["yasmin-farouk"]);
+    expect(listVisualPeople({ provider: "outlook" }).map(({ id }) => id)).toEqual(["amin-hassan"]);
+    expect(listVisualPeople({ provider: "telegram" }).map(({ id }) => id)).toEqual(["jonas-weber"]);
   });
 
   it("keeps the unified-inbox provider set and highlighted conversation tied to product authorities", () => {


### PR DESCRIPTION
## Summary

- Reshape Max Bergmann's seeded dashboard into four CRM charts plus dedicated Recent Changes, Messages, and Events timelines.
- Rotate recent changes across Max Bergmann, Sofia Rossi, and Elena Hoffmann.
- Interleave Gmail, WhatsApp, Instagram, LinkedIn, Telegram, and Outlook in the newest message fixtures.
- Put two LinkedIn connection acceptances first in Events, followed by five calendar events linked to varied CRM contacts.
- Keep fixture IDs, timestamps, natural-key reuse, reseed convergence, provider/person projections, and the approved widget configurations and positions deterministic.

## Context

This bounded synthetic seed-data change proceeds under the product owner's explicit Linear waiver, so no Linear issue is attached. It makes Max Bergmann's local/demo dashboard full and visibly varied while keeping all data synthetic and repeatable.

The branch is based on current `origin/main` at `a59a67eb`. Independent review found and removed a broad widget-name cleanup so reseeding only deletes obsolete widgets in the reserved synthetic ID namespace and cannot remove manually created widgets named Messages or Events.

## Validation

Final verification on Node 24.18.0:

- `yarn typecheck`
- `yarn lint`
- `yarn test` — 454 files passed, 19 skipped; 4,003 tests passed, 123 skipped
- focused seed regression suite — 5 files and 37 tests passed
- `yarn build` — production build completed; 60 static pages generated
- isolated local PostgreSQL reset and reseed completed
- direct chronology verification confirmed the two LinkedIn activities first, followed by five calendar events, and the requested six-provider message ordering
- `git diff --check`
- staged secret and credential-shaped-file scan

## Impact and rollback

This changes synthetic demo seed data, its dashboard fixture configuration, and the corresponding marketing visual projection only. It adds no database migration, changes no environment variable, and mutates no production data.

Roll back before merge by closing this pull request. After merge, revert the squash commit and reseed the isolated local database.

The protected-branch checks `ci` and `repository-policy` must pass, review conversations must be resolved, and a human must perform the squash merge into `main`.
