### PR TITLE
fix(preview): allow requested sandbox subdomains

### DIFF
--- a/scripts/__tests__/manage-preview-domain.test.ts
+++ b/scripts/__tests__/manage-preview-domain.test.ts
@@ -228,8 +228,8 @@ printf '%s' "$status"
 }
 
 describe("Preview-domain management", () => {
-  it.each(["feature/contact-import", "sandbox/demo", "sandbox/feat-rewe", "feat/add/inbox", "feat/xn--preview"])(
-    "ignores an unmanaged or reserved deleted branch %s",
+  it.each(["feature/contact-import", "feat/add/inbox"])(
+    "ignores a syntactically unmanaged deleted branch %s",
     (branch) => {
       const result = runDomainScript({ action: "delete", branch });
 
@@ -398,11 +398,17 @@ describe("Preview-domain management", () => {
     ["ci/example", "ci-example.customermates.com"],
     ["docs/example", "docs-example.customermates.com"],
     ["feat/example", "feat-example.customermates.com"],
+    ["feat/xn--preview", "feat-xn--preview.customermates.com"],
     ["fix/example", "fix-example.customermates.com"],
     ["perf/example", "perf-example.customermates.com"],
     ["refactor/example", "refactor-example.customermates.com"],
     ["revert/example", "revert-example.customermates.com"],
+    ["sandbox/app", "app.customermates.com"],
+    ["sandbox/demo", "demo.customermates.com"],
+    ["sandbox/feat-rewe", "feat-rewe.customermates.com"],
     ["sandbox/rewe", "rewe.customermates.com"],
+    ["sandbox/test", "test.customermates.com"],
+    ["sandbox/xn--preview", "xn--preview.customermates.com"],
     ["style/example", "style-example.customermates.com"],
     ["test/example", "test-example.customermates.com"],
   ])("maps the conventional branch %s to %s", (branch, hostname) => {

--- a/scripts/manage-preview-domain.sh
+++ b/scripts/manage-preview-domain.sh
@@ -94,22 +94,7 @@ fi
 prefix="${BASH_REMATCH[1]}"
 branch_label="${BASH_REMATCH[2]}"
 
-if [[ "$branch_label" == xn--* ]]; then
-  echo "The branch has no managed Preview domain."
-  exit 0
-fi
-
 if [[ "$prefix" == "sandbox" ]]; then
-  case "$branch_label" in
-    admin|api|app|assets|auth|blog|cdn|customermates|demo|dev|development|docs|help|internal|login|mail|main|mcp|preview|prod|production|security|staging|static|status|support|test|www)
-      echo "The sandbox name is reserved."
-      exit 0
-      ;;
-  esac
-  if [[ "$branch_label" =~ ^(build|chore|ci|docs|feat|fix|perf|refactor|revert|sandbox|style|test)- ]]; then
-    echo "The sandbox name collides with an engineering branch."
-    exit 0
-  fi
   domain_label="$branch_label"
 else
   domain_label="${prefix}-${branch_label}"


### PR DESCRIPTION
## Summary

- Remove the semantic denylist for sandbox preview labels.
- Allow valid branch labels such as `sandbox/test`, `sandbox/demo`, `sandbox/feat-rewe`, and `sandbox/xn--preview` to request their derived Preview hostname.
- Keep branch syntax, DNS length, Preview readiness/latest-SHA, configured-domain, project, alias, and ownership validation unchanged.

## Context

[CUS-283](https://linear.app/customermates/issue/CUS-283/let-sandbox-branches-claim-any-valid-preview-subdomain) adopts a simplicity-first rule: an explicit conventional branch name is the operator's requested Preview hostname. Production already uses the apex domain, so Preview subdomain names do not need a product-specific reserved-name policy.

This PR changes code and tests only. It does not mutate a live Vercel domain, DNS record, alias, or production deployment.

## Validation

- Focused preview-domain suite: 36/36 passed
- Ordinary suite: 4,046 passed, 123 skipped across 458 passed files and 19 skipped files
- Database-enabled suite against disposable local PostgreSQL 17: 4,167 passed, 2 skipped across 476 passed files and 1 skipped file
- Convention suite: 561 passed, 2 skipped
- `yarn lint`: passed
- `yarn typecheck`: passed
- `yarn build`: passed (60/60 static pages)
- Independent read-only review: no findings

## Impact and rollback

After merge, any syntactically valid managed branch can request its derived Preview hostname. Two different branches can still derive the same hostname, for example `sandbox/feat-rewe` and `feat/rewe`; existing ownership checks make the second claim fail instead of silently taking over, although simultaneous first claims retain a small race window.

Rollback is a normal revert PR. Any Preview aliases created after this behavior ships remain governed by their branch lifecycle and ownership checks; this PR itself creates none.
