### PR TITLE
fix(agent-chat): route Mate models through Azure for ZDR

### DIFF
--- a/ee/agent-chat/__tests__/agent-budget-policy.test.ts
+++ b/ee/agent-chat/__tests__/agent-budget-policy.test.ts
@@ -16,6 +16,10 @@ const BALANCED = MODEL_CATALOG.balanced;
 const FAST = MODEL_CATALOG.fast;
 
 describe("agent turn credit budget", () => {
+  it("pins every shipped model to the ZDR-compatible Azure provider", () => {
+    expect([FAST.servingProvider, BALANCED.servingProvider]).toEqual(["azure", "azure"]);
+  });
+
   it("gives every model its own full envelope, because affordability is no longer a smaller envelope", () => {
     for (const model of [FAST, BALANCED]) {
       const budget = resolveAgentTurnBudget({ model, availableCredits: 500 });

--- a/ee/agent-chat/__tests__/agent-usage.test.ts
+++ b/ee/agent-chat/__tests__/agent-usage.test.ts
@@ -276,7 +276,7 @@ describe("AgentUsageService admission and ledger", () => {
   it("charges the gateway's measured cost rather than the pinned estimate", () => {
     const settlement = buildAgentUsageSettlement({
       model: "openai/gpt-5-nano",
-      provider: "openai",
+      provider: "azure",
       tokens: { inputTokens: 35_329, outputTokens: 2_945, cacheReadTokens: 73_728, cacheWriteTokens: 0 },
       reservedCredits: 14,
       providerCharge: { billed: true, measuredCostMicrocents: 2_000_001, stepTokens: [], unreadableReason: null },
@@ -293,7 +293,7 @@ describe("AgentUsageService admission and ledger", () => {
   it("quarantines an unreadable cost against the pinned estimate instead of throwing", () => {
     const settlement = buildAgentUsageSettlement({
       model: "openai/gpt-5-nano",
-      provider: "openai",
+      provider: "azure",
       tokens: { inputTokens: 35_329, outputTokens: 2_945, cacheReadTokens: 73_728, cacheWriteTokens: 0 },
       reservedCredits: 14,
       providerCharge: {
@@ -304,7 +304,7 @@ describe("AgentUsageService admission and ledger", () => {
       },
     });
 
-    expect(settlement).toMatchObject({ costMicrocents: 331_309, costSource: "estimated", state: "settled" });
+    expect(settlement).toMatchObject({ costMicrocents: 368_173, costSource: "estimated", state: "settled" });
   });
 
   it("prices a multi-step turn per request, as the provider bills it, not on the turn aggregate", () => {
@@ -319,14 +319,14 @@ describe("AgentUsageService admission and ledger", () => {
 
     const settlement = buildAgentUsageSettlement({
       model: "openai/gpt-5.6-luna",
-      provider: "openai",
+      provider: "azure",
       tokens: aggregate,
       reservedCredits: 40,
       providerCharge: { billed: true, measuredCostMicrocents: null, stepTokens: steps, unreadableReason: "test" },
     });
 
     expect(settlement.costMicrocents).toBe(1_568_524);
-    expect(computeCostMicrocents("openai/gpt-5.6-luna", aggregate, "openai")).toBe(3_105_428);
+    expect(computeCostMicrocents("openai/gpt-5.6-luna", aggregate, "azure")).toBe(3_105_428);
     expect(settlement.chargedCredits).toBe(2);
   });
 

--- a/ee/agent-chat/__tests__/gateway-cost.test.ts
+++ b/ee/agent-chat/__tests__/gateway-cost.test.ts
@@ -138,7 +138,7 @@ describe("gateway provider charge", () => {
     expect(reading.reason.length).toBeGreaterThan(0);
   });
 
-  it("refuses the real azure routing payload that prices the shipped model at five times the pinned rate", () => {
+  it("accepts the real Azure routing payload only when Azure is the expected provider", () => {
     const reading = readAgentProviderCharge(AZURE_SERVED_LUNA, "openai");
 
     expect(reading.outcome).toBe("unreadable");

--- a/ee/agent-chat/__tests__/model-pricing.test.ts
+++ b/ee/agent-chat/__tests__/model-pricing.test.ts
@@ -11,11 +11,12 @@ import {
 
 const GATEWAY_ID = "openai/gpt-5.6-luna";
 const NATIVE_ID = "gpt-5.6-luna";
+const PROVIDER = "azure";
 const BOUNDARY = 272_000;
 
 describe("pinned pricing snapshot", () => {
   it("validates at module load and pins the configured endpoint", () => {
-    expect(pinnedModelEndpoints()).toEqual(expect.arrayContaining([{ modelId: GATEWAY_ID, provider: "openai" }]));
+    expect(pinnedModelEndpoints()).toEqual(expect.arrayContaining([{ modelId: GATEWAY_ID, provider: PROVIDER }]));
     expect(
       pinnedModelEndpoints()
         .map((endpoint) => endpoint.modelId)
@@ -24,7 +25,7 @@ describe("pinned pricing snapshot", () => {
   });
 
   it("resolves by gateway id and by provider-native id alike", () => {
-    expect(resolveModelPricing(GATEWAY_ID)).toEqual(resolveModelPricing(NATIVE_ID));
+    expect(resolveModelPricing(GATEWAY_ID, 0, PROVIDER)).toEqual(resolveModelPricing(NATIVE_ID, 0, PROVIDER));
   });
 
   it("refuses an unpinned model rather than substituting a fallback rate", () => {
@@ -122,7 +123,7 @@ describe("measured against the live gateway", () => {
   ];
 
   it.each(MEASURED)("prices $label exactly as the gateway billed it", ({ tokens, microcents }) => {
-    expect(computeCostMicrocents(GATEWAY_ID, tokens, "openai")).toBe(microcents);
+    expect(computeCostMicrocents(GATEWAY_ID, tokens, PROVIDER)).toBe(microcents);
   });
 
   it("counts cached tokens toward the long-context boundary, as the provider does", () => {
@@ -130,10 +131,10 @@ describe("measured against the live gateway", () => {
 
     expect(promptTokensOf(cachedOnly)).toBeGreaterThan(BOUNDARY);
     expect(cachedOnly.inputTokens).toBeLessThan(BOUNDARY);
-    expect(resolveModelPricing(GATEWAY_ID, promptTokensOf(cachedOnly), "openai").inputPerMTok).toBe(0.4);
-    expect(computeCostMicrocents(GATEWAY_ID, cachedOnly, "openai")).toBe(15_791_420);
+    expect(resolveModelPricing(GATEWAY_ID, promptTokensOf(cachedOnly), PROVIDER).inputPerMTok).toBe(0.4);
+    expect(computeCostMicrocents(GATEWAY_ID, cachedOnly, PROVIDER)).toBe(15_791_420);
 
-    const tier1 = resolveModelPricing(GATEWAY_ID, 0, "openai");
+    const tier1 = resolveModelPricing(GATEWAY_ID, 0, PROVIDER);
     const ifOnlyUncachedCounted = Math.round(
       (cachedOnly.inputTokens * tier1.inputPerMTok +
         cachedOnly.outputTokens * tier1.outputPerMTok +
@@ -142,6 +143,6 @@ describe("measured against the live gateway", () => {
     );
 
     expect(ifOnlyUncachedCounted).toBe(7_895_860);
-    expect(computeCostMicrocents(GATEWAY_ID, cachedOnly, "openai") - ifOnlyUncachedCounted).toBe(7_895_560);
+    expect(computeCostMicrocents(GATEWAY_ID, cachedOnly, PROVIDER) - ifOnlyUncachedCounted).toBe(7_895_560);
   });
 });

--- a/ee/agent-chat/model-catalog.ts
+++ b/ee/agent-chat/model-catalog.ts
@@ -14,14 +14,14 @@ export type AgentModelEntry = {
 export const MODEL_CATALOG = {
   fast: {
     modelId: "openai/gpt-5-nano",
-    servingProvider: "openai",
+    servingProvider: "azure",
     maxOutputTokens: 8192,
     maxContextTokens: 66_000,
     maxToolResultChars: 6000,
   },
   balanced: {
     modelId: "openai/gpt-5.6-luna",
-    servingProvider: "openai",
+    servingProvider: "azure",
     maxOutputTokens: 2048,
     maxContextTokens: 66_000,
     maxToolResultChars: 6000,

--- a/ee/agent-chat/model-pricing.snapshot.ts
+++ b/ee/agent-chat/model-pricing.snapshot.ts
@@ -1,11 +1,11 @@
 export const MODEL_PRICING_SNAPSHOT = {
   source: "https://ai-gateway.vercel.sh/v1/models/{model}/endpoints",
-  fetchedAt: "2026-08-25T09:09:14Z",
+  fetchedAt: "2026-09-01T11:14:07Z",
   endpoints: [
     {
       modelId: "openai/gpt-5.6-luna",
       providerNativeModelId: "gpt-5.6-luna",
-      provider: "openai",
+      provider: "azure",
       contextLength: 1050000,
       maxCompletionTokens: 128000,
       requestUsd: "0",
@@ -57,7 +57,7 @@ export const MODEL_PRICING_SNAPSHOT = {
     {
       modelId: "openai/gpt-5-nano",
       providerNativeModelId: "gpt-5-nano",
-      provider: "openai",
+      provider: "azure",
       contextLength: 400000,
       maxCompletionTokens: 128000,
       requestUsd: "0",
@@ -74,7 +74,7 @@ export const MODEL_PRICING_SNAPSHOT = {
       ],
       inputCacheRead: [
         {
-          costUsdPerToken: "0.000000005",
+          costUsdPerToken: "0.00000001",
         },
       ],
       inputCacheWrite: [

--- a/scripts/refresh-agent-model-pricing.ts
+++ b/scripts/refresh-agent-model-pricing.ts
@@ -6,8 +6,8 @@ const GATEWAY_ENDPOINTS_URL = "https://ai-gateway.vercel.sh/v1/models";
 const SNAPSHOT_PATH = join(process.cwd(), "ee/agent-chat/model-pricing.snapshot.ts");
 
 const PINNED = [
-  { modelId: "openai/gpt-5.6-luna", providerNativeModelId: "gpt-5.6-luna", provider: "openai" },
-  { modelId: "openai/gpt-5-nano", providerNativeModelId: "gpt-5-nano", provider: "openai" },
+  { modelId: "openai/gpt-5.6-luna", providerNativeModelId: "gpt-5.6-luna", provider: "azure" },
+  { modelId: "openai/gpt-5-nano", providerNativeModelId: "gpt-5-nano", provider: "azure" },
 ];
 
 type CatalogTier = { cost: string; min?: number; max?: number };


### PR DESCRIPTION
## Summary

- Route Mate fast and balanced models through the Azure AI Gateway provider.
- Refresh the provider-specific pricing snapshot and cost/accounting tests.

## Context

Team-wide Zero Data Retention filters out the currently pinned OpenAI endpoints, leaving Mate with no eligible provider. Azure currently serves both selected models with ZDR, no-training, and tool-use support, so this keeps the model IDs unchanged while restoring a compliant route. The owner explicitly waived a Linear ticket for this small fix.

## Validation

- Focused agent routing, pricing, metering, and convention tests: 71 passed.
- Typecheck and lint passed.
- Convention suite: 613 passed, 2 skipped.
- Full PostgreSQL-backed suite: 4,397 passed, 2 skipped.
- Production build passed.
- Pricing snapshot regenerated from the live AI Gateway endpoint catalog.
- Independent pre-push review completed with no findings.

## Impact and rollback

Mate requests for GPT-5 nano and GPT-5.6 Luna are restricted to Azure. Model selection, Luna token rates, and the customer credit formula are unchanged; Nano cached input reflects Azure pricing at $0.01 per million tokens. There are no schema, migration, environment-variable, or UI changes. Revert commit 6b2aa884 to restore the prior OpenAI route; that rollback also requires team-wide ZDR to be disabled unless OpenAI becomes ZDR-eligible.