### PR TITLE
fix(contacts): validate every row in a bulk write, not just the first failure

### DIFF
--- a/features/contacts/__tests__/bulk-row-independence.test.ts
+++ b/features/contacts/__tests__/bulk-row-independence.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { CreateManyContactsSchema } from "../upsert/create-many-contacts.interactor";
+import { CreateManyOrganizationsSchema } from "@/features/organizations/upsert/create-many-organizations.interactor";
+import { UpdateManyContactsSchema } from "../upsert/update-many-contacts.interactor";
+
+const CONTACT_ID = "60000000-0000-4000-8000-000000000001";
+
+function pathsOf(result: { success: boolean; error?: { issues: Array<{ path: Array<PropertyKey> }> } }): string[] {
+  return result.success ? [] : (result.error?.issues ?? []).map((issue) => issue.path.join("."));
+}
+
+describe("bulk contact validation is independent per row", () => {
+  it("still reports a bad channel on one row when another row is missing a required field", () => {
+    const result = CreateManyContactsSchema.safeParse({
+      contacts: [
+        { firstName: "Ada", notes: null, identifiers: [] },
+        {
+          firstName: "Grace",
+          lastName: "Hopper",
+          notes: null,
+          identifiers: [{ provider: "whatsapp", value: "hello world" }],
+        },
+      ],
+    });
+
+    expect(pathsOf(result)).toEqual(["contacts.0.lastName", "contacts.1.identifiers.0.value"]);
+  });
+
+  it("reports the same for an update batch, keyed on the missing id", () => {
+    const result = UpdateManyContactsSchema.safeParse({
+      contacts: [{ firstName: "Ada" }, { id: CONTACT_ID, identifiers: [{ provider: "mail", value: "not-an-email" }] }],
+    });
+
+    expect(pathsOf(result)).toContain("contacts.1.identifiers.0.value");
+  });
+
+  it("normalizes a channel value in place, which the row refinement must not lose", () => {
+    const result = CreateManyContactsSchema.safeParse({
+      contacts: [
+        {
+          firstName: "Ada",
+          lastName: "Lovelace",
+          notes: null,
+          identifiers: [{ provider: "whatsapp", value: "+49 151 12345678" }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.contacts[0].identifiers?.[0].value).toBe("+4915112345678");
+  });
+
+  it("still converts notes to the editor document, which the row refinement must not lose", () => {
+    const result = CreateManyContactsSchema.safeParse({
+      contacts: [{ firstName: "Ada", lastName: "Lovelace", notes: "**bold**", identifiers: [] }],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.contacts[0].notes).toMatchObject({ type: "doc" });
+  });
+
+  it("applies the same independence to an entity that only validates notes", () => {
+    const result = CreateManyOrganizationsSchema.safeParse({
+      organizations: [{ notes: null }, { name: "Acme GmbH", notes: "**bold**" }],
+    });
+
+    expect(pathsOf(result)).toEqual(["organizations.0.name"]);
+  });
+});

--- a/features/contacts/upsert/create-many-contacts.interactor.ts
+++ b/features/contacts/upsert/create-many-contacts.interactor.ts
@@ -23,17 +23,17 @@ import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { buildRelationChangePublishes } from "@/core/utils/calculate-changes";
 import { unique } from "@/core/utils/unique";
 
-export const CreateManyContactsSchema = z
-  .object({
-    contacts: z.array(BaseCreateContactSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.contacts.length; i++) {
-      const contact = data.contacts[i];
-      validateIdentifiers(contact.identifiers, ctx, ["contacts", i, "identifiers"]);
-      contact.notes = validateNotes(contact.notes, ctx, ["contacts", i, "notes"]);
-    }
-  });
+export const CreateManyContactsSchema = z.object({
+  contacts: z
+    .array(
+      BaseCreateContactSchema.superRefine((contact, ctx) => {
+        validateIdentifiers(contact.identifiers, ctx, ["identifiers"]);
+        contact.notes = validateNotes(contact.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type CreateManyContactsData = Data<typeof CreateManyContactsSchema>;
 
 @TenantInteractor({

--- a/features/contacts/upsert/update-many-contacts.interactor.ts
+++ b/features/contacts/upsert/update-many-contacts.interactor.ts
@@ -23,17 +23,17 @@ import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator"
 import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { unique } from "@/core/utils/unique";
 
-export const UpdateManyContactsSchema = z
-  .object({
-    contacts: z.array(BaseUpdateContactSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.contacts.length; i++) {
-      const contact = data.contacts[i];
-      validateIdentifiers(contact.identifiers, ctx, ["contacts", i, "identifiers"]);
-      contact.notes = validateNotes(contact.notes, ctx, ["contacts", i, "notes"]);
-    }
-  });
+export const UpdateManyContactsSchema = z.object({
+  contacts: z
+    .array(
+      BaseUpdateContactSchema.superRefine((contact, ctx) => {
+        validateIdentifiers(contact.identifiers, ctx, ["identifiers"]);
+        contact.notes = validateNotes(contact.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type UpdateManyContactsData = Data<typeof UpdateManyContactsSchema>;
 
 @TenantInteractor({

--- a/features/deals/upsert/create-many-deals.interactor.ts
+++ b/features/deals/upsert/create-many-deals.interactor.ts
@@ -23,16 +23,16 @@ import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { buildRelationChangePublishes } from "@/core/utils/calculate-changes";
 import { unique } from "@/core/utils/unique";
 
-export const CreateManyDealsSchema = z
-  .object({
-    deals: z.array(BaseCreateDealSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.deals.length; i++) {
-      const deal = data.deals[i];
-      deal.notes = validateNotes(deal.notes, ctx, ["deals", i, "notes"]);
-    }
-  });
+export const CreateManyDealsSchema = z.object({
+  deals: z
+    .array(
+      BaseCreateDealSchema.superRefine((deal, ctx) => {
+        deal.notes = validateNotes(deal.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type CreateManyDealsData = Data<typeof CreateManyDealsSchema>;
 
 @TenantInteractor({

--- a/features/deals/upsert/update-many-deals.interactor.ts
+++ b/features/deals/upsert/update-many-deals.interactor.ts
@@ -23,16 +23,16 @@ import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator"
 import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { unique } from "@/core/utils/unique";
 
-export const UpdateManyDealsSchema = z
-  .object({
-    deals: z.array(BaseUpdateDealSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.deals.length; i++) {
-      const deal = data.deals[i];
-      deal.notes = validateNotes(deal.notes, ctx, ["deals", i, "notes"]);
-    }
-  });
+export const UpdateManyDealsSchema = z.object({
+  deals: z
+    .array(
+      BaseUpdateDealSchema.superRefine((deal, ctx) => {
+        deal.notes = validateNotes(deal.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type UpdateManyDealsData = Data<typeof UpdateManyDealsSchema>;
 
 @TenantInteractor({

--- a/features/organizations/upsert/create-many-organizations.interactor.ts
+++ b/features/organizations/upsert/create-many-organizations.interactor.ts
@@ -22,16 +22,16 @@ import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { buildRelationChangePublishes } from "@/core/utils/calculate-changes";
 import { unique } from "@/core/utils/unique";
 
-export const CreateManyOrganizationsSchema = z
-  .object({
-    organizations: z.array(BaseCreateOrganizationSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.organizations.length; i++) {
-      const organization = data.organizations[i];
-      organization.notes = validateNotes(organization.notes, ctx, ["organizations", i, "notes"]);
-    }
-  });
+export const CreateManyOrganizationsSchema = z.object({
+  organizations: z
+    .array(
+      BaseCreateOrganizationSchema.superRefine((organization, ctx) => {
+        organization.notes = validateNotes(organization.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type CreateManyOrganizationsData = Data<typeof CreateManyOrganizationsSchema>;
 
 @TenantInteractor({

--- a/features/organizations/upsert/update-many-organizations.interactor.ts
+++ b/features/organizations/upsert/update-many-organizations.interactor.ts
@@ -22,16 +22,16 @@ import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator"
 import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { unique } from "@/core/utils/unique";
 
-export const UpdateManyOrganizationsSchema = z
-  .object({
-    organizations: z.array(BaseUpdateOrganizationSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.organizations.length; i++) {
-      const organization = data.organizations[i];
-      organization.notes = validateNotes(organization.notes, ctx, ["organizations", i, "notes"]);
-    }
-  });
+export const UpdateManyOrganizationsSchema = z.object({
+  organizations: z
+    .array(
+      BaseUpdateOrganizationSchema.superRefine((organization, ctx) => {
+        organization.notes = validateNotes(organization.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type UpdateManyOrganizationsData = Data<typeof UpdateManyOrganizationsSchema>;
 
 @TenantInteractor({

--- a/features/services/upsert/create-many-services.interactor.ts
+++ b/features/services/upsert/create-many-services.interactor.ts
@@ -21,16 +21,16 @@ import { validateNotes } from "@/core/validation/validate-notes";
 import { buildRelationChangePublishes } from "@/core/utils/calculate-changes";
 import { unique } from "@/core/utils/unique";
 
-export const CreateManyServicesSchema = z
-  .object({
-    services: z.array(BaseCreateServiceSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.services.length; i++) {
-      const service = data.services[i];
-      service.notes = validateNotes(service.notes, ctx, ["services", i, "notes"]);
-    }
-  });
+export const CreateManyServicesSchema = z.object({
+  services: z
+    .array(
+      BaseCreateServiceSchema.superRefine((service, ctx) => {
+        service.notes = validateNotes(service.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type CreateManyServicesData = Data<typeof CreateManyServicesSchema>;
 
 @TenantInteractor({

--- a/features/services/upsert/update-many-services.interactor.ts
+++ b/features/services/upsert/update-many-services.interactor.ts
@@ -21,16 +21,16 @@ import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { validateNotes } from "@/core/validation/validate-notes";
 import { unique } from "@/core/utils/unique";
 
-export const UpdateManyServicesSchema = z
-  .object({
-    services: z.array(BaseUpdateServiceSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.services.length; i++) {
-      const service = data.services[i];
-      service.notes = validateNotes(service.notes, ctx, ["services", i, "notes"]);
-    }
-  });
+export const UpdateManyServicesSchema = z.object({
+  services: z
+    .array(
+      BaseUpdateServiceSchema.superRefine((service, ctx) => {
+        service.notes = validateNotes(service.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type UpdateManyServicesData = Data<typeof UpdateManyServicesSchema>;
 
 @TenantInteractor({

--- a/features/tasks/upsert/create-many-tasks.interactor.ts
+++ b/features/tasks/upsert/create-many-tasks.interactor.ts
@@ -23,16 +23,16 @@ import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { buildRelationChangePublishes } from "@/core/utils/calculate-changes";
 import { unique } from "@/core/utils/unique";
 
-export const CreateManyTasksSchema = z
-  .object({
-    tasks: z.array(BaseCreateTaskSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.tasks.length; i++) {
-      const task = data.tasks[i];
-      task.notes = validateNotes(task.notes, ctx, ["tasks", i, "notes"]);
-    }
-  });
+export const CreateManyTasksSchema = z.object({
+  tasks: z
+    .array(
+      BaseCreateTaskSchema.superRefine((task, ctx) => {
+        task.notes = validateNotes(task.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type CreateManyTasksData = Data<typeof CreateManyTasksSchema>;
 
 @TenantInteractor({

--- a/features/tasks/upsert/update-many-tasks.interactor.ts
+++ b/features/tasks/upsert/update-many-tasks.interactor.ts
@@ -23,16 +23,16 @@ import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator"
 import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
 import { unique } from "@/core/utils/unique";
 
-export const UpdateManyTasksSchema = z
-  .object({
-    tasks: z.array(BaseUpdateTaskSchema).min(1).max(100),
-  })
-  .superRefine((data, ctx) => {
-    for (let i = 0; i < data.tasks.length; i++) {
-      const task = data.tasks[i];
-      task.notes = validateNotes(task.notes, ctx, ["tasks", i, "notes"]);
-    }
-  });
+export const UpdateManyTasksSchema = z.object({
+  tasks: z
+    .array(
+      BaseUpdateTaskSchema.superRefine((task, ctx) => {
+        task.notes = validateNotes(task.notes, ctx, ["notes"]);
+      }),
+    )
+    .min(1)
+    .max(100),
+});
 export type UpdateManyTasksData = Data<typeof UpdateManyTasksSchema>;
 
 @TenantInteractor({


### PR DESCRIPTION
## Summary

Bulk contact, organization, deal, task and service writes only validated rows until the first aborting failure. `validateIdentifiers` and `validateNotes` were attached as a `.superRefine` on the *collection* schema, and Zod v4 skips such a check once the payload has aborted, so one row with a missing required field silenced identifier and notes validation for the whole batch of up to 100 rows.

Moving the refinement onto the row schema fixes it. All ten bulk schemas move together, since the notes half of the bug was present on every entity type.

This PR also answers a question it was raised to settle, and the answer is no: **do not apply `PHONE_CHARSET` inside `normalizeChannelValue`.** Reasoning in Context.

## Context

**The row-independence bug.** Reproduced against the real schema before changing anything: a two-row payload where row 0 omits `lastName` and row 1 carries `{ provider: "whatsapp", value: "hello world" }` reports only `contacts.0.lastName`. Remove the bad row and the invalid channel is reported. The trigger is narrower than "any failure": only Zod *non-continuable* issues abort, so missing or null required fields and bad enum values, not `too_small` or `invalid_format`.

Nothing invalid could reach the database, because the aborted payload fails `safeParse` outright. The harm is under-reporting, and it lands on bulk API callers: `POST`/`PUT /v1/contacts/many` and the MCP bulk tools return one issue per round trip, so correcting a 100-row batch can take one request per bad row.

The spreadsheet importer is affected more narrowly than an earlier revision of this description claimed. It validates channel values client-side before the chunk is sent, using the same normalizer, so channel problems are caught whether or not the server check runs. What the importer still loses to the masking is `validateNotes`, which has no client-side counterpart, and any other server-side issue that happens to share a chunk with an aborting row.

The fix has to sit on the row, not on the `identifiers` field. `validateNotes` *replaces* its value rather than mutating it, so on the field it would need a `transform`, turning `z.any().nullish()` into a `ZodPipe` and changing the generated OpenAPI shape. On the row, identifiers and notes are fixed together with no schema-shape change — confirmed by the generated artifacts not moving.

**Why the phone guard was declined.** The proposal was to apply the file's existing `PHONE_CHARSET` inside `normalizeChannelValue`, so that text like `Rechnung 2024-000123` stops becoming `+2024000123`. The problem is real, but that guard is the wrong instrument:

- It rejects input that works today, including `030/12345678` and `0151/1234567` — ordinary German slash notation in the product's primary market — plus `+1.202.555.0199`, `+49 151/1234567`, `tel:` prefixes and extensions. Those arrive through `/v1/contacts`, the MCP tools and the contacts UI, so this is a breaking change for existing integrators.
- It regresses an ingest-derived path. WhatsApp `@lid` participants are absent from `WHATSAPP_JID_DOMAINS`, so an attendee with neither `specifics.phone_number` nor `public_identifier` is stored as `43138869645350@lid`. That normalizes today and would fail under the guard, breaking "link to contact" in the inbox.
- It would contradict `parseContactKey`, which routes phone-shaped keys with a *laxer* charset permitting `.` and a 5-character minimum. `GET /v1/contacts/+1.202.555.0199` would flip to `contactNotFound` while creation still succeeded.
- `PHONE_CHARSET` was written in the same commit as the current phone branch, deliberately for `inferChannelProviders` — classifying an *unknown* value. Reusing it as a validator for an *already declared* provider is not what it was built for.
- A real validator means libphonenumber, and `normalizeChannelValue` is imported by `add-channel.store.ts`, so that ships to the browser. Worth doing deliberately, not as a side effect.

The bulk hazard that motivated the request — a date or invoice column mapped wholesale onto WhatsApp — is already handled at the import boundary, which is where the provider is asserted by a column mapping rather than chosen by a person.

## Validation

Everything on Node 24.18.0.

- Reproduced the defect against the real `CreateManyContactsSchema` before the change, and confirmed after it that both issues are reported with byte-identical paths (`contacts.1.identifiers.0.value`).
- Proved the two things the fix could silently break: the in-place `identifier.value` normalization still reaches the parsed output (`+49 151 12345678` → `+4915112345678`), and `notes` still becomes an editor document.
- New test `features/contacts/__tests__/bulk-row-independence.test.ts` (5 cases), validated by planting the old collection-level schema back: it fails with the bug present and passes with the fix.
- `yarn typecheck` clean, `yarn lint` clean at `--max-warnings 0`, `yarn test` 4195 passed / 123 skipped, zero timeouts and zero assertion failures.
- **End to end over real HTTP**, same worktree and same database, with only the fix differing. `POST /api/v1/contacts/many` carrying a row missing `lastName` and a row with `{ provider: "whatsapp", value: "hello world" }` returns one issue (`contacts[0].lastName`) on unfixed `origin/main`, and both issues on this branch. `PUT` behaves the same, covering the update half of the change.
- **The write path still works end to end**, which the schema-level tests do not reach: a valid bulk `POST` returned 201, and in Postgres `+49 151 12345678` was stored as `+4915112345678`, `Emmy.Noether@Example.COM` was lowercased, and markdown notes were stored as a ProseMirror document. The in-place identifier mutation and the notes replacement both survive the move to row level through the real interactor and transaction.
- `yarn openapi:generate` and `yarn raw-docs:generate` produce no diff, so the published API contract is unchanged.

## Impact and rollback

Behavioural change is limited to *which* errors surface: callers that previously received one issue may now receive several from the same request. No payload that succeeded before fails now, and no payload that failed before succeeds. Issue paths and generated artifacts are unchanged, so row attribution in the importer and any client parsing `contacts[i].identifiers[j].value` keeps working.

Rollback is reverting the single commit. There is no migration and no dependency change.

Two follow-ups this work surfaced, neither included here:

1. **`@lid` should join `WHATSAPP_JID_DOMAINS`.** Independent of any guard, linking a `@lid` participant stores `+43138869645350` while the participant row holds `43138869645350@lid`, and matching is on value equality with `messagingId` cleared for deterministic providers. The link is written but never renders.
2. **A mapped channel column applies to update rows in the spreadsheet importer**, where identifiers have replace semantics. That code is on the unmerged export/import branch, so the fix belongs there rather than here.

