### PR TITLE
fix(agent-chat): render markdown in guided tours

### DIFF
--- a/app/components/agent-chat/__tests__/agent-tour-overlay.test.ts
+++ b/app/components/agent-chat/__tests__/agent-tour-overlay.test.ts
@@ -1,0 +1,28 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+vi.mock("@/core/utils/clipboard", () => ({ copyToClipboard: vi.fn() }));
+vi.mock("@/core/stores/root-store.provider", () => ({ useRootStore: vi.fn() }));
+vi.mock("../ui-control.store", () => ({ findAgentTargetElement: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { AgentTourNote } from "../agent-tour-overlay";
+
+describe("AgentTourNote", () => {
+  it("renders Markdown formatting in model-written tour notes", () => {
+    const markup = renderToStaticMarkup(
+      createElement(AgentTourNote, {
+        note: "Open **Company → Roles** to create or update permission sets.",
+      }),
+    );
+
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain('data-streamdown="strong"');
+    expect(markup).toContain("Company → Roles");
+    expect(markup).not.toContain("**Company → Roles**");
+  });
+});

--- a/app/components/agent-chat/agent-tour-overlay.tsx
+++ b/app/components/agent-chat/agent-tour-overlay.tsx
@@ -6,9 +6,20 @@ import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
 
 import { useRootStore } from "@/core/stores/root-store.provider";
+import { MessageResponse } from "@/components/ai-elements/message";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverAnchor, PopoverContent, PopoverTitle } from "@/components/ui/popover";
 import { findAgentTargetElement } from "./ui-control.store";
+
+export function AgentTourNote({ note }: { note: string }) {
+  return (
+    <div aria-live="polite" className="mt-1 text-sm">
+      <MessageResponse controls={false} mode="static" showTableActions={false}>
+        {note}
+      </MessageResponse>
+    </div>
+  );
+}
 
 export const AgentTourOverlay = observer(function AgentTourOverlay() {
   const { agentUiControlStore: store } = useRootStore();
@@ -92,11 +103,7 @@ export const AgentTourOverlay = observer(function AgentTourOverlay() {
                 </Button>
               </div>
 
-              {active.note && (
-                <p aria-live="polite" className="mt-1 text-sm">
-                  {active.note}
-                </p>
-              )}
+              {active.note && <AgentTourNote note={active.note} />}
 
               <div className="mt-3 flex justify-end gap-2">
                 <Button disabled={active.stepIndex === 0} size="sm" variant="secondary" onClick={store.previousStep}>


### PR DESCRIPTION
## Summary

- Render AI guided-tour notes with the existing hardened Markdown response component.
- Keep the tour note static and compact by disabling response and table controls.
- Add a regression test for the exact bold Markdown pattern that previously appeared literally.

## Context

Model-written guided-tour notes can contain Markdown, but the overlay rendered each note as plain paragraph text. This left syntax such as `**Company → Roles**` visible to the user.

Owner-directed Linear exception (2026-08-28T09:47:54Z):

- Issuer and source: repository owner in the current Codex task.
- Bounded outcome: fix guided-tour Markdown rendering and open this PR.
- Named waiver: no Linear issue, claim, or Linear evidence attachment is required for this change.
- Scope: `app/components/agent-chat/agent-tour-overlay.tsx` and its regression test only.
- Remaining constraints: normal verification, independent review, PR checks, synthetic local/preview data, and human-only merge still apply.
- Expiry: when this PR is merged or closed.

## Validation

- `yarn vitest run app/components/agent-chat/__tests__/agent-tour-overlay.test.ts`
- `yarn typecheck`
- `yarn lint`
- `yarn vitest run tests/conventions` — 67 files and 561 tests passed; 1 file and 2 tests skipped.
- Database-backed `yarn test` — 475 files and 4,146 tests passed; 1 file and 2 tests skipped.
- `yarn build`
- Authenticated local browser check confirmed `Company → Roles` renders as an emphasized Streamdown node, no literal `**` remains, and the live region is preserved.
- Independent diff review found no correctness, security, accessibility, test, or scope issues.

## Impact and rollback

Tour notes now use the same sanitized Markdown surface as agent responses, in static mode without interactive response controls. There are no data or schema changes.

Rollback by reverting commit `484f33b5` or closing this PR. Merge remains a human-only action.
