### PR TITLE
fix(ui): center auth cards and use single-open detail sections

### DIFF
--- a/app/components/navigation/__tests__/navigation-switch.test.ts
+++ b/app/components/navigation/__tests__/navigation-switch.test.ts
@@ -176,12 +176,24 @@ describe("NavigationSwitch account-state refresh", () => {
     const navbar = container.querySelector<HTMLElement>("[data-public-navbar]");
     const header = navbar?.parentElement;
     const page = container.querySelector<HTMLElement>("[data-page-content]");
+    const pageFrame = page?.parentElement;
     const scrollport = container.querySelector<HTMLElement>("[data-public-scrollport]");
+    const main = scrollport?.querySelector("main");
 
     expect(header?.tagName).toBe("HEADER");
     expect(header?.parentElement).toBe(scrollport);
     expect(header?.className).toContain("sticky");
+    expect(header?.classList.contains("shrink-0")).toBe(true);
     expect(page?.closest("[data-public-scrollport]")).toBe(scrollport);
+    expect(main?.parentElement).toBe(scrollport);
+    expect(pageFrame?.parentElement).toBe(main);
+    expect(main?.classList.contains("flex")).toBe(true);
+    expect(main?.classList.contains("flex-1")).toBe(true);
+    expect(main?.classList.contains("flex-col")).toBe(true);
+    expect(pageFrame?.classList.contains("flex")).toBe(true);
+    expect(pageFrame?.classList.contains("flex-1")).toBe(true);
+    expect(scrollport?.classList.contains("flex")).toBe(true);
+    expect(scrollport?.classList.contains("flex-col")).toBe(true);
     expect(scrollport?.className).toContain("h-svh");
     expect(scrollport?.className).toContain("overflow-y-auto");
     expect(scrollport?.className).toContain("[--table-sticky-top:4rem]");

--- a/app/components/navigation/navigation-switch.tsx
+++ b/app/components/navigation/navigation-switch.tsx
@@ -153,13 +153,13 @@ export function NavigationSwitch({
       <div
         ref={publicScrollportRef}
         data-public-scrollport
-        className="relative h-svh overflow-y-auto bg-background [--table-sticky-top:4rem] [--toc-sticky-top:4rem] [--toc-anchor-offset:5rem] xl:[--table-sticky-top:3.5rem] xl:[--toc-sticky-top:3.5rem] xl:[--toc-anchor-offset:4.5rem]"
+        className="relative flex h-svh flex-col overflow-y-auto bg-background [--table-sticky-top:4rem] [--toc-sticky-top:4rem] [--toc-anchor-offset:5rem] xl:[--table-sticky-top:3.5rem] xl:[--toc-sticky-top:3.5rem] xl:[--toc-anchor-offset:4.5rem]"
       >
-        <header className="sticky top-0 z-50 flex flex-col bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/75">
+        <header className="sticky top-0 z-50 flex shrink-0 flex-col bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/75">
           <PublicNavbar accountState={currentAccountState} hasValidSession={hasValidSession} />
         </header>
 
-        <main className="relative flex min-w-0 flex-col">
+        <main className="relative flex min-w-0 flex-1 flex-col">
           <div className="flex flex-col flex-1 overflow-x-clip">{children}</div>
         </main>
       </div>

--- a/components/entity-detail/__tests__/entity-detail-personalization.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-personalization.test.ts
@@ -37,8 +37,11 @@ import {
 } from "../entity-detail-personalization";
 import { EntityDetailCustomFieldsSection } from "../entity-detail-custom-fields-section";
 import {
+  collapsedSectionIdsForOpenSection,
   reconcileAvailableIds,
   reconcileColumnOrder,
+  reconcileSingleOpenSections,
+  resolveSingleOpenSectionId,
   resolveOrderedCustomColumns,
 } from "../entity-detail-personalization.utils";
 import { EntityDetailSection, EntityDetailSectionGroup } from "../entity-detail-section";
@@ -46,6 +49,8 @@ import { EntityDetailSection, EntityDetailSectionGroup } from "../entity-detail-
 const firstId = "10000000-0000-4000-8000-000000000001";
 const secondId = "10000000-0000-4000-8000-000000000002";
 const thirdId = "10000000-0000-4000-8000-000000000003";
+const detailSectionIds = ["base", "relations", "customFields"];
+const defaultCollapsedSectionIds = ["relations", "customFields"];
 const roots = new Set<Root>();
 const TestProvider = EntityDetailPersonalizationProvider as ComponentType<{
   children?: ReactNode;
@@ -63,12 +68,18 @@ const TestSectionGroup = EntityDetailSectionGroup as ComponentType<{
   children?: ReactNode;
 }>;
 
-function sectionView() {
+function sectionView(initial?: P13nEntry | null) {
   return createElement(
     TestProvider,
     {
-      config: { p13nId: "contact-detail", defaultStarredFieldIds: [] },
+      config: {
+        p13nId: "contact-detail",
+        defaultStarredFieldIds: [],
+        defaultCollapsedSectionIds,
+        sectionIds: detailSectionIds,
+      },
       customColumnIds: [],
+      initial,
       persistenceScope: "user-1",
     },
     createElement(
@@ -80,6 +91,12 @@ function sectionView() {
         createElement("input", {
           id: "identity-probe",
         }),
+      ),
+      createElement(TestSection, { label: "Relations", sectionId: "relations" }, createElement("div", null, "Links")),
+      createElement(
+        TestSection,
+        { label: "Custom fields", sectionId: "customFields" },
+        createElement("div", null, "Fields"),
       ),
     ),
   );
@@ -181,6 +198,24 @@ describe("entity detail custom field order", () => {
     act(() => root.render(view([firstId, secondId])));
 
     expect(container.querySelector("button")?.dataset.columnOrder).toBe(`${firstId},${secondId}`);
+  });
+});
+
+describe("entity detail single-open section state", () => {
+  it("defaults legacy ambiguous section preferences to Base data", () => {
+    expect(resolveSingleOpenSectionId(detailSectionIds, [], defaultCollapsedSectionIds)).toBe("base");
+    expect(resolveSingleOpenSectionId(detailSectionIds, detailSectionIds, defaultCollapsedSectionIds)).toBe("base");
+    expect(resolveSingleOpenSectionId(detailSectionIds, ["relations"], defaultCollapsedSectionIds)).toBe("base");
+    expect(reconcileSingleOpenSections(detailSectionIds, [], defaultCollapsedSectionIds)).toEqual(
+      defaultCollapsedSectionIds,
+    );
+  });
+
+  it("preserves an unambiguous saved section and collapses every other section", () => {
+    expect(resolveSingleOpenSectionId(detailSectionIds, ["base", "customFields"], defaultCollapsedSectionIds)).toBe(
+      "relations",
+    );
+    expect(collapsedSectionIdsForOpenSection(detailSectionIds, "relations")).toEqual(["base", "customFields"]);
   });
 });
 
@@ -289,7 +324,7 @@ describe("entity detail preference persistence", () => {
 
   it("stores collapsed sections in the same P13N record as pinned fields and field order", async () => {
     const { container, root } = mountNode(sectionView());
-    const trigger = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="base"]');
+    const trigger = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="relations"]');
 
     act(() => trigger?.click());
     act(() => root.unmount());
@@ -300,7 +335,7 @@ describe("entity detail preference persistence", () => {
       p13nId: "contact-detail",
       detailOptions: {
         starredFieldIds: [],
-        collapsedSectionIds: ["base"],
+        collapsedSectionIds: ["base", "customFields"],
       },
       columnOrder: [],
     });
@@ -310,30 +345,19 @@ describe("entity detail preference persistence", () => {
 describe("entity detail section", () => {
   it("clips fields throughout the collapse animation", () => {
     const { container } = mountNode(sectionView());
-    const content = container.querySelector<HTMLElement>('[data-slot="collapsible-content"]');
+    const content = container.querySelector<HTMLElement>('[data-slot="accordion-content"]');
 
-    expect(content?.className).toContain("overflow-hidden");
-    expect(content?.className).toContain("data-[state=closed]:animate-collapsible-up");
+    expect(content?.className).toContain("overflow-y-hidden");
+    expect(content?.className).toContain("data-[state=closed]:animate-accordion-up");
+    expect(content?.className).toContain("data-[state=open]:animate-accordion-down");
   });
 
-  it("uses the complete header row as its accessible collapse trigger", () => {
-    const { container } = mountNode(
-      createElement(
-        TestProvider,
-        {
-          config: { p13nId: "contact-detail", defaultStarredFieldIds: [] },
-          customColumnIds: [],
-          persistenceScope: "user-1",
-        },
-        createElement(
-          TestSectionGroup,
-          null,
-          createElement(TestSection, { label: "Base data", sectionId: "base" }, createElement("div", null, "Fields")),
-        ),
-      ),
-    );
+  it("uses the complete header row as its accessible accordion trigger", () => {
+    const { container } = mountNode(sectionView());
     const trigger = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="base"]');
     const group = container.querySelector<HTMLElement>("[data-detail-section-group]");
+    const section = container.querySelector<HTMLElement>('[data-detail-section="base"]');
+    const content = container.querySelector<HTMLElement>('[data-detail-section-content="base"]');
 
     expect(trigger?.tagName).toBe("BUTTON");
     expect(trigger?.className).toContain("w-full");
@@ -346,19 +370,65 @@ describe("entity detail section", () => {
     expect(group?.className).not.toContain("divide-y");
     expect(group?.className).not.toContain("border-b");
     expect(group?.className).not.toContain("border-t");
-    expect(trigger?.parentElement?.className).toContain("border-b");
-    expect(trigger?.parentElement?.className).toContain("border-border");
+    expect(section?.className).toContain("border-b");
+    expect(section?.className).toContain("border-border");
     expect(trigger?.textContent).toContain("Base data");
     expect(trigger?.querySelector("span")?.className).not.toContain("uppercase");
-    expect(trigger?.getAttribute("aria-label")).toBe("EntityDetail.collapseSection:Base data");
+    expect(trigger?.getAttribute("aria-label")).toBeNull();
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger?.getAttribute("aria-disabled")).toBe("true");
+    expect(trigger?.className).toContain("aria-disabled:cursor-default");
+    expect(trigger?.getAttribute("aria-controls")).toBe(content?.id);
+    expect(content?.getAttribute("aria-labelledby")).toBe(trigger?.id);
+    expect(content?.getAttribute("role")).toBe("region");
     expect(trigger?.querySelector("button")).toBeNull();
-    expect(container.querySelector('[data-detail-section-content="base"]')?.className).toContain("pb-4");
+    expect(content?.firstElementChild?.className).toContain("pb-4");
 
     act(() => trigger?.click());
 
-    expect(trigger?.getAttribute("aria-label")).toBe("EntityDetail.expandSection:Base data");
-    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("opens exactly one section and does not let the active section close", () => {
+    const stored: P13nEntry = {
+      p13nId: "contact-detail",
+      columnOrder: [],
+      detailOptions: { starredFieldIds: [], collapsedSectionIds: [] },
+    };
+    const { container } = mountNode(sectionView(stored));
+    const base = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="base"]');
+    const relations = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="relations"]');
+    const customFields = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="customFields"]');
+
+    expect(base?.getAttribute("aria-expanded")).toBe("true");
+    expect(base?.getAttribute("aria-disabled")).toBe("true");
+    expect(relations?.getAttribute("aria-expanded")).toBe("false");
+    expect(customFields?.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => relations?.click());
+
+    expect(base?.getAttribute("aria-expanded")).toBe("false");
+    expect(base?.getAttribute("aria-disabled")).toBeNull();
+    expect(relations?.getAttribute("aria-expanded")).toBe("true");
+    expect(relations?.getAttribute("aria-disabled")).toBe("true");
+    expect(customFields?.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => relations?.click());
+
+    expect(relations?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("supports arrow-key navigation between section triggers", () => {
+    const { container } = mountNode(sectionView());
+    const base = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="base"]');
+    const relations = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="relations"]');
+
+    act(() => {
+      base?.focus();
+      base?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowDown" }));
+    });
+
+    expect(document.activeElement).toBe(relations);
   });
 
   it("uses the selected full-width divider treatment", () => {
@@ -378,7 +448,12 @@ describe("entity detail section", () => {
       createElement(
         TestProvider,
         {
-          config: { p13nId: "contact-detail", defaultStarredFieldIds: [] },
+          config: {
+            p13nId: "contact-detail",
+            defaultStarredFieldIds: [],
+            defaultCollapsedSectionIds: [],
+            sectionIds: ["customFields"],
+          },
           customColumnIds: [],
           persistenceScope: "user-1",
         },

--- a/components/entity-detail/__tests__/entity-detail.registry.test.ts
+++ b/components/entity-detail/__tests__/entity-detail.registry.test.ts
@@ -79,6 +79,7 @@ describe("entity detail personalization registry", () => {
         (configuration?.defaultCollapsedSectionIds ?? []).every((id) => configuration?.sectionIds?.includes(id)),
       ).toBe(true);
       expect(configuration?.sectionIds).toEqual(["base", "relations", "customFields"]);
+      expect(configuration?.defaultCollapsedSectionIds).toEqual(["relations", "customFields"]);
     }
   });
 

--- a/components/entity-detail/entity-detail-personalization.tsx
+++ b/components/entity-detail/entity-detail-personalization.tsx
@@ -9,7 +9,13 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { upsertP13nAction } from "@/app/actions";
 import { reportApplicationError } from "@/core/errors/report-application-error";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
-import { reconcileAvailableIds, reconcileColumnOrder } from "./entity-detail-personalization.utils";
+import {
+  collapsedSectionIdsForOpenSection,
+  reconcileAvailableIds,
+  reconcileColumnOrder,
+  reconcileSingleOpenSections,
+  resolveSingleOpenSectionId,
+} from "./entity-detail-personalization.utils";
 
 export type EntityDetailPersonalizationConfig = {
   p13nId: string;
@@ -32,13 +38,13 @@ type EntityDetailPersonalizationValue = {
   isPersonalizing: boolean;
   starredFieldIds: string[];
   hiddenFieldIds: string[];
-  collapsedSectionIds: string[];
+  openSectionId?: string;
   columnOrder: string[];
   previewFieldValues: Record<string, EntityDetailPreviewItem[]>;
   setIsPersonalizing: (value: boolean) => void;
   toggleStarredField: (fieldId: string) => void;
   toggleFieldVisibility: (fieldId: string) => void;
-  setSectionCollapsed: (sectionId: string, collapsed: boolean) => void;
+  setOpenSection: (sectionId: string) => void;
   moveColumn: (columnId: string, direction: MoveDirection) => void;
   setPreviewFieldValue: (fieldId: string, items: EntityDetailPreviewItem[]) => void;
 };
@@ -49,13 +55,13 @@ const EMPTY_VALUE: EntityDetailPersonalizationValue = {
   isPersonalizing: false,
   starredFieldIds: [],
   hiddenFieldIds: [],
-  collapsedSectionIds: [],
+  openSectionId: undefined,
   columnOrder: [],
   previewFieldValues: {},
   setIsPersonalizing: () => undefined,
   toggleStarredField: () => undefined,
   toggleFieldVisibility: () => undefined,
-  setSectionCollapsed: () => undefined,
+  setOpenSection: () => undefined,
   moveColumn: () => undefined,
   setPreviewFieldValue: () => undefined,
 };
@@ -148,9 +154,10 @@ export function EntityDetailPersonalizationProvider({
     ).filter((fieldId) => !initialHiddenFieldIds.includes(fieldId)),
   );
   const [collapsedSectionIds, setCollapsedSectionIds] = useState(() =>
-    reconcileAvailableIds(
-      storedOptions?.collapsedSectionIds ?? config?.defaultCollapsedSectionIds ?? [],
+    reconcileSingleOpenSections(
       config?.sectionIds,
+      storedOptions?.collapsedSectionIds ?? config?.defaultCollapsedSectionIds ?? [],
+      config?.defaultCollapsedSectionIds,
     ),
   );
   const storedColumnOrder = latestSnapshot?.columnOrder ?? initial?.columnOrder;
@@ -174,6 +181,12 @@ export function EntityDetailPersonalizationProvider({
   const currentColumnStamp = customColumnIds?.join("|");
   const availableFieldStamp = config?.availableFieldIds?.join("|");
   const sectionStamp = config?.sectionIds?.join("|");
+  const defaultCollapsedSectionStamp = config?.defaultCollapsedSectionIds?.join("|");
+  const openSectionId = resolveSingleOpenSectionId(
+    config?.sectionIds,
+    collapsedSectionIds,
+    config?.defaultCollapsedSectionIds,
+  );
 
   useEffect(() => {
     if (currentColumnStamp === undefined) return;
@@ -197,11 +210,13 @@ export function EntityDetailPersonalizationProvider({
 
   useEffect(() => {
     const sectionIds = sectionStamp === undefined ? undefined : sectionStamp.split("|");
+    const defaultCollapsedSectionIds =
+      defaultCollapsedSectionStamp === undefined ? undefined : defaultCollapsedSectionStamp.split("|");
     setCollapsedSectionIds((current) => {
-      const next = reconcileAvailableIds(current, sectionIds);
+      const next = reconcileSingleOpenSections(sectionIds, current, defaultCollapsedSectionIds);
       return next.length === current.length && next.every((id, index) => id === current[index]) ? current : next;
     });
-  }, [sectionStamp]);
+  }, [defaultCollapsedSectionStamp, sectionStamp]);
 
   useEffect(() => {
     if (!p13nId || !persistenceChannelKey) return;
@@ -245,12 +260,17 @@ export function EntityDetailPersonalizationProvider({
     [hiddenFieldIds],
   );
 
-  const setSectionCollapsed = useCallback((sectionId: string, collapsed: boolean) => {
-    setCollapsedSectionIds((current) => {
-      if (collapsed) return current.includes(sectionId) ? current : [...current, sectionId];
-      return current.filter((id) => id !== sectionId);
-    });
-  }, []);
+  const setOpenSection = useCallback(
+    (sectionId: string) => {
+      const sectionIds = sectionStamp === undefined ? undefined : sectionStamp.split("|");
+      if (!sectionIds?.includes(sectionId)) return;
+      setCollapsedSectionIds((current) => {
+        const next = collapsedSectionIdsForOpenSection(sectionIds, sectionId);
+        return next.length === current.length && next.every((id, index) => id === current[index]) ? current : next;
+      });
+    },
+    [sectionStamp],
+  );
 
   const moveColumn = useCallback((columnId: string, direction: MoveDirection) => {
     setColumnOrder((current) => {
@@ -281,26 +301,26 @@ export function EntityDetailPersonalizationProvider({
       isPersonalizing,
       starredFieldIds,
       hiddenFieldIds,
-      collapsedSectionIds,
+      openSectionId,
       columnOrder,
       previewFieldValues,
       setIsPersonalizing,
       toggleStarredField,
       toggleFieldVisibility,
-      setSectionCollapsed,
+      setOpenSection,
       moveColumn,
       setPreviewFieldValue,
     }),
     [
-      collapsedSectionIds,
       columnOrder,
       config,
       applyFieldVisibility,
       hiddenFieldIds,
       isPersonalizing,
       moveColumn,
+      openSectionId,
       previewFieldValues,
-      setSectionCollapsed,
+      setOpenSection,
       setPreviewFieldValue,
       starredFieldIds,
       toggleFieldVisibility,

--- a/components/entity-detail/entity-detail-personalization.utils.ts
+++ b/components/entity-detail/entity-detail-personalization.utils.ts
@@ -11,6 +11,41 @@ export function reconcileAvailableIds(ids: string[] | undefined, availableIds: s
   return unique.filter((id) => available.has(id));
 }
 
+export function resolveSingleOpenSectionId(
+  sectionIds: string[] | undefined,
+  collapsedSectionIds: string[] | undefined,
+  defaultCollapsedSectionIds: string[] | undefined,
+): string | undefined {
+  const availableSectionIds = uniqueIds(sectionIds ?? []);
+  if (availableSectionIds.length === 0) return undefined;
+
+  const collapsed = new Set(reconcileAvailableIds(collapsedSectionIds, availableSectionIds));
+  const openSectionIds = availableSectionIds.filter((id) => !collapsed.has(id));
+  if (openSectionIds.length === 1) return openSectionIds[0];
+
+  const defaultCollapsed = new Set(reconcileAvailableIds(defaultCollapsedSectionIds, availableSectionIds));
+  const defaultOpenSectionIds = availableSectionIds.filter((id) => !defaultCollapsed.has(id));
+  return defaultOpenSectionIds.length === 1 ? defaultOpenSectionIds[0] : availableSectionIds[0];
+}
+
+export function collapsedSectionIdsForOpenSection(
+  sectionIds: string[] | undefined,
+  openSectionId: string | undefined,
+): string[] {
+  const availableSectionIds = uniqueIds(sectionIds ?? []);
+  if (!openSectionId || !availableSectionIds.includes(openSectionId)) return [];
+  return availableSectionIds.filter((id) => id !== openSectionId);
+}
+
+export function reconcileSingleOpenSections(
+  sectionIds: string[] | undefined,
+  collapsedSectionIds: string[] | undefined,
+  defaultCollapsedSectionIds: string[] | undefined,
+): string[] {
+  const openSectionId = resolveSingleOpenSectionId(sectionIds, collapsedSectionIds, defaultCollapsedSectionIds);
+  return collapsedSectionIdsForOpenSection(sectionIds, openSectionId);
+}
+
 export function reconcileColumnOrder(currentIds: string[], storedOrder: string[] | undefined): string[] {
   const current = uniqueIds(currentIds);
   const currentSet = new Set(current);

--- a/components/entity-detail/entity-detail-section.tsx
+++ b/components/entity-detail/entity-detail-section.tsx
@@ -2,10 +2,7 @@
 
 import type { ReactNode } from "react";
 
-import { ChevronDown } from "lucide-react";
-import { useTranslations } from "next-intl";
-
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { cn } from "@/core/utils/cn";
 
 import { useEntityDetailPersonalization } from "./entity-detail-personalization";
@@ -20,48 +17,40 @@ type Props = {
 type GroupProps = Pick<Props, "children" | "className">;
 
 export function EntityDetailSectionGroup({ children, className }: GroupProps) {
+  const { openSectionId, setOpenSection } = useEntityDetailPersonalization();
+
   return (
-    <div data-detail-section-group className={cn("-mx-4 -mt-4 flex w-auto flex-col", className)}>
+    <Accordion
+      data-detail-section-group
+      className={cn("-mx-4 -mt-4 flex w-auto flex-col", className)}
+      type="single"
+      value={openSectionId}
+      onValueChange={(sectionId) => {
+        if (sectionId) setOpenSection(sectionId);
+      }}
+    >
       {children}
-    </div>
+    </Accordion>
   );
 }
 
 export function EntityDetailSection({ sectionId, label, children, className }: Props) {
-  const t = useTranslations();
-  const { collapsedSectionIds, setSectionCollapsed } = useEntityDetailPersonalization();
-  const open = !collapsedSectionIds.includes(sectionId);
-
   return (
-    <Collapsible
-      className={cn("w-full border-b border-border", className)}
+    <AccordionItem
+      className={cn("w-full border-border last:border-b", className)}
       data-detail-section={sectionId}
-      open={open}
-      onOpenChange={(nextOpen) => setSectionCollapsed(sectionId, !nextOpen)}
+      value={sectionId}
     >
-      <CollapsibleTrigger
-        aria-label={
-          open
-            ? t("EntityDetail.collapseSection", { section: label })
-            : t("EntityDetail.expandSection", { section: label })
-        }
-        className="group flex w-full cursor-pointer items-center gap-4 rounded-none p-4 text-left text-sm font-medium outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50"
+      <AccordionTrigger
+        className="group w-full cursor-pointer items-center gap-4 rounded-none p-4 text-left text-sm font-medium outline-none transition-colors hover:no-underline hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50 aria-disabled:cursor-default [&_svg]:motion-reduce:transition-none"
         data-detail-section-trigger={sectionId}
-        type="button"
       >
         <span className="text-sm font-medium text-foreground/85">{label}</span>
+      </AccordionTrigger>
 
-        <ChevronDown
-          aria-hidden
-          className="ml-auto size-4 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90 motion-reduce:transition-none"
-        />
-      </CollapsibleTrigger>
-
-      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-        <div className="flex flex-col gap-4 px-4 pb-4" data-detail-section-content={sectionId}>
-          {children}
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+      <AccordionContent className="flex flex-col gap-4 px-4 pb-4" data-detail-section-content={sectionId}>
+        {children}
+      </AccordionContent>
+    </AccordionItem>
   );
 }

--- a/components/entity-detail/entity-detail.registry.tsx
+++ b/components/entity-detail/entity-detail.registry.tsx
@@ -93,6 +93,7 @@ function detailPersonalization({
       ...customFieldIds.slice(0, 2),
     ],
     availableFieldIds: customColumns === undefined ? undefined : [...availableBuiltInFieldIds, ...customFieldIds],
+    defaultCollapsedSectionIds: sectionIds.slice(1),
     sectionIds,
   };
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1779,7 +1779,6 @@
     "unverified": "Unbestätigt"
   },
   "EntityDetail": {
-    "collapseSection": "{section} einklappen",
     "computedFieldHelp": {
       "dealValue": "Summe aus Einzelpreis × Menge für jeden verknüpften Eintrag in „{services}“. Ändere dort verknüpfte Einträge oder Mengen, um den Wert zu aktualisieren.",
       "serviceLineValue": "Preis von „{service}“ × Menge. Ändere hier den Eintrag oder die Menge; bearbeite den verknüpften Eintrag, um seinen Preis zu ändern.",
@@ -1788,7 +1787,6 @@
       "weightedValueUnconfigured": "{dealValue} × Abschlusswahrscheinlichkeit der ausgewählten Phase. Richte unter „{company}“ Phasenwahrscheinlichkeiten ein und wähle eine Phase; ändere „{services}“ oder Mengen."
     },
     "donePersonalizing": "Fertig",
-    "expandSection": "{section} ausklappen",
     "fields": {
       "createdAt": "Erstellt am",
       "updatedAt": "Aktualisiert am"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1779,7 +1779,6 @@
     "unverified": "Unverified"
   },
   "EntityDetail": {
-    "collapseSection": "Collapse {section}",
     "computedFieldHelp": {
       "dealValue": "Sum of unit price × quantity for every linked record in {services}. Change linked records or quantities there to update it.",
       "serviceLineValue": "{service} price × quantity. Change the record or quantity here; edit the linked record to change its price.",
@@ -1788,7 +1787,6 @@
       "weightedValueUnconfigured": "{dealValue} × the selected stage’s win probability. Configure stage probabilities in {company} and select a stage; change {services} or quantities to update it."
     },
     "donePersonalizing": "Done",
-    "expandSection": "Expand {section}",
     "fields": {
       "createdAt": "Created at",
       "updatedAt": "Updated at"

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1779,7 +1779,6 @@
     "unverified": "Sin verificar"
   },
   "EntityDetail": {
-    "collapseSection": "Contraer {section}",
     "computedFieldHelp": {
       "dealValue": "Suma del precio unitario × la cantidad de cada registro vinculado en «{services}». Edita allí los registros vinculados o las cantidades para actualizarlo.",
       "serviceLineValue": "Precio de «{service}» × cantidad. Cambia aquí el registro o la cantidad; edita el registro vinculado para cambiar su precio.",
@@ -1788,7 +1787,6 @@
       "weightedValueUnconfigured": "{dealValue} × probabilidad de cierre de la etapa seleccionada. Configura las probabilidades en «{company}» y selecciona una etapa; edita «{services}» o las cantidades."
     },
     "donePersonalizing": "Listo",
-    "expandSection": "Expandir {section}",
     "fields": {
       "createdAt": "Creado el",
       "updatedAt": "Actualizado el"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1779,7 +1779,6 @@
     "unverified": "Non vérifié"
   },
   "EntityDetail": {
-    "collapseSection": "Réduire {section}",
     "computedFieldHelp": {
       "dealValue": "Somme du prix unitaire × la quantité pour chaque élément lié dans « {services} ». Modifiez-y les éléments liés ou les quantités pour l’actualiser.",
       "serviceLineValue": "Prix de « {service} » × quantité. Modifiez ici l’élément ou la quantité ; modifiez l’élément lié pour changer son prix.",
@@ -1788,7 +1787,6 @@
       "weightedValueUnconfigured": "{dealValue} × probabilité de conclusion de l’étape sélectionnée. Configurez les probabilités dans « {company} » et sélectionnez une étape ; modifiez « {services} » ou les quantités."
     },
     "donePersonalizing": "Terminé",
-    "expandSection": "Développer {section}",
     "fields": {
       "createdAt": "Créé le",
       "updatedAt": "Mis à jour le"

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1779,7 +1779,6 @@
     "unverified": "Non verificato"
   },
   "EntityDetail": {
-    "collapseSection": "Comprimi {section}",
     "computedFieldHelp": {
       "dealValue": "Somma di prezzo unitario × quantità per ogni elemento collegato in «{services}». Modifica lì gli elementi collegati o le quantità per aggiornarlo.",
       "serviceLineValue": "Prezzo di «{service}» × quantità. Modifica qui l’elemento o la quantità; modifica l’elemento collegato per cambiarne il prezzo.",
@@ -1788,7 +1787,6 @@
       "weightedValueUnconfigured": "{dealValue} × probabilità di chiusura della fase selezionata. Configura le probabilità in «{company}» e seleziona una fase; modifica «{services}» o quantità."
     },
     "donePersonalizing": "Fine",
-    "expandSection": "Espandi {section}",
     "fields": {
       "createdAt": "Creato il",
       "updatedAt": "Aggiornato il"


### PR DESCRIPTION
## Summary

- Restore the full-height flex chain in the public navigation shell so sign-in, sign-up, and the other centered public card pages align in the usable viewport beneath the navbar.
- Replace independent entity-detail collapsibles with one shared single-open accordion across contacts, organizations, deals, services, and tasks.
- Default new and ambiguous legacy preferences to Base data while preserving an explicit saved section per user and entity type.

## Context

The auth cards stopped centering because the public scrollport and main-content wrappers no longer formed a flex-height chain. Entity detail sections could also be independently opened or closed, including states with zero or multiple sections open, while the intended interaction is exactly one open section with Base data as the initial default.

Owner-directed Linear exception:

- Issuer: Customermates repository owner in the current Codex task.
- Instruction source: the current uninterrupted task conversation, including “You don't need to create a linear issue” and “skip linear and implement it locally on the same branch.”
- Bounded outcome: center the shared public auth-card layout and make the shared entity-detail sections single-open.
- Named waiver: Linear issue, claim, receipt, and Linear connection proof for this outcome.
- Exact write scope: the public navigation shell and its regression test; shared entity-detail section, personalization, registry, and tests; removal of the two now-unused section-toggle translations in all five locales.
- Remaining constraints: current `origin/main`, disposable local data only, full local verification, independent read-only review, GitHub policy checks, preview acceptance, and a human-only merge.
- Material consequence and rollback: this PR creates one remote change branch and a paid isolated preview. Before merge, close the PR and delete the branch; after merge, use a protected revert PR.
- Instruction timestamp: 2026-09-01 in the current uninterrupted task; recorded at 2026-09-01T07:30:28+02:00.
- Acceptance and expiry: the exception expires when this PR is accepted or closed. It does not authorize merge or automatic merge.
- Evidence location: this PR's Validation section, GitHub checks, independent review, and the branch preview.

## Validation

- Fast-forwarded the worktree to `origin/main@957ad367` before committing and confirmed `origin/main` remained an ancestor of the final commit.
- Rebuilt and reseeded the disposable loopback PostgreSQL database, including the latest mainline migration.
- `yarn openapi:generate` and `yarn raw-docs:generate` — passed; no generated-file drift.
- `yarn prisma generate` — refreshed the client for the latest mainline schema.
- `yarn typecheck` — passed.
- `yarn lint` — passed.
- `yarn vitest run tests/conventions` — 73 files passed, 1 skipped; 613 tests passed, 2 skipped.
- `RUN_DATABASE_TESTS=true yarn test` — 498 files passed, 1 skipped; 4,390 tests passed, 2 skipped.
- `yarn build` — passed.
- Staged secret-pattern scan and `git diff --check` — passed.
- Independent read-only review — no P0, P1, or P2 findings; 5 focused suites and 60 tests passed.
- Local desktop/mobile browser verification — auth cards center when space permits, tall sign-up content scrolls with 16 px outer spacing, the entity accordion keeps exactly one section open, and no console warnings or errors were observed.
- Branch preview — Vercel reached READY, the deterministic sign-up URL returned HTTP 200, and both sign-up and sign-in measured a 0 px center offset within the usable main area at 1280 × 1000. Visual screenshots were captured in the originating Codex task.
- Pull-request checks — `ci`, `repository-policy`, Vercel, rendered hubs, PostgreSQL 16, CodeQL, and both analysis jobs passed on commit `3dcc9972`.

## Impact and rollback

The public shell layout change applies globally to centered auth/public card pages. Entity detail pages now keep exactly one of Base data, Relations, or Custom fields open; the selected section remains scoped per user and entity type, using the existing `collapsedSectionIds` persistence format.

This PR adds no schema, migration, API, environment-variable, or secret changes. The new migration present on `main` was exercised by the fresh local database reset but is not part of this diff. The preview uses an isolated branch database with synthetic fixtures.

Before merge, rollback is closing the PR and deleting `fix/auth-card-centering`. After merge, rollback is a protected revert PR for commit `3dcc9972`.

## Screenshots

- Auth sign-up live preview: https://fix-auth-card-centering.customermates.com/en/auth/signup
- Organization detail live preview: https://fix-auth-card-centering.customermates.com/en/organizations/70000000-0000-4000-8000-000000000016

The sign-up preview is open in the originating Codex task. The organization link requires authentication against the isolated preview database.
