### PR TITLE
fix(seo): return 404 for nested locale routes

### DIFF
--- a/__tests__/proxy-locales.test.ts
+++ b/__tests__/proxy-locales.test.ts
@@ -221,6 +221,14 @@ describe("proxy locale routing", () => {
     }
   });
 
+  it("lets nested locale prefixes fall through to the app router", async () => {
+    for (const path of ["/de/de", "/en/en", "/de/en", "/en/de"]) {
+      const { status, location } = await call(path);
+      expect(location, `${path} must not redirect to sign-in`).toBeNull();
+      expect(status, `${path} should fall through to the app router`).toBe(200);
+    }
+  });
+
   it("negotiates an unprefixed path into a content locale only", async () => {
     const german = await call("/pricing", "de-DE,de;q=0.9");
     expect(german.status).toBe(307);
@@ -282,6 +290,10 @@ describe("proxy locale routing", () => {
     expect(contentOnly.status).toBe(307);
     expect(contentOnly.location).toContain("/en/dashboard");
     expect(contentOnly.location).not.toContain("/nl/auth/signin");
+
+    const germanDeals = await call("/de/deals");
+    expect(germanDeals.status).toBe(307);
+    expect(germanDeals.location).toContain("/de/auth/signin");
   });
 
   it("terminates within a bounded number of hops", async () => {

--- a/app/components/footer-content.tsx
+++ b/app/components/footer-content.tsx
@@ -327,11 +327,11 @@ export function FooterContent({ blogPosts = [], className, featureLinks = [], in
             <li>
               <a
                 className={FOOTER_LINK_CLASS}
-                href="http://www.usawebsitesdirectory.com/computers_and_internet/"
+                href="https://www.usawebsitesdirectory.com/computers_and_internet/"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                http://www.usawebsitesdirectory.com/computers_and_internet/
+                https://www.usawebsitesdirectory.com/computers_and_internet/
               </a>
             </li>
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -58,6 +58,11 @@ function isUnsupportedLocalePrefix(pathname: string): boolean {
   return LOCALE_SHAPED_SEGMENT.test(firstSegment) && routingLocaleFromUrlSegment(firstSegment) === null;
 }
 
+function hasNestedLocalePrefix(pathname: string): boolean {
+  const secondSegment = pathname.split("/")[2] ?? "";
+  return routingLocaleFromUrlSegment(secondSegment) !== null;
+}
+
 function hasSessionCookie(req: NextRequest): boolean {
   const cookieHeader = req.headers.get("cookie") ?? "";
   return cookieHeader.includes("app.session_token=");
@@ -126,6 +131,9 @@ export default async function proxy(req: NextRequest) {
     if (isUnsupportedLocalePrefix(pathname)) return NextResponse.next();
     return negotiateLocale(req, base, isAuthenticated && pathname === "/" ? "app" : "auto");
   }
+
+  if (hasNestedLocalePrefix(pathname))
+    return isContentLocale(currentLocale) ? intlContentMiddleware(req) : intlAppMiddleware(req);
 
   if (env.APP_MODE === "demo") {
     const isNonDemoUser = isAuthenticated && session?.user?.email !== SYNTHETIC_SEED_USER.email;

--- a/tests/conventions/locale-consumer-audit.test.ts
+++ b/tests/conventions/locale-consumer-audit.test.ts
@@ -82,7 +82,7 @@ const ALLOWED_VISIBLE_COPY_SITES = new Map<string, VisibleCopyException>([
   ...reviewedVisibleCopy("Reciprocal directory labels are externally defined and locale-invariant.", [
     'app/components/footer-content.tsx :: jsx-text :: "Viesearch - The Human-curated Search Engine"',
     'app/components/footer-content.tsx :: jsx-text :: "https://www.promotebusinessdirectory.com/"',
-    'app/components/footer-content.tsx :: jsx-text :: "http://www.usawebsitesdirectory.com/computers_and_internet/"',
+    'app/components/footer-content.tsx :: jsx-text :: "https://www.usawebsitesdirectory.com/computers_and_internet/"',
     'app/components/footer-content.tsx :: jsx-text :: "https://www.bestsitesindex.com/submit.php"',
   ]),
   ...reviewedVisibleCopy("The company identity and address are legal contact data, not localized prose.", [

--- a/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
+++ b/tests/public-navigation-preferences/__tests__/navbar-preferences.test.ts
@@ -101,7 +101,7 @@ describe("public navigation preferences", () => {
     for (const href of [
       "https://viesearch.com/",
       "https://www.promotebusinessdirectory.com/",
-      "http://www.usawebsitesdirectory.com/computers_and_internet/",
+      "https://www.usawebsitesdirectory.com/computers_and_internet/",
       "https://www.bestsitesindex.com/submit.php",
     ]) {
       expect(footer, `${href} is missing below the Featured On rail`).toContain(href);


### PR DESCRIPTION
## Summary

Tracks [CUS-278](https://linear.app/customermates/issue/CUS-278).

- Return real App Router 404 responses for malformed nested locale paths such as `/de/de`, `/en/en`, `/de/en`, and `/en/de` instead of sending them through the protected-route sign-in fallback.
- Upgrade the retained USA Websites Directory reciprocal footer link and its visible URL from HTTP to the verified HTTPS endpoint.

## Context

The post-release SEO crawl retained these as repository-owned hygiene findings. The nested-locale guard is intentionally narrow: it applies only when both the first and immediate second path segments are registered locales, then delegates to the correct locale middleware so the App Router owns the final 404. Normal protected routes, valid public pages, sitemap generation, canonicals, authentication, and business logic are unchanged.

The footer anchor remains in place with the same external-link behavior and relationship attributes; only its protocol and displayed URL change.

## Validation

- Focused proxy, locale-audit, and footer tests: 38/38 passed
- `yarn typecheck`
- `yarn lint`
- `yarn conventions:check`: 613 passed, 2 skipped
- `yarn test --maxWorkers=4`: 4,274 passed, 124 skipped
- `yarn build`
- `git diff --check`
- Independent review: no P0–P2 findings
- Built app, local production server:
  - `/de/de`, `/en/en`, `/de/en`, `/en/de`: 404 with no redirect
  - `/de/deals`: 307 to localized sign-in (regression control)
  - `/en/features/cloud-crm`: 200 (public Ads-page control)
  - `/en/contact`: rendered footer contains only `https://www.usawebsitesdirectory.com/computers_and_internet/`

The first unconstrained full-test run oversubscribed the machine and produced five timeout failures plus one stale generated-doc lookup. Every timeout passed in isolation; regenerating OpenAPI before the raw-doc manifest fixed the lookup. The complete bounded-worker run then passed.

## Impact and rollback

No database, API, billing, authentication, analytics, attribution, lifecycle, or other business-logic behavior changes. The only runtime change is malformed nested-locale routing; the other change is footer copy/link protocol.

Revert commit `bac420d6` to restore the previous behavior. No data migration or cleanup is required.
