### PR TITLE
fix(agent-chat): show initial response progress

### DIFF
--- a/app/components/agent-chat/__tests__/agent-chat.store.test.ts
+++ b/app/components/agent-chat/__tests__/agent-chat.store.test.ts
@@ -197,6 +197,40 @@ describe("AgentChatStore", () => {
     fetchMock.mockRestore();
   });
 
+  it("shows initial response progress until the assistant produces its first item", () => {
+    const store = new AgentChatStore(root() as never);
+    const userItem = {
+      kind: "user" as const,
+      id: "item-user",
+      messageId: "message-user",
+      text: "Summarize my open deals",
+    };
+    store.items = [userItem];
+    store.isWorking = true;
+
+    expect(store.isAwaitingAssistantResponse).toBe(true);
+
+    store.items.push({
+      kind: "activity",
+      id: "item-activity",
+      activity: {
+        kind: "records.read",
+        resource: "deals",
+        affectedResources: ["deals"],
+        risk: "read",
+      },
+      status: "running",
+    });
+    expect(store.isAwaitingAssistantResponse).toBe(false);
+
+    store.items = [userItem, { kind: "assistant", id: "item-assistant", text: "", streaming: true }];
+    expect(store.isAwaitingAssistantResponse).toBe(false);
+
+    store.items = [userItem];
+    store.isWorking = false;
+    expect(store.isAwaitingAssistantResponse).toBe(false);
+  });
+
   it("ignores a stale conversation response after the user selects another chat", async () => {
     const firstId = "00000000-0000-4000-8000-000000000001";
     const secondId = "00000000-0000-4000-8000-000000000002";

--- a/app/components/agent-chat/agent-chat.store.ts
+++ b/app/components/agent-chat/agent-chat.store.ts
@@ -175,6 +175,7 @@ export class AgentChatStore extends BaseStore {
       queuedPrompt: observable,
       isWorking: observable,
       conversationTitle: computed,
+      isAwaitingAssistantResponse: computed,
       open: action,
       close: action,
       toggle: action,
@@ -199,6 +200,10 @@ export class AgentChatStore extends BaseStore {
     if (!this.conversationId) return null;
     const summary = this.conversations.find((conversation) => conversation.id === this.conversationId);
     return summary?.title ?? null;
+  }
+
+  get isAwaitingAssistantResponse() {
+    return this.isWorking && this.items.at(-1)?.kind === "user";
   }
 
   close = () => {

--- a/app/components/agent-chat/agent-chat.tsx
+++ b/app/components/agent-chat/agent-chat.tsx
@@ -315,7 +315,7 @@ const AgentChatPanel = observer(function AgentChatPanel() {
               );
             })}
 
-            {store.isWorking && store.items.length === 0 && (
+            {store.isAwaitingAssistantResponse && (
               <div aria-label={copy.assistantWorking} className="flex items-center gap-1 py-1" role="status">
                 <TypingDots />
               </div>


### PR DESCRIPTION
## Summary

- Show an immediate, accessible typing indicator after the optimistic user message is added.
- Hand that indicator off as soon as the first activity or assistant item reaches the transcript, avoiding duplicate progress UI.
- Cover the pending, activity, assistant, and idle transitions with a focused store regression test.

## Context

Submitting a prompt already appends the optimistic user item and sets `isWorking` synchronously. The existing typing indicator was guarded by `isWorking && items.length === 0`, but it lived inside the non-empty transcript branch, so that condition could never render after a submission.

There is no intentional two- or three-second UI delay. The visible gap lasts until `/api/agent/messages` finishes admission work and the durable agent stream emits its first workflow, activity, or provider event; preview cold starts, network/database latency, workflow dispatch, and model time-to-first-token make that gap noticeable.

### Owner-directed Linear exception

- Issuer: repository owner, through the current Codex task.
- Instruction source: the explicit instruction, “You don't need to create a linear issue for this.”
- Bounded outcome: add initial response progress for new and follow-up AI chat submissions and open this pull request.
- Waived gates: Linear issue creation and the associated claim, receipt, evidence attachment, and Linear connection proof for this bounded outcome only.
- Scope: `app/components/agent-chat/agent-chat.store.ts`, `app/components/agent-chat/agent-chat.tsx`, and `app/components/agent-chat/__tests__/agent-chat.store.test.ts`.
- Constraints retained: current-main branch, local tests/build/browser verification, independent review, GitHub policy/checks, preview verification, and human-only merge.
- Consequence and rollback: one UI-only branch and its preview deployment; close this PR/delete the branch or revert commit `42c9ac2a` to undo it.
- Recorded: 2026-08-28T08:49:38Z.
- Acceptance and expiry: the indicator appears immediately and hands off on the first assistant-side item; the exception expires when this PR is accepted or closed.
- Durable evidence location: this pull request.

## Validation

- `yarn test` — 474 files passed, 1 skipped; 4,145 tests passed, 2 skipped.
- `yarn build` — production build and TypeScript passed.
- `yarn lint` — passed.
- `yarn typecheck` — passed.
- Focused store suite — 48/48 tests passed.
- Local browser verification — the visible `role="status"` typing dots appeared immediately for both a new prompt and a follow-up, then cleared on terminal failure; the state test covers handoff to activity and assistant items.
- Independent read-only review — no findings.
- Pull-request checks — CI, PostgreSQL 16, rendered-page E2E, repository policy, CodeQL, and Vercel all passed.
- Live preview — the branch alias loads successfully at `https://fix-agent-chat-initial-loading.customermates.com`.

The local AI Gateway credential is intentionally a placeholder, so a successful provider-backed handoff remains a preview acceptance check.

## Impact and rollback

This changes only agent-chat presentation state. There are no API, workflow, database, migration, environment, dependency, or translation changes. The branch preview is live at `https://fix-agent-chat-initial-loading.customermates.com`.

Rollback is a revert of `42c9ac2a`, or closing this PR and deleting the branch before merge. A human must review and merge.

## Screenshots

The immediate three-dot state was visually captured against the local synthetic workspace. The deterministic preview above is the review surface for the provider-backed transition.
