### PR TITLE
fix(entity-detail): clip collapsing section content

### DIFF
--- a/components/entity-detail/__tests__/entity-detail-personalization.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-personalization.test.ts
@@ -308,6 +308,14 @@ describe("entity detail preference persistence", () => {
 });
 
 describe("entity detail section", () => {
+  it("clips fields throughout the collapse animation", () => {
+    const { container } = mountNode(sectionView());
+    const content = container.querySelector<HTMLElement>('[data-slot="collapsible-content"]');
+
+    expect(content?.className).toContain("overflow-hidden");
+    expect(content?.className).toContain("data-[state=closed]:animate-collapsible-up");
+  });
+
   it("uses the complete header row as its accessible collapse trigger", () => {
     const { container } = mountNode(
       createElement(

--- a/components/entity-detail/entity-detail-section.tsx
+++ b/components/entity-detail/entity-detail-section.tsx
@@ -57,7 +57,7 @@ export function EntityDetailSection({ sectionId, label, children, className }: P
         />
       </CollapsibleTrigger>
 
-      <CollapsibleContent className="data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
         <div className="flex flex-col gap-4 px-4 pb-4" data-detail-section-content={sectionId}>
           {children}
         </div>


### PR DESCRIPTION
## Summary

Clip entity-detail section children inside the height-animated collapsible wrapper so fields cannot paint outside the section while it closes. Add a DOM regression test for the clipping contract.

## Context

Entity-detail sections such as Base data and Details animated their wrapper height to zero while retaining the browser default `overflow: visible`. During the 200 ms close animation, the fields therefore remained visible outside the shrinking section.

Owner-directed Linear exception:

- Issuer: Customermates owner in the current Codex task.
- Instruction source: the 2026-08-28 task conversation explicitly requested this bounded fix, waived Linear, and requested this pull request.
- Named waiver: Linear issue, claim, receipt, and Linear connection proof for this outcome only.
- Exact scope: `components/entity-detail/entity-detail-section.tsx` and its existing DOM test in `components/entity-detail/__tests__/entity-detail-personalization.test.ts`.
- Remaining constraints: local and preview verification, required GitHub checks, Code Owner review, and the human-only merge remain in force.
- Material consequence and rollback: the shared entity-detail sections clip animated content; revert the change commit to restore the prior rendering behavior.
- Acceptance and expiry: valid only through acceptance or closure of this pull request; it does not extend to another outcome.
- Evidence location: this pull request description, checks, and review thread.

## Validation

- `yarn vitest run --project dom components/entity-detail/__tests__/entity-detail-personalization.test.ts` — 12/12 passed.
- `yarn typecheck` — passed.
- `yarn lint` — passed with zero warnings.
- `yarn vitest run tests/conventions` — 561 passed, 2 skipped.
- Local browser journey on the seeded contact detail page confirmed the failing `overflow: visible` state before the change and `overflow: hidden` throughout the 200 ms collapse after it; no page error overlay or failed request occurred.
- Preview acceptance passed at https://fix-entity-details-collapse-overflow.customermates.com: the section entered `closed` with `overflow: hidden`, finished hidden, and produced no browser errors.
- Independent read-only review reported no findings.

## Impact and rollback

The shared fix applies to entity-detail sections for contacts, organizations, deals, services, and tasks. It changes no data, API, localization, migration, dependency, or environment contract.

Before merge, close the pull request and delete the change branch to remove the preview and its isolated database. After merge, revert the squash commit through a new protected pull request.
