### PR TITLE
feat(homepage): add accessible looping story motion

### DIFF
--- a/app/[locale]/(static)/components/homepage-hero.tsx
+++ b/app/[locale]/(static)/components/homepage-hero.tsx
@@ -10,6 +10,8 @@ import { AppLink } from "@/components/shared/app-link";
 import { GridPattern } from "@/components/shared/grid-pattern";
 import { Button } from "@/components/ui/button";
 
+import { RotatingAccent } from "./rotating-accent";
+
 type Props = {
   heroSection: Hero;
 };
@@ -17,6 +19,13 @@ type Props = {
 const SUPPORTED_INBOX_PROVIDERS = VISUAL_PROVIDER_SET_FIXTURES["unified-inbox"].providers;
 
 export function HomepageHero({ heroSection }: Props) {
+  const accentRotations = heroSection.titleAccentRotations?.length
+    ? heroSection.titleAccentRotations
+    : heroSection.titleAccent
+      ? [heroSection.titleAccent]
+      : [];
+  const accessibleHeadline = [heroSection.title, accentRotations[0]].filter(Boolean).join(" ");
+
   return (
     <section className="relative isolate w-full overflow-hidden" data-homepage-section="hero">
       <GridPattern className="z-0" fade="bottom" />
@@ -26,9 +35,23 @@ export function HomepageHero({ heroSection }: Props) {
           <AgplGithubBadge />
 
           <h1 className="text-hero mt-7 max-w-6xl">
-            {/* eslint-disable react/jsx-newline */}
-            {heroSection.title} {heroSection.titleAccent ? <span>{heroSection.titleAccent}</span> : null}
-            {/* eslint-enable react/jsx-newline */}
+            <span className="sr-only">{accessibleHeadline}</span>
+
+            <span aria-hidden className="flex flex-col items-center justify-center gap-y-[0.04em]">
+              <span
+                className="whitespace-nowrap [font-size:min(1em,8.6vw)] sm:text-[1em]"
+                data-homepage-hero-line="lead"
+              >
+                {heroSection.title}
+              </span>
+
+              <span
+                className="inline-flex whitespace-nowrap [font-size:min(1em,8.6vw)] sm:text-[1em]"
+                data-homepage-hero-line="rotation"
+              >
+                <RotatingAccent words={accentRotations} />
+              </span>
+            </span>
           </h1>
 
           <div className="mt-10 w-full max-w-[820px] rounded-card border border-border bg-card p-5 text-left shadow-[0_20px_70px_-48px_rgba(0,0,0,0.7)] sm:p-6">

--- a/app/[locale]/(static)/components/homepage-motion.ts
+++ b/app/[locale]/(static)/components/homepage-motion.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRef, useSyncExternalStore } from "react";
+
+import { useInView, useReducedMotion } from "framer-motion";
+
+export const HOMEPAGE_MOTION_VISIBILITY_AMOUNT = 0.35;
+
+const documentVisibilitySubscribers = new Set<() => void>();
+
+function notifyDocumentVisibilitySubscribers() {
+  for (const subscriber of documentVisibilitySubscribers) subscriber();
+}
+
+function subscribeToDocumentVisibility(subscriber: () => void) {
+  documentVisibilitySubscribers.add(subscriber);
+
+  if (documentVisibilitySubscribers.size === 1)
+    document.addEventListener("visibilitychange", notifyDocumentVisibilitySubscribers);
+
+  return () => {
+    documentVisibilitySubscribers.delete(subscriber);
+
+    if (documentVisibilitySubscribers.size === 0)
+      document.removeEventListener("visibilitychange", notifyDocumentVisibilitySubscribers);
+  };
+}
+
+function getDocumentVisibilitySnapshot() {
+  return document.visibilityState === "visible";
+}
+
+function getServerDocumentVisibilitySnapshot() {
+  return true;
+}
+
+export function useHomepageMotion<T extends Element>(amount = HOMEPAGE_MOTION_VISIBILITY_AMOUNT) {
+  const ref = useRef<T>(null);
+  const isInView = useInView(ref, { amount });
+  const shouldReduceMotion = useReducedMotion();
+  const isDocumentVisible = useSyncExternalStore(
+    subscribeToDocumentVisibility,
+    getDocumentVisibilitySnapshot,
+    getServerDocumentVisibilitySnapshot,
+  );
+
+  return {
+    ref,
+    shouldAnimate: isInView && isDocumentVisible && !shouldReduceMotion,
+    shouldReduceMotion: Boolean(shouldReduceMotion),
+  };
+}

--- a/app/[locale]/(static)/components/homepage-story-visuals.tsx
+++ b/app/[locale]/(static)/components/homepage-story-visuals.tsx
@@ -1,6 +1,11 @@
-import type { CSSProperties, ReactNode } from "react";
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactNode, Ref } from "react";
 import type { HomepageVisualLabels } from "@/core/fumadocs/schemas/homepage";
 
+import { animate, cubicBezier, motion, useMotionValue, useTransform } from "framer-motion";
+import type { MotionValue } from "framer-motion";
 import { Check, MousePointer2, Send } from "lucide-react";
 
 import {
@@ -25,6 +30,8 @@ import { VisualArtboard as MarketingVisualArtboard } from "@/components/marketin
 import { cn } from "@/core/utils/cn";
 import { formattingTagFor, type ContentLocale } from "@/i18n/locale-registry";
 
+import { useHomepageMotion } from "./homepage-motion";
+
 type VisualProps = {
   className?: string;
   labels: HomepageVisualLabels;
@@ -32,6 +39,99 @@ type VisualProps = {
 };
 
 type VisualArtboardName = "agent-record" | "human-handoff" | "omnichannel-record" | "pipeline";
+
+const MARKETING_MOTION_EASE = [0.22, 1, 0.36, 1] as const;
+const SIGNAL_EASES = {
+  drift: [0.38, 0.1, 0.3, 1],
+  settle: MARKETING_MOTION_EASE,
+  swift: [0.2, 0.75, 0.35, 1],
+} as const;
+const PIPELINE_LOOP_SECONDS = 12;
+const PIPELINE_LOOP_TRANSITION = {
+  duration: PIPELINE_LOOP_SECONDS,
+  ease: MARKETING_MOTION_EASE,
+  repeat: Number.POSITIVE_INFINITY,
+};
+const HANDOFF_DRAFT_LINES = ["w-[92%] bg-placeholder", "w-[76%] bg-muted", "w-[54%] bg-muted"];
+const SIGNAL_ACTIVITY_TIMES = [0, 0.02, 0.12, 0.9, 0.98, 1];
+const SIGNAL_ACTIVITY_VALUES = [0, 0, 1, 1, 0, 0];
+const SIGNAL_TRAVEL_TIMES = [0, 0.12, 0.9, 1];
+const SIGNAL_TRAVEL_VALUES = [0, 0, 1, 1];
+const PROVIDER_ARRIVAL_OPACITY = [0, 0.65, 0];
+const PROVIDER_ARRIVAL_SCALE = [1, 1.015, 1];
+const PROVIDER_ARRIVAL_TIMES = [0, 0.45, 1];
+const PROVIDER_ARRIVAL_DELAY_RATIO = 0.72;
+const PROVIDER_ARRIVAL_DURATION_RATIO = 0.22;
+const PIPELINE_DRAG_TIMES = [0, 0.08, 0.14, 0.3, 0.38, 0.54, 0.62, 0.76, 0.84, 0.94, 1];
+const PIPELINE_DRAG_X = ["0%", "0%", "0%", "110%", "110%", "220%", "220%", "110%", "110%", "0%", "0%"];
+const PIPELINE_DRAG_Y = [-18, -18, -12, 4, 4, 28, 28, 4, 4, -18, -18];
+const PIPELINE_SOURCE_OUTLINE_OPACITY = [0, 1, 1, 1, 1, 1, 1, 1, 0.55, 0, 0];
+const APPROVED_INBOX_PROVIDERS = new Set(VISUAL_PROVIDER_SET_FIXTURES["unified-inbox"].providers);
+
+type SignalEase = keyof typeof SIGNAL_EASES;
+type OneToThree<T> = readonly [T] | readonly [T, T] | readonly [T, T, T];
+type TimedScene = { durationMs: number };
+type TimedSignal = {
+  delayMs: number;
+  durationMs: number;
+  ease: SignalEase;
+};
+type SignalTimeline = {
+  activity: MotionValue<number>;
+  travel: MotionValue<number>;
+};
+
+const LINEAR_EASE = (progress: number) => progress;
+const SIGNAL_EASING_FUNCTIONS = {
+  drift: cubicBezier(...SIGNAL_EASES.drift),
+  settle: cubicBezier(...SIGNAL_EASES.settle),
+  swift: cubicBezier(...SIGNAL_EASES.swift),
+} satisfies Record<SignalEase, (progress: number) => number>;
+
+function useSignalTimeline(signal: TimedSignal, shouldAnimate: boolean): SignalTimeline {
+  const phase = useMotionValue(0);
+  const activity = useTransform(phase, SIGNAL_ACTIVITY_TIMES, SIGNAL_ACTIVITY_VALUES);
+  const travel = useTransform(phase, SIGNAL_TRAVEL_TIMES, SIGNAL_TRAVEL_VALUES, {
+    ease: [LINEAR_EASE, SIGNAL_EASING_FUNCTIONS[signal.ease], LINEAR_EASE],
+  });
+
+  useEffect(() => {
+    phase.set(0);
+    if (!shouldAnimate) return;
+
+    const controls = animate(phase, 1, {
+      delay: signal.delayMs / 1_000,
+      duration: signal.durationMs / 1_000,
+      ease: LINEAR_EASE,
+    });
+
+    return () => controls.stop();
+  }, [phase, shouldAnimate, signal.delayMs, signal.durationMs, signal.ease]);
+
+  return { activity, travel };
+}
+
+function useTimedSceneCycle<TScene extends TimedScene>(scenes: readonly TScene[], shouldAnimate: boolean) {
+  const [position, setPosition] = useState({ revision: 0, sceneIndex: 0 });
+
+  useEffect(() => {
+    if (!shouldAnimate) return;
+
+    const timeout = window.setTimeout(() => {
+      setPosition(({ revision, sceneIndex }) => ({
+        revision: revision + 1,
+        sceneIndex: (sceneIndex + 1) % scenes.length,
+      }));
+    }, scenes[position.sceneIndex].durationMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [position.sceneIndex, scenes, shouldAnimate]);
+
+  return {
+    revision: position.revision,
+    scene: scenes[position.sceneIndex],
+  };
+}
 
 const STAGE_CROP_CLASSES: Record<VisualArtboardName, string> = {
   "agent-record": "-right-[22%] -top-[38%] rotate-[-12deg]",
@@ -44,14 +144,18 @@ function HomepageVisualArtboard({
   children,
   className,
   label,
+  motionActive,
+  motionRef,
   name,
 }: {
   children: ReactNode;
   className?: string;
   label: string;
+  motionActive?: boolean;
+  motionRef?: Ref<HTMLDivElement>;
   name: VisualArtboardName;
 }) {
-  return (
+  const artboard = (
     <MarketingVisualArtboard
       aria-label={label}
       className={cn(
@@ -75,6 +179,19 @@ function HomepageVisualArtboard({
 
       {children}
     </MarketingVisualArtboard>
+  );
+
+  if (!motionRef) return artboard;
+
+  return (
+    <div
+      ref={motionRef}
+      className="w-full"
+      data-homepage-motion-scene={name}
+      data-motion-active={motionActive ? "true" : "false"}
+    >
+      {artboard}
+    </div>
   );
 }
 
@@ -190,17 +307,17 @@ type OrbitNode = {
 const ORBIT_NODES = [
   {
     desktop: { node: [120, 112], target: [275, 245] },
-    mobile: { node: [85, 85], target: [126, 260] },
+    mobile: { node: [85, 85], target: [138, 205] },
     provider: "gmail",
   },
   {
     desktop: { node: [95, 310], target: [275, 310] },
-    mobile: { node: [55, 330], target: [126, 340] },
+    mobile: { node: [55, 330], target: [126, 330] },
     provider: "outlook",
   },
   {
-    desktop: { node: [220, 552], target: [365, 505] },
-    mobile: { node: [160, 660], target: [220, 460] },
+    desktop: { node: [220, 552], target: [365, 400] },
+    mobile: { node: [160, 660], target: [160, 400] },
     provider: "imap",
   },
   {
@@ -210,20 +327,85 @@ const ORBIT_NODES = [
   },
   {
     desktop: { node: [880, 112], target: [725, 245] },
-    mobile: { node: [515, 85], target: [474, 260] },
+    mobile: { node: [515, 85], target: [462, 205] },
     provider: "linkedin",
   },
   {
     desktop: { node: [905, 310], target: [725, 310] },
-    mobile: { node: [545, 330], target: [474, 340] },
+    mobile: { node: [545, 330], target: [474, 330] },
     provider: "whatsapp",
   },
   {
-    desktop: { node: [780, 552], target: [635, 505] },
-    mobile: { node: [440, 660], target: [380, 460] },
+    desktop: { node: [780, 552], target: [635, 400] },
+    mobile: { node: [440, 660], target: [440, 400] },
     provider: "instagram",
   },
 ] as const satisfies readonly OrbitNode[];
+
+type OmnichannelSignalSpec = {
+  delayMs: number;
+  durationMs: number;
+  ease: SignalEase;
+  provider: VisualProviderFixtureId;
+};
+
+type OmnichannelSignalBurst = {
+  durationMs: number;
+  signals: OneToThree<OmnichannelSignalSpec>;
+};
+
+const OMNICHANNEL_SIGNAL_BURSTS = [
+  {
+    durationMs: 2_800,
+    signals: [
+      { delayMs: 0, durationMs: 2_600, ease: "settle", provider: "gmail" },
+      { delayMs: 750, durationMs: 2_000, ease: "drift", provider: "telegram" },
+    ],
+  },
+  {
+    durationMs: 3_500,
+    signals: [
+      { delayMs: 0, durationMs: 3_000, ease: "drift", provider: "whatsapp" },
+      { delayMs: 450, durationMs: 2_400, ease: "settle", provider: "linkedin" },
+      { delayMs: 1_200, durationMs: 2_200, ease: "swift", provider: "imap" },
+    ],
+  },
+  {
+    durationMs: 3_150,
+    signals: [
+      { delayMs: 0, durationMs: 2_700, ease: "settle", provider: "outlook" },
+      { delayMs: 650, durationMs: 2_400, ease: "drift", provider: "instagram" },
+    ],
+  },
+  {
+    durationMs: 3_750,
+    signals: [
+      { delayMs: 0, durationMs: 3_100, ease: "drift", provider: "telegram" },
+      { delayMs: 800, durationMs: 2_400, ease: "settle", provider: "gmail" },
+      {
+        delayMs: 1_450,
+        durationMs: 2_200,
+        ease: "swift",
+        provider: "whatsapp",
+      },
+    ],
+  },
+  {
+    durationMs: 3_200,
+    signals: [
+      { delayMs: 0, durationMs: 2_800, ease: "settle", provider: "linkedin" },
+      { delayMs: 600, durationMs: 2_500, ease: "drift", provider: "outlook" },
+    ],
+  },
+  {
+    durationMs: 3_700,
+    signals: [
+      { delayMs: 0, durationMs: 3_100, ease: "drift", provider: "instagram" },
+      { delayMs: 700, durationMs: 2_500, ease: "settle", provider: "imap" },
+      { delayMs: 1_500, durationMs: 2_100, ease: "swift", provider: "gmail" },
+    ],
+  },
+] as const satisfies readonly OmnichannelSignalBurst[];
 
 type OrbitPositionStyle = CSSProperties &
   Record<"--orbit-desktop-x" | "--orbit-desktop-y" | "--orbit-mobile-x" | "--orbit-mobile-y", string>;
@@ -235,6 +417,130 @@ function orbitPositionStyle({ desktop, mobile }: OrbitNode): OrbitPositionStyle 
     "--orbit-mobile-x": `${mobile.node[0] / 6}%`,
     "--orbit-mobile-y": `${(mobile.node[1] / 760) * 100}%`,
   };
+}
+
+function SyncedSignalPath({
+  kind,
+  path,
+  provider,
+  start,
+  timeline,
+}: {
+  kind: "handoff" | "omnichannel";
+  path: string;
+  provider: VisualAgentProviderFixtureId | VisualProviderFixtureId;
+  start: OrbitPoint;
+  timeline: SignalTimeline;
+}) {
+  const pathRef = useRef<SVGPathElement>(null);
+  const point = useTransform(timeline.travel, (progress) => {
+    const motionPath = pathRef.current;
+
+    if (!motionPath) return { x: start[0], y: start[1] };
+
+    const totalLength = motionPath.getTotalLength();
+    if (totalLength === 0) return { x: start[0], y: start[1] };
+
+    const position = motionPath.getPointAtLength(totalLength * progress);
+    return { x: position.x, y: position.y };
+  });
+  const signalX = useTransform(point, ({ x }) => x);
+  const signalY = useTransform(point, ({ y }) => y);
+
+  return (
+    <>
+      <motion.path
+        ref={pathRef}
+        d={path}
+        fill="none"
+        stroke="var(--primary)"
+        strokeLinecap="butt"
+        strokeWidth="2.5"
+        style={{ opacity: timeline.activity, pathLength: timeline.travel }}
+      />
+
+      <motion.circle
+        cx={signalX}
+        cy={signalY}
+        data-homepage-handoff-signal={kind === "handoff" ? provider : undefined}
+        data-homepage-motion-signal={kind === "omnichannel" ? provider : undefined}
+        fill="var(--primary)"
+        r="5"
+        style={{ opacity: timeline.activity }}
+      />
+    </>
+  );
+}
+
+function ProviderSignalRing({
+  provider,
+  timeline,
+}: {
+  provider: VisualAgentProviderFixtureId | VisualProviderFixtureId;
+  timeline: SignalTimeline;
+}) {
+  const pingOpacity = useTransform(timeline.travel, [0, 0.16, 0.65, 1], [0, 0.55, 0.18, 0]);
+  const pingScale = useTransform(timeline.travel, [0, 0.45, 1], [1, 1.16, 1.24]);
+
+  return (
+    <motion.span
+      aria-hidden
+      className="pointer-events-none absolute -inset-1 z-0 rounded-full border border-primary/70"
+      data-homepage-provider-ping={provider}
+      style={{ opacity: timeline.activity }}
+    >
+      <motion.span
+        className="absolute -inset-px rounded-full border border-primary/35"
+        style={{ opacity: pingOpacity, scale: pingScale }}
+      />
+    </motion.span>
+  );
+}
+
+function OrbitSignal({ orbitNode, signal }: { orbitNode: OrbitNode; signal: OmnichannelSignalSpec }) {
+  const timeline = useSignalTimeline(signal, true);
+
+  return (
+    <>
+      <svg
+        aria-hidden
+        className="absolute inset-0 hidden size-full sm:block"
+        preserveAspectRatio="none"
+        viewBox="0 0 1000 620"
+      >
+        <SyncedSignalPath
+          kind="omnichannel"
+          path={`M${orbitNode.desktop.node.join(" ")} L${orbitNode.desktop.target.join(" ")}`}
+          provider={signal.provider}
+          start={orbitNode.desktop.node}
+          timeline={timeline}
+        />
+      </svg>
+
+      <svg
+        aria-hidden
+        className="absolute inset-0 size-full sm:hidden"
+        preserveAspectRatio="none"
+        viewBox="0 0 600 760"
+      >
+        <SyncedSignalPath
+          kind="omnichannel"
+          path={`M${orbitNode.mobile.node.join(" ")} L${orbitNode.mobile.target.join(" ")}`}
+          provider={signal.provider}
+          start={orbitNode.mobile.node}
+          timeline={timeline}
+        />
+      </svg>
+
+      <span
+        aria-hidden
+        className="pointer-events-none absolute left-[var(--orbit-mobile-x)] top-[var(--orbit-mobile-y)] z-[11] size-12 -translate-1/2 sm:left-[var(--orbit-desktop-x)] sm:top-[var(--orbit-desktop-y)] sm:size-14"
+        style={orbitPositionStyle(orbitNode)}
+      >
+        <ProviderSignalRing provider={signal.provider} timeline={timeline} />
+      </span>
+    </>
+  );
 }
 
 function OrbitConnectors() {
@@ -280,70 +586,89 @@ function OrbitConnectors() {
 }
 
 export function HomepageOmnichannelVisual({ className, label, labels, locale }: VisualProps & { label: string }) {
-  const approvedProviders = new Set(VISUAL_PROVIDER_SET_FIXTURES["unified-inbox"].providers);
   const activeConversation = VISUAL_CONVERSATION_FIXTURES["gmail-rollout-next-steps"];
+  const { ref, shouldAnimate } = useHomepageMotion<HTMLDivElement>();
+  const { revision, scene: activeBurst } = useTimedSceneCycle(OMNICHANNEL_SIGNAL_BURSTS, shouldAnimate);
 
   return (
     <HomepageVisualArtboard
       className={cn("aspect-[4/5] min-h-[34rem] sm:aspect-[8/5] sm:min-h-0", className)}
       label={label}
+      motionActive={shouldAnimate}
+      motionRef={ref}
       name="omnichannel-record"
     >
       <OrbitConnectors />
 
-      {ORBIT_NODES.filter(({ provider }) => approvedProviders.has(provider)).map((orbitNode) => (
+      {shouldAnimate
+        ? activeBurst.signals.map((signal) => {
+            const orbitNode = ORBIT_NODES.find(({ provider }) => provider === signal.provider);
+
+            return orbitNode ? (
+              <OrbitSignal key={`${revision}-${signal.provider}`} orbitNode={orbitNode} signal={signal} />
+            ) : null;
+          })
+        : null}
+
+      {ORBIT_NODES.filter(({ provider }) => APPROVED_INBOX_PROVIDERS.has(provider)).map((orbitNode) => (
         <span
           key={orbitNode.provider}
-          className={cn(
-            "absolute left-[var(--orbit-mobile-x)] top-[var(--orbit-mobile-y)] z-10 grid size-12 -translate-1/2 place-items-center rounded-full border border-border bg-card shadow-sm sm:left-[var(--orbit-desktop-x)] sm:top-[var(--orbit-desktop-y)] sm:size-14",
-            orbitNode.provider === activeConversation.provider
-              ? "border-primary/50 ring-4 ring-primary/10"
-              : "opacity-75",
-          )}
+          className="absolute left-[var(--orbit-mobile-x)] top-[var(--orbit-mobile-y)] z-10 size-12 -translate-1/2 sm:left-[var(--orbit-desktop-x)] sm:top-[var(--orbit-desktop-y)] sm:size-14"
+          data-homepage-provider-shell={orbitNode.provider}
           style={orbitPositionStyle(orbitNode)}
         >
-          <ProviderMark provider={orbitNode.provider} size={22} />
+          <span className="relative z-10 grid size-full place-items-center rounded-full border border-border bg-card shadow-sm">
+            <ProviderMark provider={orbitNode.provider} size={22} />
+          </span>
         </span>
       ))}
 
-      <div className="absolute left-1/2 top-[27%] z-20 w-[58%] -translate-x-1/2 overflow-hidden rounded-card border border-border bg-card p-4 shadow-xl shadow-black/10 dark:shadow-black/30 sm:top-[29%] sm:w-[45%] sm:p-6">
-        <p className="text-meta">{labels.customerRecord}</p>
+      <div className="absolute left-1/2 top-[27%] z-20 w-[58%] -translate-x-1/2 sm:top-[29%] sm:w-[45%]">
+        <div
+          className="relative overflow-hidden rounded-card border border-border bg-card p-4 shadow-xl shadow-black/10 dark:shadow-black/30 sm:p-6"
+          data-homepage-motion-phase="signal-to-record"
+        >
+          <p className="text-meta">{labels.customerRecord}</p>
 
-        <div className="mt-3 flex items-center gap-3">
-          <PersonAvatar person="anna-mueller" size={44} />
+          <div className="mt-3 flex items-center gap-3">
+            <PersonAvatar person="anna-mueller" size={44} />
 
-          <div className="min-w-0">
-            <p className="truncate font-medium">{VISUAL_PERSON_FIXTURES["anna-mueller"].name}</p>
+            <div className="min-w-0">
+              <p className="truncate font-medium">{VISUAL_PERSON_FIXTURES["anna-mueller"].name}</p>
 
-            <p className="mt-1 text-xs text-muted-foreground">{labels.connectedRecord}</p>
-          </div>
-        </div>
-
-        <div className="-mx-4 mt-5 border-t border-border px-4 pt-4 sm:-mx-6 sm:px-6" data-homepage-rules="full-bleed">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-[9px] font-medium tracking-[0.1em] text-muted-foreground uppercase">
-              {labels.latestActivity}
-            </p>
-
-            <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-muted-foreground">
-              <span aria-hidden className="size-1.5 rounded-full bg-warning" />
-
-              {labels.open}
-            </span>
+              <p className="mt-1 text-xs text-muted-foreground">{labels.connectedRecord}</p>
+            </div>
           </div>
 
-          <div className="mt-3 flex min-w-0 items-center gap-2">
-            <ProviderIdentity className="text-[10px]" iconSize={16} provider={activeConversation.provider} />
+          <div
+            className="-mx-4 mt-5 border-t border-border px-4 pt-4 sm:-mx-6 sm:px-6"
+            data-homepage-rules="full-bleed"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[9px] font-medium tracking-[0.1em] text-muted-foreground uppercase">
+                {labels.latestActivity}
+              </p>
 
-            <span aria-hidden className="h-4 w-px shrink-0 bg-border" />
+              <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-muted-foreground">
+                <span aria-hidden className="size-1.5 rounded-full bg-warning" />
 
-            <p className="min-w-0 truncate text-[11px] font-medium">{activeConversation.localizedSubject[locale]}</p>
-          </div>
+                {labels.open}
+              </span>
+            </div>
 
-          <div aria-hidden className="mt-2 space-y-1.5 pl-6">
-            <div className="h-1.5 w-full rounded-full bg-placeholder" />
+            <div className="mt-3 flex min-w-0 items-center gap-2">
+              <ProviderIdentity className="text-[10px]" iconSize={16} provider={activeConversation.provider} />
 
-            <div className="h-1.5 w-[68%] rounded-full bg-muted" />
+              <span aria-hidden className="h-4 w-px shrink-0 bg-border" />
+
+              <p className="min-w-0 truncate text-[11px] font-medium">{activeConversation.localizedSubject[locale]}</p>
+            </div>
+
+            <div aria-hidden className="mt-2 space-y-1.5 pl-6">
+              <div className="h-1.5 w-full rounded-full bg-placeholder" />
+
+              <div className="h-1.5 w-[68%] rounded-full bg-muted" />
+            </div>
           </div>
         </div>
       </div>
@@ -354,40 +679,175 @@ export function HomepageOmnichannelVisual({ className, label, labels, locale }: 
 const HANDOFF_AGENT_PROVIDERS = [
   {
     desktop: "sm:left-[6%] sm:right-auto sm:top-[18%]",
+    desktopPoint: [232, 90],
     mobile: "left-[6%] top-[10%]",
+    mobileJustify: "justify-end",
+    mobilePoint: [264, 76],
     provider: "chatgpt",
-    y: 90,
   },
   {
     desktop: "sm:left-[6%] sm:right-auto sm:top-[36%]",
+    desktopPoint: [232, 180],
     mobile: "right-[6%] top-[10%]",
+    mobileJustify: "justify-start",
+    mobilePoint: [336, 76],
     provider: "claude",
-    y: 180,
   },
   {
     desktop: "sm:left-[6%] sm:right-auto sm:top-[54%]",
+    desktopPoint: [232, 270],
     mobile: "left-[6%] top-[22%]",
+    mobileJustify: "justify-end",
+    mobilePoint: [264, 167],
     provider: "cursor",
-    y: 270,
   },
   {
     desktop: "sm:left-[6%] sm:right-auto sm:top-[72%]",
+    desktopPoint: [232, 360],
     mobile: "right-[6%] top-[22%]",
+    mobileJustify: "justify-start",
+    mobilePoint: [336, 167],
     provider: "gemini",
-    y: 360,
   },
 ] as const satisfies readonly {
   desktop: string;
+  desktopPoint: OrbitPoint;
   mobile: string;
+  mobileJustify: string;
+  mobilePoint: OrbitPoint;
   provider: VisualAgentProviderFixtureId;
-  y: number;
 }[];
 
+type HandoffProvider = (typeof HANDOFF_AGENT_PROVIDERS)[number];
+
+type HandoffSignalSpec = {
+  delayMs: number;
+  durationMs: number;
+  ease: SignalEase;
+  provider: VisualAgentProviderFixtureId;
+};
+
+type HandoffSignalScene = {
+  durationMs: number;
+  signal: HandoffSignalSpec;
+};
+
+const HANDOFF_SIGNAL_SEQUENCE = [
+  {
+    durationMs: 2_900,
+    signal: {
+      delayMs: 80,
+      durationMs: 2_200,
+      ease: "settle",
+      provider: "chatgpt",
+    },
+  },
+  {
+    durationMs: 3_300,
+    signal: {
+      delayMs: 240,
+      durationMs: 2_450,
+      ease: "drift",
+      provider: "cursor",
+    },
+  },
+  {
+    durationMs: 2_700,
+    signal: {
+      delayMs: 0,
+      durationMs: 2_100,
+      ease: "swift",
+      provider: "claude",
+    },
+  },
+  {
+    durationMs: 3_400,
+    signal: {
+      delayMs: 360,
+      durationMs: 2_350,
+      ease: "settle",
+      provider: "chatgpt",
+    },
+  },
+  {
+    durationMs: 3_000,
+    signal: {
+      delayMs: 120,
+      durationMs: 2_250,
+      ease: "drift",
+      provider: "gemini",
+    },
+  },
+  {
+    durationMs: 3_200,
+    signal: {
+      delayMs: 260,
+      durationMs: 2_300,
+      ease: "swift",
+      provider: "cursor",
+    },
+  },
+  {
+    durationMs: 2_850,
+    signal: {
+      delayMs: 40,
+      durationMs: 2_150,
+      ease: "settle",
+      provider: "claude",
+    },
+  },
+  {
+    durationMs: 3_500,
+    signal: {
+      delayMs: 200,
+      durationMs: 2_500,
+      ease: "drift",
+      provider: "gemini",
+    },
+  },
+] as const satisfies readonly HandoffSignalScene[];
+
+function HandoffSignal({
+  layout,
+  provider,
+  timeline,
+}: {
+  layout: "desktop" | "mobile";
+  provider: HandoffProvider;
+  timeline: SignalTimeline;
+}) {
+  const [startX, startY] = layout === "desktop" ? provider.desktopPoint : provider.mobilePoint;
+  const path =
+    layout === "desktop"
+      ? `M${startX} ${startY} C285 ${startY} 285 225 320 225 H350`
+      : `M${startX} ${startY} H300 V243`;
+
+  return (
+    <SyncedSignalPath
+      kind="handoff"
+      path={path}
+      provider={provider.provider}
+      start={layout === "desktop" ? provider.desktopPoint : provider.mobilePoint}
+      timeline={timeline}
+    />
+  );
+}
+
 export function HomepageHandoffVisual({ className, labels }: VisualProps) {
+  const { ref, shouldAnimate } = useHomepageMotion<HTMLDivElement>();
+  const { revision, scene: activeScene } = useTimedSceneCycle(HANDOFF_SIGNAL_SEQUENCE, shouldAnimate);
+  const activeSignal = activeScene.signal;
+  const handoffTimeline = useSignalTimeline(activeSignal, shouldAnimate);
+  const activeProvider = HANDOFF_AGENT_PROVIDERS.find(({ provider }) => provider === activeSignal.provider);
+
+  if (!activeProvider) return null;
+
   return (
     <HomepageVisualArtboard
       className={cn("aspect-[4/5] min-h-[33rem] sm:aspect-[8/5] sm:min-h-[25rem] xl:min-h-0", className)}
       label={`${labels.draft}. ${labels.humanDecision}.`}
+      motionActive={shouldAnimate}
+      motionRef={ref}
       name="human-handoff"
     >
       <svg
@@ -397,12 +857,21 @@ export function HomepageHandoffVisual({ className, labels }: VisualProps) {
         viewBox="0 0 800 500"
       >
         <path
-          d={`${HANDOFF_AGENT_PROVIDERS.map(({ y }) => `M232 ${y} C285 ${y} 285 225 320 225`).join(" ")} M320 225 H350`}
+          d={`${HANDOFF_AGENT_PROVIDERS.map(({ desktopPoint: [, y] }) => `M232 ${y} C285 ${y} 285 225 320 225`).join(" ")} M320 225 H350`}
           fill="none"
           stroke={COMPOUND_CONNECTOR_STROKE}
           strokeLinecap="butt"
           strokeWidth="1.5"
         />
+
+        {shouldAnimate ? (
+          <HandoffSignal
+            key={`${revision}-desktop-${activeProvider.provider}`}
+            layout="desktop"
+            provider={activeProvider}
+            timeline={handoffTimeline}
+          />
+        ) : null}
       </svg>
 
       <svg
@@ -418,35 +887,76 @@ export function HomepageHandoffVisual({ className, labels }: VisualProps) {
           strokeLinecap="butt"
           strokeWidth="1.5"
         />
+
+        {shouldAnimate ? (
+          <HandoffSignal
+            key={`${revision}-mobile-${activeProvider.provider}`}
+            layout="mobile"
+            provider={activeProvider}
+            timeline={handoffTimeline}
+          />
+        ) : null}
       </svg>
 
-      {HANDOFF_AGENT_PROVIDERS.map(({ desktop, mobile, provider }) => (
-        <div
-          key={provider}
-          className={cn(
-            "absolute z-10 w-[38%] -translate-y-1/2 rounded-full border border-border bg-card px-3 shadow-sm sm:w-[23%]",
-            provider === "chatgpt"
-              ? "flex h-[3.25rem] flex-col items-start justify-center py-2"
-              : "flex h-10 items-center py-2",
-            mobile,
-            desktop,
-          )}
-        >
-          <NativeAgentProviderIdentity className="text-[10px] sm:text-xs" iconSize={18} provider={provider} />
+      {HANDOFF_AGENT_PROVIDERS.map((provider) => {
+        const isActive = shouldAnimate && activeSignal.provider === provider.provider;
 
-          {provider === "chatgpt" ? (
-            <span aria-hidden className="mt-1 flex h-1 items-center gap-1 pl-6">
-              <span className="size-1 rounded-full bg-primary" />
+        return (
+          <div
+            key={provider.provider}
+            className={cn(
+              "absolute z-10 flex w-[38%] -translate-y-1/2 sm:w-[23%] sm:justify-end",
+              provider.mobile,
+              provider.mobileJustify,
+              provider.desktop,
+            )}
+          >
+            <div
+              className="relative flex w-fit max-w-full items-center whitespace-nowrap rounded-full border border-border bg-card px-3 py-2 shadow-sm"
+              data-homepage-handoff-provider={provider.provider}
+            >
+              {isActive ? <ProviderSignalRing provider={provider.provider} timeline={handoffTimeline} /> : null}
 
-              <span className="size-1 rounded-full bg-primary/65" />
+              <NativeAgentProviderIdentity
+                className="relative z-10 shrink-0 text-[10px] sm:text-xs"
+                iconSize={18}
+                provider={provider.provider}
+              />
+            </div>
+          </div>
+        );
+      })}
 
-              <span className="size-1 rounded-full bg-primary/30" />
-            </span>
-          ) : null}
-        </div>
-      ))}
+      <div
+        className="absolute left-[8%] top-[32%] z-20 w-[84%] overflow-hidden rounded-card border border-border bg-card p-5 shadow-xl shadow-black/10 dark:shadow-black/30 sm:left-[43.75%] sm:top-[10%] sm:w-[52.25%] sm:p-7"
+        data-homepage-motion-phase="provider-to-draft"
+      >
+        <motion.span
+          key={shouldAnimate ? `${revision}-${activeSignal.provider}` : "static"}
+          aria-hidden
+          animate={
+            shouldAnimate
+              ? {
+                  opacity: PROVIDER_ARRIVAL_OPACITY,
+                  scale: PROVIDER_ARRIVAL_SCALE,
+                }
+              : { opacity: 0, scale: 1 }
+          }
+          className="pointer-events-none absolute inset-0 rounded-card border border-primary"
+          data-homepage-draft-arrival-provider={activeSignal.provider}
+          initial={{ opacity: 0, scale: 1 }}
+          transition={
+            shouldAnimate
+              ? {
+                  delay: (activeSignal.delayMs + activeSignal.durationMs * PROVIDER_ARRIVAL_DELAY_RATIO) / 1_000,
+                  duration: (activeSignal.durationMs / 1_000) * PROVIDER_ARRIVAL_DURATION_RATIO,
+                  ease: SIGNAL_EASES[activeSignal.ease],
+                  times: PROVIDER_ARRIVAL_TIMES,
+                }
+              : { duration: 0 }
+          }
+        />
 
-      <div className="absolute left-[8%] top-[32%] z-20 w-[84%] overflow-hidden rounded-card border border-border bg-card p-5 shadow-xl shadow-black/10 dark:shadow-black/30 sm:left-[43.75%] sm:top-[10%] sm:w-[52.25%] sm:p-7">
         <div
           className="-mx-5 flex items-center justify-between gap-3 border-b border-border px-5 pb-4 sm:-mx-7 sm:px-7"
           data-homepage-rules="full-bleed"
@@ -462,19 +972,17 @@ export function HomepageHandoffVisual({ className, labels }: VisualProps) {
           <PersonIdentity person="leon-becker" size={30} />
         </div>
 
-        <div className="mt-5 space-y-2.5">
-          <div className="h-1.5 w-[92%] rounded-full bg-placeholder" />
-
-          <div className="h-1.5 w-[76%] rounded-full bg-muted" />
-
-          <div className="h-1.5 w-[54%] rounded-full bg-muted" />
+        <div aria-hidden className="mt-5 space-y-2.5">
+          {HANDOFF_DRAFT_LINES.map((line) => (
+            <div key={line} className={cn("h-1.5 rounded-full", line)} />
+          ))}
         </div>
 
         <div
           className="-mx-5 mt-6 flex items-center justify-between gap-3 border-t border-border px-5 pt-4 sm:-mx-7 sm:px-7"
           data-homepage-rules="full-bleed"
         >
-          <span className="min-w-0">
+          <span className="min-w-0" data-homepage-motion-phase="human-review">
             <span className="text-[9px] text-muted-foreground">{labels.humanDecision}</span>
 
             <PersonIdentity className="mt-1 max-w-32" person="max-bergmann" size={28} />
@@ -511,13 +1019,11 @@ function formatMoney(locale: ContentLocale, amount: number) {
 
 function PipelineCard({
   className,
-  compact = false,
   labels,
   locale,
   record,
 }: {
   className?: string;
-  compact?: boolean;
   labels: HomepageVisualLabels;
   locale: ContentLocale;
   record: VisualRecordFixtureId;
@@ -529,18 +1035,14 @@ function PipelineCard({
       className={cn("overflow-hidden rounded-xl border border-border bg-card p-3 shadow-sm", className)}
       data-native-record={record}
     >
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex flex-col items-start gap-2 sm:flex-row sm:justify-between">
         <p className="line-clamp-2 text-[11px] leading-snug font-medium sm:text-xs">{fixture.name}</p>
 
-        <NativeStatusBadge
-          className={compact ? "hidden md:inline-flex" : "hidden sm:inline-flex"}
-          locale={locale}
-          status={fixture.status}
-        />
+        <NativeStatusBadge className="inline-flex" locale={locale} status={fixture.status} />
       </div>
 
       <div
-        className={cn("-mx-3 mt-3 grid-cols-2 gap-2 border-y border-border p-3", compact ? "hidden md:grid" : "grid")}
+        className="-mx-3 mt-3 grid grid-cols-1 gap-2 border-y border-border p-3 sm:grid-cols-2"
         data-homepage-rules="full-bleed"
       >
         <div>
@@ -562,10 +1064,12 @@ function PipelineCard({
         </div>
       </div>
 
-      <div className={cn("mt-3 items-center justify-between", compact ? "hidden md:flex" : "flex")}>
+      <div className="mt-3 flex items-center justify-between gap-2">
         <PersonAvatar decorative person={fixture.assignee} size={24} />
 
-        <span className="text-[9px] text-muted-foreground">{VISUAL_PERSON_FIXTURES[fixture.assignee].name}</span>
+        <span className="min-w-0 truncate text-[9px] text-muted-foreground">
+          {VISUAL_PERSON_FIXTURES[fixture.assignee].name}
+        </span>
       </div>
     </div>
   );
@@ -574,15 +1078,18 @@ function PipelineCard({
 const PIPELINE_RECORDS = {
   active: "deal-digital-customer-platform",
   lost: "deal-process-automation",
-  open: "deal-data-analytics",
   won: "deal-crm-rollout",
 } as const satisfies Record<string, VisualRecordFixtureId>;
 
 export function HomepagePipelineVisual({ className, labels, locale }: VisualProps) {
+  const { ref, shouldAnimate } = useHomepageMotion<HTMLDivElement>();
+
   return (
     <HomepageVisualArtboard
       className={cn("aspect-[4/5] min-h-[35rem] sm:aspect-[8/5] sm:min-h-0", className)}
       label={`${labels.pipeline}: ${VISUAL_RECORD_FIXTURES[PIPELINE_RECORDS.active].name}`}
+      motionActive={shouldAnimate}
+      motionRef={ref}
       name="pipeline"
     >
       <div className="absolute inset-x-[5%] inset-y-[8%] grid grid-cols-3 gap-2 sm:inset-x-[7%] sm:gap-4">
@@ -591,9 +1098,13 @@ export function HomepagePipelineVisual({ className, labels, locale }: VisualProp
           { label: labels.won, status: "deal-won" as const },
           { label: labels.lost, status: "deal-lost" as const },
         ].map(({ label, status }) => (
-          <div key={status} className="min-w-0 border-l border-border pl-2 sm:pl-4">
+          <div
+            key={status}
+            className="relative min-w-0 overflow-hidden border-l border-border pl-2 sm:pl-4"
+            data-homepage-pipeline-column={status}
+          >
             <div
-              className="-ml-2 flex items-center gap-2 border-b border-border pb-3 pl-2 sm:-ml-4 sm:pl-4"
+              className="relative z-10 -ml-2 flex items-center gap-2 border-b border-border pb-3 pl-2 sm:-ml-4 sm:pl-4"
               data-homepage-rules="full-bleed"
             >
               <span
@@ -611,42 +1122,74 @@ export function HomepagePipelineVisual({ className, labels, locale }: VisualProp
         ))}
       </div>
 
-      <PipelineCard
-        compact
-        className="absolute left-[8%] top-[24%] z-10 w-[27%] brightness-75 saturate-50 sm:left-[9%] sm:w-[25%]"
-        labels={labels}
-        locale={locale}
-        record={PIPELINE_RECORDS.open}
-      />
+      {[
+        {
+          className: "left-[38%] top-[20%] w-[25%] sm:left-[39%]",
+          record: PIPELINE_RECORDS.won,
+          status: "deal-won" as const,
+        },
+        {
+          className: "right-[7%] top-[28%] w-[26%]",
+          record: PIPELINE_RECORDS.lost,
+          status: "deal-lost" as const,
+        },
+      ].map(({ className: cardClassName, record, status }) => (
+        <div
+          key={status}
+          className={cn("absolute z-10 opacity-75 saturate-50", cardClassName)}
+          data-homepage-pipeline-background-card={status}
+        >
+          <PipelineCard labels={labels} locale={locale} record={record} />
+        </div>
+      ))}
 
-      <PipelineCard
-        compact
-        className="absolute left-[38%] top-[20%] z-10 w-[25%] brightness-[0.7] saturate-50 sm:left-[39%]"
-        labels={labels}
-        locale={locale}
-        record={PIPELINE_RECORDS.won}
-      />
+      <div className="pointer-events-none absolute inset-y-[8%] left-[8%] z-20 w-[27%] sm:left-[9%] sm:w-[25%]">
+        <span className="absolute left-0 top-[52.4%] grid w-full sm:top-[45.2%]">
+          <motion.span
+            aria-hidden
+            animate={shouldAnimate ? { opacity: PIPELINE_SOURCE_OUTLINE_OPACITY } : { opacity: 0 }}
+            className="pointer-events-none relative z-10 col-start-1 row-start-1 rounded-xl border border-dashed border-input bg-card/50"
+            data-homepage-pipeline-source-footprint="deal-open"
+            initial={false}
+            style={{ transform: `translateY(${PIPELINE_DRAG_Y[0]}px)` }}
+            transition={
+              shouldAnimate
+                ? {
+                    ...PIPELINE_LOOP_TRANSITION,
+                    times: PIPELINE_DRAG_TIMES,
+                  }
+                : { duration: 0 }
+            }
+          />
 
-      <PipelineCard
-        compact
-        className="absolute right-[7%] top-[28%] z-10 w-[26%] brightness-50 saturate-50"
-        labels={labels}
-        locale={locale}
-        record={PIPELINE_RECORDS.lost}
-      />
+          <motion.div
+            key={shouldAnimate ? "pipeline-active" : "pipeline-static"}
+            animate={
+              shouldAnimate
+                ? {
+                    x: PIPELINE_DRAG_X,
+                    y: PIPELINE_DRAG_Y,
+                  }
+                : { x: "0%", y: PIPELINE_DRAG_Y[0] }
+            }
+            className="relative z-20 col-start-1 row-start-1"
+            data-homepage-motion-phase="pipeline-drag-preview"
+            initial={shouldAnimate ? { x: "0%", y: PIPELINE_DRAG_Y[0] } : false}
+            transition={shouldAnimate ? { ...PIPELINE_LOOP_TRANSITION, times: PIPELINE_DRAG_TIMES } : { duration: 0 }}
+          >
+            <PipelineCard
+              className="border-border shadow-xl shadow-black/10 dark:shadow-black/30"
+              labels={labels}
+              locale={locale}
+              record={PIPELINE_RECORDS.active}
+            />
 
-      <PipelineCard
-        className="absolute left-[27%] top-[52%] z-20 w-[46%] border-border shadow-xl shadow-black/10 dark:shadow-black/30 sm:left-[27%] sm:top-[46%] sm:w-[46%]"
-        labels={labels}
-        locale={locale}
-        record={PIPELINE_RECORDS.active}
-      />
-
-      <MousePointer2
-        aria-hidden
-        className="absolute bottom-[10%] left-[66%] z-30 size-7 fill-card text-foreground drop-shadow-md sm:bottom-[13%] sm:left-[64%] sm:size-8"
-        strokeWidth={1.5}
-      />
+            <span aria-hidden data-homepage-drag-cursor className="absolute -bottom-5 -right-2 z-40">
+              <MousePointer2 className="size-7 fill-card text-foreground drop-shadow-md sm:size-8" strokeWidth={1.5} />
+            </span>
+          </motion.div>
+        </span>
+      </div>
     </HomepageVisualArtboard>
   );
 }

--- a/app/[locale]/(static)/components/rotating-accent.tsx
+++ b/app/[locale]/(static)/components/rotating-accent.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { AnimatePresence, motion } from "framer-motion";
+
+import { cn } from "@/core/utils/cn";
+
+import { useHomepageMotion } from "./homepage-motion";
+
+type Props = {
+  className?: string;
+  words: string[];
+};
+
+const ROTATION_INTERVAL_MS = 2_600;
+const ROTATION_DURATION_SECONDS = 0.2;
+
+export function RotatingAccent({ className, words }: Props) {
+  const { ref, shouldAnimate, shouldReduceMotion } = useHomepageMotion<HTMLSpanElement>(0.6);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!shouldAnimate || words.length <= 1) return;
+
+    const interval = window.setInterval(() => {
+      setActiveIndex((currentIndex) => (currentIndex + 1) % words.length);
+    }, ROTATION_INTERVAL_MS);
+
+    return () => window.clearInterval(interval);
+  }, [shouldAnimate, words.length]);
+
+  if (words.length === 0) return null;
+
+  const visibleIndex = shouldReduceMotion ? 0 : activeIndex % words.length;
+  const activeWord = words[visibleIndex];
+
+  return (
+    <span
+      ref={ref}
+      aria-hidden
+      className={cn("relative inline-grid overflow-hidden align-bottom", className)}
+      data-homepage-motion="rotating-accent"
+      data-motion-active={shouldAnimate ? "true" : "false"}
+    >
+      {words.map((word) => (
+        <span key={word} className="invisible col-start-1 row-start-1 whitespace-nowrap">
+          {word}
+        </span>
+      ))}
+
+      <AnimatePresence initial={false}>
+        <motion.span
+          key={activeWord}
+          animate={{ opacity: 1, y: "0%" }}
+          className="absolute inset-0 flex items-center justify-center whitespace-nowrap"
+          exit={{ opacity: 0, y: "-100%" }}
+          initial={shouldAnimate ? { opacity: 0, y: "100%" } : false}
+          transition={{
+            duration: ROTATION_DURATION_SECONDS,
+            ease: [0.22, 1, 0.36, 1],
+          }}
+        >
+          {activeWord}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  );
+}

--- a/content/homepage/de/homepage.mdx
+++ b/content/homepage/de/homepage.mdx
@@ -6,8 +6,18 @@ rootMetadata:
   defaultDescription: "Das Open-Source-CRM, das externe KI-Clients wie Claude, ChatGPT oder Gemini über MCP bedienen. Mit zentralem Posteingang, EU-Datenbankregion und Self-Hosting."
 
 hero:
-  title: Das Open-Source-CRM für
-  titleAccent: KI-Agenten.
+  title: Das Open-Source-CRM
+  titleAccent: für KI-Agenten.
+  titleAccentRotations:
+    - für KI-Agenten.
+    - für Claude.
+    - für ChatGPT.
+    - für Codex.
+    - für Cursor.
+    - für Gemini.
+    - für Hermes Agent.
+    - für OpenClaw.
+    - für n8n.
   subtitle: "Verwalten Sie Kontakte und Deals gemeinsam mit einem Posteingang für E-Mail, LinkedIn, WhatsApp, Instagram und Telegram. Verbinden Sie ChatGPT, Claude, Gemini oder Cursor über MCP und prüfen Sie jeden Entwurf und jede CRM-Aktualisierung."
   buttonLeftText: "[[commercial.trial.days]]-Tage-Testphase für 0€ starten"
   buttonLeftHref: /auth/signup

--- a/content/homepage/en/homepage.mdx
+++ b/content/homepage/en/homepage.mdx
@@ -6,8 +6,18 @@ rootMetadata:
   defaultDescription: "The open-source CRM your own Claude, ChatGPT, or Gemini operates through MCP, with a unified inbox and an EU database region. From [[commercial.price.starter.monthly]] per user per month."
 
 hero:
-  title: The open-source CRM built for
-  titleAccent: AI agents.
+  title: The open-source CRM
+  titleAccent: for AI agents.
+  titleAccentRotations:
+    - for AI agents.
+    - for Claude.
+    - for ChatGPT.
+    - for Codex.
+    - for Cursor.
+    - for Gemini.
+    - for Hermes Agent.
+    - for OpenClaw.
+    - for n8n.
   subtitle: "Manage contacts and deals alongside one inbox for email, LinkedIn, WhatsApp, Instagram, and Telegram. Connect ChatGPT, Claude, Gemini, or Cursor through MCP—and review every draft and CRM update."
   buttonLeftText: Start a [[commercial.trial.days]]-day trial for 0€
   buttonLeftHref: /auth/signup

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -7,30 +7,49 @@ import { REPO_ROOT } from "./walk";
 
 const HOMEPAGE_ROOT = join(REPO_ROOT, "app", "[locale]", "(static)");
 const COMPONENT_ROOT = join(HOMEPAGE_ROOT, "components");
-const globalStyles = readFileSync(
-  join(REPO_ROOT, "styles", "globals.css"),
-  "utf8",
-);
-const englishHomepage = readFileSync(
-  join(REPO_ROOT, "content", "homepage", "en", "homepage.mdx"),
-  "utf8",
-);
+const globalStyles = readFileSync(join(REPO_ROOT, "styles", "globals.css"), "utf8");
+const englishHomepage = readFileSync(join(REPO_ROOT, "content", "homepage", "en", "homepage.mdx"), "utf8");
+const germanHomepage = readFileSync(join(REPO_ROOT, "content", "homepage", "de", "homepage.mdx"), "utf8");
+const motionSource = readFileSync(join(COMPONENT_ROOT, "homepage-motion.ts"), "utf8");
 const previewBoundarySource = [
   readFileSync(join(REPO_ROOT, "proxy.ts"), "utf8"),
-  readFileSync(
-    join(
-      REPO_ROOT,
-      "app",
-      "components",
-      "navigation",
-      "navigation-switch.tsx",
-    ),
-    "utf8",
-  ),
+  readFileSync(join(REPO_ROOT, "app", "components", "navigation", "navigation-switch.tsx"), "utf8"),
 ].join("\n");
 
 function readComponent(file: string) {
   return readFileSync(join(COMPONENT_ROOT, file), "utf8");
+}
+
+function parseLiteralKeyframes(values: string) {
+  return values
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => (value.startsWith('"') ? JSON.parse(value) : Number(value))) as Array<number | string>;
+}
+
+function readLiteralKeyframes(source: string, constantName: string) {
+  const declaration = source.match(
+    new RegExp(`const ${constantName}\\s*=\\s*\\[([\\s\\S]*?)\\](?:\\s+(?:as const|satisfies [^;]+))?;`, "u"),
+  );
+
+  if (!declaration) {
+    throw new Error(`${constantName} must remain an authored literal keyframe array`);
+  }
+
+  return parseLiteralKeyframes(declaration[1]);
+}
+
+function readOpeningElementContaining(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker);
+  const elementStart = source.lastIndexOf("<", markerIndex);
+  const elementEnd = source.indexOf(">", markerIndex);
+
+  if (markerIndex < 0 || elementStart < 0 || elementEnd < 0) {
+    throw new Error(`${marker} must remain on an opening element`);
+  }
+
+  return source.slice(elementStart, elementEnd + 1);
 }
 
 const page = readFileSync(join(HOMEPAGE_ROOT, "page.tsx"), "utf8");
@@ -43,6 +62,7 @@ const components = [
   "homepage-pipeline.tsx",
   "homepage-pricing.tsx",
   "homepage-product-proof.tsx",
+  "rotating-accent.tsx",
   "homepage-stats-row.tsx",
   "homepage-story-visuals.tsx",
   "homepage-viewport-video.tsx",
@@ -68,15 +88,9 @@ describe("homepage visual-system adoption", () => {
     expect(proof.match(/<HomepageViewportVideo\b/gu)).toHaveLength(1);
     expect(viewportVideo.match(/<video\b/gu)).toHaveLength(1);
     expect(proof).not.toMatch(/HeroDemoIframe|<iframe\b/u);
-    expect(page.indexOf("<HomepageHero")).toBeLessThan(
-      page.indexOf("<HomepageLiveDemo"),
-    );
-    expect(page.indexOf("<HomepageLiveDemo")).toBeLessThan(
-      page.indexOf("<HomepageProductProof"),
-    );
-    expect(page.indexOf("<HomepageProductProof")).toBeLessThan(
-      page.indexOf("<HomepageStatsRow"),
-    );
+    expect(page.indexOf("<HomepageHero")).toBeLessThan(page.indexOf("<HomepageLiveDemo"));
+    expect(page.indexOf("<HomepageLiveDemo")).toBeLessThan(page.indexOf("<HomepageProductProof"));
+    expect(page.indexOf("<HomepageProductProof")).toBeLessThan(page.indexOf("<HomepageStatsRow"));
     expect(visuals).not.toMatch(/<video\b|<iframe\b|HeroDemoIframe/u);
     expect(componentSource).not.toMatch(/GoldenStoryVisual|GOLDEN_LAYOUT/u);
   });
@@ -106,11 +120,68 @@ describe("homepage visual-system adoption", () => {
     expect(hero).toContain("ProviderMark");
     expect(hero).toContain("GridPattern");
     expect(hero).toContain('fade="bottom"');
-    expect(hero).not.toMatch(
-      /HomepageAgentRecordVisual|GoogleCalendar|OutlookCalendar|Messenger|XTwitter/u,
+    expect(hero).not.toMatch(/HomepageAgentRecordVisual|GoogleCalendar|OutlookCalendar|Messenger|XTwitter/u);
+    expect(englishHomepage).toContain("title: The open-source CRM");
+    expect(englishHomepage).toContain("titleAccent: for AI agents.");
+  });
+
+  it("rotates a width-reserved, accessible hero reel only while motion is appropriate", () => {
+    const hero = readComponent("homepage-hero.tsx");
+    const rotatingAccent = readComponent("rotating-accent.tsx");
+    const leadLine = readOpeningElementContaining(hero, 'data-homepage-hero-line="lead"');
+    const rotationLine = readOpeningElementContaining(hero, 'data-homepage-hero-line="rotation"');
+
+    expect(hero).toContain("accessibleHeadline");
+    expect(hero).toContain("[heroSection.title, accentRotations[0]]");
+    expect(hero).toContain('className="sr-only"');
+    expect(hero).toContain("<RotatingAccent");
+    expect(hero.match(/data-homepage-hero-line="lead"/gu)).toHaveLength(1);
+    expect(hero.match(/data-homepage-hero-line="rotation"/gu)).toHaveLength(1);
+    expect(hero.indexOf('data-homepage-hero-line="lead"')).toBeLessThan(
+      hero.indexOf('data-homepage-hero-line="rotation"'),
     );
-    expect(englishHomepage).toContain("title: The open-source CRM built for");
-    expect(englishHomepage).toContain("titleAccent: AI agents.");
+    expect(leadLine).toContain("whitespace-nowrap");
+    expect(rotationLine).toContain("whitespace-nowrap");
+    expect(rotatingAccent).toContain("AnimatePresence");
+    expect(rotatingAccent).toContain("ROTATION_INTERVAL_MS = 2_600");
+    expect(rotatingAccent).toContain("ROTATION_DURATION_SECONDS = 0.2");
+    expect(rotatingAccent).toContain("invisible col-start-1 row-start-1 whitespace-nowrap");
+    expect(rotatingAccent).toContain('data-homepage-motion="rotating-accent"');
+    expect(rotatingAccent).not.toContain("aria-live");
+    expect(motionSource).toContain("useInView");
+    expect(motionSource).toContain("useReducedMotion");
+    expect(motionSource).toContain('document.visibilityState === "visible"');
+    expect(motionSource).toContain('document.addEventListener("visibilitychange"');
+
+    for (const label of [
+      "for AI agents.",
+      "for Claude.",
+      "for ChatGPT.",
+      "for Codex.",
+      "for Cursor.",
+      "for Gemini.",
+      "for Hermes Agent.",
+      "for OpenClaw.",
+      "for n8n.",
+    ]) {
+      expect(englishHomepage).toContain(`    - ${label}`);
+    }
+
+    expect(germanHomepage).toContain("title: Das Open-Source-CRM");
+    expect(germanHomepage).toContain("titleAccentRotations:");
+    expect(germanHomepage).toContain("    - für KI-Agenten.");
+    for (const label of [
+      "für Claude.",
+      "für ChatGPT.",
+      "für Codex.",
+      "für Cursor.",
+      "für Gemini.",
+      "für Hermes Agent.",
+      "für OpenClaw.",
+      "für n8n.",
+    ]) {
+      expect(germanHomepage).toContain(`    - ${label}`);
+    }
   });
 
   it("keeps the live workspace on-page and gives the walkthrough the contrasting story band", () => {
@@ -134,29 +205,199 @@ describe("homepage visual-system adoption", () => {
     for (const provider of ["chatgpt", "claude", "cursor", "gemini"]) {
       expect(visuals).toContain(`provider: "${provider}"`);
     }
+    for (const provider of ["gmail", "outlook", "imap", "telegram", "linkedin", "whatsapp", "instagram"]) {
+      expect(visuals).toContain(`provider: "${provider}"`);
+    }
     expect(visuals).toContain("M320 225 H350");
     expect(visuals).toContain("M300 76 V243");
     expect(visuals).toContain("COMPOUND_CONNECTOR_STROKE");
-    expect(
-      visuals.match(/stroke=\{COMPOUND_CONNECTOR_STROKE\}/gu),
-    ).toHaveLength(2);
+    expect(visuals.match(/stroke=\{COMPOUND_CONNECTOR_STROKE\}/gu)).toHaveLength(2);
     expect(visuals).not.toContain('strokeOpacity="0.36"');
-    expect(visuals).toContain('"flex h-10 items-center py-2"');
+    expect(visuals).not.toContain("h-[3.25rem]");
     expect(visuals).not.toContain('<span aria-hidden className="mt-1 h-1" />');
+    expect(visuals).toContain("SyncedSignalPath");
+    expect(visuals).not.toContain("<animateMotion");
+    expect(visuals).not.toMatch(/HandoffWander|HANDOFF_SIGNAL_WANDER|\bwander:/u);
     expect(visuals).toContain("ProviderIdentity");
     expect(visuals).toContain("activeConversation.localizedSubject[locale]");
-    expect(visuals).toContain(
-      "desktop: { node: [220, 552], target: [365, 505] }",
-    );
-    expect(visuals).toContain(
-      "desktop: { node: [780, 552], target: [635, 505] }",
-    );
-    expect(visuals).toContain(
+    expect(visuals).toContain("desktop: { node: [220, 552], target: [365, 400] }");
+    expect(visuals).toContain("desktop: { node: [780, 552], target: [635, 400] }");
+    for (const mobileConnector of [
+      "mobile: { node: [85, 85], target: [138, 205] }",
+      "mobile: { node: [55, 330], target: [126, 330] }",
+      "mobile: { node: [160, 660], target: [160, 400] }",
       "mobile: { node: [300, 55], target: [300, 205] }",
-    );
+      "mobile: { node: [515, 85], target: [462, 205] }",
+      "mobile: { node: [545, 330], target: [474, 330] }",
+      "mobile: { node: [440, 660], target: [440, 400] }",
+    ]) {
+      expect(visuals).toContain(mobileConnector);
+    }
+    expect(visuals).not.toMatch(/target: \[(?:220|380), 460\]/u);
     expect(visuals).toContain("style={orbitPositionStyle(orbitNode)}");
     expect(visuals).toContain('strokeLinecap="butt"');
     expect(visuals).not.toContain("strokeDasharray");
+  });
+
+  it("keeps page-specific story loops causal, visibility-gated, and separate from shared primitives", () => {
+    const visuals = readComponent("homepage-story-visuals.tsx");
+
+    const omnichannelChoreographyStart = visuals.indexOf("const OMNICHANNEL_SIGNAL_BURSTS");
+    const handoffChoreographyStart = visuals.indexOf("const HANDOFF_SIGNAL_SEQUENCE");
+    const omnichannelChoreography = visuals.slice(omnichannelChoreographyStart, handoffChoreographyStart);
+    const omnichannelSceneDurations = [...omnichannelChoreography.matchAll(/^\s{4}durationMs:\s*([\d_]+),$/gmu)].map(
+      ([, duration]) => Number(duration.replaceAll("_", "")),
+    );
+    const omnichannelSignalDurations = [
+      ...omnichannelChoreography.matchAll(/\{\s*delayMs:\s*[\d_]+,\s*durationMs:\s*([\d_]+)/gu),
+    ].map(([, duration]) => Number(duration.replaceAll("_", "")));
+    const signalTravelTimes = readLiteralKeyframes(visuals, "SIGNAL_TRAVEL_TIMES").map(Number);
+    const signalTravelValues = readLiteralKeyframes(visuals, "SIGNAL_TRAVEL_VALUES").map(Number);
+    const signalTimelineStart = visuals.indexOf("function useSignalTimeline");
+    const syncedSignalPathStart = visuals.indexOf("function SyncedSignalPath");
+    const providerSignalRingStart = visuals.indexOf("function ProviderSignalRing");
+    const orbitSignalStart = visuals.indexOf("function OrbitSignal");
+    const orbitConnectorsStart = visuals.indexOf("function OrbitConnectors");
+    const handoffSignalStart = visuals.indexOf("function HandoffSignal");
+    const handoffVisualStart = visuals.indexOf("export function HomepageHandoffVisual");
+    const pipelineStart = visuals.indexOf("function PipelineCard");
+    const pipelineRecordsStart = visuals.indexOf("const PIPELINE_RECORDS");
+    const signalTimeline = visuals.slice(signalTimelineStart, syncedSignalPathStart);
+    const syncedSignalPath = visuals.slice(syncedSignalPathStart, providerSignalRingStart);
+    const providerSignalRing = visuals.slice(providerSignalRingStart, orbitSignalStart);
+    const orbitSignal = visuals.slice(orbitSignalStart, orbitConnectorsStart);
+    const handoffSignal = visuals.slice(handoffSignalStart, handoffVisualStart);
+    const handoffVisual = visuals.slice(handoffVisualStart, pipelineStart);
+    const pipelineCard = visuals.slice(pipelineStart, pipelineRecordsStart);
+    const providerShell = readOpeningElementContaining(visuals, "data-homepage-provider-shell");
+    const providerPingOpening = readOpeningElementContaining(visuals, "data-homepage-provider-ping={provider}");
+    const handoffProviderMarker = visuals.indexOf("data-homepage-handoff-provider={provider.provider}");
+    const handoffProviderStart = visuals.lastIndexOf("<div", handoffProviderMarker);
+    const handoffProviderEnd = visuals.indexOf("</div>", handoffProviderMarker);
+    const handoffProviderOpening = readOpeningElementContaining(visuals, "data-homepage-handoff-provider");
+    const handoffWrapperStart = visuals.lastIndexOf("<div", handoffProviderStart - 1);
+    const handoffWrapperEnd = visuals.indexOf(">", handoffWrapperStart);
+    const handoffWrapperOpening = visuals.slice(handoffWrapperStart, handoffWrapperEnd + 1);
+
+    expect(visuals).toContain('"use client"');
+    expect(visuals).toContain("useHomepageMotion");
+    expect(visuals).toContain("useTimedSceneCycle");
+    expect(visuals).toContain("setTimeout");
+    expect(visuals).toContain("Number.POSITIVE_INFINITY");
+    expect(visuals).toContain("OMNICHANNEL_SIGNAL_BURSTS");
+    expect(visuals).toContain("HANDOFF_SIGNAL_SEQUENCE");
+    expect(visuals).toMatch(/type OneToThree<T> =[^;]*readonly \[T\][^;]*readonly \[T, T\][^;]*readonly \[T, T, T\]/su);
+    expect(visuals).toContain("signals: OneToThree<OmnichannelSignalSpec>");
+    expect(visuals).toContain("activeBurst.signals.map");
+    expect(omnichannelChoreographyStart).toBeGreaterThanOrEqual(0);
+    expect(handoffChoreographyStart).toBeGreaterThan(omnichannelChoreographyStart);
+    expect(omnichannelChoreography).toMatch(/signals:\s*\[\s*\{[^}]*provider:[^}]*\}\s*,\s*\{[^}]*provider:/su);
+    expect(omnichannelChoreography).toContain("delayMs:");
+    expect(omnichannelChoreography).toContain("durationMs:");
+    expect(omnichannelChoreography).toContain("ease:");
+    expect(omnichannelSceneDurations.length).toBeGreaterThan(0);
+    expect(omnichannelSignalDurations.length).toBeGreaterThan(0);
+    expect(Math.min(...omnichannelSceneDurations)).toBeGreaterThanOrEqual(2_200);
+    expect(Math.min(...omnichannelSignalDurations)).toBeGreaterThanOrEqual(1_400);
+    expect(signalTravelValues).toHaveLength(signalTravelTimes.length);
+    expect([...new Set(signalTravelValues)]).toEqual([0, 1]);
+    expect(signalTravelValues.every((value, index) => index === 0 || value >= signalTravelValues[index - 1])).toBe(
+      true,
+    );
+    expect(signalTimelineStart).toBeGreaterThanOrEqual(0);
+    expect(syncedSignalPathStart).toBeGreaterThan(signalTimelineStart);
+    expect(providerSignalRingStart).toBeGreaterThan(syncedSignalPathStart);
+    expect(orbitSignalStart).toBeGreaterThan(providerSignalRingStart);
+    expect(handoffSignalStart).toBeGreaterThan(orbitSignalStart);
+    expect(handoffVisualStart).toBeGreaterThan(handoffSignalStart);
+    expect(signalTimeline.match(/useMotionValue\(0\)/gu)).toHaveLength(1);
+    expect(signalTimeline).toContain("const phase = useMotionValue(0)");
+    expect(signalTimeline.match(/\banimate\(phase,\s*1,/gu)).toHaveLength(1);
+    expect(signalTimeline).toContain("const travel = useTransform(");
+    expect(signalTimeline).toContain("SIGNAL_TRAVEL_TIMES");
+    expect(signalTimeline).toContain("SIGNAL_TRAVEL_VALUES");
+    expect(syncedSignalPath).toContain("useTransform(timeline.travel");
+    expect(syncedSignalPath).toContain("pathRef.current");
+    expect(syncedSignalPath).toContain("getTotalLength()");
+    expect(syncedSignalPath).toContain("getPointAtLength(");
+    expect(syncedSignalPath).toContain("ref={pathRef}");
+    expect(syncedSignalPath).toContain("pathLength: timeline.travel");
+    expect(syncedSignalPath).toContain("cx={signalX}");
+    expect(syncedSignalPath).toContain("cy={signalY}");
+    expect(providerSignalRing.match(/useTransform\(\s*timeline\.travel,/gu)).toHaveLength(2);
+    expect(providerSignalRing).toContain("style={{ opacity: timeline.activity }}");
+    expect(providerSignalRing).toContain("data-homepage-provider-ping={provider}");
+    expect(providerSignalRing).toContain("pointer-events-none absolute -inset-1");
+    expect(providerSignalRing).toContain("rounded-full border border-primary/70");
+    expect(providerPingOpening).toMatch(/^<motion\.span\b/u);
+    expect(providerPingOpening).toContain("aria-hidden");
+    expect(providerPingOpening).not.toMatch(/\blayout(?:=|\s)|\b(?:m|p)[trblxy]?-/u);
+    expect(orbitSignal.match(/<SyncedSignalPath\b/gu)).toHaveLength(2);
+    expect(orbitSignal.match(/\buseSignalTimeline\(signal,\s*true\)/gu)).toHaveLength(1);
+    expect(orbitSignal.match(/<ProviderSignalRing\b/gu)).toHaveLength(1);
+    expect(handoffSignal.match(/<SyncedSignalPath\b/gu)).toHaveLength(1);
+    expect(visuals).not.toContain("ORBIT_NODES[0]");
+    expect(visuals).not.toContain('shouldAnimate && provider === "chatgpt"');
+    expect(visuals).not.toContain('shouldAnimate && status === "deal-won"');
+    expect(visuals).not.toMatch(/Math\.random|Date\.now|performance\.now|setInterval/u);
+    expect(visuals).toContain("<motion.path");
+    expect(visuals).toContain("<motion.circle");
+    expect(visuals).toContain("data-homepage-motion-signal=");
+    expect(visuals).toContain("data-homepage-provider-shell={orbitNode.provider}");
+    expect(providerShell).toMatch(/^<span\b/u);
+    expect(providerShell).not.toMatch(/\banimate=|\btransition=|\blayout(?:=|\s)/u);
+    expect(visuals).not.toMatch(/PROVIDER_NODE_OPACITY|PROVIDER_NODE_SCALE|PROVIDER_RING_OPACITY/u);
+    expect(visuals.match(/<ProviderSignalRing\b/gu)).toHaveLength(2);
+    expect(visuals).toContain("data-homepage-handoff-signal=");
+    expect(visuals).toContain("data-homepage-handoff-provider={provider.provider}");
+    expect(visuals).not.toContain("<animateMotion");
+    expect(visuals).not.toMatch(/HandoffWander|HANDOFF_SIGNAL_WANDER|\bwander:/u);
+    expect(handoffProviderStart).toBeGreaterThanOrEqual(0);
+    expect(handoffProviderEnd).toBeGreaterThan(handoffProviderStart);
+    expect(handoffProviderOpening).toMatch(/^<div\b/u);
+    expect(handoffProviderOpening).toContain("w-fit max-w-full");
+    expect(handoffProviderOpening).not.toMatch(
+      /\banimate=|\btransition=|\blayout(?:=|\s)|\bstyle=|(?:^|\s)(?:h|min-h)-/u,
+    );
+    expect(handoffWrapperOpening).toContain("flex");
+    expect(handoffWrapperOpening).toContain("w-[38%]");
+    expect(handoffWrapperOpening).toContain("sm:w-[23%]");
+    expect(visuals).toContain("justify-end");
+    expect(visuals).toContain("justify-start");
+    expect(handoffVisual).toMatch(/\{isActive\s*\?\s*(?:\(\s*)?<ProviderSignalRing/u);
+    expect(handoffVisual).toContain('className="relative z-10 shrink-0 text-[10px] sm:text-xs"');
+    expect(handoffVisual).not.toContain('<span className="relative z-10 shrink-0">');
+    expect(visuals).not.toMatch(
+      /HANDOFF_TYPING_DOT_INDEXES|createTypingDotTimeline|loaderWidth|loaderMarginLeft|loaderOpacity|data-homepage-handoff-dots/u,
+    );
+    expect(pipelineRecordsStart).toBeGreaterThan(pipelineStart);
+    expect(pipelineCard).not.toMatch(/\bcompact\b|hidden md:(?:inline-flex|grid|flex)/u);
+    expect(pipelineCard).toContain("flex flex-col items-start gap-2 sm:flex-row");
+    expect(pipelineCard).toContain('className="inline-flex"');
+    expect(pipelineCard).toContain("grid grid-cols-1");
+    expect(pipelineCard).toContain("sm:grid-cols-2");
+    expect(pipelineCard).toContain('className="mt-3 flex items-center justify-between gap-2"');
+    expect(visuals).toContain("data-homepage-pipeline-column={status}");
+    expect(visuals).toContain('{ label: labels.open, status: "deal-open" as const }');
+    expect(visuals).not.toContain("PIPELINE_RECORDS.open");
+    expect(visuals).not.toContain('data-homepage-pipeline-source-card="deal-open"');
+    expect(visuals.match(/data-homepage-pipeline-source-footprint="deal-open"/gu)).toHaveLength(1);
+    expect(visuals).not.toMatch(/PIPELINE_COLUMN_ACTIVITY|PIPELINE_COLUMN_TIMES/u);
+    expect(visuals).not.toMatch(/data-homepage-pipeline-highlight|data-homepage-pipeline-card-dim/u);
+    expect(visuals).toContain("data-homepage-drag-cursor");
+    expect(visuals).toContain("PIPELINE_DRAG_X");
+    expect(visuals).toContain("PIPELINE_DRAG_Y");
+    expect(visuals).not.toContain("PIPELINE_SOURCE_CARD_OPACITY");
+    expect(visuals).toContain("PIPELINE_SOURCE_OUTLINE_OPACITY");
+    expect(visuals).not.toMatch(/PIPELINE_OPEN_CARD_FILTER|data-homepage-pipeline-open-card-blur|blur\(/u);
+    expect(visuals).not.toContain("PIPELINE_DRAG_OPACITY");
+    expect(visuals).toContain('data-homepage-motion-phase="signal-to-record"');
+    expect(visuals).toContain('data-homepage-motion-phase="provider-to-draft"');
+    expect(visuals).toContain('data-homepage-motion-phase="human-review"');
+    expect(visuals).toContain('data-homepage-motion-phase="pipeline-drag-preview"');
+    expect(visuals).toContain("data-homepage-motion-scene={name}");
+    expect(visuals).toContain('data-motion-active={motionActive ? "true" : "false"}');
+    expect(visuals).not.toMatch(/remotion|hyperframes|requestAnimationFrame/iu);
   });
 
   it("runs horizontal rules to the edges of their owning surfaces", () => {
@@ -164,33 +405,19 @@ describe("homepage visual-system adoption", () => {
     const hero = readComponent("homepage-hero.tsx");
     const strip = readComponent("homepage-stats-row.tsx");
 
-    expect(
-      componentSource.match(/data-homepage-rules="full-bleed"/gu)?.length,
-    ).toBeGreaterThanOrEqual(7);
-    expect(benefits).toContain(
-      '<section className="relative w-full border-y border-border" id="facts">',
-    );
+    expect(componentSource.match(/data-homepage-rules="full-bleed"/gu)?.length).toBeGreaterThanOrEqual(7);
+    expect(benefits).toContain('<section className="relative w-full border-y border-border" id="facts">');
     expect(benefits).toContain("lg:grid-cols-5");
     expect(benefits).not.toContain("absolute inset-x-0 top-1/2");
-    for (const figure of [
-      'figure: "5"',
-      "figure: MCP",
-      "figure: AGPL-3.0",
-      "figure: EU",
-      "figure: DE",
-    ]) {
+    for (const figure of ['figure: "5"', "figure: MCP", "figure: AGPL-3.0", "figure: EU", "figure: DE"]) {
       expect(englishHomepage).toContain(figure);
     }
     expect(benefits).not.toContain("grid grid-cols-2 border-y border-border");
     expect(strip).toContain('className="w-full border-y border-border"');
-    expect(hero).toContain(
-      'className="relative isolate w-full overflow-hidden"',
-    );
+    expect(hero).toContain('className="relative isolate w-full overflow-hidden"');
     expect(hero).toContain('data-homepage-section="hero"');
     expect(page).toContain('data-marketing-flow="continuous"');
-    expect(globalStyles).toMatch(
-      /\[data-marketing-flow="continuous"\]\s+\.marketing-section:not/u,
-    );
+    expect(globalStyles).toMatch(/\[data-marketing-flow="continuous"\]\s+\.marketing-section:not/u);
   });
 
   it("keeps display typography neutral while reserving accent for signals and actions", () => {
@@ -216,49 +443,92 @@ describe("homepage visual-system adoption", () => {
   });
 
   it("uses the shared 80rem marketing shell and exactly one inverse story band", () => {
-    expect(componentSource).not.toMatch(
-      /max-w-\[(?:1100|1200|1240|1400|1440)px\]/u,
-    );
+    expect(componentSource).not.toMatch(/max-w-\[(?:1100|1200|1240|1400|1440)px\]/u);
     expect(componentSource.match(/tone="inverse"/gu)).toHaveLength(1);
     expect(componentSource).toMatch(/MarketingContainer|MarketingSection/u);
   });
 
   it("recomposes illustrations for narrow and split placements without an outer border", () => {
     const visuals = readComponent("homepage-story-visuals.tsx");
-    const artboard = readFileSync(
-      join(
-        REPO_ROOT,
-        "components",
-        "marketing",
-        "visuals",
-        "visual-artboard.tsx",
-      ),
-      "utf8",
-    );
+    const artboard = readFileSync(join(REPO_ROOT, "components", "marketing", "visuals", "visual-artboard.tsx"), "utf8");
 
     expect(visuals).toContain("aspect-[4/5]");
     expect(visuals).toContain("sm:aspect-[8/5]");
     expect(visuals).toContain("MarketingVisualArtboard");
     expect(artboard).toContain("overflow-hidden rounded-xl bg-sidebar");
-    expect(visuals).toContain(
-      'className="absolute inset-0 size-full sm:hidden"',
-    );
-    expect(visuals).toContain(
-      'className="absolute inset-0 hidden size-full sm:block"',
-    );
-    expect(visuals).not.toMatch(
-      /data-homepage-visual=[\s\S]{0,240}border border/u,
-    );
+    expect(visuals).toContain('className="absolute inset-0 size-full sm:hidden"');
+    expect(visuals).toContain('className="absolute inset-0 hidden size-full sm:block"');
+    expect(visuals).not.toMatch(/data-homepage-visual=[\s\S]{0,240}border border/u);
   });
 
-  it("keeps pipeline atmosphere behind opaque supporting cards", () => {
+  it("drags one pipeline card out and back while showing only an empty source footprint", () => {
     const visuals = readComponent("homepage-story-visuals.tsx");
 
-    expect(visuals).toContain("brightness-75 saturate-50");
-    expect(visuals).toContain("brightness-[0.7] saturate-50");
-    expect(visuals).toContain("brightness-50 saturate-50");
-    expect(visuals).not.toMatch(
-      /w-\[(?:25|26|27)%\][^\n]*opacity-(?:35|40|45)/u,
+    const x = readLiteralKeyframes(visuals, "PIPELINE_DRAG_X");
+    const y = readLiteralKeyframes(visuals, "PIPELINE_DRAG_Y").map(Number);
+    const sourceOutlineOpacity = readLiteralKeyframes(visuals, "PIPELINE_SOURCE_OUTLINE_OPACITY").map(Number);
+    const dragTimes = readLiteralKeyframes(visuals, "PIPELINE_DRAG_TIMES").map(Number);
+    const sourceOutlineElement = readOpeningElementContaining(
+      visuals,
+      'data-homepage-pipeline-source-footprint="deal-open"',
     );
+    const sourceOutlineIndex = visuals.indexOf('data-homepage-pipeline-source-footprint="deal-open"');
+    const sourceOutlineEnd = visuals.indexOf("/>", sourceOutlineIndex);
+    const sourceOutlineBlock = visuals.slice(sourceOutlineIndex, sourceOutlineEnd);
+    const movingPhaseIndex = visuals.indexOf('data-homepage-motion-phase="pipeline-drag-preview"');
+    const movingElementStart = visuals.lastIndexOf("<motion.div", movingPhaseIndex);
+    const movingElementEnd = visuals.indexOf("</motion.div>", movingPhaseIndex);
+    const movingElement = visuals.slice(movingElementStart, movingElementEnd);
+    const xAsNumbers = x.map((value) => Number.parseFloat(String(value)));
+    const dragStartIndex = xAsNumbers.findIndex((value, index) => value !== xAsNumbers[0] || y[index] !== y[0]);
+    const furthestX = Math.max(...xAsNumbers);
+    const furthestXIndex = xAsNumbers.lastIndexOf(furthestX);
+    const returnIndex = xAsNumbers.findIndex(
+      (value, index) => index > furthestXIndex && value === xAsNumbers[0] && y[index] === y[0],
+    );
+
+    expect(x).toHaveLength(dragTimes.length);
+    expect(y).toHaveLength(dragTimes.length);
+    expect(sourceOutlineOpacity).toHaveLength(dragTimes.length);
+    expect(Math.max(...y)).toBeGreaterThan(Math.min(...y));
+    expect(furthestX).toBeGreaterThan(xAsNumbers[0]);
+    expect(returnIndex).toBeGreaterThan(furthestXIndex);
+    expect(
+      xAsNumbers.slice(furthestXIndex + 1, returnIndex).some((value) => value > xAsNumbers[0] && value < furthestX),
+    ).toBe(true);
+    expect(xAsNumbers.at(-1)).toBe(xAsNumbers[0]);
+    expect(y.at(-1)).toBe(y[0]);
+    expect(dragStartIndex).toBeGreaterThan(0);
+    expect(sourceOutlineOpacity[0]).toBe(0);
+    expect(sourceOutlineOpacity[dragStartIndex - 1]).toBe(1);
+    expect(Math.max(...sourceOutlineOpacity)).toBeGreaterThan(0);
+    expect(sourceOutlineOpacity.at(-1)).toBe(0);
+    expect(sourceOutlineOpacity.slice(dragStartIndex, returnIndex).every((opacity) => opacity > 0)).toBe(true);
+    expect(sourceOutlineOpacity[returnIndex]).toBe(0);
+    expect(movingElementStart).toBeGreaterThanOrEqual(0);
+    expect(movingElementEnd).toBeGreaterThan(movingPhaseIndex);
+    expect(movingElement).toContain("x: PIPELINE_DRAG_X");
+    expect(movingElement).toContain("y: PIPELINE_DRAG_Y");
+    expect(movingElement).toContain("times: PIPELINE_DRAG_TIMES");
+    expect(movingElement).not.toMatch(/\bopacity:/u);
+    expect(movingElement).toContain("record={PIPELINE_RECORDS.active}");
+    expect(visuals.match(/record=\{PIPELINE_RECORDS\.active\}/gu)).toHaveLength(1);
+    expect(visuals).toContain("transform: `translateY(${PIPELINE_DRAG_Y[0]}px)`");
+    expect(sourceOutlineElement).toMatch(/^<motion\.span\b/u);
+    expect(sourceOutlineElement).toContain("aria-hidden");
+    expect(sourceOutlineElement).toContain("pointer-events-none relative z-10 col-start-1 row-start-1");
+    expect(sourceOutlineElement).toContain("rounded-xl border border-dashed border-input");
+    expect(sourceOutlineElement).toContain("bg-card/50");
+    expect(sourceOutlineElement).toContain("opacity: PIPELINE_SOURCE_OUTLINE_OPACITY");
+    expect(sourceOutlineBlock).not.toContain("PipelineCard");
+    expect(movingElement).toContain("relative z-20 col-start-1 row-start-1");
+    expect(visuals).not.toContain('data-homepage-pipeline-source-card="deal-open"');
+    expect(visuals.match(/data-homepage-pipeline-source-footprint="deal-open"/gu)).toHaveLength(1);
+    expect(visuals).toContain("data-homepage-pipeline-background-card={status}");
+    expect(visuals).not.toMatch(/PIPELINE_COLUMN_ACTIVITY|PIPELINE_COLUMN_TIMES|PIPELINE_DRAG_OPACITY/u);
+    expect(visuals).not.toMatch(/data-homepage-pipeline-highlight|data-homepage-pipeline-card-dim/u);
+    expect(visuals).not.toMatch(/PIPELINE_OPEN_CARD_FILTER|data-homepage-pipeline-open-card-blur|blur\(/u);
+    expect(visuals).not.toMatch(/brightness-(?:50|75|\[0\.7\])/u);
+    expect(visuals).not.toMatch(/w-\[(?:25|26|27)%\][^\n]*opacity-(?:35|40|45)/u);
   });
 });


### PR DESCRIPTION
## Summary

- Add a responsive rotating homepage headline for AI agents, Claude, ChatGPT, Codex, Cursor, Gemini, Hermes Agent, OpenClaw, and n8n in English and German.
- Turn the unified context, human control, and pipeline visuals into continuous, visibility-aware loops with reduced-motion support and responsive connector geometry.

## Context

Implements [CUS-288](https://linear.app/customermates/issue/CUS-288). The final feedback required provider lines to meet the live customer card at every breakpoint, fixed-size provider cards with ping rings, a single draggable pipeline card with an aligned dashed source footprint, and no duplicate Open-column card.

## Validation

- Node 24.18.0; disposable PostgreSQL 17 database reset and seeded with synthetic fixtures.
- yarn typecheck
- yarn lint
- yarn conventions:check — 603 passed, 2 skipped.
- RUN_DATABASE_TESTS=true yarn test --maxWorkers=4 — 4,192 passed, 123 skipped across 491 test files.
- yarn i18n:audit — locale parity passed; advisory findings only.
- yarn build
- Browser geometry and responsive visual sweep at 320, 390, 639, 640, 768, 883, 896, 1023, 1024, 1280, 1440, and 1920 px. All seven connectors reach the customer card, including the reported 883 px case.
- Independent product review: no high- or medium-severity findings.

## Impact and rollback

Frontend and localized homepage content only. No database migration, dependency, API, environment-variable, or production-data impact. Roll back by reverting commit 302e60c1 or close this PR before merge. This PR does not authorize merge, publication, or production changes.