### PR TITLE
feat(marketing): polish public website experience

### DIFF
--- a/app/[locale]/(public)/contact/contact-form.tsx
+++ b/app/[locale]/(public)/contact/contact-form.tsx
@@ -9,9 +9,11 @@ import { AppCardBody } from "@/components/card/app-card-body";
 import { AppCardFooter } from "@/components/card/app-card-footer";
 import { AppForm } from "@/components/forms/form-context";
 import { Button } from "@/components/ui/button";
+import { FormCheckbox } from "@/components/forms/form-checkbox";
 import { FormInput } from "@/components/forms/form-input";
 import { FormTextarea } from "@/components/forms/form-textarea";
 import { AppImage } from "@/components/shared/app-image";
+import { AppLink } from "@/components/shared/app-link";
 import { useRootStore } from "@/core/stores/root-store.provider";
 
 export const ContactForm = observer(() => {
@@ -71,6 +73,19 @@ export const ContactForm = observer(() => {
           <FormInput autoComplete="organization" id="company" />
 
           <FormTextarea required id="message" placeholder={t("ContactPage.form.messagePlaceholder")} rows={6} />
+
+          <FormCheckbox
+            required
+            errorMessage={t("ContactPage.form.privacyAcknowledgementRequired")}
+            id="privacyAcknowledged"
+            label={t.rich("ContactPage.form.privacyAcknowledgement", {
+              dataPrivacyLink: (chunks) => (
+                <AppLink inheritSize appearance="inline" href="/privacy" target="_blank">
+                  {chunks}
+                </AppLink>
+              ),
+            })}
+          />
         </AppCardBody>
 
         <AppCardFooter>

--- a/app/[locale]/(public)/contact/contact.store.ts
+++ b/app/[locale]/(public)/contact/contact.store.ts
@@ -12,7 +12,13 @@ export class ContactStore extends BaseFormStore<SendContactInquiryData> {
   isSent = false;
 
   constructor(rootStore: RootStore) {
-    super(rootStore, { name: "", email: "", company: "", message: "" });
+    super(rootStore, {
+      name: "",
+      email: "",
+      company: "",
+      message: "",
+      privacyAcknowledged: false,
+    });
 
     makeObservable(this, {
       isSent: observable,
@@ -23,7 +29,13 @@ export class ContactStore extends BaseFormStore<SendContactInquiryData> {
 
   reset = () => {
     this.isSent = false;
-    this.onInitOrRefresh({ name: "", email: "", company: "", message: "" });
+    this.onInitOrRefresh({
+      name: "",
+      email: "",
+      company: "",
+      message: "",
+      privacyAcknowledged: false,
+    });
   };
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
@@ -39,7 +51,13 @@ export class ContactStore extends BaseFormStore<SendContactInquiryData> {
 
       if (res.ok) {
         this.isSent = true;
-        this.onInitOrRefresh({ name: "", email: "", company: "", message: "" });
+        this.onInitOrRefresh({
+          name: "",
+          email: "",
+          company: "",
+          message: "",
+          privacyAcknowledged: false,
+        });
         this.toastSuccess("ContactPage.form.successToast");
       } else this.setError(res.error);
     } finally {

--- a/app/[locale]/(static)/components/hero-demo-iframe.tsx
+++ b/app/[locale]/(static)/components/hero-demo-iframe.tsx
@@ -5,14 +5,20 @@ import { useLocale, useTranslations } from "next-intl";
 import { BrowserFrame } from "@/components/marketing/browser-frame";
 import { cn } from "@/core/utils/cn";
 
-export function HeroDemoIframe({ className, src }: { className?: string; src?: string }) {
+type Props = {
+  className?: string;
+  size?: "article" | "full";
+  src?: string;
+};
+
+export function HeroDemoIframe({ className, size = "full", src }: Props) {
   const locale = useLocale();
   const t = useTranslations();
   const demoSrc = src ?? `https://demo.customermates.com/${locale}/dashboard?agentChat=open`;
 
   return (
     <div className={cn("mx-auto w-full", className)}>
-      <BrowserFrame src={demoSrc} title={t("BrowserFrame.liveDemoTitle")} />
+      <BrowserFrame size={size} src={demoSrc} title={t("BrowserFrame.liveDemoTitle")} />
     </div>
   );
 }

--- a/app/[locale]/(static)/components/homepage-benefits.tsx
+++ b/app/[locale]/(static)/components/homepage-benefits.tsx
@@ -48,7 +48,7 @@ export function HomepageBenefits({ benefitsSection }: Props) {
                 key={group.title}
                 className="col-span-12 flex min-h-64 flex-col rounded-card border border-border bg-card p-6 sm:col-span-6 lg:col-span-4 lg:p-7"
               >
-                <span className="grid size-10 place-items-center rounded-lg bg-muted text-muted-foreground">
+                <span className="grid size-10 place-items-center rounded-lg border border-primary/20 bg-primary/10 text-primary">
                   <Icon aria-hidden className="size-[18px]" strokeWidth={1.75} />
                 </span>
 

--- a/app/[locale]/(static)/components/homepage-hero.tsx
+++ b/app/[locale]/(static)/components/homepage-hero.tsx
@@ -37,7 +37,7 @@ export function HomepageHero({ heroSection }: Props) {
           <h1 className="text-hero mt-7 max-w-6xl">
             <span className="sr-only">{accessibleHeadline}</span>
 
-            <span aria-hidden className="flex flex-col items-center justify-center gap-y-[0.04em]">
+            <span aria-hidden className="flex flex-col items-center justify-center gap-y-[0.1em] lg:gap-y-[0.06em]">
               <span
                 className="whitespace-nowrap [font-size:min(1em,8.6vw)] sm:text-[1em]"
                 data-homepage-hero-line="lead"
@@ -49,18 +49,28 @@ export function HomepageHero({ heroSection }: Props) {
                 className="inline-flex whitespace-nowrap [font-size:min(1em,8.6vw)] sm:text-[1em]"
                 data-homepage-hero-line="rotation"
               >
-                <RotatingAccent words={accentRotations} />
+                <RotatingAccent
+                  activeClassName="rounded-xl bg-primary/10 px-[0.12em]"
+                  className="p-[0.12em] text-primary"
+                  words={accentRotations}
+                />
               </span>
             </span>
           </h1>
 
           <div className="mt-10 w-full max-w-[820px] rounded-card border border-border bg-card p-5 text-left shadow-[0_20px_70px_-48px_rgba(0,0,0,0.7)] sm:p-6">
-            <p className="max-w-[700px] text-[15px] leading-relaxed text-muted-foreground sm:text-base">
+            <p className="text-eyebrow">{heroSection.useCaseEyebrow}</p>
+
+            <p className="mt-3 max-w-[700px] text-base leading-relaxed font-medium text-foreground sm:text-lg">
+              {heroSection.useCase}
+            </p>
+
+            <p className="mt-4 max-w-[700px] text-[15px] leading-relaxed text-muted-foreground sm:text-base">
               {heroSection.subtitle}
             </p>
 
-            <div className="mt-7 flex items-end justify-between gap-4">
-              <ul className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-2.5">
+            <div className="mt-7">
+              <ul className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-2.5">
                 {SUPPORTED_INBOX_PROVIDERS.map((provider) => (
                   <li
                     key={provider}
@@ -70,12 +80,6 @@ export function HomepageHero({ heroSection }: Props) {
                   </li>
                 ))}
               </ul>
-
-              <Button asChild className="size-11 shrink-0 rounded-full p-0" size="icon-lg">
-                <AppLink aria-label={heroSection.buttonLeftText} href={heroSection.buttonLeftHref}>
-                  <ArrowUpRight aria-hidden className="size-5" />
-                </AppLink>
-              </Button>
             </div>
           </div>
 

--- a/app/[locale]/(static)/components/homepage-live-demo.tsx
+++ b/app/[locale]/(static)/components/homepage-live-demo.tsx
@@ -33,7 +33,7 @@ export function HomepageLiveDemo({ locale, proof }: { locale: ContentLocale; pro
         </p>
 
         <div className="col-span-12 mt-4">
-          <HeroDemoIframe src={demoSrc} />
+          <HeroDemoIframe className="max-w-7xl" size="article" src={demoSrc} />
         </div>
       </div>
     </MarketingSection>

--- a/app/[locale]/(static)/components/homepage-live-demo.tsx
+++ b/app/[locale]/(static)/components/homepage-live-demo.tsx
@@ -17,7 +17,7 @@ export function HomepageLiveDemo({ locale, proof }: { locale: ContentLocale; pro
 
   return (
     <MarketingSection containerClassName="scroll-mt-6" containerSize="wide" id="live-demo">
-      <div className="marketing-grid items-end gap-y-6">
+      <div className="marketing-grid mx-auto max-w-[84rem] items-end gap-y-6">
         <div className="col-span-12 lg:col-span-5">
           <p className="text-eyebrow flex items-center gap-2">
             <MousePointerClick aria-hidden className="size-3.5" />
@@ -33,7 +33,7 @@ export function HomepageLiveDemo({ locale, proof }: { locale: ContentLocale; pro
         </p>
 
         <div className="col-span-12 mt-4">
-          <HeroDemoIframe className="max-w-7xl" size="article" src={demoSrc} />
+          <HeroDemoIframe size="article" src={demoSrc} />
         </div>
       </div>
     </MarketingSection>

--- a/app/[locale]/(static)/components/homepage-live-demo.tsx
+++ b/app/[locale]/(static)/components/homepage-live-demo.tsx
@@ -33,7 +33,7 @@ export function HomepageLiveDemo({ locale, proof }: { locale: ContentLocale; pro
         </p>
 
         <div className="col-span-12 mt-4">
-          <HeroDemoIframe size="article" src={demoSrc} />
+          <HeroDemoIframe size="full" src={demoSrc} />
         </div>
       </div>
     </MarketingSection>

--- a/app/[locale]/(static)/components/homepage-live-demo.tsx
+++ b/app/[locale]/(static)/components/homepage-live-demo.tsx
@@ -16,7 +16,7 @@ export function HomepageLiveDemo({ locale, proof }: { locale: ContentLocale; pro
       : `https://demo.customermates.com${demoPath}`;
 
   return (
-    <MarketingSection containerClassName="scroll-mt-24" id="live-demo">
+    <MarketingSection containerClassName="scroll-mt-6" containerSize="wide" id="live-demo">
       <div className="marketing-grid items-end gap-y-6">
         <div className="col-span-12 lg:col-span-5">
           <p className="text-eyebrow flex items-center gap-2">

--- a/app/[locale]/(static)/components/rotating-accent.tsx
+++ b/app/[locale]/(static)/components/rotating-accent.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/core/utils/cn";
 import { useHomepageMotion } from "./homepage-motion";
 
 type Props = {
+  activeClassName?: string;
   className?: string;
   words: string[];
 };
@@ -16,7 +17,7 @@ type Props = {
 const ROTATION_INTERVAL_MS = 2_600;
 const ROTATION_DURATION_SECONDS = 0.2;
 
-export function RotatingAccent({ className, words }: Props) {
+export function RotatingAccent({ activeClassName, className, words }: Props) {
   const { ref, shouldAnimate, shouldReduceMotion } = useHomepageMotion<HTMLSpanElement>(0.6);
   const [activeIndex, setActiveIndex] = useState(0);
 
@@ -39,7 +40,7 @@ export function RotatingAccent({ className, words }: Props) {
     <span
       ref={ref}
       aria-hidden
-      className={cn("relative inline-grid overflow-hidden align-bottom", className)}
+      className={cn("relative inline-grid max-w-full overflow-hidden align-bottom", className)}
       data-homepage-motion="rotating-accent"
       data-motion-active={shouldAnimate ? "true" : "false"}
     >
@@ -61,7 +62,7 @@ export function RotatingAccent({ className, words }: Props) {
             ease: [0.22, 1, 0.36, 1],
           }}
         >
-          {activeWord}
+          <span className={cn("inline-block", activeClassName)}>{activeWord}</span>
         </motion.span>
       </AnimatePresence>
     </span>

--- a/app/[locale]/(static)/features/[slug]/page.tsx
+++ b/app/[locale]/(static)/features/[slug]/page.tsx
@@ -8,6 +8,8 @@ import { AcquisitionStoryVisual } from "@/components/marketing/acquisition-story
 import { LandingArticle } from "@/components/marketing/landing-article";
 import { PageHero } from "@/components/marketing/page-hero";
 import { PageEnding } from "@/components/marketing/page-ending";
+import { productDemoForFeature } from "@/components/marketing/product-demo-config";
+import { ProductDemoSection } from "@/components/marketing/product-demo-section";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { featurePagesSource } from "@/core/fumadocs/source";
@@ -45,6 +47,7 @@ export default async function FeaturePage({ params }: Props) {
 
   const MDX = page.data.body;
   const components = getMDXComponents();
+  const demo = productDemoForFeature(slug);
   const visual =
     page.data.acquisition?.visual.kind === "brand-illustration" ? (
       <AcquisitionStoryVisual brief={page.data.acquisition.visual} locale={locale} />
@@ -61,6 +64,8 @@ export default async function FeaturePage({ params }: Props) {
       />
 
       <PageHero {...page.data.hero} visual={visual} />
+
+      {demo ? <ProductDemoSection {...demo} /> : null}
 
       <LandingArticle founderContact items={page.data.toc}>
         <MDX components={components} />

--- a/app/[locale]/(static)/features/components/base-features-section.tsx
+++ b/app/[locale]/(static)/features/components/base-features-section.tsx
@@ -26,7 +26,7 @@ export function BaseFeaturesSection({ features, index, subtitle, title }: Props)
 
             return (
               <article key={feature.title} className="border-b border-r border-border bg-background p-5 sm:p-6">
-                <span className="grid size-8 place-items-center rounded-md border border-border bg-sidebar text-muted-foreground">
+                <span className="grid size-8 place-items-center rounded-md border border-primary/20 bg-primary/10 text-primary">
                   <Icon aria-hidden icon={IconComponent} size="sm" />
                 </span>
 

--- a/app/[locale]/(static)/features/components/why-features-section.tsx
+++ b/app/[locale]/(static)/features/components/why-features-section.tsx
@@ -26,7 +26,9 @@ export function WhyFeaturesSection({ description, features, title }: Props) {
 
             return (
               <article key={feature.title} className="border-b border-r border-border bg-sidebar p-5 sm:p-6">
-                <Icon aria-hidden className="text-muted-foreground" icon={IconComponent} size="md" />
+                <span className="grid size-9 place-items-center rounded-lg border border-primary/20 bg-primary/10 text-primary">
+                  <Icon aria-hidden icon={IconComponent} />
+                </span>
 
                 <h3 className="mt-5 text-sm font-semibold">{feature.title}</h3>
 

--- a/app/[locale]/(static)/features/page.tsx
+++ b/app/[locale]/(static)/features/page.tsx
@@ -9,8 +9,7 @@ import { WhyFeaturesSection } from "./components/why-features-section";
 
 import { Footer } from "@/app/components/footer";
 import { CTASection } from "@/components/marketing/cta-section";
-import { MarketingContainer } from "@/components/marketing/marketing-container";
-import { ProductDemo } from "@/components/marketing/product-demo";
+import { ProductDemoSection } from "@/components/marketing/product-demo-section";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { featuresSource } from "@/core/fumadocs/source";
 
@@ -34,11 +33,7 @@ export default async function FeaturesPage() {
     <div className="flex flex-col items-center justify-center">
       <FeaturesHero {...hero} />
 
-      <section className="w-full border-b border-border bg-background">
-        <MarketingContainer>
-          <ProductDemo hostedBoundary path="/dashboard" presentation="standalone" />
-        </MarketingContainer>
-      </section>
+      <ProductDemoSection hostedBoundary path="/dashboard" />
 
       {features.map((section, index) => (
         <BaseFeaturesSection key={section.title} index={index} {...section} />

--- a/app/[locale]/(static)/for/[industry]/page.tsx
+++ b/app/[locale]/(static)/for/[industry]/page.tsx
@@ -8,6 +8,8 @@ import { AcquisitionStoryVisual } from "@/components/marketing/acquisition-story
 import { LandingArticle } from "@/components/marketing/landing-article";
 import { PageHero } from "@/components/marketing/page-hero";
 import { PageEnding } from "@/components/marketing/page-ending";
+import { productDemoForIndustry } from "@/components/marketing/product-demo-config";
+import { ProductDemoSection } from "@/components/marketing/product-demo-section";
 import { JsonLd } from "@/components/seo/json-ld";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { forPagesSource } from "@/core/fumadocs/source";
@@ -45,6 +47,7 @@ export default async function ForIndustryPage({ params }: Props) {
 
   const MDX = page.data.body;
   const components = getMDXComponents();
+  const demo = productDemoForIndustry(industry);
   const visual =
     page.data.acquisition?.visual.kind === "brand-illustration" ? (
       <AcquisitionStoryVisual brief={page.data.acquisition.visual} locale={locale} />
@@ -61,6 +64,8 @@ export default async function ForIndustryPage({ params }: Props) {
       />
 
       <PageHero {...page.data.hero} visual={visual} />
+
+      {demo ? <ProductDemoSection {...demo} /> : null}
 
       <LandingArticle founderContact items={page.data.toc}>
         <MDX components={components} />

--- a/app/[locale]/(static)/n8n-crm/components/automation-benefits.tsx
+++ b/app/[locale]/(static)/n8n-crm/components/automation-benefits.tsx
@@ -19,7 +19,7 @@ export function AutomationBenefits({ benefitsSection }: Props) {
               key={benefit.title}
               className="border-b border-border p-6 last:border-b-0 sm:border-r sm:p-7 sm:[&:nth-child(even)]:border-r-0 lg:[&:nth-child(even)]:border-r lg:[&:nth-child(3n)]:border-r-0 lg:[&:nth-last-child(-n+3)]:border-b-0"
             >
-              <span className="grid size-9 place-items-center rounded-lg border border-border bg-sidebar text-subdued">
+              <span className="grid size-9 place-items-center rounded-lg border border-primary/20 bg-primary/10 text-primary">
                 <Icon aria-hidden className="size-4" strokeWidth={1.75} />
               </span>
 

--- a/app/components/navigation/__tests__/navigation-switch.test.ts
+++ b/app/components/navigation/__tests__/navigation-switch.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   appMode: "cloud" as "cloud" | "demo",
+  pathname: "/dashboard",
   refresh: vi.fn(),
   closeAllModals: vi.fn(),
   setCompany: vi.fn(),
@@ -17,7 +18,7 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => ({ getAll: () => [] }),
 }));
 vi.mock("@/i18n/navigation", () => ({
-  usePathname: () => "/dashboard",
+  usePathname: () => state.pathname,
   useRouter: () => ({ refresh: state.refresh }),
 }));
 vi.mock("@/core/stores/root-store.provider", () => ({
@@ -32,8 +33,12 @@ vi.mock("@/core/stores/root-store.provider", () => ({
 }));
 
 vi.mock("@/app/components/app-sidebar", () => ({ AppSidebar: () => null }));
-vi.mock("@/app/components/app-topbar", () => ({ AppTopBar: () => jsx("div", { "data-app-topbar": true }) }));
-vi.mock("@/app/components/public-navbar", () => ({ PublicNavbar: () => null }));
+vi.mock("@/app/components/app-topbar", () => ({
+  AppTopBar: () => jsx("div", { "data-app-topbar": true }),
+}));
+vi.mock("@/app/components/public-navbar", () => ({
+  PublicNavbar: () => jsx("div", { "data-public-navbar": true }),
+}));
 vi.mock("@/app/components/shell-header", () => ({ ShellHeader: () => null }));
 vi.mock("@/app/[locale]/(static)/docs/components/docs-sidebar", () => ({
   DocsSidebar: () => null,
@@ -89,6 +94,7 @@ let root: Root;
 beforeEach(() => {
   vi.clearAllMocks();
   state.appMode = "cloud";
+  state.pathname = "/dashboard";
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -153,5 +159,45 @@ describe("NavigationSwitch account-state refresh", () => {
     expect(scrollport).toBe(page?.parentElement?.parentElement);
     expect(scrollport?.className).toContain("overflow-y-auto");
     expect(scrollport?.className).toContain("[--table-sticky-top:4rem]");
+  });
+
+  it("keeps the public header and page in one route-resetting scrollport", () => {
+    state.pathname = "/styleguide";
+
+    act(() => {
+      root.render(
+        jsx(NavigationSwitch, {
+          ...allowedProps(),
+          children: jsx("div", { "data-page-content": true }),
+        }),
+      );
+    });
+
+    const navbar = container.querySelector<HTMLElement>("[data-public-navbar]");
+    const header = navbar?.parentElement;
+    const page = container.querySelector<HTMLElement>("[data-page-content]");
+    const scrollport = container.querySelector<HTMLElement>("[data-public-scrollport]");
+
+    expect(header?.tagName).toBe("HEADER");
+    expect(header?.parentElement).toBe(scrollport);
+    expect(header?.className).toContain("sticky");
+    expect(page?.closest("[data-public-scrollport]")).toBe(scrollport);
+    expect(scrollport?.className).toContain("h-svh");
+    expect(scrollport?.className).toContain("overflow-y-auto");
+    expect(scrollport?.className).toContain("[--table-sticky-top:4rem]");
+    expect(scrollport?.className).toContain("[--toc-sticky-top:4rem]");
+    expect(scrollport?.className).toContain("[--toc-anchor-offset:5rem]");
+
+    if (scrollport) scrollport.scrollTop = 480;
+    state.pathname = "/styleguide/patterns";
+    act(() => {
+      root.render(
+        jsx(NavigationSwitch, {
+          ...allowedProps(),
+          children: jsx("div", { "data-page-content": true }),
+        }),
+      );
+    });
+    expect(scrollport?.scrollTop).toBe(0);
   });
 });

--- a/app/components/navigation/__tests__/public-navbar-menu.test.ts
+++ b/app/components/navigation/__tests__/public-navbar-menu.test.ts
@@ -4,7 +4,7 @@ import type { Root } from "react-dom/client";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Boxes, UsersRound } from "lucide-react";
+import { Boxes, Cable, FileText, Inbox, Megaphone, Server, UsersRound } from "lucide-react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/shared/app-link", () => ({
@@ -43,6 +43,7 @@ import {
   PublicNavbarMenu,
   resolveActivePublicNavGroup,
   type PublicNavGroup,
+  type PublicNavLink,
 } from "../public-navbar-menu";
 
 const groups: PublicNavGroup[] = [
@@ -51,8 +52,12 @@ const groups: PublicNavGroup[] = [
     columns: 2,
     icon: Boxes,
     links: [
-      { href: "/features/self-hosted", title: "Self-hosted" },
-      { href: "/features/all", title: "All features" },
+      {
+        icon: Server,
+        href: "/features/self-hosted",
+        title: "Self-hosted",
+      },
+      { href: "/features/all", icon: Boxes, title: "All features" },
     ],
     id: "product",
     title: "Product",
@@ -63,8 +68,8 @@ const groups: PublicNavGroup[] = [
     id: "solutions",
     icon: UsersRound,
     links: [
-      { href: "/for/agencies", title: "Agencies" },
-      { href: "/for", title: "All solutions" },
+      { href: "/for/agencies", icon: Megaphone, title: "Agencies" },
+      { href: "/for", icon: UsersRound, title: "All solutions" },
     ],
     title: "Solutions",
   },
@@ -120,6 +125,25 @@ describe("PublicNavbarMenu", () => {
     expect(markup).not.toContain("Find a solution");
     expect(markup).not.toContain("<section");
     expect(markup).not.toContain("<footer");
+    expect(markup.match(/data-public-nav-icon="true"/gu)).toHaveLength(4);
+  });
+
+  it("renders generic navigation icons as decorative link visuals", () => {
+    act(() => root?.render(menu()));
+
+    const product = container?.querySelector<HTMLButtonElement>('[data-public-nav-trigger="product"]');
+    if (!product) throw new Error("product navigation trigger did not render");
+    act(() => product.click());
+
+    const link = container?.querySelector<HTMLAnchorElement>('a[href="/features/self-hosted"]');
+    const icon = link?.querySelector<HTMLElement>('[data-public-nav-icon="true"]');
+    if (!link || !icon) throw new Error("generic navigation icon did not render");
+
+    expect(icon.getAttribute("aria-hidden")).toBe("true");
+    expect(icon.classList.contains("text-primary")).toBe(false);
+    expect(icon.querySelector("svg")).not.toBeNull();
+    expect(link.querySelector("[data-public-nav-mark]")).toBeNull();
+    expect(link.textContent).toContain("Self-hosted");
   });
 
   it("opens one panel at a time, restores focus on Escape, and closes on navigation", async () => {
@@ -539,11 +563,17 @@ describe("PublicNavbarMenu", () => {
     const productGroup = groups[0];
     if (!productGroup) throw new Error("product navigation fixture did not render");
 
-    const unifiedInbox = {
+    const unifiedInbox: PublicNavLink = {
+      icon: Inbox,
       href: "/features/unified-inbox",
       title: "Unified inbox",
     };
-    const whatsapp = { activeMatch: false, href: "/features/unified-inbox", title: "WhatsApp" };
+    const whatsapp: PublicNavLink = {
+      activeMatch: false,
+      href: "/features/unified-inbox",
+      mark: { kind: "channel", provider: "whatsapp" },
+      title: "WhatsApp",
+    };
     const overlappingGroups: PublicNavGroup[] = [
       {
         ...productGroup,
@@ -555,9 +585,18 @@ describe("PublicNavbarMenu", () => {
         icon: Boxes,
         id: "integrations",
         links: [
-          { href: "/features/linkedin-integration", title: "LinkedIn" },
+          {
+            href: "/features/linkedin-integration",
+            mark: { kind: "channel", provider: "linkedin" },
+            title: "LinkedIn",
+          },
           whatsapp,
-          { activeMatch: false, href: "/docs/mcp", title: "MCP guide" },
+          {
+            activeMatch: false,
+            icon: Cable,
+            href: "/docs/mcp",
+            title: "MCP guide",
+          },
         ],
         title: "Integrations",
       },
@@ -567,8 +606,8 @@ describe("PublicNavbarMenu", () => {
         icon: UsersRound,
         id: "resources",
         links: [
-          { href: "/docs", title: "Documentation" },
-          { href: "/docs/mcp", title: "MCP guide" },
+          { href: "/docs", icon: FileText, title: "Documentation" },
+          { href: "/docs/mcp", icon: Cable, title: "MCP guide" },
         ],
         title: "Resources",
       },

--- a/app/components/navigation/navigation-switch.tsx
+++ b/app/components/navigation/navigation-switch.tsx
@@ -9,7 +9,7 @@ import type { AccountState } from "@/features/auth/account-state";
 import type { SidebarUser } from "./sidebar-user";
 
 import { useSearchParams } from "next/navigation";
-import { useEffect, useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import * as Sentry from "@sentry/nextjs";
 
 import { AppSidebar } from "../app-sidebar";
@@ -83,6 +83,7 @@ export function NavigationSwitch({
     isRegistered,
   });
   const rootStore = useRootStore();
+  const publicScrollportRef = useRef<HTMLDivElement>(null);
   const { userStore, companyStore, subscriptionStore, terminologyStore } = rootStore;
   const accountAllowed = currentAccountState === "allowed";
   const protectedEnhancementsAllowed = accountAllowed && shellMode === "app";
@@ -129,6 +130,11 @@ export function NavigationSwitch({
     terminology,
   ]);
 
+  useLayoutEffect(() => {
+    if (shellMode !== "public" || !publicScrollportRef.current) return;
+    publicScrollportRef.current.scrollTop = 0;
+  }, [pathname, shellMode]);
+
   let shell: React.ReactNode;
   if (shellMode === "docs") {
     shell = (
@@ -144,12 +150,16 @@ export function NavigationSwitch({
     );
   } else if (shellMode === "public") {
     shell = (
-      <div className="h-svh flex">
-        <main className="flex flex-col relative flex-1 overflow-y-auto bg-background min-w-0 [--table-sticky-top:4rem] [--toc-sticky-top:4rem] [--toc-anchor-offset:5rem] xl:[--table-sticky-top:3.5rem] xl:[--toc-sticky-top:3.5rem] xl:[--toc-anchor-offset:4.5rem]">
-          <header className="sticky top-0 z-50 flex flex-col bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/75">
-            <PublicNavbar accountState={currentAccountState} hasValidSession={hasValidSession} />
-          </header>
+      <div
+        ref={publicScrollportRef}
+        data-public-scrollport
+        className="relative h-svh overflow-y-auto bg-background [--table-sticky-top:4rem] [--toc-sticky-top:4rem] [--toc-anchor-offset:5rem] xl:[--table-sticky-top:3.5rem] xl:[--toc-sticky-top:3.5rem] xl:[--toc-anchor-offset:4.5rem]"
+      >
+        <header className="sticky top-0 z-50 flex flex-col bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/75">
+          <PublicNavbar accountState={currentAccountState} hasValidSession={hasValidSession} />
+        </header>
 
+        <main className="relative flex min-w-0 flex-col">
           <div className="flex flex-col flex-1 overflow-x-clip">{children}</div>
         </main>
       </div>

--- a/app/components/navigation/public-navbar-menu.tsx
+++ b/app/components/navigation/public-navbar-menu.tsx
@@ -14,12 +14,14 @@ import { ProviderMark } from "@/components/marketing/visuals/native-visual-primi
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/core/utils/cn";
 
-export type PublicNavLink = {
+type PublicNavLinkBase = {
   activeMatch?: boolean;
   href: string;
-  mark?: PublicNavMark;
   title: string;
 };
+
+export type PublicNavLink = PublicNavLinkBase &
+  ({ icon: LucideIcon; mark?: never } | { icon?: never; mark: PublicNavMark });
 
 type PublicNavAgentProvider = Extract<AiClientLogoProvider, "chatgpt" | "claude" | "codex" | "cursor" | "gemini">;
 
@@ -118,6 +120,14 @@ export function PublicNavLinkMark({ mark }: { mark: PublicNavMark }) {
       data-public-nav-mark={`${mark.kind}:${mark.provider}`}
     >
       {icon}
+    </span>
+  );
+}
+
+export function PublicNavLinkIcon({ icon: LinkIcon }: { icon: LucideIcon }) {
+  return (
+    <span aria-hidden className="grid h-[18px] w-[22px] shrink-0 place-items-center" data-public-nav-icon="true">
+      <LinkIcon className="size-4" />
     </span>
   );
 }
@@ -340,7 +350,7 @@ export function PublicNavbarMenu({ ariaLabel, docsLabel, groups, onNavigate, pat
             className={cn(
               "max-h-[min(34rem,calc(100svh-5rem))] overflow-y-auto overscroll-contain rounded-lg border-0 bg-transparent p-0 shadow-none transition-[width] duration-200 ease-marketing data-[state=closed]:pointer-events-none data-[state=closed]:invisible data-[state=closed]:animate-none data-[state=open]:animate-none motion-reduce:transition-none",
               visibleColumnCount === 3
-                ? "w-[min(45rem,calc(100vw-2rem))]"
+                ? "w-[min(48rem,calc(100vw-2rem))]"
                 : visibleLinkCount <= 4
                   ? "w-[min(28rem,calc(100vw-2rem))]"
                   : "w-[min(34rem,calc(100vw-2rem))]",
@@ -396,7 +406,11 @@ export function PublicNavbarMenu({ ariaLabel, docsLabel, groups, onNavigate, pat
                             onKeyDown={(event) => handlePanelLinkKeyDown(event, group.id)}
                             onNavigate={navigate}
                           >
-                            {link.mark ? <PublicNavLinkMark mark={link.mark} /> : null}
+                            {link.mark ? (
+                              <PublicNavLinkMark mark={link.mark} />
+                            ) : (
+                              <PublicNavLinkIcon icon={link.icon} />
+                            )}
 
                             <span className="min-w-0 truncate">{link.title}</span>
                           </AppLink>

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -2,7 +2,35 @@
 
 import type { AccountState } from "@/features/auth/account-state";
 
-import { BookOpen, Boxes, CircleDollarSign, FileText, LogOut, Menu, Plug, UsersRound, X } from "lucide-react";
+import {
+  BookOpen,
+  Bot,
+  Boxes,
+  BriefcaseBusiness,
+  Building2,
+  Cable,
+  CheckCircle2,
+  CircleDollarSign,
+  FileText,
+  GitCompareArrows,
+  Github,
+  HeartPulse,
+  Inbox,
+  LayoutGrid,
+  LogOut,
+  Megaphone,
+  Menu,
+  Plug,
+  Presentation,
+  Rocket,
+  Server,
+  Store,
+  TrendingUp,
+  UserRoundSearch,
+  Users,
+  UsersRound,
+  X,
+} from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { observer } from "mobx-react-lite";
@@ -31,6 +59,7 @@ import { runUserAction } from "@/core/errors/report-application-error";
 import { resolvePublicNavbarActions } from "./navigation/public-navbar-model";
 import {
   isPrimaryPublicNavLink,
+  PublicNavLinkIcon,
   PublicNavLinkMark,
   PublicNavbarMenu,
   type PublicNavGroup,
@@ -68,39 +97,48 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
       id: "product",
       links: [
         {
+          icon: Inbox,
           href: "/features/unified-inbox",
           title: t("NavigationBar.public.unifiedInbox"),
         },
         {
+          icon: Users,
           href: "/features/contact-management",
           title: t("NavigationBar.public.contactManagement"),
         },
         {
+          icon: TrendingUp,
           href: "/features/pipeline",
           title: t("NavigationBar.public.pipeline"),
         },
         {
+          icon: TrendingUp,
           href: "/features/sales-tracking",
           title: t("NavigationBar.public.salesTracking"),
         },
         {
+          icon: CheckCircle2,
           href: "/features/task-management",
           title: t("NavigationBar.public.taskManagement"),
         },
         {
+          icon: LayoutGrid,
           href: "/features/cloud-crm",
           title: t("NavigationBar.public.cloudCrm"),
         },
         {
+          icon: Server,
           href: "/features/self-hosted",
           title: t("NavigationBar.public.selfHosted"),
         },
         {
           activeMatch: false,
+          icon: Cable,
           href: "/docs/mcp",
           title: t("NavigationBar.public.mcp"),
         },
         {
+          icon: Boxes,
           href: "/features/all",
           title: t("NavigationBar.public.allFeatures"),
         },
@@ -114,38 +152,47 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
       id: "solutions",
       links: [
         {
+          icon: BriefcaseBusiness,
           href: "/for/professional-services",
           title: t("NavigationBar.public.professionalServices"),
         },
         {
+          icon: Megaphone,
           href: "/for/agencies",
           title: t("NavigationBar.public.agencies"),
         },
         {
+          icon: Presentation,
           href: "/for/consultants",
           title: t("NavigationBar.public.consultants"),
         },
         {
+          icon: UserRoundSearch,
           href: "/for/recruiting",
           title: t("NavigationBar.public.recruiting"),
         },
         {
+          icon: HeartPulse,
           href: "/for/healthcare",
           title: t("NavigationBar.public.healthcare"),
         },
         {
+          icon: Building2,
           href: "/for/property-management",
           title: t("NavigationBar.public.propertyManagement"),
         },
         {
+          icon: Rocket,
           href: "/for/startups",
           title: t("NavigationBar.public.startups"),
         },
         {
+          icon: Store,
           href: "/for/smb",
           title: t("NavigationBar.public.smallBusiness"),
         },
         {
+          icon: UsersRound,
           href: "/for",
           title: t("NavigationBar.public.allSolutions"),
         },
@@ -246,15 +293,22 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
       id: "resources",
       links: [
         {
+          icon: BookOpen,
           href: "/blog",
           title: t("NavigationBar.public.blog"),
         },
-        { href: "/compare", title: t("NavigationBar.public.compare") },
         {
+          icon: GitCompareArrows,
+          href: "/compare",
+          title: t("NavigationBar.public.compare"),
+        },
+        {
+          icon: Bot,
           href: "/blog/agentic-crm",
           title: t("NavigationBar.public.agenticCrm"),
         },
         {
+          icon: Github,
           href: "/blog/open-source-crm",
           title: t("NavigationBar.public.openSourceCrm"),
         },
@@ -434,7 +488,11 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
                                   href={link.href}
                                   onNavigate={closeMenu}
                                 >
-                                  {link.mark ? <PublicNavLinkMark mark={link.mark} /> : null}
+                                  {link.mark ? (
+                                    <PublicNavLinkMark mark={link.mark} />
+                                  ) : (
+                                    <PublicNavLinkIcon icon={link.icon} />
+                                  )}
 
                                   {link.title}
                                 </AppLink>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -77,6 +77,7 @@ export default async function RootLayout({ children }: Props) {
     <html
       suppressHydrationWarning
       className={`${latin.variable} ${mono.variable} ${serif.variable} ${latin.className}`}
+      data-scroll-behavior="smooth"
       lang={displayLanguage}
     >
       <body className="h-svh flex flex-col font-sans antialiased">

--- a/components/forms/form-checkbox.tsx
+++ b/components/forms/form-checkbox.tsx
@@ -14,22 +14,26 @@ import { useFormFieldErrors } from "./use-form-field";
 type Props = {
   id: string;
   label?: ReactNode;
+  errorMessage?: ReactNode;
   required?: boolean;
   className?: string;
   containerClassName?: string;
 };
 
-export const FormCheckbox = observer(({ id, label, required, className, containerClassName }: Props) => {
+export const FormCheckbox = observer(({ id, label, errorMessage, required, className, containerClassName }: Props) => {
   const store = useAppForm();
   const checked = Boolean(store?.getValue(id));
-  const { hasError } = useFormFieldErrors(id);
+  const { errors, hasError } = useFormFieldErrors(id);
   const isLoading = store?.isLoading ?? false;
   const isReadOnly = !isLoading && (store?.isReadOnly ?? false);
+  const errorId = `${id}-error`;
+  const resolvedErrorMessage = errorMessage ?? (Array.isArray(errors) ? errors.join(" ") : errors);
 
   return (
     <div className={cn("space-y-1.5", containerClassName)}>
       <div className="flex items-center gap-2">
         <Checkbox
+          aria-describedby={hasError ? errorId : undefined}
           aria-invalid={hasError}
           aria-readonly={isReadOnly || undefined}
           aria-required={required}
@@ -50,6 +54,12 @@ export const FormCheckbox = observer(({ id, label, required, className, containe
           </FormLabel>
         )}
       </div>
+
+      {hasError && resolvedErrorMessage ? (
+        <p className="text-xs text-destructive" id={errorId} role="alert">
+          {resolvedErrorMessage}
+        </p>
+      ) : null}
     </div>
   );
 });

--- a/components/marketing/landing-article.tsx
+++ b/components/marketing/landing-article.tsx
@@ -20,7 +20,7 @@ export function LandingArticle({ children, founderContact = false, items }: Prop
       tone="canvas"
     >
       <Toc asideFooter={founderContact ? <FounderContactCard /> : undefined} items={items} layout="article">
-        <div className="prose prose-sm prose-neutral mx-auto max-w-[96ch] dark:prose-invert prose-headings:text-balance prose-headings:tracking-tight prose-a:font-medium prose-a:decoration-primary/40 prose-a:underline-offset-4 prose-img:rounded-card lg:mx-0 lg:max-w-none [&>ol]:max-w-[82ch] [&>p]:max-w-[82ch] [&>ul]:max-w-[82ch]">
+        <div className="prose prose-sm prose-neutral mx-auto max-w-[96ch] dark:prose-invert prose-headings:font-medium prose-headings:text-balance prose-headings:tracking-tight prose-a:font-medium prose-a:decoration-primary/40 prose-a:underline-offset-4 prose-img:rounded-card lg:mx-0 lg:max-w-none [&>ol]:max-w-[82ch] [&>p]:max-w-[82ch] [&>ul]:max-w-[82ch]">
           {children}
         </div>
       </Toc>

--- a/components/marketing/marketing-container.tsx
+++ b/components/marketing/marketing-container.tsx
@@ -5,8 +5,13 @@ import { cn } from "@/core/utils/cn";
 type Props = {
   children: ReactNode;
   className?: string;
+  size?: "default" | "wide";
 };
 
-export function MarketingContainer({ children, className }: Props) {
-  return <div className={cn("marketing-container", className)}>{children}</div>;
+export function MarketingContainer({ children, className, size = "default" }: Props) {
+  return (
+    <div className={cn("marketing-container", size === "wide" && "marketing-container-wide", className)}>
+      {children}
+    </div>
+  );
 }

--- a/components/marketing/marketing-section.tsx
+++ b/components/marketing/marketing-section.tsx
@@ -18,6 +18,7 @@ type Props = {
   id?: string;
   title?: string;
   tone?: MarketingSectionTone;
+  containerSize?: "default" | "wide";
 };
 
 export function MarketingSection({
@@ -32,11 +33,12 @@ export function MarketingSection({
   id,
   title,
   tone = "page",
+  containerSize = "default",
 }: Props) {
   const Heading = headingAs ?? "h2";
   const hasHeader = Boolean(title || description);
   const content = (
-    <MarketingContainer className={containerClassName}>
+    <MarketingContainer className={containerClassName} size={containerSize}>
       {hasHeader ? (
         <div className="mx-auto max-w-3xl text-center">
           {title ? <Heading className={cn("text-display-sm m-0", headingClassName)}>{title}</Heading> : null}

--- a/components/marketing/page-hero.tsx
+++ b/components/marketing/page-hero.tsx
@@ -97,7 +97,7 @@ export function PageHero(props: Props) {
               </div>
             ) : null}
 
-            <h1 className={cn("text-display m-0", !visual && "max-w-5xl")}>
+            <h1 className={cn("m-0", visual ? "text-display-sm" : "text-display max-w-5xl")}>
               {title}
 
               {titleAccent ? <span> {titleAccent}</span> : null}

--- a/components/marketing/product-demo-config.ts
+++ b/components/marketing/product-demo-config.ts
@@ -1,0 +1,46 @@
+import type { ProductDemoPath } from "./product-demo";
+
+export type ProductDemoConfig = {
+  hostedBoundary?: boolean;
+  path: ProductDemoPath;
+};
+
+export const FEATURE_PRODUCT_DEMOS = {
+  "account-management": { path: "/organizations" },
+  api: { path: "/profile/api-keys" },
+  "cloud-crm": { hostedBoundary: true, path: "/dashboard" },
+  "contact-management": { path: "/contacts" },
+  "crm-integration": { path: "/company/webhooks" },
+  "customer-service": { hostedBoundary: true, path: "/inbox" },
+  "email-integration": { hostedBoundary: true, path: "/inbox" },
+  "follow-up": { path: "/tasks" },
+  integrations: { hostedBoundary: true, path: "/profile/connected-accounts" },
+  "lead-management": { path: "/contacts" },
+  "lead-tracking": { path: "/deals" },
+  "linkedin-integration": { hostedBoundary: true, path: "/inbox" },
+  "outlook-integration": { hostedBoundary: true, path: "/inbox" },
+  pipeline: { path: "/deals" },
+  "project-management": { path: "/tasks" },
+  reporting: { path: "/dashboard" },
+  "sales-automation": { path: "/company/webhooks" },
+  "sales-tracking": { path: "/deals" },
+  sales: { path: "/deals" },
+  "self-hosted": { hostedBoundary: true, path: "/dashboard" },
+  "simple-crm": { path: "/dashboard" },
+  "slack-integration": { path: "/company/webhooks" },
+  "task-management": { path: "/tasks" },
+  "unified-inbox": { hostedBoundary: true, path: "/inbox" },
+  "workflow-automation": { path: "/company/webhooks" },
+} as const satisfies Record<string, ProductDemoConfig>;
+
+export const INDUSTRY_PRODUCT_DEMOS = {
+  "professional-services": { path: "/deals" },
+} as const satisfies Record<string, ProductDemoConfig>;
+
+export function productDemoForFeature(slug: string): ProductDemoConfig | null {
+  return slug in FEATURE_PRODUCT_DEMOS ? FEATURE_PRODUCT_DEMOS[slug as keyof typeof FEATURE_PRODUCT_DEMOS] : null;
+}
+
+export function productDemoForIndustry(slug: string): ProductDemoConfig | null {
+  return slug in INDUSTRY_PRODUCT_DEMOS ? INDUSTRY_PRODUCT_DEMOS[slug as keyof typeof INDUSTRY_PRODUCT_DEMOS] : null;
+}

--- a/components/marketing/product-demo-section.tsx
+++ b/components/marketing/product-demo-section.tsx
@@ -1,0 +1,12 @@
+import type { ProductDemoConfig } from "./product-demo-config";
+
+import { MarketingSection } from "./marketing-section";
+import { ProductDemo } from "./product-demo";
+
+export function ProductDemoSection({ hostedBoundary = false, path }: ProductDemoConfig) {
+  return (
+    <MarketingSection divider className="py-12 sm:py-16 lg:py-20" containerSize="wide">
+      <ProductDemo hostedBoundary={hostedBoundary} path={path} presentation="standalone" />
+    </MarketingSection>
+  );
+}

--- a/components/marketing/product-demo.tsx
+++ b/components/marketing/product-demo.tsx
@@ -6,7 +6,17 @@ import { BrowserFrame } from "./browser-frame";
 import { cn } from "@/core/utils/cn";
 import { type ContentLocale, contentLocaleOrDefault } from "@/i18n/locale-registry";
 
-export const PRODUCT_DEMO_PATHS = ["/dashboard", "/inbox", "/deals"] as const;
+export const PRODUCT_DEMO_PATHS = [
+  "/dashboard",
+  "/inbox",
+  "/deals",
+  "/contacts",
+  "/organizations",
+  "/tasks",
+  "/profile/api-keys",
+  "/profile/connected-accounts",
+  "/company/webhooks",
+] as const;
 
 export type ProductDemoPath = (typeof PRODUCT_DEMO_PATHS)[number];
 export type ProductDemoPresentation = "article" | "standalone";
@@ -28,8 +38,26 @@ const COPY = {
     guideLabel: "Try these three things",
     guidedTasks: {
       "/dashboard": ["Scan the seeded overview", "Open a core CRM record", "Check how the workspace is organized"],
+      "/contacts": ["Scan the contact list", "Open one seeded contact", "Review its linked CRM context"],
       "/deals": ["Review the pipeline stages", "Open one seeded deal", "Compare total and weighted value"],
       "/inbox": ["Open a seeded conversation", "Check its participant context", "Compare the connected channels"],
+      "/organizations": ["Scan the account list", "Open one seeded organization", "Review its linked records"],
+      "/tasks": ["Switch between task views", "Open one seeded task", "Review its owner and linked records"],
+      "/profile/api-keys": [
+        "Review the API-key controls",
+        "Check how a key is created",
+        "Review key status and access",
+      ],
+      "/profile/connected-accounts": [
+        "Review the available providers",
+        "Open one connected account",
+        "Check its sharing and sync state",
+      ],
+      "/company/webhooks": [
+        "Review the configured endpoints",
+        "Open the create-webhook flow",
+        "Inspect the available event choices",
+      ],
     },
     standardDisclosure:
       "Public, seeded product demo. It uses synthetic sample data; no customer account or customer data is shown. When Mate is enabled for this demo environment, it starts closed so the CRM workflow stays unobstructed.",
@@ -37,21 +65,66 @@ const COPY = {
       "Public, seeded demo of hosted Customermates. It uses synthetic sample data; no customer account or customer data is shown. When Mate is enabled for this demo environment, it starts closed. This illustrates the managed product UI, not a self-hosted deployment.",
     titles: {
       "/dashboard": "Customermates dashboard with synthetic sample data",
+      "/contacts": "Customermates contact list with synthetic sample data",
       "/deals": "Customermates deal pipeline with synthetic sample data",
       "/inbox": "Customermates unified inbox with synthetic sample data",
+      "/organizations": "Customermates organization list with synthetic sample data",
+      "/tasks": "Customermates task workspace with synthetic sample data",
+      "/profile/api-keys": "Customermates API-key settings with synthetic sample data",
+      "/profile/connected-accounts": "Customermates connected-account settings with synthetic sample data",
+      "/company/webhooks": "Customermates webhook settings with synthetic sample data",
     },
   },
   de: {
     eyebrow: "Produkt kennenlernen",
-    fallback: "Die eingebettete Demo braucht länger als erwartet. Öffne sie in einem neuen Tab, um weiterzumachen.",
-    guideLabel: "Probiere diese drei Schritte",
+    fallback:
+      "Die eingebettete Demo braucht länger als erwartet. Öffnen Sie sie in einem neuen Tab, um weiterzumachen.",
+    guideLabel: "Probieren Sie diese drei Schritte",
     guidedTasks: {
-      "/dashboard": ["Verschaffe dir einen Überblick", "Öffne einen CRM-Datensatz", "Prüfe den Aufbau des Workspaces"],
-      "/deals": ["Prüfe die Pipeline-Phasen", "Öffne einen Beispiel-Deal", "Vergleiche Gesamt- und gewichteten Wert"],
+      "/dashboard": [
+        "Verschaffen Sie sich einen Überblick",
+        "Öffnen Sie einen CRM-Datensatz",
+        "Prüfen Sie den Aufbau des Workspaces",
+      ],
+      "/contacts": [
+        "Prüfen Sie die Kontaktliste",
+        "Öffnen Sie einen Beispielkontakt",
+        "Prüfen Sie den verknüpften CRM-Kontext",
+      ],
+      "/deals": [
+        "Prüfen Sie die Pipeline-Phasen",
+        "Öffnen Sie einen Beispiel-Deal",
+        "Vergleichen Sie Gesamt- und gewichteten Wert",
+      ],
       "/inbox": [
-        "Öffne eine Beispiel-Konversation",
-        "Prüfe den Teilnehmerkontext",
-        "Vergleiche die verbundenen Kanäle",
+        "Öffnen Sie eine Beispiel-Konversation",
+        "Prüfen Sie den Teilnehmerkontext",
+        "Vergleichen Sie die verbundenen Kanäle",
+      ],
+      "/organizations": [
+        "Prüfen Sie die Unternehmensliste",
+        "Öffnen Sie ein Beispielunternehmen",
+        "Prüfen Sie die verknüpften Datensätze",
+      ],
+      "/tasks": [
+        "Wechseln Sie zwischen den Aufgabenansichten",
+        "Öffnen Sie eine Beispielaufgabe",
+        "Prüfen Sie Verantwortliche und Verknüpfungen",
+      ],
+      "/profile/api-keys": [
+        "Prüfen Sie die API-Key-Verwaltung",
+        "Öffnen Sie den Erstellungsablauf",
+        "Prüfen Sie Status und Zugriff",
+      ],
+      "/profile/connected-accounts": [
+        "Prüfen Sie die verfügbaren Anbieter",
+        "Öffnen Sie ein verbundenes Konto",
+        "Prüfen Sie Freigabe und Synchronisierung",
+      ],
+      "/company/webhooks": [
+        "Prüfen Sie die konfigurierten Endpunkte",
+        "Öffnen Sie den Webhook-Dialog",
+        "Prüfen Sie die verfügbaren Ereignisse",
       ],
     },
     standardDisclosure:
@@ -60,8 +133,14 @@ const COPY = {
       "Öffentliche, vorbefüllte Demo der gehosteten Customermates-Version mit synthetischen Beispieldaten. Es werden weder ein Kundenkonto noch Kundendaten angezeigt. Wenn Mate für diese Demo-Umgebung aktiviert ist, startet es geschlossen. Die Demo zeigt die Managed-Cloud-Oberfläche, kein Self-Hosted-Deployment.",
     titles: {
       "/dashboard": "Customermates-Dashboard mit synthetischen Beispieldaten",
+      "/contacts": "Customermates-Kontaktliste mit synthetischen Beispieldaten",
       "/deals": "Customermates-Deal-Pipeline mit synthetischen Beispieldaten",
       "/inbox": "Einheitlicher Customermates-Posteingang mit synthetischen Beispieldaten",
+      "/organizations": "Customermates-Unternehmensliste mit synthetischen Beispieldaten",
+      "/tasks": "Customermates-Aufgabenbereich mit synthetischen Beispieldaten",
+      "/profile/api-keys": "Customermates-API-Key-Einstellungen mit synthetischen Beispieldaten",
+      "/profile/connected-accounts": "Einstellungen für verbundene Customermates-Konten mit Beispieldaten",
+      "/company/webhooks": "Customermates-Webhook-Einstellungen mit synthetischen Beispieldaten",
     },
   },
 } as const satisfies Record<ContentLocale, DemoCopy>;
@@ -88,7 +167,11 @@ export function ProductDemo({ hostedBoundary = false, path, presentation = "arti
   const disclosure = hostedBoundary ? copy.hostedDisclosure : copy.standardDisclosure;
 
   return (
-    <figure className="not-prose my-12" data-product-demo={path} data-product-demo-presentation={presentation}>
+    <figure
+      className={cn("not-prose", presentation === "article" ? "my-12" : "my-0")}
+      data-product-demo={path}
+      data-product-demo-presentation={presentation}
+    >
       <figcaption
         className={cn(
           "mb-5 grid gap-5 sm:grid-cols-[minmax(0,1fr)_minmax(16rem,.75fr)] sm:items-start",
@@ -120,7 +203,7 @@ export function ProductDemo({ hostedBoundary = false, path, presentation = "arti
 
       <BrowserFrame
         fallbackMessage={copy.fallback}
-        size="article"
+        size={presentation === "standalone" ? "full" : "article"}
         src={buildProductDemoUrl(locale, path)}
         title={copy.titles[path]}
       />

--- a/components/shared/toc.tsx
+++ b/components/shared/toc.tsx
@@ -35,7 +35,7 @@ export function Toc({ items, children, actions, asideFooter, layout = "default" 
 
         <aside
           className={cn(
-            "top-[var(--toc-sticky-top,0px)] min-h-0 shrink-0 self-start lg:flex lg:max-h-[calc(100svh-var(--toc-sticky-top,0px))] lg:flex-col",
+            "top-[var(--toc-sticky-top,0px)] min-h-0 shrink-0 self-start lg:flex lg:max-h-[calc(100svh-var(--toc-viewport-offset,0px)-var(--toc-sticky-top,0px))] lg:flex-col",
             hasMobileFooter ? "static mt-10 flex flex-col lg:sticky lg:mt-0" : "sticky hidden",
             layout === "article" ? "lg:w-60" : "max-w-68",
           )}

--- a/content/auth/de/forgot-password.mdx
+++ b/content/auth/de/forgot-password.mdx
@@ -1,4 +1,4 @@
 ---
 title: CRM-Konto Passwort zurücksetzen
-description: Setzen Sie Ihr Customermates-Passwort zurück. Geben Sie Ihre E-Mail-Adresse ein und wir senden Ihnen einen sicheren Link zum Zurücksetzen Ihres Passworts.
+description: Setze dein Customermates-Passwort zurück. Gib deine E-Mail-Adresse ein und wir senden dir einen sicheren Link zum Zurücksetzen deines Passworts.
 ---

--- a/content/auth/de/reset-password.mdx
+++ b/content/auth/de/reset-password.mdx
@@ -1,4 +1,4 @@
 ---
-title: Neues Passwort für Ihr Konto erstellen
-description: Erstellen Sie ein neues Passwort für Ihr Customermates-Konto. Geben Sie Ihr neues Passwort ein, um wieder Zugriff auf Ihr Konto zu erhalten.
+title: Neues Passwort für dein Konto erstellen
+description: Erstelle ein neues Passwort für dein Customermates-Konto. Gib dein neues Passwort ein, um wieder Zugriff auf dein Konto zu erhalten.
 ---

--- a/content/auth/de/signin.mdx
+++ b/content/auth/de/signin.mdx
@@ -1,4 +1,4 @@
 ---
-title: Bei Ihrem CRM-Konto anmelden
-description: Melden Sie sich bei Customermates an - dem agentischen Open-Source-CRM mit MCP-Zugriff für externe KI-Clients, offenen Automatisierungsschnittstellen und einer verwalteten Datenbank in einer EU-Region.
+title: Bei deinem CRM-Konto anmelden
+description: Melde dich bei Customermates an - dem agentischen Open-Source-CRM mit MCP-Zugriff für externe KI-Clients, offenen Automatisierungsschnittstellen und einer verwalteten Datenbank in einer EU-Region.
 ---

--- a/content/auth/de/signup.mdx
+++ b/content/auth/de/signup.mdx
@@ -1,4 +1,4 @@
 ---
 title: Kostenloses CRM-Konto erstellen
-description: Erstellen Sie Ihr Customermates-Konto in Minuten. Agentisches Open-Source-CRM mit MCP-Zugriff für externe KI-Clients, offenen Automatisierungsschnittstellen und einer verwalteten Datenbank in einer EU-Region.
+description: Erstelle dein Customermates-Konto in Minuten. Agentisches Open-Source-CRM mit MCP-Zugriff für externe KI-Clients, offenen Automatisierungsschnittstellen und einer verwalteten Datenbank in einer EU-Region.
 ---

--- a/content/blog/de/blog.mdx
+++ b/content/blog/de/blog.mdx
@@ -13,7 +13,7 @@ hero:
 
 cta:
   action: Kundenarbeit in einem klaren System bündeln
-  description: Starte mit dem Open-Source-CRM oder nutze Customermates Cloud, um unterstützte Kanäle und verwaltete Funktionen zusammenzuführen.
+  description: Starten Sie mit dem Open-Source-CRM oder nutzen Sie Customermates Cloud, um unterstützte Kanäle und verwaltete Funktionen zusammenzuführen.
   buttonLeftText: Kostenlos starten
   buttonLeftHref: /auth/signup
   buttonRightText: Produkt entdecken

--- a/content/contact/de/contact.mdx
+++ b/content/contact/de/contact.mdx
@@ -1,4 +1,4 @@
 ---
 title: Customermates kontaktieren
-description: Frage stellen, Walkthrough buchen oder über eine Partnerschaft sprechen. Schreib dem Gründer von Customermates, Antwort innerhalb eines Werktags.
+description: Frage stellen, Walkthrough buchen oder über eine Partnerschaft sprechen. Schreiben Sie dem Gründer von Customermates; Antwort innerhalb eines Werktags.
 ---

--- a/content/docs/de/intro-page.mdx
+++ b/content/docs/de/intro-page.mdx
@@ -2,7 +2,7 @@
 title: "Customermates-CRM-Dokumentation"
 description: Open-Source-CRM mit nativem MCP-Endpoint, sodass KI-Clients Ihr CRM direkt lesen und schreiben. Hier starten.
 demo:
-  src: https://demo.customermates.com/de/dashboard?agentChat=open
+  src: https://demo.customermates.com/de/dashboard?agentChat=closed
   title: Customermates Demo
 ---
 

--- a/content/docs/en/intro-page.mdx
+++ b/content/docs/en/intro-page.mdx
@@ -2,7 +2,7 @@
 title: "Customermates CRM Documentation"
 description: Open-source CRM with a native MCP endpoint, so AI clients can read and write your CRM directly. Start here.
 demo:
-  src: https://demo.customermates.com/en/dashboard?agentChat=open
+  src: https://demo.customermates.com/en/dashboard?agentChat=closed
   title: Customermates Demo
 ---
 

--- a/content/feature-pages/de/cloud-crm.mdx
+++ b/content/feature-pages/de/cloud-crm.mdx
@@ -108,8 +108,6 @@ Eine **Cloud-CRM-Software** ist ein Kundenmanagementsystem, das der Anbieter als
   <ProofItem label="Betrieb">Managed Cloud oder Self-Hosted-Kern</ProofItem>
 </ProofRail>
 
-<ProductDemo hostedBoundary path="/dashboard" />
-
 ## Was Customermates Cloud tatsächlich umfasst
 
 Das verwaltete Produkt verbindet Kontakte, Organisationen, Deals, Services und Aufgaben in einem Workspace. Teams können typisierte eigene Felder definieren, Tabellen-, Karten- und Kanban-Ansichten nutzen, Aktivitäten prüfen und Deal-Phasen mit Wahrscheinlichkeiten konfigurieren. Dashboards zeigen aktuelle operative Werte, darunter Gesamt- und gewichtete Deal- oder Pipeline-Werte.

--- a/content/feature-pages/de/linkedin-integration.mdx
+++ b/content/feature-pages/de/linkedin-integration.mdx
@@ -106,8 +106,6 @@ Eine **LinkedIn CRM-Integration** kann sehr unterschiedliche Funktionen bezeichn
   <ProofItem label="Sales Navigator">Suche und vorhandene Listen</ProofItem>
 </ProofRail>
 
-<ProductDemo hostedBoundary path="/inbox" />
-
 ## LinkedIn-Nachrichten im CRM-Kontext bearbeiten
 
 Ein berechtigtes Cloud-Konto kann unterstützte LinkedIn-Classic-, Sales-Navigator- oder Recruiter-Varianten verbinden. Das einheitliche Postfach zeigt die unterstützten Gespräche neben E-Mail und weiteren verbundenen Kanälen. Ein Teammitglied kann einen Thread lesen, einen Entwurf speichern, antworten oder einen einzelnen Chat starten. InMails aus Sales Navigator oder Recruiter verwenden Betreff und Signatur, wenn das jeweilige Produkt diese Angaben verlangt.

--- a/content/feature-pages/de/unified-inbox.mdx
+++ b/content/feature-pages/de/unified-inbox.mdx
@@ -140,8 +140,6 @@ Die Funktion gehört zur Managed Cloud ab Pro. Starter und Self-Hosted Customerm
   <ProofItem label="CRM-Kontext">Teilnehmer mit Kontakten abgleichen</ProofItem>
 </ProofRail>
 
-<ProductDemo path="/inbox" />
-
 ## Eine Unterhaltung in den CRM-Kontext überführen
 
 <Steps>

--- a/content/feature-pages/en/cloud-crm.mdx
+++ b/content/feature-pages/en/cloud-crm.mdx
@@ -107,8 +107,6 @@ cta:
   <ProofItem label="Deployment">Managed cloud or self-hosted core</ProofItem>
 </ProofRail>
 
-<ProductDemo hostedBoundary path="/dashboard" />
-
 ## What Customermates Cloud actually includes
 
 The managed product brings contacts, organizations, deals, services and tasks into one workspace. Teams can define typed custom fields, work in table, card and kanban views, inspect activity history and configure deal stages with probabilities. Dashboards show current operational values, including total and weighted deal or pipeline values.

--- a/content/feature-pages/en/linkedin-integration.mdx
+++ b/content/feature-pages/en/linkedin-integration.mdx
@@ -105,8 +105,6 @@ A **LinkedIn CRM integration** can mean very different things. Customermates pro
   <ProofItem label="Sales Navigator">Search and existing lists</ProofItem>
 </ProofRail>
 
-<ProductDemo hostedBoundary path="/inbox" />
-
 ## LinkedIn messages in CRM context
 
 An entitled cloud account can connect supported LinkedIn Classic, Sales Navigator or Recruiter variants. The unified inbox then presents supported conversations beside email and other connected channels. A teammate can read a thread, keep a draft, reply, or start an individual chat. Sales Navigator and Recruiter InMail use the subject and signature fields required by the connected product.

--- a/content/feature-pages/en/unified-inbox.mdx
+++ b/content/feature-pages/en/unified-inbox.mdx
@@ -140,8 +140,6 @@ It is a managed-cloud feature from Pro upward. Starter and self-hosted Customerm
   <ProofItem label="CRM context">Participant-to-contact matching</ProofItem>
 </ProofRail>
 
-<ProductDemo path="/inbox" />
-
 ## Follow one conversation into the CRM context
 
 <Steps>

--- a/content/for-pages/de/professional-services.mdx
+++ b/content/for-pages/de/professional-services.mdx
@@ -136,8 +136,6 @@ Customermates ist ein **CRM für Dienstleister**, die Expertise über Beziehunge
   <ProofItem label="Schnittstellen">REST, Webhooks und MCP</ProofItem>
 </ProofRail>
 
-<ProductDemo path="/deals" />
-
 ## Eine Verkaufschance vom Erstkontakt bis zum nächsten Schritt
 
 Nehmen wir eine Beratung, die mit einem Kundenunternehmen über ein mehrteiliges Mandat spricht. Zur Entscheidungsgruppe gehören ein Sponsor, ein fachlicher Ansprechpartner und der Einkauf. In Customermates bleiben diese Personen mit demselben Unternehmen verbunden, während die Verkaufschance die Phasen des eigenen Vertriebsprozesses durchläuft.

--- a/content/for-pages/en/professional-services.mdx
+++ b/content/for-pages/en/professional-services.mdx
@@ -136,8 +136,6 @@ Customermates is a **CRM for professional services** teams that sell expertise t
   <ProofItem label="Extensions">REST, webhooks and MCP</ProofItem>
 </ProofRail>
 
-<ProductDemo path="/deals" />
-
 ## Follow one opportunity from relationship to next action
 
 Imagine a consultancy speaking with a client organization about a multi-part engagement. The buying group includes an executive sponsor, a day-to-day contact and a procurement stakeholder. In Customermates, those people stay related to the same organization while the opportunity moves through the stages that match the firm's sales process.

--- a/content/homepage/de/homepage.mdx
+++ b/content/homepage/de/homepage.mdx
@@ -18,6 +18,8 @@ hero:
     - für Hermes Agent.
     - für OpenClaw.
     - für n8n.
+  useCaseEyebrow: Ein konkreter Ablauf
+  useCase: Lassen Sie ChatGPT das nächste Follow-up für einen interessierten Lead vorbereiten. Prüfen Sie den Entwurf in Customermates und senden Sie ihn anschließend per E-Mail oder LinkedIn.
   subtitle: "Verwalten Sie Kontakte und Deals gemeinsam mit einem Posteingang für E-Mail, LinkedIn, WhatsApp, Instagram und Telegram. Verbinden Sie ChatGPT, Claude, Gemini oder Cursor über MCP und prüfen Sie jeden Entwurf und jede CRM-Aktualisierung."
   buttonLeftText: "[[commercial.trial.days]]-Tage-Testphase für 0€ starten"
   buttonLeftHref: /auth/signup

--- a/content/homepage/en/homepage.mdx
+++ b/content/homepage/en/homepage.mdx
@@ -18,6 +18,8 @@ hero:
     - for Hermes Agent.
     - for OpenClaw.
     - for n8n.
+  useCaseEyebrow: A real workflow
+  useCase: Ask ChatGPT to prepare the next follow-up for a warm lead. Review the draft in Customermates, then send it through email or LinkedIn.
   subtitle: "Manage contacts and deals alongside one inbox for email, LinkedIn, WhatsApp, Instagram, and Telegram. Connect ChatGPT, Claude, Gemini, or Cursor through MCP—and review every draft and CRM update."
   buttonLeftText: Start a [[commercial.trial.days]]-day trial for 0€
   buttonLeftHref: /auth/signup

--- a/core/fumadocs/schemas/homepage.ts
+++ b/core/fumadocs/schemas/homepage.ts
@@ -42,6 +42,8 @@ export const heroSchema = z.object({
   title: z.string(),
   titleAccent: z.string().optional(),
   titleAccentRotations: z.array(z.string()).optional(),
+  useCase: z.string(),
+  useCaseEyebrow: z.string(),
 });
 export type Hero = z.infer<typeof heroSchema>;
 

--- a/features/contact/send-contact-inquiry.schema.ts
+++ b/features/contact/send-contact-inquiry.schema.ts
@@ -7,6 +7,7 @@ export const SendContactInquirySchema = z.object({
   email: z.email(),
   company: z.string().trim().max(200).optional(),
   message: z.string().trim().min(10).max(5000),
+  privacyAcknowledged: z.boolean().refine((value) => value),
 });
 
 export type SendContactInquiryData = Data<typeof SendContactInquirySchema>;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1487,12 +1487,14 @@
     "title": "Kontakt"
   },
   "ContactPage": {
-    "description": "Frage, Walkthrough oder Partnerschaft? Schreib mir kurz, ich melde mich innerhalb eines Tages zurück.",
+    "description": "Frage, Walkthrough oder Partnerschaft? Schreiben Sie mir kurz, ich melde mich innerhalb eines Tages zurück.",
     "form": {
       "founderName": "Benjamin Wagner",
-      "founderNote": "Deine Nachricht kommt direkt bei mir an. Schreib kurz, was du heute nutzt und wo der Workflow hakt.",
+      "founderNote": "Ihre Nachricht kommt direkt bei mir an. Schreiben Sie kurz, was Sie heute nutzen und wo der Workflow hakt.",
       "founderRole": "Gründer von Customermates",
-      "messagePlaceholder": "Woran arbeitest du und wie kann ich helfen?",
+      "messagePlaceholder": "Woran arbeiten Sie und wie kann ich helfen?",
+      "privacyAcknowledgement": "Ich habe die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> gelesen.",
+      "privacyAcknowledgementRequired": "Bitte bestätigen Sie, dass Sie die Datenschutzerklärung gelesen haben.",
       "submit": "Nachricht senden",
       "successBody": "Ich melde mich unter der angegebenen E‑Mail, meist innerhalb von 24 Stunden.",
       "successCta": "Weitere Nachricht senden",
@@ -1501,7 +1503,7 @@
     },
     "highlights": {
       "direct": {
-        "body": "Lieber E‑Mail? Schreib direkt, deine Nachricht landet an derselben Stelle.",
+        "body": "Lieber per E‑Mail? Schreiben Sie direkt; Ihre Nachricht landet an derselben Stelle.",
         "title": "Mail: mail@customermates.com"
       },
       "fast": {
@@ -1509,11 +1511,11 @@
         "title": "Schnelle Antwort"
       },
       "personal": {
-        "body": "Schick mir kurz dein heutiges Setup. Ich sage dir direkt, was passt und wo eine separate Integration die ehrliche Antwort ist.",
+        "body": "Schicken Sie mir kurz Ihr heutiges Setup. Ich sage Ihnen direkt, was passt und wo eine separate Integration die ehrliche Antwort ist.",
         "title": "Den Workflow kurz durchgehen"
       }
     },
-    "title": "Lass uns reden."
+    "title": "Lassen Sie uns reden."
   },
   "Dashboard": {
     "activityWidget": {
@@ -1660,7 +1662,7 @@
     "copyMcpConfig": "MCP-Config kopieren",
     "copyPage": "Seite kopieren",
     "englishOnlyAlert": "Die technische API-Endpunkt-Dokumentation ist nur auf Englisch verfügbar. Dies liegt daran, dass API-Dokumentation präzise technische Terminologie und Konsistenz mit Industriestandards erfordert.",
-    "liveDataAlert": "Das Ausführen von Operationen im API-Playground wirkt sich auf deine Live-Daten aus.",
+    "liveDataAlert": "Das Ausführen von Operationen im API-Playground wirkt sich auf Ihre Live-Daten aus.",
     "markdownCopied": "Seite in die Zwischenablage kopiert.",
     "mcpCommandCopied": "MCP-Command in die Zwischenablage kopiert.",
     "mcpConfigCopied": "MCP-Config in die Zwischenablage kopiert.",
@@ -2030,16 +2032,16 @@
       "featureUsers": "Workspace-Nutzer",
       "period": "unter AGPL",
       "price": "Kern kostenlos",
-      "tag": "Betreibe die AGPL-Kernanwendung und PostgreSQL mit Docker Compose auf deinem Server im Starter-Umfang. Externe Dienste bleiben separat.",
+      "tag": "Betreiben Sie die AGPL-Kernanwendung und PostgreSQL mit Docker Compose auf Ihrem Server im Starter-Umfang. Externe Dienste bleiben separat.",
       "title": "Self-Hosted"
     },
-    "subtitle": "Transparente Tarife, keine versteckten Kosten. Der AGPL-Kern bleibt beim Self-Hosting kostenlos; externe Dienste bleiben separat. Oder starte ohne Kreditkarte in der Cloud.",
+    "subtitle": "Transparente Tarife, keine versteckten Kosten. Der AGPL-Kern bleibt beim Self-Hosting kostenlos; externe Dienste bleiben separat. Oder starten Sie ohne Kreditkarte in der Cloud.",
     "title": "Einfach, ehrlich, europäisch"
   },
   "HomepageStatsRow": {
     "automationLabel": "Automatisierung",
     "taglineMcp": "MCP",
-    "taglinePost": ". Automatisierung über REST, Webhooks und deine n8n-Instanz.",
+    "taglinePost": ". Automatisierung über REST, Webhooks und Ihre n8n-Instanz.",
     "taglinePre": "Externe KI über"
   },
   "Inbox": {
@@ -2297,7 +2299,7 @@
     "body": "Wir wurden automatisch benachrichtigt, dass diese Seite in den Urlaub gefahren ist. Wir werden sie finden und bald zurückbringen!",
     "ctaLabel": "Zurück zur Startseite",
     "subtitle": "Diese Seite ist ohne uns zu informieren in den Urlaub gefahren",
-    "title": "Huch! Du hast die Leere betreten"
+    "title": "Huch! Sie haben die Leere betreten"
   },
   "OnboardingForm": {
     "agreeToTerms": "Ich bin berechtigt, für den Geschäftskunden zu handeln, und stimme den <termsOfServiceLink>AGB</termsOfServiceLink> sowie dem <dpaLink>AVV</dpaLink> zu. Die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> habe ich gelesen.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1493,6 +1493,8 @@
       "founderNote": "Your message comes directly to me. Tell me what you use today and where the workflow gets stuck.",
       "founderRole": "Founder, Customermates",
       "messagePlaceholder": "What are you working on, and how can I help?",
+      "privacyAcknowledgement": "I have read the <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+      "privacyAcknowledgementRequired": "Please confirm that you have read the Privacy Policy.",
       "submit": "Send message",
       "successBody": "I'll get back to you at the email you provided, usually within 24 hours.",
       "successCta": "Send another",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1493,6 +1493,8 @@
       "founderNote": "Tu mensaje me llega directamente. Cuéntame qué utilizas ahora y en qué punto se atasca el flujo de trabajo.",
       "founderRole": "Fundador de Customermates",
       "messagePlaceholder": "¿En qué estás trabajando y cómo puedo ayudarte?",
+      "privacyAcknowledgement": "He leído la <dataPrivacyLink>Política de privacidad</dataPrivacyLink>.",
+      "privacyAcknowledgementRequired": "Confirma que has leído la Política de privacidad.",
       "submit": "Enviar el mensaje",
       "successBody": "Te responderé al correo que has indicado, normalmente en menos de 24 horas.",
       "successCta": "Enviar otro mensaje",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1493,6 +1493,8 @@
       "founderNote": "Votre message m’arrive directement. Dites-moi ce que vous utilisez aujourd’hui et où le workflow bloque.",
       "founderRole": "Fondateur de Customermates",
       "messagePlaceholder": "Sur quoi travaillez-vous et comment puis-je vous aider ?",
+      "privacyAcknowledgement": "J’ai lu la <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>.",
+      "privacyAcknowledgementRequired": "Veuillez confirmer que vous avez lu la politique de confidentialité.",
       "submit": "Envoyer le message",
       "successBody": "Je vous réponds à l'adresse indiquée, généralement sous 24 heures.",
       "successCta": "Envoyer un autre message",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1493,6 +1493,8 @@
       "founderNote": "Il tuo messaggio arriva direttamente a me. Dimmi cosa usi oggi e dove il flusso di lavoro si blocca.",
       "founderRole": "Fondatore di Customermates",
       "messagePlaceholder": "A cosa stai lavorando e come posso aiutarti?",
+      "privacyAcknowledgement": "Ho letto l’<dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>.",
+      "privacyAcknowledgementRequired": "Conferma di aver letto l’Informativa sulla privacy.",
       "submit": "Invia il messaggio",
       "successBody": "Ti rispondo all'indirizzo che hai indicato, di solito entro 24 ore.",
       "successCta": "Invia un altro messaggio",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -506,6 +506,10 @@
   html {
     --scrollbar-thumb: #d4d4d8;
     --scrollbar-track: #f4f4f500;
+  }
+
+  html[data-scroll-behavior="smooth"],
+  html[data-scroll-behavior="smooth"] [data-public-scrollport] {
     scroll-behavior: smooth;
   }
 
@@ -660,6 +664,10 @@ path:focus {
     padding-inline: var(--marketing-gutter);
   }
 
+  .marketing-container-wide {
+    max-width: 96rem;
+  }
+
   @media (width >= 40rem) {
     .marketing-container {
       padding-inline: var(--marketing-gutter-lg);
@@ -711,7 +719,7 @@ path:focus {
   }
 
   .text-display {
-    @apply font-bold text-balance;
+    @apply font-medium text-balance;
     font-size: clamp(2.5rem, 1.7325rem + 3.275vw, 5.25rem);
     line-height: 0.98;
     letter-spacing: -0.045em;

--- a/tests/conventions/acquisition-ui-contract.test.ts
+++ b/tests/conventions/acquisition-ui-contract.test.ts
@@ -194,7 +194,9 @@ describe("public acquisition UI contract", () => {
     const hero = source("components/marketing/page-hero.tsx");
     expect(hero).toContain("<GridPattern");
     expect(hero).toContain("<MarketingContainer");
-    expect(hero).toContain("text-display");
+    expect(hero).toContain(
+      'visual ? "text-display-sm" : "text-display max-w-5xl"',
+    );
     expect(hero).toContain("visual?: ReactNode");
     expect(hero).not.toContain("WaveDecoration");
     expect(hero).not.toContain("var(--font-serif)");
@@ -230,13 +232,19 @@ describe("public acquisition UI contract", () => {
       "app/[locale]/(static)/help-and-feedback/page.tsx",
     ]) {
       expect(source(route), route).toContain("<PageHero");
-      expect(source(route), route).toContain('data-marketing-flow="continuous"');
+      expect(source(route), route).toContain(
+        'data-marketing-flow="continuous"',
+      );
     }
 
     const runtimeFiles = ["app", "components", "styles"].flatMap((directory) =>
-      walkFiles(join(REPO_ROOT, directory), (path) => /\.(?:css|tsx?)$/u.test(path)),
+      walkFiles(join(REPO_ROOT, directory), (path) =>
+        /\.(?:css|tsx?)$/u.test(path),
+      ),
     );
-    const runtimeSource = runtimeFiles.map((path) => readFileSync(path, "utf8")).join("\n");
+    const runtimeSource = runtimeFiles
+      .map((path) => readFileSync(path, "utf8"))
+      .join("\n");
 
     expect(runtimeSource).not.toContain("WaveDecoration");
     expect(runtimeSource).not.toContain("wave-decoration");
@@ -275,9 +283,15 @@ describe("public acquisition UI contract", () => {
   });
 
   it("aligns pricing summaries without pretending that unequal benefits are table rows", () => {
-    const section = source("app/[locale]/(static)/pricing/components/pricing-section.tsx");
-    const card = source("app/[locale]/(static)/pricing/components/pricing-card.tsx");
-    const comparison = source("components/marketing/responsive-comparison-table.tsx");
+    const section = source(
+      "app/[locale]/(static)/pricing/components/pricing-section.tsx",
+    );
+    const card = source(
+      "app/[locale]/(static)/pricing/components/pricing-card.tsx",
+    );
+    const comparison = source(
+      "components/marketing/responsive-comparison-table.tsx",
+    );
 
     expect(section).toContain("rounded-card border border-border bg-card");
     expect(section).toContain("<output");
@@ -306,7 +320,9 @@ describe("public acquisition UI contract", () => {
       "app/[locale]/(static)/n8n-crm/components/automation-benefits.tsx",
     ]) {
       const section = source(route);
-      expect(section, route).toContain("rounded-card border border-border bg-card");
+      expect(section, route).toContain(
+        "rounded-card border border-border bg-card",
+      );
       expect(section, route).not.toContain("grid border-y border-border");
     }
   });
@@ -317,12 +333,12 @@ describe("public acquisition UI contract", () => {
     expect(article).toContain("mx-auto max-w-[96ch]");
     expect(article).toContain("[&>p]:max-w-[82ch]");
     expect(article).toContain("lg:mx-0 lg:max-w-none");
+    expect(article).toContain("prose-headings:font-medium");
     expect(article).toContain(
       "asideFooter={founderContact ? <FounderContactCard /> : undefined}",
     );
     expect(article).toContain("[--toc-sticky-top:5.5rem]");
-    expect(article).toContain("xl:[--toc-sticky-top:5rem]");
-    expect(article).toContain("xl:[--toc-anchor-offset:5rem]");
+    expect(article).toContain("[--toc-anchor-offset:5.5rem]");
     expect(article).not.toContain("rounded-panel");
     expect(article).not.toContain("shadow-sm");
 
@@ -336,6 +352,31 @@ describe("public acquisition UI contract", () => {
       expect(routeSource, route).toContain("<LandingArticle");
       expect(routeSource, route).not.toContain("<ShowcaseFrame");
     }
+  });
+
+  it("uses primary accents for generic marketing icons without recoloring provider marks", () => {
+    for (const route of [
+      "app/[locale]/(static)/components/homepage-benefits.tsx",
+      "app/[locale]/(static)/features/components/base-features-section.tsx",
+      "app/[locale]/(static)/features/components/why-features-section.tsx",
+      "app/[locale]/(static)/n8n-crm/components/automation-benefits.tsx",
+    ]) {
+      const section = source(route);
+      expect(section, route).toContain(
+        "border-primary/20 bg-primary/10 text-primary",
+      );
+    }
+
+    const whyFeatures = source(
+      "app/[locale]/(static)/features/components/why-features-section.tsx",
+    );
+    expect(whyFeatures).toContain("<Icon aria-hidden icon={IconComponent} />");
+
+    const hero = source("app/[locale]/(static)/components/homepage-hero.tsx");
+    expect(hero).toContain("<ProviderMark");
+    expect(hero).not.toMatch(
+      /<ProviderMark[^>]*className=.*(?:grayscale|text-primary)/u,
+    );
   });
 
   it("keeps the founder contact on every long-form detail page", () => {
@@ -366,7 +407,6 @@ describe("public acquisition UI contract", () => {
     expect(source("app/[locale]/(static)/blog/[slug]/page.tsx")).toContain(
       "<LandingArticle founderContact items={page.data.toc}",
     );
-
   });
 
   it("uses one route-owned related-content and CTA ending across acquisition and blog pages", () => {

--- a/tests/conventions/contact-privacy-contract.test.ts
+++ b/tests/conventions/contact-privacy-contract.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SendContactInquirySchema } from "@/features/contact/send-contact-inquiry.schema";
+import { REGISTERED_LOCALES } from "@/i18n/locale-registry";
+import { REPO_ROOT } from "./walk";
+
+const validInquiry = {
+  company: "Example GmbH",
+  email: "founder@example.com",
+  message: "I would like to understand the product workflow.",
+  name: "Example Founder",
+};
+
+function source(path: string) {
+  return readFileSync(join(REPO_ROOT, path), "utf8");
+}
+
+describe("contact privacy acknowledgement", () => {
+  it("requires acknowledgement at the server validation boundary", () => {
+    expect(
+      SendContactInquirySchema.safeParse({
+        ...validInquiry,
+        privacyAcknowledged: false,
+      }).success,
+    ).toBe(false);
+    expect(
+      SendContactInquirySchema.safeParse({
+        ...validInquiry,
+        privacyAcknowledged: true,
+      }).success,
+    ).toBe(true);
+    expect(SendContactInquirySchema.safeParse(validInquiry).success).toBe(
+      false,
+    );
+  });
+
+  it("renders a required acknowledgement with a localized privacy link", () => {
+    const form = source("app/[locale]/(public)/contact/contact-form.tsx");
+    const store = source("app/[locale]/(public)/contact/contact.store.ts");
+
+    expect(form).toContain("<FormCheckbox");
+    expect(form).toContain('id="privacyAcknowledged"');
+    expect(form).toContain('t.rich("ContactPage.form.privacyAcknowledgement"');
+    expect(form).toContain('t("ContactPage.form.privacyAcknowledgementRequired")');
+    expect(form).toContain('href="/privacy"');
+    expect(source("components/forms/form-checkbox.tsx")).toContain("aria-describedby={hasError ? errorId : undefined}");
+    expect(source("components/forms/form-checkbox.tsx")).toContain('role="alert"');
+    expect(source("features/contact/send-contact-inquiry.schema.ts")).not.toContain(
+      "Privacy policy acknowledgement is required",
+    );
+    expect(store.match(/privacyAcknowledged: false/gu)).toHaveLength(3);
+  });
+
+  it("keeps the acknowledgement available in every routing locale", () => {
+    for (const locale of REGISTERED_LOCALES) {
+      const messages = JSON.parse(source(`i18n/locales/${locale}.json`)) as {
+        ContactPage: {
+          form: {
+            privacyAcknowledgement?: string;
+            privacyAcknowledgementRequired?: string;
+          };
+        };
+      };
+      expect(
+        messages.ContactPage.form.privacyAcknowledgement,
+        locale,
+      ).toContain("<dataPrivacyLink>");
+      expect(
+        messages.ContactPage.form.privacyAcknowledgementRequired,
+        locale,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/tests/conventions/docs-nav-completeness.test.ts
+++ b/tests/conventions/docs-nav-completeness.test.ts
@@ -38,6 +38,16 @@ describe("docs navigation completeness", () => {
     expect(missing).toEqual([]);
   });
 
+  it("starts the localized landing-page demos with the agent chat closed", () => {
+    for (const locale of CONTENT_LOCALES) {
+      const landingPage = readFileSync(join(REPO_ROOT, "content", "docs", locale, "intro-page.mdx"), "utf8");
+
+      expect(landingPage).toContain(
+        `src: https://demo.customermates.com/${locale}/dashboard?agentChat=closed`,
+      );
+    }
+  });
+
   it("labels every registered slug in every app locale", () => {
     const locales = readdirSync(join(REPO_ROOT, "i18n", "locales")).filter((file) => file.endsWith(".json"));
     const missing: string[] = [];

--- a/tests/conventions/german-public-website-voice.test.ts
+++ b/tests/conventions/german-public-website-voice.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT } from "./walk";
+
+function source(path: string) {
+  return readFileSync(join(REPO_ROOT, path), "utf8");
+}
+
+describe("German website voice boundary", () => {
+  it("uses formal address on public acquisition surfaces", () => {
+    const messages = JSON.parse(source("i18n/locales/de.json")) as Record<
+      string,
+      unknown
+    >;
+    const publicCopy = JSON.stringify({
+      ContactPage: messages.ContactPage,
+      DocsPage: messages.DocsPage,
+      HomepagePricing: messages.HomepagePricing,
+      HomepageStatsRow: messages.HomepageStatsRow,
+      NotFoundPage: messages.NotFoundPage,
+    });
+
+    expect(publicCopy).toMatch(/Sie|Ihre|Ihnen/u);
+    expect(publicCopy).not.toMatch(
+      /\b(?:du|dein(?:e|em|en|er|es)?|dir|dich|schreib|schick|starte|betreibe|lass)\b/iu,
+    );
+    expect(source("content/contact/de/contact.mdx")).toContain(
+      "Schreiben Sie dem Gründer",
+    );
+    expect(source("content/blog/de/blog.mdx")).not.toMatch(
+      /\b(?:du|dein(?:e|em|en|er|es)?|dir|dich|starte|nutze)\b/iu,
+    );
+
+    const demo = source("components/marketing/product-demo.tsx");
+    expect(demo).not.toMatch(
+      /\b(?:Verschaffe dir|Öffne|Prüfe|Vergleiche|Probiere)\b/u,
+    );
+  });
+
+  it("keeps the product-entry auth flow consistently informal", () => {
+    for (const file of [
+      "forgot-password",
+      "reset-password",
+      "signin",
+      "signup",
+    ]) {
+      const metadata = source(`content/auth/de/${file}.mdx`);
+      expect(metadata, file).not.toMatch(/\b(?:Sie|Ihr(?:e|em|en|er|es)?)\b/u);
+      expect(metadata, file).toMatch(
+        /\b(?:du|dein(?:e|em|en|er|es)?|dich|dir)\b/iu,
+      );
+    }
+  });
+});

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -206,7 +206,8 @@ describe("homepage visual-system adoption", () => {
     expect(liveDemo).toContain("proof.demoTitle");
     expect(liveDemo).toContain("proof.demoDescription");
     expect(liveDemo).toContain('containerSize="wide"');
-    expect(liveDemo).toContain('<HeroDemoIframe className="max-w-7xl" size="article" src={demoSrc} />');
+    expect(liveDemo).toContain('className="marketing-grid mx-auto max-w-[84rem] items-end gap-y-6"');
+    expect(liveDemo).toContain('<HeroDemoIframe size="article" src={demoSrc} />');
     expect(demoIframe).toContain('size = "full"');
     expect(demoIframe).toContain("<BrowserFrame size={size}");
   });

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -196,6 +196,7 @@ describe("homepage visual-system adoption", () => {
   });
 
   it("keeps the live workspace on-page and gives the walkthrough the contrasting story band", () => {
+    const demoIframe = readComponent("hero-demo-iframe.tsx");
     const liveDemo = readComponent("homepage-live-demo.tsx");
     const proof = readComponent("homepage-product-proof.tsx");
 
@@ -205,6 +206,9 @@ describe("homepage visual-system adoption", () => {
     expect(liveDemo).toContain("proof.demoTitle");
     expect(liveDemo).toContain("proof.demoDescription");
     expect(liveDemo).toContain('containerSize="wide"');
+    expect(liveDemo).toContain('<HeroDemoIframe className="max-w-7xl" size="article" src={demoSrc} />');
+    expect(demoIframe).toContain('size = "full"');
+    expect(demoIframe).toContain("<BrowserFrame size={size}");
   });
 
   it("authors page-specific visuals from the approved native fixture layer", () => {

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -207,7 +207,7 @@ describe("homepage visual-system adoption", () => {
     expect(liveDemo).toContain("proof.demoDescription");
     expect(liveDemo).toContain('containerSize="wide"');
     expect(liveDemo).toContain('className="marketing-grid mx-auto max-w-[84rem] items-end gap-y-6"');
-    expect(liveDemo).toContain('<HeroDemoIframe size="article" src={demoSrc} />');
+    expect(liveDemo).toContain('<HeroDemoIframe size="full" src={demoSrc} />');
     expect(demoIframe).toContain('size = "full"');
     expect(demoIframe).toContain("<BrowserFrame size={size}");
   });

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -123,6 +123,8 @@ describe("homepage visual-system adoption", () => {
     expect(hero).not.toMatch(/HomepageAgentRecordVisual|GoogleCalendar|OutlookCalendar|Messenger|XTwitter/u);
     expect(englishHomepage).toContain("title: The open-source CRM");
     expect(englishHomepage).toContain("titleAccent: for AI agents.");
+    expect(hero).toContain("heroSection.useCaseEyebrow");
+    expect(hero).toContain("heroSection.useCase");
   });
 
   it("rotates a width-reserved, accessible hero reel only while motion is appropriate", () => {
@@ -140,14 +142,21 @@ describe("homepage visual-system adoption", () => {
     expect(hero.indexOf('data-homepage-hero-line="lead"')).toBeLessThan(
       hero.indexOf('data-homepage-hero-line="rotation"'),
     );
+    expect(hero).toContain("gap-y-[0.1em] lg:gap-y-[0.06em]");
     expect(leadLine).toContain("whitespace-nowrap");
     expect(rotationLine).toContain("whitespace-nowrap");
     expect(rotatingAccent).toContain("AnimatePresence");
     expect(rotatingAccent).toContain("ROTATION_INTERVAL_MS = 2_600");
     expect(rotatingAccent).toContain("ROTATION_DURATION_SECONDS = 0.2");
+    expect(rotatingAccent).toContain("relative inline-grid max-w-full overflow-hidden");
     expect(rotatingAccent).toContain("invisible col-start-1 row-start-1 whitespace-nowrap");
+    expect(rotatingAccent).toContain('className={cn("inline-block", activeClassName)}');
     expect(rotatingAccent).toContain('data-homepage-motion="rotating-accent"');
     expect(rotatingAccent).not.toContain("aria-live");
+    expect(rotatingAccent).toContain("useHomepageMotion<HTMLSpanElement>(0.6)");
+    expect(hero).toContain('activeClassName="rounded-xl bg-primary/10 px-[0.12em]"');
+    expect(hero).toContain('className="p-[0.12em] text-primary"');
+    expect(motionSource).toContain("HOMEPAGE_MOTION_VISIBILITY_AMOUNT = 0.35");
     expect(motionSource).toContain("useInView");
     expect(motionSource).toContain("useReducedMotion");
     expect(motionSource).toContain('document.visibilityState === "visible"');
@@ -182,6 +191,8 @@ describe("homepage visual-system adoption", () => {
     ]) {
       expect(germanHomepage).toContain(`    - ${label}`);
     }
+    expect(englishHomepage).toContain("useCaseEyebrow: A real workflow");
+    expect(germanHomepage).toContain("useCaseEyebrow: Ein konkreter Ablauf");
   });
 
   it("keeps the live workspace on-page and gives the walkthrough the contrasting story band", () => {
@@ -193,6 +204,7 @@ describe("homepage visual-system adoption", () => {
     expect(liveDemo).toContain("proof.demoEyebrow");
     expect(liveDemo).toContain("proof.demoTitle");
     expect(liveDemo).toContain("proof.demoDescription");
+    expect(liveDemo).toContain('containerSize="wide"');
   });
 
   it("authors page-specific visuals from the approved native fixture layer", () => {
@@ -420,12 +432,14 @@ describe("homepage visual-system adoption", () => {
     expect(globalStyles).toMatch(/\[data-marketing-flow="continuous"\]\s+\.marketing-section:not/u);
   });
 
-  it("keeps display typography neutral while reserving accent for signals and actions", () => {
+  it("keeps the base display neutral while accenting the rotating subject", () => {
     const hero = readComponent("homepage-hero.tsx");
     const walkthrough = readComponent("homepage-walkthrough.tsx");
+    const heroHeading = readOpeningElementContaining(hero, 'className="text-hero mt-7 max-w-6xl"');
 
-    expect(hero).not.toMatch(/<h1[\s\S]{0,500}text-primary/u);
+    expect(heroHeading).not.toContain("text-primary");
     expect(hero).toContain('className="text-hero mt-7 max-w-6xl"');
+    expect(hero).toContain('className="p-[0.12em] text-primary"');
     expect(hero).not.toContain("text-[clamp(");
     expect(walkthrough).not.toMatch(/<h2[\s\S]{0,240}text-primary/u);
   });

--- a/tests/conventions/marketing-tokens.test.ts
+++ b/tests/conventions/marketing-tokens.test.ts
@@ -123,6 +123,9 @@ describe("style-guide CSS isolation", () => {
     expect(css).toContain("--radius-md: calc(var(--radius) - 2px);");
     expect(css).toContain("--radius-xl: calc(var(--radius) + 4px);");
     expect(css).toContain("--container-marketing: 80rem;");
+    expect(css).toMatch(
+      /\.marketing-container-wide\s*\{\s*max-width:\s*96rem;/u,
+    );
     expect(css).toMatch(/\.dark,[\s\S]*?--background:\s*#0d0d10;/u);
     expect(css).toMatch(/\.dark,[\s\S]*?--card:\s*#151518;/u);
     expect(css).toMatch(
@@ -143,6 +146,12 @@ describe("style-guide CSS isolation", () => {
 
     expect(css).toMatch(
       /\.text-hero\s*\{[\s\S]*?font-size:\s*clamp\(3rem, 6\.5vw, 6rem\);/u,
+    );
+    expect(css).toMatch(
+      /\.text-display\s*\{[\s\S]*?@apply font-medium text-balance;/u,
+    );
+    expect(css).toMatch(
+      /\.text-display-sm\s*\{[\s\S]*?@apply font-medium text-balance;/u,
     );
     expect(css).toMatch(
       /\[data-marketing-flow="continuous"\]\s+\.marketing-section:not/u,

--- a/tests/conventions/product-demo-contract.test.ts
+++ b/tests/conventions/product-demo-contract.test.ts
@@ -3,69 +3,24 @@ import { join, relative } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { PRODUCT_DEMO_PATHS, buildProductDemoUrl } from "@/components/marketing/product-demo";
+import {
+  FEATURE_PRODUCT_DEMOS,
+  INDUSTRY_PRODUCT_DEMOS,
+} from "@/components/marketing/product-demo-config";
+import {
+  PRODUCT_DEMO_PATHS,
+  buildProductDemoUrl,
+} from "@/components/marketing/product-demo";
 import { REPO_ROOT, walkFiles } from "./walk";
 
 type PageDemo = {
   file: string;
+  hostedBoundary?: true;
   path: string;
   precedingCopy: string;
-  hostedBoundary?: boolean;
-  presentation?: "standalone";
 };
 
-const PAGE_DEMOS: readonly PageDemo[] = [
-  {
-    file: "app/[locale]/(static)/features/page.tsx",
-    path: "/dashboard",
-    precedingCopy: "<FeaturesHero {...hero} />",
-    hostedBoundary: true,
-    presentation: "standalone",
-  },
-  {
-    file: "content/feature-pages/en/cloud-crm.mdx",
-    path: "/dashboard",
-    precedingCopy: '<ProofRail label="Verified Customermates Cloud capabilities">',
-    hostedBoundary: true,
-  },
-  {
-    file: "content/feature-pages/de/cloud-crm.mdx",
-    path: "/dashboard",
-    precedingCopy: '<ProofRail label="Verifizierte Funktionen von Customermates Cloud">',
-    hostedBoundary: true,
-  },
-  {
-    file: "content/feature-pages/en/linkedin-integration.mdx",
-    path: "/inbox",
-    precedingCopy: '<ProofRail label="Verified LinkedIn CRM integration capabilities">',
-    hostedBoundary: true,
-  },
-  {
-    file: "content/feature-pages/de/linkedin-integration.mdx",
-    path: "/inbox",
-    precedingCopy: '<ProofRail label="Verifizierte Funktionen der LinkedIn CRM-Integration">',
-    hostedBoundary: true,
-  },
-  {
-    file: "content/feature-pages/en/unified-inbox.mdx",
-    path: "/inbox",
-    precedingCopy: "It is a managed-cloud feature from Pro upward.",
-  },
-  {
-    file: "content/feature-pages/de/unified-inbox.mdx",
-    path: "/inbox",
-    precedingCopy: "Die Funktion gehört zur Managed Cloud ab Pro.",
-  },
-  {
-    file: "content/for-pages/en/professional-services.mdx",
-    path: "/deals",
-    precedingCopy: "<ProofRail label=\"Verified professional-services CRM capabilities\">",
-  },
-  {
-    file: "content/for-pages/de/professional-services.mdx",
-    path: "/deals",
-    precedingCopy: "<ProofRail label=\"Verifizierte CRM-Funktionen für Dienstleister\">",
-  },
+const INLINE_PAGE_DEMOS: readonly PageDemo[] = [
   {
     file: "content/blog-posts/en/open-source-crm.mdx",
     path: "/dashboard",
@@ -97,29 +52,111 @@ function read(relativePath: string): string {
 }
 
 describe("seeded public product demo", () => {
-  it("builds locale-aware URLs for only the three reviewed demo surfaces", () => {
-    expect(PRODUCT_DEMO_PATHS).toStrictEqual(["/dashboard", "/inbox", "/deals"]);
+  it("builds locale-aware URLs only for reviewed demo surfaces", () => {
+    expect(PRODUCT_DEMO_PATHS).toStrictEqual([
+      "/dashboard",
+      "/inbox",
+      "/deals",
+      "/contacts",
+      "/organizations",
+      "/tasks",
+      "/profile/api-keys",
+      "/profile/connected-accounts",
+      "/company/webhooks",
+    ]);
     expect(buildProductDemoUrl("en", "/inbox")).toBe(
       "https://demo.customermates.com/en/inbox?agentChat=closed",
     );
     expect(buildProductDemoUrl("de", "/deals")).toBe(
       "https://demo.customermates.com/de/deals?agentChat=closed",
     );
-    expect(() => buildProductDemoUrl("en", "/contacts")).toThrow("Unsupported product demo path: /contacts");
+    expect(buildProductDemoUrl("en", "/contacts")).toBe(
+      "https://demo.customermates.com/en/contacts?agentChat=closed",
+    );
+    expect(() => buildProductDemoUrl("en", "/services")).toThrow(
+      "Unsupported product demo path: /services",
+    );
   });
 
-  it("registers one disclosed, appropriately placed demo per reviewed source", () => {
-    for (const page of PAGE_DEMOS) {
+  it("maps every localized feature page to one relevant reviewed demo surface", () => {
+    const englishSlugs = walkFiles(
+      join(REPO_ROOT, "content", "feature-pages", "en"),
+      (path) => path.endsWith(".mdx"),
+    )
+      .map((path) =>
+        relative(
+          join(REPO_ROOT, "content", "feature-pages", "en"),
+          path,
+        ).replace(/\.mdx$/u, ""),
+      )
+      .sort();
+    const germanSlugs = walkFiles(
+      join(REPO_ROOT, "content", "feature-pages", "de"),
+      (path) => path.endsWith(".mdx"),
+    )
+      .map((path) =>
+        relative(
+          join(REPO_ROOT, "content", "feature-pages", "de"),
+          path,
+        ).replace(/\.mdx$/u, ""),
+      )
+      .sort();
+
+    expect(germanSlugs).toStrictEqual(englishSlugs);
+    expect(Object.keys(FEATURE_PRODUCT_DEMOS).sort()).toStrictEqual(
+      englishSlugs,
+    );
+    expect(
+      Object.values(FEATURE_PRODUCT_DEMOS).every(({ path }) =>
+        PRODUCT_DEMO_PATHS.includes(path),
+      ),
+    ).toBe(true);
+    expect(FEATURE_PRODUCT_DEMOS["self-hosted"].hostedBoundary).toBe(true);
+    expect(FEATURE_PRODUCT_DEMOS["crm-integration"]).toStrictEqual({
+      path: "/company/webhooks",
+    });
+    expect(FEATURE_PRODUCT_DEMOS["sales-automation"]).toStrictEqual({
+      path: "/company/webhooks",
+    });
+    for (const slug of [
+      "customer-service",
+      "email-integration",
+      "integrations",
+      "linkedin-integration",
+      "outlook-integration",
+      "unified-inbox",
+    ] as const) {
+      expect(FEATURE_PRODUCT_DEMOS[slug].hostedBoundary, slug).toBe(true);
+    }
+    expect(INDUSTRY_PRODUCT_DEMOS).toStrictEqual({
+      "professional-services": { path: "/deals" },
+    });
+
+    const featureRoute = read("app/[locale]/(static)/features/[slug]/page.tsx");
+    const industryRoute = read("app/[locale]/(static)/for/[industry]/page.tsx");
+    const demoSection = read("components/marketing/product-demo-section.tsx");
+    expect(featureRoute).toContain("productDemoForFeature(slug)");
+    expect(featureRoute.indexOf("<ProductDemoSection")).toBeLessThan(
+      featureRoute.indexOf("<LandingArticle"),
+    );
+    expect(industryRoute).toContain("productDemoForIndustry(industry)");
+    expect(industryRoute.indexOf("<ProductDemoSection")).toBeLessThan(
+      industryRoute.indexOf("<LandingArticle"),
+    );
+    expect(demoSection).toContain('containerSize="wide"');
+    expect(demoSection).toContain('presentation="standalone"');
+  });
+
+  it("keeps long-form blog demos inline and disclosed", () => {
+    for (const page of INLINE_PAGE_DEMOS) {
       const source = read(page.file);
-      const expectedTag = page.presentation
-        ? `<ProductDemo hostedBoundary path="${page.path}" presentation="${page.presentation}" />`
-        : page.hostedBoundary
-          ? `<ProductDemo hostedBoundary path="${page.path}" />`
-          : `<ProductDemo path="${page.path}" />`;
+      const expectedTag = `<ProductDemo hostedBoundary path="${page.path}" />`;
 
       expect(source.match(/<ProductDemo\b/gu)).toHaveLength(1);
       expect(source).toContain(expectedTag);
-      expect(source.indexOf(expectedTag)).toBeGreaterThan(source.indexOf(page.precedingCopy));
+      expect(source.indexOf(expectedTag)).toBeGreaterThan(
+        source.indexOf(page.precedingCopy),
+      );
     }
 
     const discovered = [join(REPO_ROOT, "content"), join(REPO_ROOT, "app")]
@@ -131,10 +168,14 @@ describe("seeded public product demo", () => {
       )
       .map((path) => relative(REPO_ROOT, path))
       .sort();
-    expect(discovered).toStrictEqual(PAGE_DEMOS.map((page) => page.file).sort());
+    expect(discovered).toStrictEqual(
+      INLINE_PAGE_DEMOS.map((page) => page.file).sort(),
+    );
 
     const componentRegistry = read("core/fumadocs/mdx-components.tsx");
-    expect(componentRegistry).toContain('import { ProductDemo } from "@/components/marketing/product-demo";');
+    expect(componentRegistry).toContain(
+      'import { ProductDemo } from "@/components/marketing/product-demo";',
+    );
     expect(componentRegistry).toMatch(/\n\s*ProductDemo,\n/u);
   });
 
@@ -142,30 +183,42 @@ describe("seeded public product demo", () => {
     const demo = read("components/marketing/product-demo.tsx");
     const frame = read("components/marketing/browser-frame.tsx");
     const proxy = read("proxy.ts");
-    const navigationSwitch = read("app/components/navigation/navigation-switch.tsx");
+    const navigationSwitch = read(
+      "app/components/navigation/navigation-switch.tsx",
+    );
 
     expect(demo).toContain("Public, seeded product demo");
     expect(demo).toContain("synthetic sample data");
     expect(demo).toContain("Öffentliche, vorbefüllte Produktdemo");
     expect(demo).toContain("not a self-hosted deployment");
     expect(demo).toContain("kein Self-Hosted-Deployment");
-    expect(demo).toContain("When Mate is enabled for this demo environment, it starts closed");
-    expect(demo).toContain("Wenn Mate für diese Demo-Umgebung aktiviert ist, startet es geschlossen");
+    expect(demo).toContain(
+      "When Mate is enabled for this demo environment, it starts closed",
+    );
+    expect(demo).toContain(
+      "Wenn Mate für diese Demo-Umgebung aktiviert ist, startet es geschlossen",
+    );
     expect(demo).not.toMatch(/(?:^|[.!?]\s+)Mate starts closed/);
     expect(demo).not.toMatch(/(?:^|[.!?]\s+)Mate startet geschlossen/);
     expect(demo).toContain("copy.guidedTasks[path].map");
     expect(demo).toContain('presentation = "article"');
     expect(demo).toContain("data-product-demo-presentation={presentation}");
-    expect(demo).toContain('presentation === "article" && "border-y border-border py-5"');
+    expect(demo).toContain(
+      'presentation === "article" && "border-y border-border py-5"',
+    );
     expect(demo).toContain("fallbackMessage={copy.fallback}");
     expect(demo).toContain("title={copy.titles[path]}");
-    expect(demo).toContain('size="article"');
+    expect(demo).toContain(
+      'size={presentation === "standalone" ? "full" : "article"}',
+    );
 
     expect(frame).toContain('size?: "article" | "full"');
     expect(frame).toContain('article: "h-[420px] sm:h-[520px] lg:h-[600px]"');
     expect(frame).toContain("IntersectionObserver");
     expect(frame).toContain('loading="lazy"');
-    expect(frame).toContain('sandbox="allow-scripts allow-same-origin allow-popups allow-forms"');
+    expect(frame).toContain(
+      'sandbox="allow-scripts allow-same-origin allow-popups allow-forms"',
+    );
     expect(frame).toContain('referrerPolicy="strict-origin-when-cross-origin"');
     expect(frame).toContain("12_000");
     expect(frame).toContain("motion-reduce:animate-none");

--- a/tests/conventions/toc-scroll-contract.test.ts
+++ b/tests/conventions/toc-scroll-contract.test.ts
@@ -5,9 +5,17 @@ import { describe, expect, it } from "vitest";
 
 import { REPO_ROOT } from "./walk";
 
-const tocSource = readFileSync(join(REPO_ROOT, "components", "shared", "toc.tsx"), "utf8");
+const tocSource = readFileSync(
+  join(REPO_ROOT, "components", "shared", "toc.tsx"),
+  "utf8",
+);
 const navigationSource = readFileSync(
   join(REPO_ROOT, "app", "components", "navigation", "navigation-switch.tsx"),
+  "utf8",
+);
+const layoutSource = readFileSync(join(REPO_ROOT, "app", "layout.tsx"), "utf8");
+const globalStyles = readFileSync(
+  join(REPO_ROOT, "styles", "globals.css"),
   "utf8",
 );
 const styleguideSource = readFileSync(
@@ -24,23 +32,36 @@ const styleguideSource = readFileSync(
 );
 
 describe("shared table-of-contents scroll contract", () => {
-  it("offsets the public rail and heading anchors below the sticky navbar", () => {
+  it("preserves the public rail and heading offsets", () => {
+    expect(navigationSource).toContain("[--table-sticky-top:4rem]");
     expect(navigationSource).toContain("[--toc-sticky-top:4rem]");
     expect(navigationSource).toContain("[--toc-anchor-offset:5rem]");
     expect(navigationSource).toContain("xl:[--table-sticky-top:3.5rem]");
     expect(navigationSource).toContain("xl:[--toc-sticky-top:3.5rem]");
     expect(navigationSource).toContain("xl:[--toc-anchor-offset:4.5rem]");
-    expect(styleguideSource).toContain("xl:top-14");
+    expect(styleguideSource).toContain("sticky top-16");
     expect(tocSource).toContain("top-[var(--toc-sticky-top,0px)]");
-    expect(tocSource).toContain("max-h-[calc(100svh-var(--toc-sticky-top,0px))]");
-    expect(tocSource).toContain("[&_[id]]:scroll-mt-[var(--toc-anchor-offset,0px)]");
+    expect(tocSource).toContain(
+      "max-h-[calc(100svh-var(--toc-viewport-offset,0px)-var(--toc-sticky-top,0px))]",
+    );
+    expect(tocSource).toContain(
+      "[&_[id]]:scroll-mt-[var(--toc-anchor-offset,0px)]",
+    );
     expect(tocSource).toContain("self-start");
+  });
+
+  it("lets Next disable global smooth scrolling during route transitions", () => {
+    expect(globalStyles).toContain('html[data-scroll-behavior="smooth"] [data-public-scrollport]');
+    expect(layoutSource).toContain('data-scroll-behavior="smooth"');
+    expect(navigationSource).toContain("publicScrollportRef.current.scrollTop = 0");
   });
 
   it("lets Fumadocs manage active-item scrolling without a polling workaround", () => {
     expect(tocSource).toContain("<FumaToc.TOCScrollArea");
     expect(tocSource).toContain("<TocClerk.TOCItems />");
-    expect(tocSource).not.toMatch(/\b(?:setInterval|clearInterval|useEffect|useRef|ScrollProvider)\b/u);
+    expect(tocSource).not.toMatch(
+      /\b(?:setInterval|clearInterval|useEffect|useRef|ScrollProvider)\b/u,
+    );
     expect(tocSource).not.toMatch(/<main\b/u);
   });
 
@@ -57,7 +78,9 @@ describe("shared table-of-contents scroll contract", () => {
     );
     expect(tocSource).toContain("lg:grid-cols-[minmax(0,96ch)_15rem]");
     expect(tocSource).toContain("lg:gap-6");
-    expect(tocSource).toContain('layout === "article" ? "lg:w-60" : "max-w-68"');
+    expect(tocSource).toContain(
+      'layout === "article" ? "lg:w-60" : "max-w-68"',
+    );
     expect(tocSource).toContain('layout === "default" && "flex-1"');
   });
 });

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -184,6 +184,8 @@ describe("public navigation preferences", () => {
     expect(menu).toContain("<Slack");
     expect(menu).toContain("/icons/integrations/n8n.svg");
     expect(menu).toContain("<PublicNavLinkMark mark={link.mark} />");
+    expect(menu).toContain("<PublicNavLinkIcon icon={link.icon} />");
+    expect(menu).toContain('data-public-nav-icon="true"');
     expect(menu).toContain('<span className="min-w-0 truncate">{link.title}</span>');
     expect(menu).not.toContain("group.featured");
     expect(menu).toContain(
@@ -204,6 +206,7 @@ describe("public navigation preferences", () => {
     }
     expect(mobile).toContain("icon={CircleDollarSign}");
     expect(mobile).toContain("icon={FileText}");
+    expect(mobile).toContain("<PublicNavLinkIcon icon={link.icon} />");
     expect(mobile).not.toContain('cn("py-3 text-base"');
 
     expectHrefOrder(product, [
@@ -229,6 +232,56 @@ describe("public navigation preferences", () => {
       "/for",
     ]);
     expectHrefOrder(resources, ["/blog", "/compare", "/blog/agentic-crm", "/blog/open-source-crm"]);
+
+    const iconMaps = [
+      [
+        product,
+        [
+          ["/features/unified-inbox", "Inbox"],
+          ["/features/contact-management", "Users"],
+          ["/features/pipeline", "TrendingUp"],
+          ["/features/sales-tracking", "TrendingUp"],
+          ["/features/task-management", "CheckCircle2"],
+          ["/features/cloud-crm", "LayoutGrid"],
+          ["/features/self-hosted", "Server"],
+          ["/docs/mcp", "Cable"],
+          ["/features/all", "Boxes"],
+        ],
+      ],
+      [
+        solutions,
+        [
+          ["/for/professional-services", "BriefcaseBusiness"],
+          ["/for/agencies", "Megaphone"],
+          ["/for/consultants", "Presentation"],
+          ["/for/recruiting", "UserRoundSearch"],
+          ["/for/healthcare", "HeartPulse"],
+          ["/for/property-management", "Building2"],
+          ["/for/startups", "Rocket"],
+          ["/for/smb", "Store"],
+          ["/for", "UsersRound"],
+        ],
+      ],
+      [
+        resources,
+        [
+          ["/blog", "BookOpen"],
+          ["/compare", "GitCompareArrows"],
+          ["/blog/agentic-crm", "Bot"],
+          ["/blog/open-source-crm", "Github"],
+        ],
+      ],
+    ] as const;
+
+    for (const [group, links] of iconMaps) {
+      expect(group.match(/icon: \w+,\s+href:/gu)).toHaveLength(links.length);
+      for (const [href, icon] of links) {
+        expect(group, `${href} should use the ${icon} navigation icon`).toMatch(
+          new RegExp(`icon: ${icon},\\s+href: "${href}"`, "u"),
+        );
+      }
+    }
+    expect(integrations).not.toMatch(/icon: \w+,\s+href:/u);
 
     const accordionEnd = mobile.indexOf("</Accordion>");
     const pricingIndex = mobile.indexOf('href="/pricing"');


### PR DESCRIPTION
## Summary

- Rework the public desktop navigation into structured, icon-led product, solution, integration, and resource menus while keeping the mobile drawer visually consistent.
- Polish the homepage hierarchy with a clearer use-case hero, stable rotating AI-client headline, wider live product proof, refined spacing, and responsive provider marks.
- Add context-aware product demos to feature and industry pages, improve marketing typography and icon treatment, and fix sticky header, scroll restoration, and blog table-of-contents behavior.
- Add privacy consent to the contact form, standardize the German public-site voice, and make the localized documentation demo start with the agent chat closed.

## Context

This implements the consolidated public-website feedback reviewed locally in the originating Codex task. It keeps the existing provider coverage, responsive drawer behavior, and latest homepage animation/title changes from `main` while improving navigation structure, visual consistency, demo usefulness, readability, privacy consent, and sticky navigation behavior.

### Owner-directed Linear exception

- Issuer: Customermates owner in the current Codex conversation.
- Instruction source and time: direct conversation instruction on 2026-08-31 (Europe/Berlin).
- Bounded outcome: deliver the reviewed website-polish change through this pull request.
- Named waiver: Linear issue, claim, and receipt requirements only.
- Exact write scope: the 62 product-repository files in `origin/main...feat/website-polish-feedback`, limited to public navigation, marketing/homepage and demo presentation, localized public content, contact privacy consent, sticky/scroll behavior, and their tests.
- Remaining constraints: local verification, independent read-only review, GitHub pull request and required checks, isolated preview validation, no production data, and a human-only merge.
- Material consequence and rollback: the change updates public-site UX and contact-form validation; close the unmerged PR/delete its branch, or revert the eventual squash merge, to restore the prior behavior.
- Acceptance and expiry: this exception expires when this PR is merged or closed. Evidence is recorded below and in the PR checks/preview.

## Validation

- `yarn test`: 474 files passed, 19 skipped; 4,202 tests passed, 123 skipped.
- `yarn typecheck`: passed.
- Full ESLint gate: passed on the final commit through the pre-commit hook.
- Production `next build`: passed.
- Focused homepage/docs convention tests: 18 passed.
- Browser acceptance: all nine hero rotations verified at 803×857 with stable spacing and no horizontal overflow; English and German verified at 320 px; the rendered English docs iframe uses `agentChat=closed` and no `agentChat=open` override.
- The branch is based directly on current `origin/main`; its initial publication tree hash matched the fully tested pre-publication tree.
- Final base refresh: rebased conflict-free onto `e7271439`; the four Conventional PR commits remain linear, and the only tree change versus the previous PR head is `main`'s promo-video update.
- Pull-request checks passed: `ci`, `repository-policy`, rendered-page coverage, self-hosted PostgreSQL 16, CodeQL, and Vercel.
- Preview acceptance passed at `https://feat-website-polish-feedback.customermates.com/en`: desktop navigation and hero geometry are correct; docs and sales-tracking demos start with chat closed; contact privacy consent is present; and the German homepage has no horizontal overflow at 320 px.
- Homepage demo follow-ups: production build, typecheck, ESLint, and 14 focused tests passed. The copy grid and frame share a 1,344 px width at 1440 px, while the original frame height is restored: 792 px overall at 1440 px, 742 px at 803 px, and 642 px at 320 px, without horizontal overflow.

## Impact and rollback

- No database migrations, environment-variable changes, production data access, or external messages.
- The contact form now requires explicit privacy consent; public navigation, marketing layouts, embedded-demo defaults, and localized copy change visibly.
- The branch push creates one standard Vercel preview using isolated preview data. Production remains unchanged until a human squash-merges the PR.
- Roll back by reverting the squash merge. Before merge, close the PR and delete the branch.

## Screenshots

Local visual acceptance was completed in the browser at desktop and narrow viewports; reviewers can use the deterministic preview for final visual acceptance.
