### PR TITLE
feat(entity-detail): allow fields to be hidden

### DIFF
--- a/app/[locale]/(protected)/contacts/components/contact-detail-view.tsx
+++ b/app/[locale]/(protected)/contacts/components/contact-detail-view.tsx
@@ -8,7 +8,8 @@ import { EntityDetailBody } from "@/components/entity-detail/entity-detail-body"
 import { EntityDetailCustomFieldsSection } from "@/components/entity-detail/entity-detail-custom-fields-section";
 import { EntityDetailSection, EntityDetailSectionGroup } from "@/components/entity-detail/entity-detail-section";
 import { EntityDetailStaticField } from "@/components/entity-detail/entity-detail-static-field";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { EntityRelationField, AssignedUsersField } from "@/components/entity-detail/relation-fields";
 import { CustomFieldInputs } from "@/components/data-view/custom-columns/custom-field-inputs";
 import { FormInput } from "@/components/forms/form-input";
@@ -32,18 +33,25 @@ export const ContactDetailView = observer(({ layout = "drawer" }: Props) => {
     layout === "drawer" ? (
       <>
         <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
-          <FormInput autoFocus required id="firstName" />
+          <EntityDetailField fieldId={CONTACT_DETAIL_FIELD.firstName}>
+            <FormInput autoFocus required id="firstName" />
+          </EntityDetailField>
 
-          <FormInput id="lastName" />
+          <EntityDetailField fieldId={CONTACT_DETAIL_FIELD.lastName}>
+            <FormInput id="lastName" />
+          </EntityDetailField>
         </div>
 
-        <ContactChannels contactId={fetchedEntity?.id} />
+        <EntityDetailField fieldId={CONTACT_DETAIL_FIELD.identifiers}>
+          <ContactChannels contactId={fetchedEntity?.id} />
+        </EntityDetailField>
 
         <EntityRelationField
           currentEntityId={fetchedEntity?.id}
           currentEntityType="contact"
           items={fetchedEntity?.organizations}
           target="organization"
+          visibilityFieldId={CONTACT_DETAIL_FIELD.organizationIds}
         />
 
         <EntityRelationField
@@ -51,6 +59,7 @@ export const ContactDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="contact"
           items={fetchedEntity?.deals}
           target="deal"
+          visibilityFieldId={CONTACT_DETAIL_FIELD.dealIds}
         />
 
         <EntityRelationField
@@ -58,37 +67,50 @@ export const ContactDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="contact"
           items={fetchedEntity?.tasks}
           target="task"
+          visibilityFieldId={CONTACT_DETAIL_FIELD.taskIds}
         />
 
         <CustomFieldInputs columns={customColumns} isEditing={isEditingCustomField} />
 
-        <AssignedUsersField items={fetchedEntity?.users} />
+        <AssignedUsersField items={fetchedEntity?.users} visibilityFieldId={CONTACT_DETAIL_FIELD.userIds} />
       </>
     ) : (
       <EntityDetailSectionGroup>
         <EntityDetailSection label={t("EntityDetail.sections.base")} sectionId={CONTACT_DETAIL_SECTION.base}>
-          <FormInput
-            autoFocus
-            required
-            id="firstName"
-            labelEndAddon={
-              <EntityDetailPinButton fieldId={CONTACT_DETAIL_FIELD.firstName} label={t("Common.inputs.firstName")} />
-            }
-          />
+          <EntityDetailField fieldId={CONTACT_DETAIL_FIELD.firstName}>
+            <FormInput
+              autoFocus
+              required
+              id="firstName"
+              labelEndAddon={
+                <EntityDetailFieldActions
+                  fieldId={CONTACT_DETAIL_FIELD.firstName}
+                  label={t("Common.inputs.firstName")}
+                />
+              }
+            />
+          </EntityDetailField>
 
-          <FormInput
-            id="lastName"
-            labelEndAddon={
-              <EntityDetailPinButton fieldId={CONTACT_DETAIL_FIELD.lastName} label={t("Common.inputs.lastName")} />
-            }
-          />
+          <EntityDetailField fieldId={CONTACT_DETAIL_FIELD.lastName}>
+            <FormInput
+              id="lastName"
+              labelEndAddon={
+                <EntityDetailFieldActions fieldId={CONTACT_DETAIL_FIELD.lastName} label={t("Common.inputs.lastName")} />
+              }
+            />
+          </EntityDetailField>
 
-          <ContactChannels
-            contactId={fetchedEntity?.id}
-            headingEndAddon={
-              <EntityDetailPinButton fieldId={CONTACT_DETAIL_FIELD.identifiers} label={t("EntityChannels.heading")} />
-            }
-          />
+          <EntityDetailField fieldId={CONTACT_DETAIL_FIELD.identifiers}>
+            <ContactChannels
+              contactId={fetchedEntity?.id}
+              headingEndAddon={
+                <EntityDetailFieldActions
+                  fieldId={CONTACT_DETAIL_FIELD.identifiers}
+                  label={t("EntityChannels.heading")}
+                />
+              }
+            />
+          </EntityDetailField>
 
           <AssignedUsersField
             items={fetchedEntity?.users}

--- a/app/[locale]/(protected)/deals/components/__tests__/deal-services-selection.test.ts
+++ b/app/[locale]/(protected)/deals/components/__tests__/deal-services-selection.test.ts
@@ -2,7 +2,16 @@ import type { ComponentType, ReactNode } from "react";
 
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const personalization = vi.hoisted(() => ({
+  applyFieldVisibility: true,
+  enabled: true,
+  hiddenFieldIds: [] as string[],
+  isPersonalizing: false,
+  starredFieldIds: [] as string[],
+  toggleStarredField: vi.fn(),
+}));
 
 const dealDetailStore = vi.hoisted(() => ({
   form: { services: [] as Array<{ quantity?: number; serviceId?: string }> },
@@ -54,11 +63,7 @@ vi.mock("@/i18n/navigation", () => ({
 }));
 
 vi.mock("@/components/entity-detail/entity-detail-personalization", () => ({
-  useEntityDetailPersonalization: () => ({
-    enabled: true,
-    starredFieldIds: [],
-    toggleStarredField: vi.fn(),
-  }),
+  useEntityDetailPersonalization: () => personalization,
 }));
 
 vi.mock("@/components/entity-detail/hooks/use-entity-drawer-stack", () => ({
@@ -94,6 +99,14 @@ vi.mock("@/core/stores/use-hydrated-intl-store", () => ({
 import { DealServicesSelection } from "../deal-services-selection";
 
 describe("DealServicesSelection relation actions", () => {
+  beforeEach(() => {
+    dealDetailStore.form.services = [];
+    dealDetailStore.totalQuantity = 0;
+    dealDetailStore.totalValue = 0;
+    dealDetailStore.weightedValueBreakdown = null;
+    personalization.hiddenFieldIds = [];
+  });
+
   it("renders pin and go-to actions together on the page detail row", () => {
     const markup = renderToStaticMarkup(
       createElement(DealServicesSelection, {
@@ -135,10 +148,28 @@ describe("DealServicesSelection relation actions", () => {
     expect(markup).toContain("EntityDetail.computedFieldHelp.dealValue");
     expect(markup).toContain("EntityDetail.computedFieldHelp.weightedValue");
     expect(markup).toContain("EntityDetail.computedFieldHelp.serviceQuantity");
+  });
 
-    dealDetailStore.form.services = [];
-    dealDetailStore.totalQuantity = 0;
-    dealDetailStore.totalValue = 0;
-    dealDetailStore.weightedValueBreakdown = null;
+  it("applies drawer visibility independently to services and each computed total", () => {
+    dealDetailStore.form.services = [{ quantity: 2, serviceId: "service-1" }];
+    dealDetailStore.totalQuantity = 2;
+    dealDetailStore.totalValue = 400;
+    dealDetailStore.weightedValueBreakdown = {
+      percent: 50,
+      stage: "Qualified",
+      weightedValue: 200,
+    };
+
+    const fieldIds = ["serviceIds", "totalValue", "weightedValue", "totalQuantity"];
+
+    for (const hiddenFieldId of fieldIds) {
+      personalization.hiddenFieldIds = [hiddenFieldId];
+      const markup = renderToStaticMarkup(createElement(DealServicesSelection));
+
+      for (const fieldId of fieldIds) {
+        const fieldMarker = `data-entity-field="${fieldId}"`;
+        expect(markup.includes(fieldMarker)).toBe(fieldId !== hiddenFieldId);
+      }
+    }
   });
 });

--- a/app/[locale]/(protected)/deals/components/deal-detail-view.tsx
+++ b/app/[locale]/(protected)/deals/components/deal-detail-view.tsx
@@ -8,7 +8,8 @@ import { CustomFieldInputs } from "@/components/data-view/custom-columns/custom-
 import { EntityDetailBody } from "@/components/entity-detail/entity-detail-body";
 import { EntityDetailCustomFieldsSection } from "@/components/entity-detail/entity-detail-custom-fields-section";
 import { EntityDetailSection, EntityDetailSectionGroup } from "@/components/entity-detail/entity-detail-section";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { EntityDetailStaticField } from "@/components/entity-detail/entity-detail-static-field";
 import { AssignedUsersField, EntityRelationField } from "@/components/entity-detail/relation-fields";
 import { useColumnLabel } from "@/components/entity-terminology/use-column-label";
@@ -45,13 +46,16 @@ export const DealDetailView = observer(({ layout = "drawer" }: Props) => {
   const content =
     layout === "drawer" ? (
       <>
-        <FormInput autoFocus required id="name" />
+        <EntityDetailField fieldId={DEAL_DETAIL_FIELD.name}>
+          <FormInput autoFocus required id="name" />
+        </EntityDetailField>
 
         <EntityRelationField
           currentEntityId={fetchedEntity?.id}
           currentEntityType="deal"
           items={fetchedEntity?.contacts}
           target="contact"
+          visibilityFieldId={DEAL_DETAIL_FIELD.contactIds}
         />
 
         <EntityRelationField
@@ -59,6 +63,7 @@ export const DealDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="deal"
           items={fetchedEntity?.organizations}
           target="organization"
+          visibilityFieldId={DEAL_DETAIL_FIELD.organizationIds}
         />
 
         <EntityRelationField
@@ -66,23 +71,28 @@ export const DealDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="deal"
           items={fetchedEntity?.tasks}
           target="task"
+          visibilityFieldId={DEAL_DETAIL_FIELD.taskIds}
         />
 
         <CustomFieldInputs columns={customColumns} isEditing={isEditingCustomField} />
 
-        <AssignedUsersField items={fetchedEntity?.users} />
+        <AssignedUsersField items={fetchedEntity?.users} visibilityFieldId={DEAL_DETAIL_FIELD.userIds} />
 
         <DealServicesSelection />
       </>
     ) : (
       <EntityDetailSectionGroup>
         <EntityDetailSection label={t("EntityDetail.sections.base")} sectionId={DEAL_DETAIL_SECTION.base}>
-          <FormInput
-            autoFocus
-            required
-            id="name"
-            labelEndAddon={<EntityDetailPinButton fieldId={DEAL_DETAIL_FIELD.name} label={t("Common.inputs.name")} />}
-          />
+          <EntityDetailField fieldId={DEAL_DETAIL_FIELD.name}>
+            <FormInput
+              autoFocus
+              required
+              id="name"
+              labelEndAddon={
+                <EntityDetailFieldActions fieldId={DEAL_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
+              }
+            />
+          </EntityDetailField>
 
           <AssignedUsersField items={fetchedEntity?.users} personalization={{ fieldId: DEAL_DETAIL_FIELD.userIds }} />
 

--- a/app/[locale]/(protected)/deals/components/deal-services-selection.tsx
+++ b/app/[locale]/(protected)/deals/components/deal-services-selection.tsx
@@ -18,6 +18,7 @@ import { FormFieldHelp } from "@/components/forms/form-field-help";
 import { Icon } from "@/components/shared/icon";
 import { InfoRow } from "@/components/shared/info-row";
 import { TruncatedText } from "@/components/shared/truncated-text";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
 import { useEntityHref } from "@/components/entity-detail/hooks/use-entity-drawer-stack";
 import {
   EntityRelationActions,
@@ -29,6 +30,7 @@ import { AppChip } from "@/components/chip/app-chip";
 import { useColumnLabel } from "@/components/entity-terminology/use-column-label";
 import { useEntityTerminology } from "@/components/entity-terminology/use-entity-terminology";
 import { terminologyLabelForSentence } from "@/features/entity-terminology/entity-terminology-label.utils";
+import { DEAL_DETAIL_FIELD } from "./deal-detail-personalization";
 import { useDealComputedFieldHelp } from "./use-deal-computed-field-help";
 
 type Props = {
@@ -62,204 +64,214 @@ export const DealServicesSelection = observer(({ labelEndAddon, personalization,
 
   return (
     <div className="flex w-full flex-col space-y-2 items-start">
-      <div className="w-full grid grid-cols-[minmax(40px,1fr)_minmax(70px,112px)_40px] gap-2 gap-y-3 items-center">
-        <div className="flex items-center w-full min-w-0 gap-2">
-          <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <FormLabel className="block truncate min-w-0">{plural(EntityType.service)}</FormLabel>
+      <EntityDetailField fieldId={DEAL_DETAIL_FIELD.serviceIds}>
+        <div className="flex w-full flex-col space-y-2 items-start">
+          <div className="w-full grid grid-cols-[minmax(40px,1fr)_minmax(70px,112px)_40px] gap-2 gap-y-3 items-center">
+            <div className="flex items-center w-full min-w-0 gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                <FormLabel className="block truncate min-w-0">{plural(EntityType.service)}</FormLabel>
 
-            <EntityRelationActions
-              currentEntityId={fetchedEntity?.id}
-              currentEntityType="deal"
-              personalization={personalization}
-              targetEntityType="service"
-            >
-              {labelEndAddon}
-            </EntityRelationActions>
-          </div>
-
-          <FormLabel className="block w-[4.5rem] shrink-0 text-right truncate">
-            {t("DealModal.quantityLabel")}
-          </FormLabel>
-        </div>
-
-        <span className="flex min-w-0 items-center justify-end gap-1.5">
-          <FormLabel className="block truncate">{t("DealModal.valueLabel")}</FormLabel>
-
-          <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: t("DealModal.valueLabel") })}>
-            {computedFieldHelp.serviceLineValue}
-          </FormFieldHelp>
-        </span>
-
-        <span />
-
-        {(form.services || []).map((service, index) => {
-          const selectedServiceIds = (form.services || [])
-            .map((s) => s.serviceId)
-            .filter((id, idx) => idx !== index && id && id.trim() !== "");
-
-          const lineAmount = service.serviceId ? (serviceAmountById.get(service.serviceId) ?? 0) : 0;
-          const lineQuantity = service.quantity ?? 0;
-          const lineTotal = lineAmount * lineQuantity;
-
-          return (
-            <Fragment key={index}>
-              <div className="flex items-stretch w-full gap-2">
-                <FormAutocomplete
-                  required
-                  chipHref={(id) => entityHref(EntityType.service, id)}
-                  containerClassName="flex-1 min-w-0"
-                  filterFunction={(availableService) => !selectedServiceIds.includes(availableService.id)}
-                  getItems={dealDetailStore.searchServiceOptions}
-                  id={`services[${index}].serviceId`}
-                  items={fetchedEntity?.services.filter((it) => !selectedServiceIds.includes(it.id)) ?? []}
-                  label={null}
-                  popoverFitContent={true}
-                  renderValue={(items) =>
-                    items.map((item, idx) => {
-                      const unitAmount = item?.data?.amount ?? 0;
-                      return (
-                        <AppChip
-                          key={item?.data?.id ?? item?.key ?? idx}
-                          endContent={
-                            unitAmount > 0 ? (
-                              <span className="flex shrink-0 items-center gap-1">
-                                <span className="opacity-60">·</span>
-
-                                <span className="tabular-nums">{intlStore.formatCurrency(unitAmount)}</span>
-                              </span>
-                            ) : undefined
-                          }
-                        >
-                          {item?.data?.name}
-                        </AppChip>
-                      );
-                    })
-                  }
-                  onCreate={dealDetailStore.createServiceOption}
+                <EntityRelationActions
+                  currentEntityId={fetchedEntity?.id}
+                  currentEntityType="deal"
+                  personalization={personalization}
+                  targetEntityType="service"
                 >
-                  {(service) =>
-                    FormAutocompleteItem({
-                      textValue: service.name,
-
-                      children: (
-                        <div className="flex w-full items-center gap-3 whitespace-nowrap">
-                          <span className="text-sm">{service.name}</span>
-
-                          <span className="opacity-60">·</span>
-
-                          <span className="text-xs tabular-nums text-muted-foreground">
-                            {intlStore.formatCurrency(service.amount)}
-                          </span>
-                        </div>
-                      ),
-                    })
-                  }
-                </FormAutocomplete>
-
-                <FormNumberInput
-                  required
-                  className="text-right font-mono tabular-nums"
-                  containerClassName="w-[4.5rem] shrink-0"
-                  id={`services[${index}].quantity`}
-                  label={null}
-                />
+                  {labelEndAddon}
+                </EntityRelationActions>
               </div>
 
-              <TruncatedText className="text-x-md text-right font-mono tabular-nums text-foreground/80">
-                {lineTotal > 0 ? intlStore.formatCurrency(lineTotal) : ""}
-              </TruncatedText>
+              <FormLabel className="block w-[4.5rem] shrink-0 text-right truncate">
+                {t("DealModal.quantityLabel")}
+              </FormLabel>
+            </div>
 
-              {canManage ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      aria-label={t("Common.actions.delete")}
-                      className="text-destructive hover:text-destructive"
-                      size="icon-sm"
-                      type="button"
-                      variant="ghost"
-                      onClick={() => deleteService(index)}
+            <span className="flex min-w-0 items-center justify-end gap-1.5">
+              <FormLabel className="block truncate">{t("DealModal.valueLabel")}</FormLabel>
+
+              <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: t("DealModal.valueLabel") })}>
+                {computedFieldHelp.serviceLineValue}
+              </FormFieldHelp>
+            </span>
+
+            <span />
+
+            {(form.services || []).map((service, index) => {
+              const selectedServiceIds = (form.services || [])
+                .map((s) => s.serviceId)
+                .filter((id, idx) => idx !== index && id && id.trim() !== "");
+
+              const lineAmount = service.serviceId ? (serviceAmountById.get(service.serviceId) ?? 0) : 0;
+              const lineQuantity = service.quantity ?? 0;
+              const lineTotal = lineAmount * lineQuantity;
+
+              return (
+                <Fragment key={index}>
+                  <div className="flex items-stretch w-full gap-2">
+                    <FormAutocomplete
+                      required
+                      chipHref={(id) => entityHref(EntityType.service, id)}
+                      containerClassName="flex-1 min-w-0"
+                      filterFunction={(availableService) => !selectedServiceIds.includes(availableService.id)}
+                      getItems={dealDetailStore.searchServiceOptions}
+                      id={`services[${index}].serviceId`}
+                      items={fetchedEntity?.services.filter((it) => !selectedServiceIds.includes(it.id)) ?? []}
+                      label={null}
+                      popoverFitContent={true}
+                      renderValue={(items) =>
+                        items.map((item, idx) => {
+                          const unitAmount = item?.data?.amount ?? 0;
+                          return (
+                            <AppChip
+                              key={item?.data?.id ?? item?.key ?? idx}
+                              endContent={
+                                unitAmount > 0 ? (
+                                  <span className="flex shrink-0 items-center gap-1">
+                                    <span className="opacity-60">·</span>
+
+                                    <span className="tabular-nums">{intlStore.formatCurrency(unitAmount)}</span>
+                                  </span>
+                                ) : undefined
+                              }
+                            >
+                              {item?.data?.name}
+                            </AppChip>
+                          );
+                        })
+                      }
+                      onCreate={dealDetailStore.createServiceOption}
                     >
-                      <Icon icon={Trash2} />
-                    </Button>
-                  </TooltipTrigger>
+                      {(service) =>
+                        FormAutocompleteItem({
+                          textValue: service.name,
 
-                  <TooltipContent>{t("Common.actions.delete")}</TooltipContent>
-                </Tooltip>
-              ) : (
+                          children: (
+                            <div className="flex w-full items-center gap-3 whitespace-nowrap">
+                              <span className="text-sm">{service.name}</span>
+
+                              <span className="opacity-60">·</span>
+
+                              <span className="text-xs tabular-nums text-muted-foreground">
+                                {intlStore.formatCurrency(service.amount)}
+                              </span>
+                            </div>
+                          ),
+                        })
+                      }
+                    </FormAutocomplete>
+
+                    <FormNumberInput
+                      required
+                      className="text-right font-mono tabular-nums"
+                      containerClassName="w-[4.5rem] shrink-0"
+                      id={`services[${index}].quantity`}
+                      label={null}
+                    />
+                  </div>
+
+                  <TruncatedText className="text-x-md text-right font-mono tabular-nums text-foreground/80">
+                    {lineTotal > 0 ? intlStore.formatCurrency(lineTotal) : ""}
+                  </TruncatedText>
+
+                  {canManage ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          aria-label={t("Common.actions.delete")}
+                          className="text-destructive hover:text-destructive"
+                          size="icon-sm"
+                          type="button"
+                          variant="ghost"
+                          onClick={() => deleteService(index)}
+                        >
+                          <Icon icon={Trash2} />
+                        </Button>
+                      </TooltipTrigger>
+
+                      <TooltipContent>{t("Common.actions.delete")}</TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <span />
+                  )}
+                </Fragment>
+              );
+            })}
+
+            {canManage && (
+              <>
+                <Button
+                  className="w-full justify-start text-muted-foreground"
+                  type="button"
+                  variant="secondary"
+                  onClick={addService}
+                >
+                  <Icon icon={Plus} />
+
+                  {t("Common.inputs.addService")}
+                </Button>
+
                 <span />
-              )}
-            </Fragment>
-          );
-        })}
 
-        {canManage && (
-          <>
-            <Button
-              className="w-full justify-start text-muted-foreground"
-              type="button"
-              variant="secondary"
-              onClick={addService}
-            >
-              <Icon icon={Plus} />
+                <span />
+              </>
+            )}
+          </div>
 
-              {t("Common.inputs.addService")}
-            </Button>
-
-            <span />
-
-            <span />
-          </>
-        )}
-      </div>
+          {(form.services || []).length === 0 && (
+            <p className="text-x-sm text-subdued">
+              {t("DealModal.noServicesAdded", {
+                entity: terminologyLabelForSentence(plural(EntityType.service), locale),
+              })}
+            </p>
+          )}
+        </div>
+      </EntityDetailField>
 
       {showTotals && (form.services || []).length > 0 && (
         <div className="mt-3 flex w-full flex-col gap-1.5 pr-12">
-          <InfoRow
-            label={columnLabel("totalValue")}
-            labelEndAddon={
-              <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: columnLabel("totalValue") })}>
-                {computedFieldHelp.dealValue}
-              </FormFieldHelp>
-            }
-          >
-            <span className="text-x-md font-mono tabular-nums">{intlStore.formatCurrency(totalValue)}</span>
-          </InfoRow>
-
-          {weightedValueBreakdown && (
+          <EntityDetailField fieldId={DEAL_DETAIL_FIELD.totalValue}>
             <InfoRow
-              label={`${columnLabel("weightedValue")} · ${weightedValueBreakdown.stage} ${weightedValueBreakdown.percent}%`}
+              label={columnLabel("totalValue")}
               labelEndAddon={
-                <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: columnLabel("weightedValue") })}>
-                  {computedFieldHelp.weightedValue}
+                <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: columnLabel("totalValue") })}>
+                  {computedFieldHelp.dealValue}
                 </FormFieldHelp>
               }
             >
-              <span className="text-x-md font-mono tabular-nums">
-                {intlStore.formatCurrency(weightedValueBreakdown.weightedValue)}
-              </span>
+              <span className="text-x-md font-mono tabular-nums">{intlStore.formatCurrency(totalValue)}</span>
             </InfoRow>
+          </EntityDetailField>
+
+          {weightedValueBreakdown && (
+            <EntityDetailField fieldId={DEAL_DETAIL_FIELD.weightedValue}>
+              <InfoRow
+                label={`${columnLabel("weightedValue")} · ${weightedValueBreakdown.stage} ${weightedValueBreakdown.percent}%`}
+                labelEndAddon={
+                  <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: columnLabel("weightedValue") })}>
+                    {computedFieldHelp.weightedValue}
+                  </FormFieldHelp>
+                }
+              >
+                <span className="text-x-md font-mono tabular-nums">
+                  {intlStore.formatCurrency(weightedValueBreakdown.weightedValue)}
+                </span>
+              </InfoRow>
+            </EntityDetailField>
           )}
 
-          <InfoRow
-            label={columnLabel("totalQuantity")}
-            labelEndAddon={
-              <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: columnLabel("totalQuantity") })}>
-                {computedFieldHelp.serviceQuantity}
-              </FormFieldHelp>
-            }
-          >
-            <span className="text-x-md font-mono tabular-nums">{intlStore.formatNumber(totalQuantity)}</span>
-          </InfoRow>
+          <EntityDetailField fieldId={DEAL_DETAIL_FIELD.totalQuantity}>
+            <InfoRow
+              label={columnLabel("totalQuantity")}
+              labelEndAddon={
+                <FormFieldHelp label={t("Common.ariaLabels.explainField", { field: columnLabel("totalQuantity") })}>
+                  {computedFieldHelp.serviceQuantity}
+                </FormFieldHelp>
+              }
+            >
+              <span className="text-x-md font-mono tabular-nums">{intlStore.formatNumber(totalQuantity)}</span>
+            </InfoRow>
+          </EntityDetailField>
         </div>
-      )}
-
-      {(form.services || []).length === 0 && (
-        <p className="text-x-sm text-subdued">
-          {t("DealModal.noServicesAdded", {
-            entity: terminologyLabelForSentence(plural(EntityType.service), locale),
-          })}
-        </p>
       )}
     </div>
   );

--- a/app/[locale]/(protected)/organizations/components/organization-detail-view.tsx
+++ b/app/[locale]/(protected)/organizations/components/organization-detail-view.tsx
@@ -8,7 +8,8 @@ import { CustomFieldInputs } from "@/components/data-view/custom-columns/custom-
 import { EntityDetailBody } from "@/components/entity-detail/entity-detail-body";
 import { EntityDetailCustomFieldsSection } from "@/components/entity-detail/entity-detail-custom-fields-section";
 import { EntityDetailSection, EntityDetailSectionGroup } from "@/components/entity-detail/entity-detail-section";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { EntityDetailStaticField } from "@/components/entity-detail/entity-detail-static-field";
 import { EntityRelationField, AssignedUsersField } from "@/components/entity-detail/relation-fields";
 import { FormInput } from "@/components/forms/form-input";
@@ -32,13 +33,16 @@ export const OrganizationDetailView = observer(({ layout = "drawer" }: Props) =>
   const content =
     layout === "drawer" ? (
       <>
-        <FormInput autoFocus required id="name" />
+        <EntityDetailField fieldId={ORGANIZATION_DETAIL_FIELD.name}>
+          <FormInput autoFocus required id="name" />
+        </EntityDetailField>
 
         <EntityRelationField
           currentEntityId={fetchedEntity?.id}
           currentEntityType="organization"
           items={fetchedEntity?.contacts}
           target="contact"
+          visibilityFieldId={ORGANIZATION_DETAIL_FIELD.contactIds}
         />
 
         <EntityRelationField
@@ -46,6 +50,7 @@ export const OrganizationDetailView = observer(({ layout = "drawer" }: Props) =>
           currentEntityType="organization"
           items={fetchedEntity?.deals}
           target="deal"
+          visibilityFieldId={ORGANIZATION_DETAIL_FIELD.dealIds}
         />
 
         <EntityRelationField
@@ -53,23 +58,26 @@ export const OrganizationDetailView = observer(({ layout = "drawer" }: Props) =>
           currentEntityType="organization"
           items={fetchedEntity?.tasks}
           target="task"
+          visibilityFieldId={ORGANIZATION_DETAIL_FIELD.taskIds}
         />
 
         <CustomFieldInputs columns={customColumns} isEditing={isEditingCustomField} />
 
-        <AssignedUsersField items={fetchedEntity?.users} />
+        <AssignedUsersField items={fetchedEntity?.users} visibilityFieldId={ORGANIZATION_DETAIL_FIELD.userIds} />
       </>
     ) : (
       <EntityDetailSectionGroup>
         <EntityDetailSection label={t("EntityDetail.sections.base")} sectionId={ORGANIZATION_DETAIL_SECTION.base}>
-          <FormInput
-            autoFocus
-            required
-            id="name"
-            labelEndAddon={
-              <EntityDetailPinButton fieldId={ORGANIZATION_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
-            }
-          />
+          <EntityDetailField fieldId={ORGANIZATION_DETAIL_FIELD.name}>
+            <FormInput
+              autoFocus
+              required
+              id="name"
+              labelEndAddon={
+                <EntityDetailFieldActions fieldId={ORGANIZATION_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
+              }
+            />
+          </EntityDetailField>
 
           <AssignedUsersField
             items={fetchedEntity?.users}

--- a/app/[locale]/(protected)/services/components/service-detail-view.tsx
+++ b/app/[locale]/(protected)/services/components/service-detail-view.tsx
@@ -8,7 +8,8 @@ import { CustomFieldInputs } from "@/components/data-view/custom-columns/custom-
 import { EntityDetailBody } from "@/components/entity-detail/entity-detail-body";
 import { EntityDetailCustomFieldsSection } from "@/components/entity-detail/entity-detail-custom-fields-section";
 import { EntityDetailSection, EntityDetailSectionGroup } from "@/components/entity-detail/entity-detail-section";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { EntityDetailStaticField } from "@/components/entity-detail/entity-detail-static-field";
 import { EntityRelationField, AssignedUsersField } from "@/components/entity-detail/relation-fields";
 import { FormInput } from "@/components/forms/form-input";
@@ -37,15 +38,20 @@ export const ServiceDetailView = observer(({ layout = "drawer" }: Props) => {
   const content =
     layout === "drawer" ? (
       <>
-        <FormInput autoFocus required id="name" />
+        <EntityDetailField fieldId={SERVICE_DETAIL_FIELD.name}>
+          <FormInput autoFocus required id="name" />
+        </EntityDetailField>
 
-        <FormNumberInput required endContent={amountEndContent} id="amount" />
+        <EntityDetailField fieldId={SERVICE_DETAIL_FIELD.amount}>
+          <FormNumberInput required endContent={amountEndContent} id="amount" />
+        </EntityDetailField>
 
         <EntityRelationField
           currentEntityId={fetchedEntity?.id}
           currentEntityType="service"
           items={fetchedEntity?.deals}
           target="deal"
+          visibilityFieldId={SERVICE_DETAIL_FIELD.dealIds}
         />
 
         <EntityRelationField
@@ -53,32 +59,37 @@ export const ServiceDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="service"
           items={fetchedEntity?.tasks}
           target="task"
+          visibilityFieldId={SERVICE_DETAIL_FIELD.taskIds}
         />
 
         <CustomFieldInputs columns={customColumns} isEditing={isEditingCustomField} />
 
-        <AssignedUsersField items={fetchedEntity?.users} />
+        <AssignedUsersField items={fetchedEntity?.users} visibilityFieldId={SERVICE_DETAIL_FIELD.userIds} />
       </>
     ) : (
       <EntityDetailSectionGroup>
         <EntityDetailSection label={t("EntityDetail.sections.base")} sectionId={SERVICE_DETAIL_SECTION.base}>
-          <FormInput
-            autoFocus
-            required
-            id="name"
-            labelEndAddon={
-              <EntityDetailPinButton fieldId={SERVICE_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
-            }
-          />
+          <EntityDetailField fieldId={SERVICE_DETAIL_FIELD.name}>
+            <FormInput
+              autoFocus
+              required
+              id="name"
+              labelEndAddon={
+                <EntityDetailFieldActions fieldId={SERVICE_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
+              }
+            />
+          </EntityDetailField>
 
-          <FormNumberInput
-            required
-            endContent={amountEndContent}
-            id="amount"
-            labelEndAddon={
-              <EntityDetailPinButton fieldId={SERVICE_DETAIL_FIELD.amount} label={t("Common.inputs.amount")} />
-            }
-          />
+          <EntityDetailField fieldId={SERVICE_DETAIL_FIELD.amount}>
+            <FormNumberInput
+              required
+              endContent={amountEndContent}
+              id="amount"
+              labelEndAddon={
+                <EntityDetailFieldActions fieldId={SERVICE_DETAIL_FIELD.amount} label={t("Common.inputs.amount")} />
+              }
+            />
+          </EntityDetailField>
 
           <AssignedUsersField
             items={fetchedEntity?.users}

--- a/app/[locale]/(protected)/tasks/components/task-detail-view.tsx
+++ b/app/[locale]/(protected)/tasks/components/task-detail-view.tsx
@@ -8,7 +8,8 @@ import { CustomFieldInputs } from "@/components/data-view/custom-columns/custom-
 import { EntityDetailBody } from "@/components/entity-detail/entity-detail-body";
 import { EntityDetailCustomFieldsSection } from "@/components/entity-detail/entity-detail-custom-fields-section";
 import { EntityDetailSection, EntityDetailSectionGroup } from "@/components/entity-detail/entity-detail-section";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { EntityDetailStaticField } from "@/components/entity-detail/entity-detail-static-field";
 import { EntityRelationField, AssignedUsersField } from "@/components/entity-detail/relation-fields";
 import { useEntityTerminology } from "@/components/entity-terminology/use-entity-terminology";
@@ -73,7 +74,7 @@ export const TaskDetailView = observer(({ layout = "drawer" }: Props) => {
         <div className="flex items-center gap-1.5">
           <FormLabel htmlFor="name">{t("Common.inputs.name")}</FormLabel>
 
-          <EntityDetailPinButton fieldId={TASK_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
+          <EntityDetailFieldActions fieldId={TASK_DETAIL_FIELD.name} label={t("Common.inputs.name")} />
         </div>
 
         <Input readOnly id="name" value={systemTaskDisplayName} />
@@ -82,7 +83,7 @@ export const TaskDetailView = observer(({ layout = "drawer" }: Props) => {
       <FormInput
         required
         id="name"
-        labelEndAddon={<EntityDetailPinButton fieldId={TASK_DETAIL_FIELD.name} label={t("Common.inputs.name")} />}
+        labelEndAddon={<EntityDetailFieldActions fieldId={TASK_DETAIL_FIELD.name} label={t("Common.inputs.name")} />}
       />
     );
 
@@ -91,13 +92,14 @@ export const TaskDetailView = observer(({ layout = "drawer" }: Props) => {
       <>
         {systemTaskAlert}
 
-        {drawerNameField}
+        <EntityDetailField fieldId={TASK_DETAIL_FIELD.name}>{drawerNameField}</EntityDetailField>
 
         <EntityRelationField
           currentEntityId={fetchedEntity?.id}
           currentEntityType="task"
           items={fetchedEntity?.contacts}
           target="contact"
+          visibilityFieldId={TASK_DETAIL_FIELD.contactIds}
         />
 
         <EntityRelationField
@@ -105,6 +107,7 @@ export const TaskDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="task"
           items={fetchedEntity?.organizations}
           target="organization"
+          visibilityFieldId={TASK_DETAIL_FIELD.organizationIds}
         />
 
         <EntityRelationField
@@ -112,6 +115,7 @@ export const TaskDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="task"
           items={fetchedEntity?.deals}
           target="deal"
+          visibilityFieldId={TASK_DETAIL_FIELD.dealIds}
         />
 
         <EntityRelationField
@@ -119,18 +123,19 @@ export const TaskDetailView = observer(({ layout = "drawer" }: Props) => {
           currentEntityType="task"
           items={fetchedEntity?.services}
           target="service"
+          visibilityFieldId={TASK_DETAIL_FIELD.serviceIds}
         />
 
         <CustomFieldInputs columns={customColumns} isEditing={isEditingCustomField} />
 
-        <AssignedUsersField items={fetchedEntity?.users} />
+        <AssignedUsersField items={fetchedEntity?.users} visibilityFieldId={TASK_DETAIL_FIELD.userIds} />
       </>
     ) : (
       <EntityDetailSectionGroup>
         <EntityDetailSection label={t("EntityDetail.sections.base")} sectionId={TASK_DETAIL_SECTION.base}>
           {systemTaskAlert}
 
-          {pageNameField}
+          <EntityDetailField fieldId={TASK_DETAIL_FIELD.name}>{pageNameField}</EntityDetailField>
 
           <AssignedUsersField
             items={fetchedEntity?.users}

--- a/components/data-view/custom-columns/custom-field-inputs.tsx
+++ b/components/data-view/custom-columns/custom-field-inputs.tsx
@@ -4,7 +4,8 @@ import { ArrowDown, ArrowUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { CustomFieldValueInput } from "@/components/data-view/custom-columns/custom-field-value-input";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { IconButton } from "@/components/ui/icon-button";
 import { useEntityDetailPersonalization } from "@/components/entity-detail/entity-detail-personalization";
 import { resolveOrderedCustomColumns } from "@/components/entity-detail/entity-detail-personalization.utils";
@@ -25,43 +26,44 @@ export function CustomFieldInputs({ columns, isEditing, personalizable = false }
   return (
     <>
       {orderedColumns.map(({ column, formIndex }, visualIndex) => (
-        <CustomFieldValueInput
-          key={column.id}
-          column={column}
-          index={formIndex}
-          isEditing={isEditing}
-          labelEndAddon={
-            personalizable ? (
-              <span className="flex items-center gap-0.5">
-                <EntityDetailPinButton fieldId={column.id} label={column.label} />
+        <EntityDetailField key={column.id} fieldId={column.id}>
+          <CustomFieldValueInput
+            column={column}
+            index={formIndex}
+            isEditing={isEditing}
+            labelEndAddon={
+              personalizable ? (
+                <span className="flex items-center gap-0.5">
+                  <EntityDetailFieldActions fieldId={column.id} label={column.label} />
 
-                {isPersonalizing && (
-                  <>
-                    <IconButton
-                      className="size-5"
-                      disabled={visualIndex === 0}
-                      icon={ArrowUp}
-                      label={t("EntityDetail.moveFieldUp", {
-                        field: column.label,
-                      })}
-                      onClick={() => moveColumn(column.id, "up")}
-                    />
+                  {isPersonalizing && (
+                    <>
+                      <IconButton
+                        className="size-5"
+                        disabled={visualIndex === 0}
+                        icon={ArrowUp}
+                        label={t("EntityDetail.moveFieldUp", {
+                          field: column.label,
+                        })}
+                        onClick={() => moveColumn(column.id, "up")}
+                      />
 
-                    <IconButton
-                      className="size-5"
-                      disabled={visualIndex === orderedColumns.length - 1}
-                      icon={ArrowDown}
-                      label={t("EntityDetail.moveFieldDown", {
-                        field: column.label,
-                      })}
-                      onClick={() => moveColumn(column.id, "down")}
-                    />
-                  </>
-                )}
-              </span>
-            ) : undefined
-          }
-        />
+                      <IconButton
+                        className="size-5"
+                        disabled={visualIndex === orderedColumns.length - 1}
+                        icon={ArrowDown}
+                        label={t("EntityDetail.moveFieldDown", {
+                          field: column.label,
+                        })}
+                        onClick={() => moveColumn(column.id, "down")}
+                      />
+                    </>
+                  )}
+                </span>
+              ) : undefined
+            }
+          />
+        </EntityDetailField>
       ))}
     </>
   );

--- a/components/entity-detail/__tests__/entity-detail-static-field-accessibility.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-static-field-accessibility.test.ts
@@ -9,9 +9,13 @@ vi.mock("next-intl", () => ({
     key === "Common.ariaLabels.explainField" ? `About ${values?.field ?? "field"}` : key,
 }));
 
-vi.mock("../entity-detail-pin-button", () => ({
-  EntityDetailPinButton: ({ fieldId, label }: { fieldId: string; label: string }) =>
-    createElement("button", { "aria-label": `Pin ${label}`, "data-pin-field": fieldId, type: "button" }),
+vi.mock("../entity-detail-field-actions", () => ({
+  EntityDetailFieldActions: ({ fieldId, label }: { fieldId: string; label: string }) =>
+    createElement("button", {
+      "aria-label": `Pin ${label}`,
+      "data-pin-field": fieldId,
+      type: "button",
+    }),
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({

--- a/components/entity-detail/__tests__/entity-detail-summary.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-summary.test.ts
@@ -24,6 +24,9 @@ vi.mock("next-intl", () => ({
 vi.mock("../entity-detail-pin-button", () => ({
   EntityDetailPinButton: ({ fieldId }: { fieldId: string }) => createElement("button", { "data-pin": fieldId }),
 }));
+vi.mock("../entity-detail-field-actions", () => ({
+  EntityDetailFieldActions: ({ fieldId }: { fieldId: string }) => createElement("button", { "data-pin": fieldId }),
+}));
 vi.mock("../hooks/use-entity-drawer-stack", () => ({
   useEntityHref: () => vi.fn(),
 }));

--- a/components/entity-detail/__tests__/entity-detail-visibility.test.tsx
+++ b/components/entity-detail/__tests__/entity-detail-visibility.test.tsx
@@ -1,0 +1,198 @@
+import type { Root } from "react-dom/client";
+import type { ComponentType, ReactNode } from "react";
+import type { EntityDetailPersonalizationConfig } from "../entity-detail-personalization";
+import type { P13nEntry } from "@/features/p13n/prisma-p13n.repository";
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const upsertP13nAction = vi.hoisted(() => vi.fn());
+
+vi.mock("@/app/actions", () => ({ upsertP13nAction }));
+vi.mock("@/core/errors/report-application-error", () => ({
+  reportApplicationError: vi.fn(),
+}));
+vi.mock("@/core/utils/toast-zod-error-tree", () => ({
+  toastZodErrorTree: vi.fn(),
+}));
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: { field?: string }) => `${key}:${values?.field ?? ""}`,
+}));
+vi.mock("@/components/ui/icon-button", () => ({
+  IconButton: ({
+    disabled,
+    label,
+    onClick,
+    pressed,
+  }: {
+    disabled?: boolean;
+    label: string;
+    onClick: () => void;
+    pressed?: boolean;
+  }) =>
+    createElement(
+      "button",
+      {
+        "aria-label": label,
+        "aria-pressed": pressed,
+        disabled,
+        type: "button",
+        onClick,
+      },
+      label,
+    ),
+}));
+vi.mock("../entity-detail-pin-button", () => ({
+  EntityDetailPinButton: ({ disabled, fieldId }: { disabled?: boolean; fieldId: string }) =>
+    createElement("button", { "data-pin": fieldId, disabled, type: "button" }),
+}));
+
+import {
+  EntityDetailPersonalizationProvider,
+  resetEntityDetailPersonalizationPersistenceForTests,
+  useEntityDetailPersonalization,
+} from "../entity-detail-personalization";
+import { EntityDetailField } from "../entity-detail-field";
+import { EntityDetailFieldActions } from "../entity-detail-field-actions";
+
+const roots = new Set<Root>();
+const config: EntityDetailPersonalizationConfig = {
+  p13nId: "contact-detail",
+  defaultStarredFieldIds: [],
+  availableFieldIds: ["name"],
+};
+const TestProvider = EntityDetailPersonalizationProvider as ComponentType<{
+  applyFieldVisibility?: boolean;
+  children?: ReactNode;
+  config: EntityDetailPersonalizationConfig;
+  initial?: P13nEntry | null;
+  persistenceScope: string;
+}>;
+const TestField = EntityDetailField as ComponentType<{
+  children?: ReactNode;
+  fieldId: string;
+}>;
+
+function Controls() {
+  const { isPersonalizing, setIsPersonalizing } = useEntityDetailPersonalization();
+
+  return createElement(
+    "button",
+    {
+      "data-personalizing": isPersonalizing,
+      type: "button",
+      onClick: () => setIsPersonalizing(!isPersonalizing),
+    },
+    "Customize",
+  );
+}
+
+function view({
+  applyFieldVisibility = true,
+  hidden = [],
+  starred = [],
+}: {
+  applyFieldVisibility?: boolean;
+  hidden?: string[];
+  starred?: string[];
+}) {
+  return createElement(
+    TestProvider,
+    {
+      applyFieldVisibility,
+      config,
+      initial: {
+        p13nId: config.p13nId,
+        detailOptions: {
+          collapsedSectionIds: [],
+          hiddenFieldIds: hidden,
+          starredFieldIds: starred,
+        },
+      },
+      persistenceScope: "user-1",
+    },
+    createElement(Controls),
+    createElement(
+      TestField,
+      { fieldId: "name" },
+      createElement(
+        "div",
+        { "data-field-content": true },
+        createElement("span", null, "Name"),
+        createElement(EntityDetailFieldActions, {
+          fieldId: "name",
+          label: "Name",
+        }),
+      ),
+    ),
+  );
+}
+
+function mount(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.add(root);
+  act(() => root.render(node));
+  return { container, root };
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  resetEntityDetailPersonalizationPersistenceForTests();
+  upsertP13nAction.mockReset();
+  upsertP13nAction.mockResolvedValue({ ok: true, data: {} });
+});
+
+afterEach(() => {
+  act(() => roots.forEach((root) => root.unmount()));
+  roots.clear();
+  document.body.replaceChildren();
+});
+
+describe("entity detail field visibility", () => {
+  it("keeps hidden fields restorable in Customize and removes them from the normal detail view", () => {
+    const { container } = mount(view({ hidden: ["name"] }));
+
+    expect(container.querySelector("[data-field-content]")).toBeNull();
+
+    act(() => container.querySelector<HTMLButtonElement>("[data-personalizing]")?.click());
+
+    expect(container.querySelector('[data-entity-field="name"]')?.getAttribute("data-field-hidden")).toBe("true");
+    expect(container.querySelector('[data-entity-field="name"]')?.className).toContain("opacity-50");
+    expect(container.querySelector<HTMLButtonElement>('[data-pin="name"]')?.disabled).toBe(true);
+    expect(container.querySelector('[aria-label="EntityDetail.showField:Name"]')).not.toBeNull();
+  });
+
+  it("hides and unpins a field together, then persists the visibility preference", async () => {
+    const { container, root } = mount(view({ starred: ["name"] }));
+
+    act(() => container.querySelector<HTMLButtonElement>("[data-personalizing]")?.click());
+    act(() => container.querySelector<HTMLButtonElement>('[aria-label="EntityDetail.hideField:Name"]')?.click());
+    act(() => container.querySelector<HTMLButtonElement>("[data-personalizing]")?.click());
+
+    expect(container.querySelector("[data-field-content]")).toBeNull();
+
+    act(() => root.unmount());
+    roots.delete(root);
+    await act(async () => Promise.resolve());
+
+    expect(upsertP13nAction).toHaveBeenCalledExactlyOnceWith({
+      p13nId: "contact-detail",
+      detailOptions: {
+        collapsedSectionIds: [],
+        hiddenFieldIds: ["name"],
+        starredFieldIds: [],
+      },
+      columnOrder: [],
+    });
+  });
+
+  it("does not apply saved visibility while creating a new record", () => {
+    const { container } = mount(view({ applyFieldVisibility: false, hidden: ["name"] }));
+
+    expect(container.querySelector("[data-field-content]")).not.toBeNull();
+    expect(container.querySelector('[data-entity-field="name"]')?.hasAttribute("data-field-hidden")).toBe(false);
+  });
+});

--- a/components/entity-detail/__tests__/entity-drawer-personalization.test.ts
+++ b/components/entity-detail/__tests__/entity-drawer-personalization.test.ts
@@ -32,6 +32,7 @@ const harness = vi.hoisted(() => {
     reportApplicationError: vi.fn(),
     rootStore,
     store,
+    top: { entityType: "contact", id: "contact-1" } as { entityType: "contact"; id: string },
   };
 });
 
@@ -41,7 +42,7 @@ vi.mock("@/components/entity-detail/hooks/use-entity-drawer-stack", () => ({
   focusEntityDrawerInvoker: () => false,
   useEntityDrawerStack: () => ({
     popTop: harness.popTop,
-    top: { entityType: "contact", id: "contact-1" },
+    top: harness.top,
   }),
 }));
 vi.mock("@/components/entity-detail/entity-detail.registry", () => ({
@@ -56,12 +57,14 @@ vi.mock("@/components/entity-detail/entity-detail.registry", () => ({
 }));
 vi.mock("@/components/entity-detail/entity-detail-personalization", () => ({
   EntityDetailPersonalizationProvider: ({
+    applyFieldVisibility,
     children,
     config,
     customColumnIds,
     initial,
     persistenceScope,
   }: {
+    applyFieldVisibility?: boolean;
     children: ReactNode;
     config?: { p13nId: string };
     customColumnIds?: string[];
@@ -71,6 +74,7 @@ vi.mock("@/components/entity-detail/entity-detail-personalization", () => ({
     createElement(
       "div",
       {
+        "data-apply-field-visibility": applyFieldVisibility,
         "data-column-ids": customColumnIds?.join(","),
         "data-initial-order": initial?.columnOrder?.join(","),
         "data-p13n-id": config?.p13nId,
@@ -121,8 +125,10 @@ beforeEach(() => {
   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   vi.clearAllMocks();
   harness.store.entityLoadState = "ready";
+  harness.store.add.mockResolvedValue(undefined);
   harness.store.loadById.mockResolvedValue(undefined);
   harness.rootStore.userStore.user = observable({ id: "user-1" });
+  harness.top.id = "contact-1";
 });
 
 afterEach(() => {
@@ -166,10 +172,41 @@ describe("EntityDrawer personalization", () => {
     const provider = container.querySelector<HTMLElement>("[data-personalization-provider]");
 
     expect(provider?.dataset.p13nId).toBe("contact-detail");
+    expect(provider?.dataset.applyFieldVisibility).toBe("true");
     expect(provider?.dataset.persistenceScope).toBe("user-1");
     expect(provider?.dataset.columnIds).toBe("custom-1,custom-2");
     expect(provider?.dataset.initialOrder).toBe("custom-2,custom-1");
     expect(container.querySelector('[data-detail-view][data-layout="drawer"]')).not.toBeNull();
+  });
+
+  it("keeps all creation fields visible regardless of saved detail visibility", async () => {
+    harness.top.id = "new";
+    harness.getP13nAction.mockResolvedValue({
+      ok: true,
+      data: {
+        p13nId: "contact-detail",
+        detailOptions: {
+          starredFieldIds: [],
+          collapsedSectionIds: [],
+          hiddenFieldIds: ["firstName"],
+        },
+      },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+
+    await act(async () => {
+      root.render(createElement(EntityDrawer));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(harness.store.add).toHaveBeenCalledOnce();
+    expect(container.querySelector<HTMLElement>("[data-personalization-provider]")?.dataset.applyFieldVisibility).toBe(
+      "false",
+    );
   });
 
   it("restarts the load after Strict Mode replays the mount effect", async () => {

--- a/components/entity-detail/entity-detail-field-actions.tsx
+++ b/components/entity-detail/entity-detail-field-actions.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Eye, EyeOff } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { IconButton } from "@/components/ui/icon-button";
+import { cn } from "@/core/utils/cn";
+
+import { useEntityDetailPersonalization } from "./entity-detail-personalization";
+import { EntityDetailPinButton } from "./entity-detail-pin-button";
+
+type Props = {
+  fieldId: string;
+  label: string;
+  className?: string;
+};
+
+export function EntityDetailFieldActions({ fieldId, label, className }: Props) {
+  const t = useTranslations();
+  const {
+    enabled,
+    hiddenFieldIds = [],
+    isPersonalizing = false,
+    toggleFieldVisibility = () => undefined,
+  } = useEntityDetailPersonalization();
+  const hidden = hiddenFieldIds.includes(fieldId);
+
+  if (!enabled) return null;
+
+  return (
+    <span className={cn("flex items-center gap-0.5", className)}>
+      <EntityDetailPinButton disabled={hidden} fieldId={fieldId} label={label} />
+
+      {isPersonalizing ? (
+        <IconButton
+          fieldAction
+          className="size-5"
+          icon={hidden ? EyeOff : Eye}
+          iconClassName={cn(hidden && "text-primary")}
+          label={hidden ? t("EntityDetail.showField", { field: label }) : t("EntityDetail.hideField", { field: label })}
+          pressed={hidden}
+          onClick={() => toggleFieldVisibility(fieldId)}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/components/entity-detail/entity-detail-field.tsx
+++ b/components/entity-detail/entity-detail-field.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/core/utils/cn";
+
+import { useEntityDetailPersonalization } from "./entity-detail-personalization";
+
+type Props = {
+  children: ReactNode;
+  fieldId?: string;
+  className?: string;
+};
+
+export function EntityDetailField({ children, fieldId, className }: Props) {
+  const {
+    applyFieldVisibility = true,
+    enabled,
+    hiddenFieldIds = [],
+    isPersonalizing = false,
+  } = useEntityDetailPersonalization();
+  const hidden = Boolean(fieldId && applyFieldVisibility && enabled && hiddenFieldIds.includes(fieldId));
+
+  if (hidden && !isPersonalizing) return null;
+
+  return (
+    <div
+      className={cn("contents", hidden && "[&>*]:opacity-50", className)}
+      data-entity-field={fieldId}
+      data-field-hidden={hidden || undefined}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/entity-detail/entity-detail-personalization.tsx
+++ b/components/entity-detail/entity-detail-personalization.tsx
@@ -28,13 +28,16 @@ export type EntityDetailPreviewItem = {
 
 type EntityDetailPersonalizationValue = {
   enabled: boolean;
+  applyFieldVisibility: boolean;
   isPersonalizing: boolean;
   starredFieldIds: string[];
+  hiddenFieldIds: string[];
   collapsedSectionIds: string[];
   columnOrder: string[];
   previewFieldValues: Record<string, EntityDetailPreviewItem[]>;
   setIsPersonalizing: (value: boolean) => void;
   toggleStarredField: (fieldId: string) => void;
+  toggleFieldVisibility: (fieldId: string) => void;
   setSectionCollapsed: (sectionId: string, collapsed: boolean) => void;
   moveColumn: (columnId: string, direction: MoveDirection) => void;
   setPreviewFieldValue: (fieldId: string, items: EntityDetailPreviewItem[]) => void;
@@ -42,13 +45,16 @@ type EntityDetailPersonalizationValue = {
 
 const EMPTY_VALUE: EntityDetailPersonalizationValue = {
   enabled: false,
+  applyFieldVisibility: false,
   isPersonalizing: false,
   starredFieldIds: [],
+  hiddenFieldIds: [],
   collapsedSectionIds: [],
   columnOrder: [],
   previewFieldValues: {},
   setIsPersonalizing: () => undefined,
   toggleStarredField: () => undefined,
+  toggleFieldVisibility: () => undefined,
   setSectionCollapsed: () => undefined,
   moveColumn: () => undefined,
   setPreviewFieldValue: () => undefined,
@@ -62,6 +68,7 @@ type ProviderProps = {
   initial?: P13nEntry | null;
   customColumnIds?: string[];
   persistenceScope: string;
+  applyFieldVisibility?: boolean;
 };
 
 type PersonalizationSnapshot = {
@@ -125,17 +132,20 @@ export function EntityDetailPersonalizationProvider({
   initial,
   customColumnIds,
   persistenceScope,
+  applyFieldVisibility = true,
 }: ProviderProps) {
   const p13nId = config?.p13nId;
   const persistenceChannelKey = p13nId ? `${persistenceScope}:${p13nId}` : undefined;
   const latestSnapshot = persistenceChannelKey ? persistenceChannels.get(persistenceChannelKey)?.latest : undefined;
   const storedOptions = latestSnapshot?.detailOptions ?? initial?.detailOptions;
   const [isPersonalizing, setIsPersonalizing] = useState(false);
+  const initialHiddenFieldIds = reconcileAvailableIds(storedOptions?.hiddenFieldIds ?? [], config?.availableFieldIds);
+  const [hiddenFieldIds, setHiddenFieldIds] = useState(() => initialHiddenFieldIds);
   const [starredFieldIds, setStarredFieldIds] = useState(() =>
     reconcileAvailableIds(
       storedOptions?.starredFieldIds ?? config?.defaultStarredFieldIds ?? [],
       config?.availableFieldIds,
-    ),
+    ).filter((fieldId) => !initialHiddenFieldIds.includes(fieldId)),
   );
   const [collapsedSectionIds, setCollapsedSectionIds] = useState(() =>
     reconcileAvailableIds(
@@ -153,7 +163,11 @@ export function EntityDetailPersonalizationProvider({
   const lastPersistenceStamp = useRef(
     JSON.stringify({
       p13nId,
-      detailOptions: { starredFieldIds, collapsedSectionIds },
+      detailOptions: {
+        starredFieldIds,
+        collapsedSectionIds,
+        ...(hiddenFieldIds.length > 0 ? { hiddenFieldIds } : {}),
+      },
       columnOrder,
     }),
   );
@@ -175,6 +189,10 @@ export function EntityDetailPersonalizationProvider({
       const next = reconcileAvailableIds(current, availableFieldIds);
       return next.length === current.length && next.every((id, index) => id === current[index]) ? current : next;
     });
+    setHiddenFieldIds((current) => {
+      const next = reconcileAvailableIds(current, availableFieldIds);
+      return next.length === current.length && next.every((id, index) => id === current[index]) ? current : next;
+    });
   }, [availableFieldStamp]);
 
   useEffect(() => {
@@ -192,6 +210,7 @@ export function EntityDetailPersonalizationProvider({
       detailOptions: {
         starredFieldIds,
         collapsedSectionIds,
+        ...(hiddenFieldIds.length > 0 ? { hiddenFieldIds } : {}),
       },
       columnOrder,
     };
@@ -200,7 +219,7 @@ export function EntityDetailPersonalizationProvider({
 
     lastPersistenceStamp.current = stamp;
     schedulePersistence(persistenceChannelKey, snapshot);
-  }, [collapsedSectionIds, columnOrder, p13nId, persistenceChannelKey, starredFieldIds]);
+  }, [collapsedSectionIds, columnOrder, hiddenFieldIds, p13nId, persistenceChannelKey, starredFieldIds]);
 
   useEffect(
     () => () => {
@@ -214,6 +233,17 @@ export function EntityDetailPersonalizationProvider({
       current.includes(fieldId) ? current.filter((id) => id !== fieldId) : [...current, fieldId],
     );
   }, []);
+
+  const toggleFieldVisibility = useCallback(
+    (fieldId: string) => {
+      const hiding = !hiddenFieldIds.includes(fieldId);
+      setHiddenFieldIds((current) =>
+        current.includes(fieldId) ? current.filter((id) => id !== fieldId) : [...current, fieldId],
+      );
+      if (hiding) setStarredFieldIds((starred) => starred.filter((id) => id !== fieldId));
+    },
+    [hiddenFieldIds],
+  );
 
   const setSectionCollapsed = useCallback((sectionId: string, collapsed: boolean) => {
     setCollapsedSectionIds((current) => {
@@ -247,13 +277,16 @@ export function EntityDetailPersonalizationProvider({
   const value = useMemo<EntityDetailPersonalizationValue>(
     () => ({
       enabled: Boolean(config),
+      applyFieldVisibility,
       isPersonalizing,
       starredFieldIds,
+      hiddenFieldIds,
       collapsedSectionIds,
       columnOrder,
       previewFieldValues,
       setIsPersonalizing,
       toggleStarredField,
+      toggleFieldVisibility,
       setSectionCollapsed,
       moveColumn,
       setPreviewFieldValue,
@@ -262,12 +295,15 @@ export function EntityDetailPersonalizationProvider({
       collapsedSectionIds,
       columnOrder,
       config,
+      applyFieldVisibility,
+      hiddenFieldIds,
       isPersonalizing,
       moveColumn,
       previewFieldValues,
       setSectionCollapsed,
       setPreviewFieldValue,
       starredFieldIds,
+      toggleFieldVisibility,
       toggleStarredField,
     ],
   );

--- a/components/entity-detail/entity-detail-pin-button.tsx
+++ b/components/entity-detail/entity-detail-pin-button.tsx
@@ -12,9 +12,10 @@ type Props = {
   fieldId: string;
   label: string;
   className?: string;
+  disabled?: boolean;
 };
 
-export function EntityDetailPinButton({ fieldId, label, className }: Props) {
+export function EntityDetailPinButton({ fieldId, label, className, disabled }: Props) {
   const t = useTranslations();
   const { enabled, starredFieldIds, toggleStarredField } = useEntityDetailPersonalization();
   const pinned = starredFieldIds.includes(fieldId);
@@ -29,6 +30,7 @@ export function EntityDetailPinButton({ fieldId, label, className }: Props) {
     <IconButton
       fieldAction
       className={className}
+      disabled={disabled}
       icon={Pin}
       iconClassName={cn(pinned && "fill-current text-primary")}
       label={actionLabel}

--- a/components/entity-detail/entity-detail-static-field.tsx
+++ b/components/entity-detail/entity-detail-static-field.tsx
@@ -4,7 +4,8 @@ import type { ReactNode } from "react";
 
 import { FormOutputField } from "@/components/forms/form-output-field";
 
-import { EntityDetailPinButton } from "./entity-detail-pin-button";
+import { EntityDetailField } from "./entity-detail-field";
+import { EntityDetailFieldActions } from "./entity-detail-field-actions";
 
 type Props = {
   fieldId: string;
@@ -17,14 +18,16 @@ export function EntityDetailStaticField({ fieldId, label, value, help }: Props) 
   const displayValue = value === null || value === undefined || value === "" ? "—" : value;
 
   return (
-    <FormOutputField
-      help={help}
-      label={label}
-      labelEndAddon={<EntityDetailPinButton fieldId={fieldId} label={label} />}
-    >
-      <span suppressHydrationWarning className="select-text truncate">
-        {displayValue}
-      </span>
-    </FormOutputField>
+    <EntityDetailField fieldId={fieldId}>
+      <FormOutputField
+        help={help}
+        label={label}
+        labelEndAddon={<EntityDetailFieldActions fieldId={fieldId} label={label} />}
+      >
+        <span suppressHydrationWarning className="select-text truncate">
+          {displayValue}
+        </span>
+      </FormOutputField>
+    </EntityDetailField>
   );
 }

--- a/components/entity-detail/entity-drawer.tsx
+++ b/components/entity-detail/entity-drawer.tsx
@@ -189,6 +189,7 @@ export const EntityDrawer = observer(() => {
       drawerBody = DetailView ? (
         <EntityDetailPersonalizationProvider
           key={`${personalizationScope}:${personalization?.p13nId ?? "disabled"}:${activeKey}`}
+          applyFieldVisibility={top?.id !== "new"}
           config={personalization}
           customColumnIds={detailStore?.customColumns.map((column) => column.id)}
           initial={personalizationInitial}

--- a/components/entity-detail/entity-relation-actions.tsx
+++ b/components/entity-detail/entity-relation-actions.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import type { RelationEntityType } from "@/components/entity-detail/entity-relations";
 import { useEntityTerminology } from "@/components/entity-terminology/use-entity-terminology";
 
@@ -36,7 +36,7 @@ export function EntityRelationActions({
 
   return (
     <span className="flex items-center gap-1">
-      {personalization && <EntityDetailPinButton fieldId={personalization.fieldId} label={fieldLabel} />}
+      {personalization && <EntityDetailFieldActions fieldId={personalization.fieldId} label={fieldLabel} />}
 
       {children}
 

--- a/components/entity-detail/relation-fields.tsx
+++ b/components/entity-detail/relation-fields.tsx
@@ -27,7 +27,8 @@ import {
   EntityRelationActions,
   type EntityDetailFieldPersonalization,
 } from "@/components/entity-detail/entity-relation-actions";
-import { EntityDetailPinButton } from "@/components/entity-detail/entity-detail-pin-button";
+import { EntityDetailField } from "@/components/entity-detail/entity-detail-field";
+import { EntityDetailFieldActions } from "@/components/entity-detail/entity-detail-field-actions";
 import { AppChip } from "@/components/chip/app-chip";
 import { FormAutocomplete } from "@/components/forms/form-autocomplete";
 import { FormAutocompleteAvatar } from "@/components/forms/form-autocomplete-avatar";
@@ -102,6 +103,7 @@ type RelationFieldProps = {
   labelEndAddon?: ReactNode;
   previewFieldId?: string;
   personalization?: EntityDetailFieldPersonalization;
+  visibilityFieldId?: string;
 };
 
 export const EntityRelationField = observer(
@@ -113,6 +115,7 @@ export const EntityRelationField = observer(
     labelEndAddon,
     previewFieldId,
     personalization,
+    visibilityFieldId,
   }: RelationFieldProps) => {
     const { userStore } = useRootStore();
     const entityHref = useEntityHref();
@@ -154,21 +157,31 @@ export const EntityRelationField = observer(
       onCreate: (name: string) => config.onCreate(name, userStore.user?.id),
     };
 
-    if (config.variant === "avatar") return <FormAutocompleteAvatar {...common} />;
+    const fieldId = personalization?.fieldId ?? visibilityFieldId;
+
+    if (config.variant === "avatar") {
+      return (
+        <EntityDetailField fieldId={fieldId}>
+          <FormAutocompleteAvatar {...common} />
+        </EntityDetailField>
+      );
+    }
 
     return (
-      <FormAutocomplete
-        {...common}
-        renderValue={(values) => values.map((v) => <AppChip key={v.key}>{resolveLabel(v.data)}</AppChip>)}
-      >
-        {(item) => {
-          const label = resolveLabel(item);
-          return FormAutocompleteItem({
-            children: label,
-            textValue: typeof label === "string" ? label : item.name,
-          });
-        }}
-      </FormAutocomplete>
+      <EntityDetailField fieldId={fieldId}>
+        <FormAutocomplete
+          {...common}
+          renderValue={(values) => values.map((v) => <AppChip key={v.key}>{resolveLabel(v.data)}</AppChip>)}
+        >
+          {(item) => {
+            const label = resolveLabel(item);
+            return FormAutocompleteItem({
+              children: label,
+              textValue: typeof label === "string" ? label : item.name,
+            });
+          }}
+        </FormAutocomplete>
+      </EntityDetailField>
     );
   },
 );
@@ -179,11 +192,13 @@ export const AssignedUsersField = observer(
     labelEndAddon,
     previewFieldId,
     personalization,
+    visibilityFieldId,
   }: {
     items: readonly any[] | undefined;
     labelEndAddon?: ReactNode;
     previewFieldId?: string;
     personalization?: EntityDetailFieldPersonalization;
+    visibilityFieldId?: string;
   }) => {
     const { userModalStore, userStore } = useRootStore();
     const { setPreviewFieldValue } = useEntityDetailPersonalization();
@@ -200,23 +215,25 @@ export const AssignedUsersField = observer(
     if (!userStore.canAccess(Resource.users)) return null;
 
     return (
-      <FormAutocompleteAvatar
-        getItems={getUsersAction}
-        id="userIds"
-        items={items ?? []}
-        labelEndAddon={
-          personalization || labelEndAddon ? (
-            <span className="flex items-center gap-1">
-              {personalization && <EntityDetailPinButton fieldId={personalization.fieldId} label={fieldLabel} />}
+      <EntityDetailField fieldId={personalization?.fieldId ?? visibilityFieldId}>
+        <FormAutocompleteAvatar
+          getItems={getUsersAction}
+          id="userIds"
+          items={items ?? []}
+          labelEndAddon={
+            personalization || labelEndAddon ? (
+              <span className="flex items-center gap-1">
+                {personalization && <EntityDetailFieldActions fieldId={personalization.fieldId} label={fieldLabel} />}
 
-              {labelEndAddon}
-            </span>
-          ) : undefined
-        }
-        selectionMode="multiple"
-        onChipClick={(id) => runUserAction(() => userModalStore.loadById(id))}
-        onSelectionDataChange={effectivePreviewFieldId ? publishSelection : undefined}
-      />
+                {labelEndAddon}
+              </span>
+            ) : undefined
+          }
+          selectionMode="multiple"
+          onChipClick={(id) => runUserAction(() => userModalStore.loadById(id))}
+          onSelectionDataChange={effectivePreviewFieldId ? publishSelection : undefined}
+        />
+      </EntityDetailField>
     );
   },
 );

--- a/features/p13n/__tests__/p13n-user-isolation.database.test.ts
+++ b/features/p13n/__tests__/p13n-user-isolation.database.test.ts
@@ -55,6 +55,7 @@ describeDatabase("P13n user isolation on PostgreSQL", () => {
         detailOptions: {
           starredFieldIds: ["identifiers", "first-custom-field"],
           collapsedSectionIds: ["relations"],
+          hiddenFieldIds: ["lastName"],
         },
       }),
     );
@@ -65,6 +66,7 @@ describeDatabase("P13n user isolation on PostgreSQL", () => {
         detailOptions: {
           starredFieldIds: ["userIds", "second-custom-field"],
           collapsedSectionIds: ["customFields"],
+          hiddenFieldIds: ["createdAt"],
         },
       }),
     );
@@ -77,6 +79,7 @@ describeDatabase("P13n user isolation on PostgreSQL", () => {
       detailOptions: {
         starredFieldIds: ["identifiers", "first-custom-field"],
         collapsedSectionIds: ["relations"],
+        hiddenFieldIds: ["lastName"],
       },
     });
     expect(second).toMatchObject({
@@ -84,6 +87,7 @@ describeDatabase("P13n user isolation on PostgreSQL", () => {
       detailOptions: {
         starredFieldIds: ["userIds", "second-custom-field"],
         collapsedSectionIds: ["customFields"],
+        hiddenFieldIds: ["createdAt"],
       },
     });
 

--- a/features/p13n/__tests__/prisma-p13n.repository.test.ts
+++ b/features/p13n/__tests__/prisma-p13n.repository.test.ts
@@ -135,6 +135,7 @@ describe("PrismaP13nRepo legacy filter normalization", () => {
       detailOptions: {
         starredFieldIds: ["identifiers", "custom-column"],
         collapsedSectionIds: ["notes"],
+        hiddenFieldIds: ["createdAt"],
       },
     });
 
@@ -143,9 +144,13 @@ describe("PrismaP13nRepo legacy filter normalization", () => {
     expect(valid?.detailOptions).toEqual({
       starredFieldIds: ["identifiers", "custom-column"],
       collapsedSectionIds: ["notes"],
+      hiddenFieldIds: ["createdAt"],
     });
 
-    p13nFindUnique.mockResolvedValueOnce({ ...baseRow, detailOptions: { starredFieldIds: "identifiers" } });
+    p13nFindUnique.mockResolvedValueOnce({
+      ...baseRow,
+      detailOptions: { starredFieldIds: "identifiers" },
+    });
 
     const malformed = await runWithTenant(mockUser, () => new PrismaP13nRepo().getP13n("contact-detail"));
 

--- a/features/p13n/p13n.schema.ts
+++ b/features/p13n/p13n.schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const EntityDetailOptionsSchema = z.object({
   starredFieldIds: z.array(z.string().min(1)),
   collapsedSectionIds: z.array(z.string().min(1)),
+  hiddenFieldIds: z.array(z.string().min(1)).optional(),
 });
 
 export type EntityDetailOptions = z.infer<typeof EntityDetailOptionsSchema>;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1784,6 +1784,7 @@
       "createdAt": "Erstellt am",
       "updatedAt": "Aktualisiert am"
     },
+    "hideField": "{field} in den Details ausblenden",
     "moveFieldDown": "{field} nach unten verschieben",
     "moveFieldUp": "{field} nach oben verschieben",
     "personalize": "Anpassen",
@@ -1794,6 +1795,7 @@
       "notes": "Notizen",
       "relations": "Beziehungen"
     },
+    "showField": "{field} in den Details anzeigen",
     "unpinField": "{field} von der Übersicht lösen"
   },
   "EntityTerminology": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1784,6 +1784,7 @@
       "createdAt": "Created at",
       "updatedAt": "Updated at"
     },
+    "hideField": "Hide {field} from details",
     "moveFieldDown": "Move {field} down",
     "moveFieldUp": "Move {field} up",
     "personalize": "Customize",
@@ -1794,6 +1795,7 @@
       "notes": "Notes",
       "relations": "Relations"
     },
+    "showField": "Show {field} in details",
     "unpinField": "Unpin {field} from the overview"
   },
   "EntityTerminology": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1784,6 +1784,7 @@
       "createdAt": "Creado el",
       "updatedAt": "Actualizado el"
     },
+    "hideField": "Ocultar {field} de los detalles",
     "moveFieldDown": "Mover {field} hacia abajo",
     "moveFieldUp": "Mover {field} hacia arriba",
     "personalize": "Personalizar",
@@ -1794,6 +1795,7 @@
       "notes": "Notas",
       "relations": "Relaciones"
     },
+    "showField": "Mostrar {field} en los detalles",
     "unpinField": "Desfijar {field} del resumen"
   },
   "EntityTerminology": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1784,6 +1784,7 @@
       "createdAt": "Créé le",
       "updatedAt": "Mis à jour le"
     },
+    "hideField": "Masquer {field} dans les détails",
     "moveFieldDown": "Déplacer {field} vers le bas",
     "moveFieldUp": "Déplacer {field} vers le haut",
     "personalize": "Personnaliser",
@@ -1794,6 +1795,7 @@
       "notes": "Notes",
       "relations": "Relations"
     },
+    "showField": "Afficher {field} dans les détails",
     "unpinField": "Désépingler {field} de l’aperçu"
   },
   "EntityTerminology": {

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1784,6 +1784,7 @@
       "createdAt": "Creato il",
       "updatedAt": "Aggiornato il"
     },
+    "hideField": "Nascondi {field} dai dettagli",
     "moveFieldDown": "Sposta {field} in basso",
     "moveFieldUp": "Sposta {field} in alto",
     "personalize": "Personalizza",
@@ -1794,6 +1795,7 @@
       "notes": "Note",
       "relations": "Relazioni"
     },
+    "showField": "Mostra {field} nei dettagli",
     "unpinField": "Togli {field} dalla panoramica"
   },
   "EntityTerminology": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,7 @@ const domTestFiles = [
   "components/data-view/filter-modal/inputs/__tests__/filter-input-number.test.ts",
   "components/entity-detail/__tests__/entity-detail-personalization.test.ts",
   "components/entity-detail/__tests__/entity-detail-summary.test.ts",
+  "components/entity-detail/__tests__/entity-detail-visibility.test.tsx",
   "components/entity-detail/__tests__/entity-drawer-personalization.test.ts",
   "components/entity-detail/__tests__/use-entity-detail-server-snapshot.test.ts",
   "components/forms/__tests__/form-context.test.ts",


### PR DESCRIPTION
## Summary

- show eye and crossed-eye controls beside the existing pin action in Customize mode
- keep hidden fields muted and restorable while customizing, then omit them from normal entity pages and existing-record edit drawers
- persist hidden field IDs through the existing per-user P13n detail options; hiding a pinned field also unpins it
- cover built-in, relation, custom, and computed fields across contacts, organizations, deals, services, and tasks
- keep Services, Total Value, Weighted Value, and Total Quantity independently hideable in the deal drawer
- preserve backward compatibility with existing P13n JSON and require no database migration
- provide localized accessible labels in English, German, French, Italian, and Spanish

## Context

Entity detail customization already stores pinned fields, collapsed sections, and custom-field order as server-backed P13n records keyed by company, user, and detail view. This change adds hidden field IDs to that same personal setting so one user's visibility choices do not affect coworkers.

The preference is intentionally applied to entity pages and existing-record edit drawers. New-record drawers always show every available field so a saved preference cannot produce an incomplete or confusing creation form.

### Owner-directed Linear exception

- Issuer: human repository owner directing this Codex task
- Instruction source: the active Codex conversation, with the explicit instruction "do not create a linear ticket"
- Instruction timestamp: 2026-08-28, Europe/Berlin
- Bounded outcome: add per-user hide and restore controls for fields on entity detail experiences
- Named waiver: the Linear issue, claim, receipt, and Linear evidence attachment for this outcome
- Exact write scope: entity detail presentation and personalization components, the five entity detail views, deal service and computed-total boundaries, P13n schema coverage, translations, Vitest registration, and related tests in this repository
- Remaining constraints: no secrets or production data, no merge, no production mutation, no unrelated cleanup, and all normal local tests, review, PR, and rollback gates remain
- Material consequence: this PR proposes user-visible personal field visibility preferences; no production behavior changes until a human merges it
- Rollback: close this PR and delete the branch before merge, or revert commit 234259f1 after merge
- Acceptance and expiry: valid only for this bounded PR until it is merged or closed
- Evidence location: this PR Validation section, commit 234259f1, and the conversation that issued the waiver

## Validation

- independent architecture review completed; the deal composite-field finding was fixed and no blocking findings remain
- manual local browser flow against the seeded PostgreSQL sandbox: hide a contact field, finish customization, reload to verify persistence, restore it, and reload again
- focused visibility, drawer, deal computed-field, and database user-isolation regression tests: 13 passed
- yarn typecheck
- yarn lint
- yarn i18n:audit
- RUN_DATABASE_TESTS=true yarn test: 4,152 passed, 2 skipped
- yarn build

The existing-record drawer and new-record safety policy are covered by component tests. A separate feature-specific automated browser E2E suite was not run.

## Impact and rollback

The change adds an optional member to an existing JSON preference payload, so legacy rows remain valid and no schema migration or data backfill is needed. Visibility is personal to the active user and detail type; it does not alter entity data or company-wide configuration. Existing records honor the preference in both page and drawer views, while creation drawers show all fields.

Before merge, rollback is closing the PR and deleting the branch. After merge, revert commit 234259f1; stored hidden field IDs are harmless to older code because unknown JSON members are ignored by the previous schema.
