### PR TITLE
fix(agent-chat): persist and control panel open state

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -93,7 +93,7 @@ describe("automatic demo authentication proxy", () => {
 
   it("round-trips an unauthenticated visitor through a same-URL redirect carrying every auth cookie", async () => {
     mocks.signInEmail.mockResolvedValue(responseWithCookies(200, [SESSION_TOKEN_COOKIE, SESSION_DATA_COOKIE]));
-    const incomingRequest = request("/en/dashboard?view=demo");
+    const incomingRequest = request("/en/dashboard?agentChat=closed");
 
     const response = await proxy(incomingRequest);
 
@@ -108,7 +108,7 @@ describe("automatic demo authentication proxy", () => {
       asResponse: true,
     });
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe("http://localhost:4000/en/dashboard?view=demo");
+    expect(response.headers.get("location")).toBe("http://localhost:4000/en/dashboard?agentChat=closed");
     expect(setCookieHeaders(response)).toEqual([SESSION_TOKEN_COOKIE, SESSION_DATA_COOKIE]);
     expect(mocks.intlMiddleware).not.toHaveBeenCalled();
     expect(mocks.isPublicPage).not.toHaveBeenCalled();
@@ -132,6 +132,18 @@ describe("automatic demo authentication proxy", () => {
     expect(mocks.intlMiddleware).toHaveBeenCalledWith(incomingRequest);
     expect(response.headers.get("x-middleware-next")).toBe("1");
     expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("preserves the agent chat override when the localized demo root redirects to the dashboard", async () => {
+    mocks.getSession.mockResolvedValue({
+      session: { expiresAt: new Date(Date.now() + 60_000) },
+      user: { email: SYNTHETIC_SEED_USER.email },
+    });
+
+    const response = await proxy(request("/en?agentChat=closed", "app.session_token=existing-synthetic-token"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost:4000/dashboard?agentChat=closed");
   });
 
   it("replaces a non-demo session and forwards both the sign-out and sign-in cookies", async () => {

--- a/app/[locale]/(static)/components/hero-demo-iframe.tsx
+++ b/app/[locale]/(static)/components/hero-demo-iframe.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/core/utils/cn";
 export function HeroDemoIframe({ className, src }: { className?: string; src?: string }) {
   const locale = useLocale();
   const t = useTranslations();
-  const demoSrc = src ?? `https://demo.customermates.com/${locale}`;
+  const demoSrc = src ?? `https://demo.customermates.com/${locale}/dashboard?agentChat=open`;
 
   return (
     <div className={cn("mx-auto w-full", className)}>

--- a/app/[locale]/(static)/components/homepage-live-demo.tsx
+++ b/app/[locale]/(static)/components/homepage-live-demo.tsx
@@ -9,7 +9,7 @@ import { HeroDemoIframe } from "./hero-demo-iframe";
 
 export function HomepageLiveDemo({ locale, proof }: { locale: ContentLocale; proof: HomepageProductProof }) {
   const localBaseUrl = process.env.BASE_URL?.replace(/\/$/u, "");
-  const demoPath = `/${locale}/dashboard`;
+  const demoPath = `/${locale}/dashboard?agentChat=open`;
   const demoSrc =
     process.env.NODE_ENV === "development" && localBaseUrl
       ? `${localBaseUrl}${demoPath}`

--- a/app/components/agent-chat/__tests__/agent-chat.store.test.ts
+++ b/app/components/agent-chat/__tests__/agent-chat.store.test.ts
@@ -81,10 +81,16 @@ function root(
   };
 }
 
-function stubBrowser(pathname = "/") {
-  const values = new Map<string, string>();
+function stubBrowser(
+  pathname = "/",
+  {
+    hostname = "localhost",
+    search = "",
+    values = new Map<string, string>(),
+  }: { hostname?: string; search?: string; values?: Map<string, string> } = {},
+) {
   vi.stubGlobal("window", {
-    location: { pathname },
+    location: { hostname, pathname, search },
     localStorage: {
       getItem: (key: string) => values.get(key) ?? null,
       setItem: (key: string, value: string) => values.set(key, value),
@@ -215,6 +221,59 @@ describe("AgentChatStore", () => {
 
     expect(reloaded.isOpen).toBe(false);
   });
+
+  it("uses an open URL override without changing the saved closed preference", async () => {
+    const storageKey = "customermates:agentChat:open:v1:company-1:user-1";
+    const values = new Map([[storageKey, "false"]]);
+    stubBrowser("/en/dashboard", { search: "?agentChat=open", values });
+    const store = new AgentChatStore(root() as never);
+
+    expect(store.isOpen).toBe(true);
+    store.close();
+    await store.loadConfig();
+    expect(store.isOpen).toBe(false);
+    expect(values.get(storageKey)).toBe("false");
+
+    expect(new AgentChatStore(root() as never).isOpen).toBe(true);
+    stubBrowser("/en/dashboard", { values });
+    expect(new AgentChatStore(root() as never).isOpen).toBe(false);
+  });
+
+  it("uses a closed URL override without changing the saved open preference or auto-opening", async () => {
+    const storageKey = "customermates:agentChat:open:v1:company-1:user-1";
+    const values = new Map([[storageKey, "true"]]);
+    stubBrowser("/en/dashboard", {
+      hostname: "demo.customermates.test",
+      search: "?agentChat=closed",
+      values,
+    });
+    const store = new AgentChatStore(root() as never);
+
+    expect(store.isOpen).toBe(false);
+    await store.loadConfig();
+    expect(store.isOpen).toBe(false);
+
+    store.open();
+    expect(store.isOpen).toBe(true);
+    expect(values.get(storageKey)).toBe("true");
+    expect(new AgentChatStore(root() as never).isOpen).toBe(false);
+
+    stubBrowser("/en/dashboard", { hostname: "demo.customermates.test", values });
+    expect(new AgentChatStore(root() as never).isOpen).toBe(true);
+  });
+
+  it.each(["?agentChat=", "?agentChat=OPEN", "?agentChat=open&agentChat=closed"])(
+    "ignores the invalid URL override %s",
+    async (search) => {
+      const values = stubBrowser("/en/profile", { hostname: "demo.customermates.test", search });
+      const store = new AgentChatStore(root() as never);
+
+      await store.loadConfig();
+
+      expect(store.isOpen).toBe(true);
+      expect([...values.values()]).toEqual(["true"]);
+    },
+  );
 
   it("retries transient and validation failures but latches off for an explicit denial code", async () => {
     actionsMock.getAgentConfigAction

--- a/app/components/agent-chat/__tests__/agent-chat.store.test.ts
+++ b/app/components/agent-chat/__tests__/agent-chat.store.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTranslator } from "next-intl";
+import { observable, runInAction } from "mobx";
 
 import en from "@/i18n/locales/en.json";
 
@@ -43,6 +44,7 @@ const CONFIG = {
     deals: false,
     services: false,
     tasks: false,
+    widgets: false,
     connectedAccounts: false,
   },
   conversationId: null,
@@ -52,11 +54,15 @@ const CONFIG = {
   archivedConversationNextCursor: null,
 };
 
-function root(uiOverrides: Record<string, unknown> = {}) {
+function root(
+  uiOverrides: Record<string, unknown> = {},
+  user: { id: string; companyId: string } = { id: "user-1", companyId: "company-1" },
+) {
   const refreshStore = () => ({
     refresh: vi.fn().mockResolvedValue(undefined),
   });
   return {
+    userStore: { user },
     localeStore: { locale: "en", translation: null, getTranslation: englishTranslator },
     contactsStore: refreshStore(),
     organizationsStore: refreshStore(),
@@ -73,6 +79,18 @@ function root(uiOverrides: Record<string, unknown> = {}) {
       ...uiOverrides,
     },
   };
+}
+
+function stubBrowser(pathname = "/") {
+  const values = new Map<string, string>();
+  vi.stubGlobal("window", {
+    location: { pathname },
+    localStorage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    },
+  });
+  return values;
 }
 
 describe("AgentChatStore", () => {
@@ -95,6 +113,10 @@ describe("AgentChatStore", () => {
     });
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("uses one toggle action for opening and closing the assistant", () => {
     const store = new AgentChatStore(root() as never);
 
@@ -103,6 +125,95 @@ describe("AgentChatStore", () => {
 
     store.toggle();
     expect(store.isOpen).toBe(false);
+  });
+
+  it("restores the user's explicit open and closed state across reloads", async () => {
+    const stored = stubBrowser("/en/deals");
+    const first = new AgentChatStore(root() as never);
+
+    first.open();
+    expect(new AgentChatStore(root() as never).isOpen).toBe(true);
+    expect([...stored.values()]).toEqual(["true"]);
+
+    first.close();
+    await first.loadConfig();
+
+    expect(new AgentChatStore(root() as never).isOpen).toBe(false);
+    expect([...stored.values()]).toEqual(["false"]);
+  });
+
+  it("scopes the open preference to the current company and user", () => {
+    stubBrowser();
+    new AgentChatStore(root() as never).open();
+
+    expect(new AgentChatStore(root() as never).isOpen).toBe(true);
+    expect(new AgentChatStore(root({}, { id: "user-2", companyId: "company-1" }) as never).isOpen).toBe(false);
+    expect(new AgentChatStore(root({}, { id: "user-1", companyId: "company-2" }) as never).isOpen).toBe(false);
+  });
+
+  it("re-hydrates the preference when the active identity changes", () => {
+    stubBrowser();
+    const firstUser = { id: "user-1", companyId: "company-1" };
+    const secondUser = { id: "user-2", companyId: "company-1" };
+    new AgentChatStore(root({}, secondUser) as never).open();
+    const userStore = observable({ user: firstUser });
+    const store = new AgentChatStore({ ...root(), userStore } as never);
+
+    expect(store.isOpen).toBe(false);
+    runInAction(() => {
+      userStore.user = secondUser;
+    });
+    expect(store.isOpen).toBe(true);
+
+    store.close();
+    runInAction(() => {
+      userStore.user = firstUser;
+    });
+    expect(store.isOpen).toBe(false);
+  });
+
+  it("auto-opens after onboarding on a widget-empty dashboard and persists that default", async () => {
+    const stored = stubBrowser("/en/dashboard");
+    actionsMock.getAgentConfigAction.mockResolvedValue({
+      ok: true,
+      data: {
+        ...CONFIG,
+        counts: { ...CONFIG.counts, contacts: true, organizations: true, tasks: true, widgets: false },
+      },
+    });
+    const store = new AgentChatStore(root() as never);
+
+    await store.loadConfig();
+
+    expect(store.isOpen).toBe(true);
+    expect([...stored.values()]).toEqual(["true"]);
+  });
+
+  it("does not auto-open a dashboard that already has a widget", async () => {
+    const stored = stubBrowser("/en/dashboard");
+    actionsMock.getAgentConfigAction.mockResolvedValue({
+      ok: true,
+      data: { ...CONFIG, counts: { ...CONFIG.counts, widgets: true } },
+    });
+    const store = new AgentChatStore(root() as never);
+
+    await store.loadConfig();
+
+    expect(store.isOpen).toBe(false);
+    expect(stored.size).toBe(0);
+  });
+
+  it("keeps an explicitly closed Assistant closed on an empty page", async () => {
+    stubBrowser("/en/dashboard");
+    const first = new AgentChatStore(root() as never);
+    first.open();
+    first.close();
+    await first.loadConfig();
+
+    const reloaded = new AgentChatStore(root() as never);
+    await reloaded.loadConfig();
+
+    expect(reloaded.isOpen).toBe(false);
   });
 
   it("retries transient and validation failures but latches off for an explicit denial code", async () => {

--- a/app/components/agent-chat/agent-chat.store.ts
+++ b/app/components/agent-chat/agent-chat.store.ts
@@ -95,6 +95,15 @@ function readAgentChatOpenPreference(storageKey: string | null): boolean | null 
   }
 }
 
+function readAgentChatOpenOverride(): boolean | null {
+  if (typeof window === "undefined") return null;
+  const values = new URLSearchParams(window.location.search).getAll("agentChat");
+  if (values.length !== 1) return null;
+  if (values[0] === "open") return true;
+  if (values[0] === "closed") return false;
+  return null;
+}
+
 function writeAgentChatOpenPreference(storageKey: string | null, isOpen: boolean) {
   if (!storageKey || typeof window === "undefined") return;
   try {
@@ -171,14 +180,16 @@ export class AgentChatStore extends BaseStore {
   private streamSequence = 0;
   private uiCommandQueue: Promise<void> = Promise.resolve();
   private demoAutoOpened = false;
+  private readonly openOverride: boolean | null;
   private openStorageKey: string | null;
   private openPreference: boolean | null;
 
   constructor(rootStore: RootStore) {
     super(rootStore);
+    this.openOverride = readAgentChatOpenOverride();
     this.openStorageKey = agentChatOpenStorageKey(rootStore);
     this.openPreference = readAgentChatOpenPreference(this.openStorageKey);
-    this.isOpen = this.openPreference === true;
+    this.isOpen = this.openOverride ?? this.openPreference === true;
     makeObservable(this, {
       isOpen: observable,
       isExpanded: observable,
@@ -274,6 +285,7 @@ export class AgentChatStore extends BaseStore {
   private setOpenState(isOpen: boolean) {
     this.syncOpenPreferenceScope();
     this.isOpen = isOpen;
+    if (this.openOverride !== null) return;
     this.openPreference = isOpen;
     writeAgentChatOpenPreference(this.openStorageKey, isOpen);
   }
@@ -283,14 +295,21 @@ export class AgentChatStore extends BaseStore {
     if (storageKey === this.openStorageKey) return;
     this.openStorageKey = storageKey;
     this.openPreference = readAgentChatOpenPreference(storageKey);
-    this.isOpen = this.openPreference === true;
+    this.isOpen = this.openOverride ?? this.openPreference === true;
     this.autoOpenedPages.clear();
     this.demoAutoOpened = false;
   }
 
   openForEmptyPage = (pathname: string) => {
     this.syncOpenPreferenceScope();
-    if (!this.enabled || this.isOpen || this.openPreference === false || this.autoOpenedPages.has(pathname)) return;
+    if (
+      this.openOverride !== null ||
+      !this.enabled ||
+      this.isOpen ||
+      this.openPreference === false ||
+      this.autoOpenedPages.has(pathname)
+    )
+      return;
     if (!this.counts) return;
 
     const page = agentActionPageFromPathname(pathname);
@@ -685,7 +704,13 @@ export class AgentChatStore extends BaseStore {
       if (typeof window !== "undefined") this.openForEmptyPage(window.location.pathname);
       if (!this.conversationId && !this.isDraftConversationSelected && config.conversationId)
         await this.loadConversation(config.conversationId);
-      if (isDemoEnvironment() && !this.isOpen && this.openPreference !== false && !this.demoAutoOpened) {
+      if (
+        this.openOverride === null &&
+        isDemoEnvironment() &&
+        !this.isOpen &&
+        this.openPreference !== false &&
+        !this.demoAutoOpened
+      ) {
         this.demoAutoOpened = true;
         runInAction(() => {
           this.setOpenState(true);

--- a/app/components/agent-chat/agent-chat.store.ts
+++ b/app/components/agent-chat/agent-chat.store.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable, action, computed, runInAction } from "mobx";
+import { makeObservable, observable, action, computed, reaction, runInAction } from "mobx";
 
 import type { RootStore } from "@/core/stores/root.store";
 import type { AgentUsageSummary } from "@/ee/agent-chat/agent-usage.service";
@@ -74,8 +74,33 @@ let itemSeq = 0;
 const nextItemId = () => `item-${++itemSeq}`;
 const UI_COMMAND_NAMES = ["navigate", "highlight_element", "start_tour", "click_ui_target", "open_record"] as const;
 const AGENT_CONFIG_LOAD_TIMEOUT_MS = 15000;
+const AGENT_CHAT_OPEN_STORAGE_PREFIX = "customermates:agentChat:open:v1";
 type UiCommandName = (typeof UI_COMMAND_NAMES)[number];
 export type AgentConfigLoadStatus = "ready" | "disabled" | "retry";
+
+function agentChatOpenStorageKey(rootStore: RootStore): string | null {
+  const user = rootStore.userStore.user;
+  return user ? `${AGENT_CHAT_OPEN_STORAGE_PREFIX}:${user.companyId}:${user.id}` : null;
+}
+
+function readAgentChatOpenPreference(storageKey: string | null): boolean | null {
+  if (!storageKey || typeof window === "undefined") return null;
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored === null) return null;
+    const parsed = JSON.parse(stored);
+    return typeof parsed === "boolean" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeAgentChatOpenPreference(storageKey: string | null, isOpen: boolean) {
+  if (!storageKey || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(isOpen));
+  } catch {}
+}
 
 async function withDeadline<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -146,9 +171,14 @@ export class AgentChatStore extends BaseStore {
   private streamSequence = 0;
   private uiCommandQueue: Promise<void> = Promise.resolve();
   private demoAutoOpened = false;
+  private openStorageKey: string | null;
+  private openPreference: boolean | null;
 
   constructor(rootStore: RootStore) {
     super(rootStore);
+    this.openStorageKey = agentChatOpenStorageKey(rootStore);
+    this.openPreference = readAgentChatOpenPreference(this.openStorageKey);
+    this.isOpen = this.openPreference === true;
     makeObservable(this, {
       isOpen: observable,
       isExpanded: observable,
@@ -189,10 +219,14 @@ export class AgentChatStore extends BaseStore {
       newConversation: action,
       toggleHistory: action,
     });
+    reaction(
+      () => agentChatOpenStorageKey(rootStore),
+      () => this.syncOpenPreferenceScope(),
+    );
   }
 
   open = () => {
-    this.isOpen = true;
+    this.setOpenState(true);
     void this.loadConfig();
   };
 
@@ -207,7 +241,7 @@ export class AgentChatStore extends BaseStore {
   }
 
   close = () => {
-    this.isOpen = false;
+    this.setOpenState(false);
   };
 
   toggle = () => {
@@ -237,15 +271,33 @@ export class AgentChatStore extends BaseStore {
     this.isHistoryOpen = false;
   }
 
+  private setOpenState(isOpen: boolean) {
+    this.syncOpenPreferenceScope();
+    this.isOpen = isOpen;
+    this.openPreference = isOpen;
+    writeAgentChatOpenPreference(this.openStorageKey, isOpen);
+  }
+
+  private syncOpenPreferenceScope() {
+    const storageKey = agentChatOpenStorageKey(this.rootStore);
+    if (storageKey === this.openStorageKey) return;
+    this.openStorageKey = storageKey;
+    this.openPreference = readAgentChatOpenPreference(storageKey);
+    this.isOpen = this.openPreference === true;
+    this.autoOpenedPages.clear();
+    this.demoAutoOpened = false;
+  }
+
   openForEmptyPage = (pathname: string) => {
-    if (!this.enabled || this.isOpen || this.autoOpenedPages.has(pathname)) return;
+    this.syncOpenPreferenceScope();
+    if (!this.enabled || this.isOpen || this.openPreference === false || this.autoOpenedPages.has(pathname)) return;
     if (!this.counts) return;
 
     const page = agentActionPageFromPathname(pathname);
     if (!page || agentPageState(page, this.counts) !== "empty") return;
 
     this.autoOpenedPages.add(pathname);
-    this.isOpen = true;
+    this.setOpenState(true);
   };
 
   setComposerDraft = (value: string) => {
@@ -264,7 +316,7 @@ export class AgentChatStore extends BaseStore {
       this.composerDraft = "";
       return;
     }
-    this.isOpen = true;
+    this.setOpenState(true);
     this.composerDraft = "";
     void this.sendMessage(text);
   };
@@ -630,12 +682,13 @@ export class AgentChatStore extends BaseStore {
           this.historyRefreshError = false;
         }
       });
+      if (typeof window !== "undefined") this.openForEmptyPage(window.location.pathname);
       if (!this.conversationId && !this.isDraftConversationSelected && config.conversationId)
         await this.loadConversation(config.conversationId);
-      if (isDemoEnvironment() && !this.isOpen && !this.demoAutoOpened) {
+      if (isDemoEnvironment() && !this.isOpen && this.openPreference !== false && !this.demoAutoOpened) {
         this.demoAutoOpened = true;
         runInAction(() => {
-          this.isOpen = true;
+          this.setOpenState(true);
         });
       }
       return "ready";

--- a/content/docs/de/app-assistant.mdx
+++ b/content/docs/de/app-assistant.mdx
@@ -9,6 +9,8 @@ Customermates Cloud enthält **Mate**, den gehosteten In-App-Assistenten. Diese 
 
 Mate sitzt in der Seitenleiste als **KI fragen** und öffnet sich überall in der App mit Cmd/Strg+J. Stellen Sie Fragen zu Ihrem Workspace oder zum Produkt, lassen Sie Daten ändern, die Oberfläche bedienen oder sich durch die App führen. Mate antwortet in Ihrer Oberflächensprache.
 
+Mate merkt sich pro Benutzer, ob das Panel geöffnet oder geschlossen war, und stellt diese Auswahl nach einem Neuladen wieder her. Auf einer vollständig leeren Seite öffnet es sich automatisch, bis der Benutzer es ausdrücklich schließt. Demo-Einbettungen können ihren Anfangszustand unabhängig wählen, indem sie den exakten Query-Parameter `agentChat=open` oder `agentChat=closed` an die Iframe-URL anhängen. Der Parameter gilt nur für die aktuelle eingebettete Seite und überschreibt die gespeicherte Benutzerauswahl nicht.
+
 ## Was sofort läuft und was erst fragt
 
 Gewöhnliche CRM-Arbeit läuft, sobald Sie sie anstoßen: Einträge anlegen und ändern, Notizen, Verknüpfungen, Nachrichtenentwürfe, Posteingangs-Triage, Workspace-Einstellungen, eigene Felder, Widget- und Webhook-Einrichtung, Rollen- oder Statusänderungen bei Teammitgliedern und das Erzeugen sicherer Links für Kontoverbindungen. Mate sagt vorher, was es ändert, und berichtet danach genau, was sich geändert hat. Um ein Anbieterkonto zu verbinden, öffnen Sie den erzeugten Link und schließen den QR-Code- oder Anmeldeablauf selbst ab; das Erzeugen des Links bedeutet noch nicht, dass das Konto verbunden ist.

--- a/content/docs/de/intro-page.mdx
+++ b/content/docs/de/intro-page.mdx
@@ -2,7 +2,7 @@
 title: "Customermates-CRM-Dokumentation"
 description: Open-Source-CRM mit nativem MCP-Endpoint, sodass KI-Clients Ihr CRM direkt lesen und schreiben. Hier starten.
 demo:
-  src: https://demo.customermates.com/de
+  src: https://demo.customermates.com/de/dashboard?agentChat=open
   title: Customermates Demo
 ---
 

--- a/content/docs/en/app-assistant.mdx
+++ b/content/docs/en/app-assistant.mdx
@@ -9,6 +9,8 @@ Customermates Cloud ships with **Mate**, the hosted in-app assistant. This page 
 
 Mate lives in the sidebar as **Ask AI**, and opens with Cmd/Ctrl+J from anywhere in the app. Ask it questions about your workspace or the product, tell it to change data, have it operate the interface, or let it walk you through the app. It answers in your interface language.
 
+Mate remembers whether each user left the panel open or closed and restores that choice after a refresh. On a completely empty page, it opens automatically until the user explicitly closes it. Demo embeds can choose their initial presentation independently by adding the exact query parameter `agentChat=open` or `agentChat=closed` to the iframe URL. That parameter applies only to the current embedded page and does not overwrite the user's saved choice.
+
 ## What runs immediately and what asks first
 
 Ordinary CRM work runs as soon as you ask: creating and updating records, notes, record links, message drafts, inbox triage, workspace settings, custom fields, widget and webhook setup, team member role or status changes, and generating secure account-connection links. Mate says what it is about to change and reports exactly what changed. To connect a provider account, you open the generated link and complete its QR code or sign-in flow yourself; creating the link does not mean the account is connected yet.

--- a/content/docs/en/intro-page.mdx
+++ b/content/docs/en/intro-page.mdx
@@ -2,7 +2,7 @@
 title: "Customermates CRM Documentation"
 description: Open-source CRM with a native MCP endpoint, so AI clients can read and write your CRM directly. Start here.
 demo:
-  src: https://demo.customermates.com/en
+  src: https://demo.customermates.com/en/dashboard?agentChat=open
   title: Customermates Demo
 ---
 

--- a/ee/agent-chat/__tests__/agent-config.test.ts
+++ b/ee/agent-chat/__tests__/agent-config.test.ts
@@ -29,6 +29,7 @@ const COUNTS = {
   deals: true,
   services: false,
   tasks: true,
+  widgets: false,
   connectedAccounts: false,
 };
 

--- a/ee/agent-chat/__tests__/agent-experience-contract.test.ts
+++ b/ee/agent-chat/__tests__/agent-experience-contract.test.ts
@@ -39,6 +39,7 @@ const EMPTY_COUNTS = {
   deals: false,
   services: false,
   tasks: false,
+  widgets: false,
   connectedAccounts: false,
 };
 

--- a/ee/agent-chat/__tests__/prisma-agent-chat.repository.test.ts
+++ b/ee/agent-chat/__tests__/prisma-agent-chat.repository.test.ts
@@ -19,6 +19,7 @@ const prismaMock = vi.hoisted(() => ({
   deal: { findFirst: vi.fn() },
   service: { findFirst: vi.fn() },
   task: { findFirst: vi.fn() },
+  widget: { findFirst: vi.fn() },
   connectedAccount: { findFirst: vi.fn() },
   user: { findUnique: vi.fn() },
   agentApproval: {
@@ -498,8 +499,10 @@ describe("PrismaAgentChatRepo tenant boundaries", () => {
     });
   });
 
-  it("permission-scopes empty-state signals instead of leaking company-wide existence", async () => {
-    await runWithTenant(user, () => new PrismaAgentChatRepo().getSuggestionSignals());
+  it("permission-scopes entity signals and reads only the current user's dashboard widgets", async () => {
+    prismaMock.widget.findFirst.mockResolvedValue({ id: "widget-1" });
+
+    const signals = await runWithTenant(user, () => new PrismaAgentChatRepo().getSuggestionSignals());
 
     expect(prismaMock.contact.findFirst).toHaveBeenCalledWith({
       where: { id: { in: [] }, companyId: user.companyId },
@@ -509,6 +512,11 @@ describe("PrismaAgentChatRepo tenant boundaries", () => {
       where: { companyId: user.companyId, id: { in: [] } },
       select: { id: true },
     });
+    expect(prismaMock.widget.findFirst).toHaveBeenCalledWith({
+      where: { companyId: user.companyId, userId: user.id },
+      select: { id: true },
+    });
+    expect(signals.widgets).toBe(true);
   });
 
   it("persists an assistant reply only after atomically claiming an active conversation", async () => {

--- a/ee/agent-chat/__tests__/suggestions.test.ts
+++ b/ee/agent-chat/__tests__/suggestions.test.ts
@@ -27,6 +27,7 @@ const NO_DATA: AgentDataCounts = {
   deals: false,
   services: false,
   tasks: false,
+  widgets: false,
   connectedAccounts: false,
 };
 
@@ -67,8 +68,9 @@ describe("suggestionVariant", () => {
     expect(suggestionVariant("connected-accounts", { ...NO_DATA, connectedAccounts: true })).toBe("data");
   });
 
-  it("uses contacts or deals for dashboard and default", () => {
-    expect(suggestionVariant("dashboard", { ...NO_DATA, deals: true })).toBe("data");
+  it("uses widgets for dashboard and contacts or deals for default", () => {
+    expect(suggestionVariant("dashboard", { ...NO_DATA, widgets: true })).toBe("data");
+    expect(suggestionVariant("dashboard", { ...NO_DATA, contacts: true, deals: true })).toBe("empty");
     expect(suggestionVariant("default", { ...NO_DATA, contacts: true })).toBe("data");
     expect(suggestionVariant("default", NO_DATA)).toBe("empty");
   });

--- a/ee/agent-chat/agent-chat.schema.ts
+++ b/ee/agent-chat/agent-chat.schema.ts
@@ -123,6 +123,7 @@ export const AgentDataCountsSchema = z.object({
   deals: z.boolean(),
   services: z.boolean(),
   tasks: z.boolean(),
+  widgets: z.boolean(),
   connectedAccounts: z.boolean(),
 });
 
@@ -171,6 +172,8 @@ export function suggestionVariant(pageId: SuggestionPageId, counts: AgentDataCou
       return counts.services ? "data" : "empty";
     case "tasks":
       return counts.tasks ? "data" : "empty";
+    case "dashboard":
+      return counts.widgets ? "data" : "empty";
     case "inbox":
     case "connected-accounts":
       return counts.connectedAccounts ? "data" : "empty";

--- a/ee/agent-chat/agent-page-actions.ts
+++ b/ee/agent-chat/agent-page-actions.ts
@@ -134,9 +134,7 @@ const TERM_RULES: Partial<Record<AppLocale, LocaleTermRules>> = {
 export function agentPageState(page: SupportedPage, counts: AgentDataCounts): PageState {
   switch (page) {
     case "dashboard":
-      return counts.contacts || counts.organizations || counts.deals || counts.services || counts.tasks
-        ? "data"
-        : "empty";
+      return counts.widgets ? "data" : "empty";
     case "inbox":
     case "connected-accounts":
       return counts.connectedAccounts ? "data" : "empty";

--- a/ee/agent-chat/prisma-agent-chat.repository.ts
+++ b/ee/agent-chat/prisma-agent-chat.repository.ts
@@ -441,7 +441,7 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
 
   async getSuggestionSignals() {
     const select = { id: true };
-    const [contact, organization, deal, service, task, connectedAccount] = await Promise.all([
+    const [contact, organization, deal, service, task, widget, connectedAccount] = await Promise.all([
       this.prisma.contact.findFirst({
         where: this.accessWhere("contact"),
         select,
@@ -462,6 +462,13 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
         where: this.accessWhere("task"),
         select,
       }),
+      this.prisma.widget.findFirst({
+        where: {
+          companyId: this.companyId,
+          userId: this.userId,
+        },
+        select,
+      }),
       this.prisma.connectedAccount.findFirst({
         where: this.canAccess(Resource.inboxMessages)
           ? {
@@ -479,6 +486,7 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
       deals: Boolean(deal),
       services: Boolean(service),
       tasks: Boolean(task),
+      widgets: Boolean(widget),
       connectedAccounts: Boolean(connectedAccount),
     };
   }

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -62,7 +62,7 @@ describe("homepage visual-system adoption", () => {
     expect(page).toContain("HomepageLiveDemo");
     expect(page).toContain("HomepageProductProof");
     expect(liveDemo.match(/<HeroDemoIframe\b/gu)).toHaveLength(1);
-    expect(liveDemo).toContain("const demoPath = `/${locale}/dashboard`");
+    expect(liveDemo).toContain("const demoPath = `/${locale}/dashboard?agentChat=open`");
     expect(liveDemo).not.toMatch(/inbox|threadId|DEMO_INBOX_THREAD_ID/u);
     expect(hero).not.toMatch(/HeroDemoIframe|<iframe\b/u);
     expect(proof.match(/<HomepageViewportVideo\b/gu)).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Auto-open Mate after onboarding when the dashboard is visibly empty because the current user has no widgets.
- Persist the Assistant panel open or closed preference per company and user.
- Add the exact document-scoped URL contract `?agentChat=open|closed` for deterministic demo embeds without overwriting the saved preference.
- Make the homepage demo and the English and German documentation embeds explicitly request `agentChat=open`; other Markdown demo URLs can choose `closed`.

## Context

CUS-125 follow-up. The dashboard UI defined true-empty by widget count, while the Assistant inferred dashboard state from CRM records. After onboarding, seeded CRM data could therefore suppress auto-open on a visibly empty dashboard. The panel open state was also memory-only and reset on every browser refresh. Demo iframes additionally needed an explicit per-embed presentation choice that could not contaminate another iframe through shared browser storage.

Valid URL values take precedence over the saved preference plus empty-page and demo auto-open defaults for that document load. The user can still open or close the panel during the current document, but those interactions do not alter the underlying saved preference while an override is present. Missing, invalid, differently cased, empty, or duplicated values preserve normal behavior.

## Validation

- Feature-focused suites after the final rebase: 81 tests passed.
- Full Vitest suite: 4,037 tests passed.
- TypeScript typecheck passed.
- Zero-warning ESLint passed, including the commit hook rerun.
- Conventions suite passed: 561 tests.
- Production build passed.
- Disposable PostgreSQL reset, migrations, seed, and workflow schema setup passed.
- Literal local onboarding E2E passed: a new account completed all three wizard steps, redirected to a widget-empty dashboard with Mate open, retained open after refresh, retained explicit close after refresh, and retained manual reopen after refresh.
- URL override E2E passed with opposing saved preferences: `closed` stayed closed through refresh and removal restored saved open; `open` stayed open through refresh and removal restored saved closed.
- The real Markdown → docs demo → BrowserFrame path rendered both the open and closed iframe variants locally, including closed after refresh.
- Browser console errors: zero for the onboarding and docs-iframe runs.
- Independent diff review found no actionable issues.

## Impact and rollback

No migration, API, or environment change. Browser storage contains only one versioned boolean preference scoped to company and user; no chat content is stored. The URL override is UI-only and never writes browser storage. Before merge, close this PR and delete the remote branch. After merge, revert these commits to restore the prior behavior. Production remains unchanged until a human performs the protected merge.

## Screenshots

Not applicable: this changes state behavior without changing the existing panel or empty-state visuals. The complete local browser evidence is summarized above and on CUS-125.
