### PR TITLE
fix(operator): grant platform access to a member whose identity is unbound

### DIFF
--- a/ee/operator/__tests__/prisma-operator.repository.database.test.ts
+++ b/ee/operator/__tests__/prisma-operator.repository.database.test.ts
@@ -47,7 +47,13 @@ class RollbackOperatorTest extends Error {}
 
 async function createPlatformAccessUser(
   tx: AppPrismaClient,
-  args: { email?: string; status?: "active" | "inactive"; isPlatformOperator?: boolean; emailVerified?: boolean },
+  args: {
+    email?: string;
+    status?: "active" | "inactive";
+    isPlatformOperator?: boolean;
+    emailVerified?: boolean;
+    authCompanyId?: string | null;
+  },
 ) {
   const companyId = randomUUID();
   const userId = randomUUID();
@@ -68,13 +74,13 @@ async function createPlatformAccessUser(
   await tx.authUser.create({
     data: {
       id: authUserId,
-      companyId,
+      companyId: args.authCompanyId === undefined ? companyId : args.authCompanyId,
       email,
       name: "Platform Candidate",
       emailVerified: args.emailVerified ?? true,
     },
   });
-  return { userId, companyId, email };
+  return { userId, companyId, email, authUserId };
 }
 
 function operatorActor(userId = `operator-${randomUUID()}`): OperatorActor {
@@ -371,6 +377,169 @@ describeDatabase("PrismaOperatorRepo against a real database", { timeout: 120_00
       prisma.subscription.findUniqueOrThrow({ where: { companyId: target.companyId } }),
     );
     expect(subscription.enterpriseAgentCreditsPerUser).toBe(10);
+  });
+
+  it("grants platform access without reading or writing the invite marker", async () => {
+    const actor = operatorActor();
+    let observed: { granted: boolean; markerLeftAlone: boolean } | null = null;
+
+    try {
+      await runWithOperator(actor, () =>
+        runWithoutTenant(() =>
+          runInTransaction(async () => {
+            const tx = getTransactionClient<AppPrismaClient>();
+            if (!tx) throw new Error("Expected platform-access test transaction.");
+
+            const target = await createPlatformAccessUser(tx, { authCompanyId: null });
+            const repo = new PrismaOperatorRepo();
+
+            const granted = await repo.updateUserPlatformAccessUnscoped({
+              userId: target.userId,
+              isPlatformOperator: true,
+            });
+            assertAdmitted(granted);
+
+            const identity = await tx.authUser.findUniqueOrThrow({
+              where: { id: target.authUserId },
+              select: { companyId: true },
+            });
+
+            observed = { granted: granted.isPlatformOperator, markerLeftAlone: identity.companyId === null };
+            throw new RollbackOperatorTest();
+          }),
+        ),
+      );
+    } catch (error) {
+      if (!(error instanceof RollbackOperatorTest)) throw error;
+    }
+
+    expect(observed).toEqual({ granted: true, markerLeftAlone: true });
+  });
+
+  it("lets the access gate admit a member identified by email alone", async () => {
+    const actor = operatorActor();
+    let admitted: unknown = null;
+
+    try {
+      await runWithOperator(actor, () =>
+        runWithoutTenant(() =>
+          runInTransaction(async () => {
+            const tx = getTransactionClient<AppPrismaClient>();
+            if (!tx) throw new Error("Expected platform-access test transaction.");
+
+            const target = await createPlatformAccessUser(tx, { authCompanyId: null });
+            const granted = await new PrismaOperatorRepo().updateUserPlatformAccessUnscoped({
+              userId: target.userId,
+              isPlatformOperator: true,
+            });
+            assertAdmitted(granted);
+
+            const sessionId = randomUUID();
+            await tx.authSession.create({
+              data: {
+                id: sessionId,
+                token: randomUUID(),
+                userId: target.authUserId,
+                expiresAt: new Date(Date.now() + 86_400_000),
+              },
+            });
+
+            admitted = await new PrismaOperatorAccessRepo().findAuthorizedActorUnscoped({
+              session: { id: sessionId },
+              user: { id: target.authUserId, email: target.email },
+            } as never);
+
+            throw new RollbackOperatorTest();
+          }),
+        ),
+      );
+    } catch (error) {
+      if (!(error instanceof RollbackOperatorTest)) throw error;
+    }
+
+    expect(admitted).toMatchObject({ userId: expect.any(String), email: expect.any(String) });
+  });
+
+  it("ignores a stale invite marker pointing at another workspace", async () => {
+    const actor = operatorActor();
+    let outcome: unknown = null;
+
+    try {
+      await runWithOperator(actor, () =>
+        runWithoutTenant(() =>
+          runInTransaction(async () => {
+            const tx = getTransactionClient<AppPrismaClient>();
+            if (!tx) throw new Error("Expected platform-access test transaction.");
+
+            const foreignCompanyId = randomUUID();
+            await tx.company.create({ data: { id: foreignCompanyId } });
+            const target = await createPlatformAccessUser(tx, { authCompanyId: foreignCompanyId });
+            const repo = new PrismaOperatorRepo();
+
+            outcome = await repo.updateUserPlatformAccessUnscoped({
+              userId: target.userId,
+              isPlatformOperator: true,
+            });
+            throw new RollbackOperatorTest();
+          }),
+        ),
+      );
+    } catch (error) {
+      if (!(error instanceof RollbackOperatorTest)) throw error;
+    }
+
+    expect(outcome).toMatchObject({ isPlatformOperator: true });
+  });
+
+  it("resolves an address whose local part contains a pattern wildcard", async () => {
+    const actor = operatorActor();
+    let observed: { granted: boolean; admittedMatchesOperator: boolean } | null = null;
+
+    try {
+      await runWithOperator(actor, () =>
+        runWithoutTenant(() =>
+          runInTransaction(async () => {
+            const tx = getTransactionClient<AppPrismaClient>();
+            if (!tx) throw new Error("Expected platform-access test transaction.");
+
+            const marker = randomUUID().slice(0, 8);
+            const operator = await createPlatformAccessUser(tx, { email: `a_c${marker}@example.invalid` });
+            await createPlatformAccessUser(tx, { email: `abc${marker}@example.invalid` });
+
+            const granted = await new PrismaOperatorRepo().updateUserPlatformAccessUnscoped({
+              userId: operator.userId,
+              isPlatformOperator: true,
+            });
+            assertAdmitted(granted);
+
+            const sessionId = randomUUID();
+            await tx.authSession.create({
+              data: {
+                id: sessionId,
+                token: randomUUID(),
+                userId: operator.authUserId,
+                expiresAt: new Date(Date.now() + 86_400_000),
+              },
+            });
+
+            const admitted = (await new PrismaOperatorAccessRepo().findAuthorizedActorUnscoped({
+              session: { id: sessionId },
+              user: { id: operator.authUserId, email: operator.email },
+            } as never)) as { userId: string } | null;
+
+            observed = {
+              granted: granted.isPlatformOperator,
+              admittedMatchesOperator: admitted?.userId === operator.userId,
+            };
+            throw new RollbackOperatorTest();
+          }),
+        ),
+      );
+    } catch (error) {
+      if (!(error instanceof RollbackOperatorTest)) throw error;
+    }
+
+    expect(observed).toEqual({ granted: true, admittedMatchesOperator: true });
   });
 
   it("grants and revokes platform access, counting active operators in every workspace", async () => {

--- a/ee/operator/prisma-operator-access.repository.ts
+++ b/ee/operator/prisma-operator-access.repository.ts
@@ -18,35 +18,34 @@ export class PrismaOperatorAccessRepo extends BaseRepository implements Operator
       }),
       this.prisma.authUser.findUnique({
         where: { id: session.user.id },
-        select: { id: true, email: true, emailVerified: true, companyId: true },
+        select: { id: true, email: true, emailVerified: true },
       }),
     ]);
     if (!freshSession || freshSession.userId !== session.user.id || freshSession.expiresAt.getTime() <= Date.now())
       return null;
-    if (!authUser?.emailVerified || !authUser.companyId) return null;
+    if (!authUser?.emailVerified) return null;
 
     const sessionEmail = normalizeOperatorEmail(session.user.email);
     const freshAuthEmail = normalizeOperatorEmail(authUser.email);
     if (sessionEmail !== freshAuthEmail) return null;
 
-    const users = await this.prisma.user.findMany({
-      where: { email: { equals: freshAuthEmail, mode: "insensitive" }, companyId: authUser.companyId },
-      take: 2,
-      select: {
-        id: true,
-        email: true,
-        companyId: true,
-        status: true,
-        isPlatformOperator: true,
-      },
-    });
-    if (users.length !== 1) return null;
+    const operatorUserSelect = {
+      id: true,
+      email: true,
+      companyId: true,
+      status: true,
+      isPlatformOperator: true,
+    } as const;
 
-    const user = users[0];
+    const user = await this.prisma.user.findUnique({
+      where: { email: freshAuthEmail },
+      select: operatorUserSelect,
+    });
+    if (!user) return null;
+
     if (
       user.status !== Status.active ||
       !user.isPlatformOperator ||
-      authUser.companyId !== user.companyId ||
       normalizeOperatorEmail(user.email) !== freshAuthEmail
     )
       return null;

--- a/ee/operator/prisma-operator.repository.ts
+++ b/ee/operator/prisma-operator.repository.ts
@@ -288,7 +288,7 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
     return new Map(
       users.map((user) => {
         const matches = byEmail.get(normalizeOperatorEmail(user.email)) ?? [];
-        const verified = matches.length === 1 && matches[0].emailVerified && matches[0].companyId === user.companyId;
+        const verified = matches.length === 1 && matches[0].emailVerified;
         return [user.id, verified];
       }),
     );
@@ -506,7 +506,6 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           FROM "User" AS domain_user
           JOIN "AuthUser" AS auth_user
             ON lower(auth_user."email") = lower(domain_user."email")
-            AND auth_user."companyId" = domain_user."companyId"
             AND auth_user."emailVerified" = true
           WHERE (
             SELECT COUNT(*)
@@ -660,19 +659,17 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           if (target.status !== Status.active) return "conflict";
 
           const email = normalizeOperatorEmail(target.email);
-          const domainUsers = await this.prisma.user.count({
-            where: { email: { equals: email, mode: "insensitive" } },
+          const resolvedMember = await this.prisma.user.findUnique({
+            where: { email },
+            select: { id: true },
           });
-          if (domainUsers !== 1) return "conflict";
+          if (resolvedMember?.id !== data.userId) return "conflict";
 
-          const authUsers = await this.prisma.authUser.findMany({
-            where: { email: { equals: email, mode: "insensitive" } },
-            take: 2,
-            select: { companyId: true, emailVerified: true },
+          const identity = await this.prisma.authUser.findUnique({
+            where: { email },
+            select: { emailVerified: true },
           });
-          if (authUsers.length !== 1) return "conflict";
-          if (!authUsers[0].emailVerified) return "conflict";
-          if (authUsers[0].companyId !== companyId) return "conflict";
+          if (!identity?.emailVerified) return "conflict";
         } else if (target.isPlatformOperator) {
           const otherActiveOperators = await this.prisma.user.count({
             where: { id: { not: data.userId }, isPlatformOperator: true, status: Status.active },


### PR DESCRIPTION
## Summary

- Identifies the operator by their email address, which is uniquely indexed, instead of by `AuthUser.companyId`.
- Removes that column from both the console's access gate and the platform access grant. It is an invite marker, not a record of which workspace a member administers.
- Disambiguates a case-variant email collision by exact case rather than by company, which closes a lockout this change would otherwise have opened.

## Context

Granting platform operator access required `AuthUser.companyId` to be non-null and to equal the member's workspace. `features/user/register/register-user.interactor.ts:106` shows what that column is for: it is read once at registration to decide whether the registrant joins an existing company or gets a new one. It is an invite marker. Nothing writes it afterwards.

The consequence on live data: it is null for **147 of 164** identities, because only invited people ever get one, and the grant was refused for **12 of the 22** members who were otherwise eligible. The refusal surfaced as the generic conflict toast, "The record may have changed since the list loaded... Reload and check the current state", naming a cause that was not the cause and a remedy that could not work.

Both `User.email` and `AuthUser.email` carry unique indexes, so the address already identifies the member and the marker adds nothing.

It cannot simply be deleted, though, and this is the part worth reviewing. Resolution moves to an exact lookup on the normalised address rather than a case-insensitive comparison, for two independent reasons. Those indexes are **case-sensitive** while the lookup is case-**insensitive**, so `op@x.com` and `OP@x.com` can coexist as two rows. Scoping the lookup by company was accidentally hiding that. Removing it with nothing in its place means a stranger who registers a case-variant of an operator's address **locks that operator out of the console**. The suite already covers this, in "keeps authorizing an operator when a stranger holds a case-variant of their email", and the first draft of this change failed it.

The second reason is worse and was not on my radar until an adversarial review of this change raised it: Prisma compiles `equals` with `mode: "insensitive"` to `ILIKE`, where `_` and `%` are wildcards. I confirmed it against the database: querying for `a_c@…` also returns `abc@…`. Underscores are ordinary in real addresses. That both refused legitimate grants and let an unrelated person's identity satisfy the "a verified identity exists" precondition.

So both the gate and the grant now resolve by exact lookup on the normalised address, which better-auth guarantees is lowercase at creation. It is unique-index backed, immune to both the case-variant lockout and the wildcard collision, and it fails closed when no row matches. The grant additionally asserts that the address resolves back to the member being promoted, which subsumes the ambiguity count it replaces.

Two further readers encoded the same assumption and are corrected here, because shipping without them would mean the console grants a member access while reporting that member's identity as unverified: the per-user badge and the overview's verified-identity count. Measured on live data, the join term suppresses those to **18** of the **144** identities that actually qualify.

An earlier draft bound the marker on promotion instead. That was wrong, and the field's owner corrected it: the marker describes where an invitee should land at registration, not which workspace an existing member administers. Nothing in this change writes it.

## Validation

- Reproduced before fixing, and each protection proven by removing it and watching the matching test fail: the case-variant lockout, and the grant of an unbound identity.
- A test asks the access gate itself whether a member promoted this way would be admitted, so the console cannot record an operator who is then refused at sign-in.
- `yarn typecheck`, `yarn lint`, full suite with database tests at **4,596 passed, 2 skipped across 525 files**.
- Data checked rather than assumed: unique indexes confirmed to exist in the database itself, zero case-insensitive duplicates in either table today, all 153 matched identity pairs agree on case, and zero `AuthUser.id` values coincide with a `User.id`, which is why the address is the only available link.
- One pre-existing test flake is worth knowing about, because it can make this pull request look red without being about it. `prisma-operator.repository.database.test.ts` proves the last-operator guard by clearing every platform operator globally, while `operator-lists.database.test.ts:98` commits an active one from a file running in parallel. Both lines are on main and this change removes neither. It passed four of four runs of the operator suite and failed one full-suite run.
- Driven in a browser against a copy of live data: the account that originally hit the refusal is promoted successfully and the change is audited with previous and next.

## Impact and rollback

Behaviour changes in two places, both inside the operator console: the access gate and the platform access grant. No schema change, no migration, no environment variable, and no write to any auth row.

Access is not widened. Every existing condition survives: a fresh unexpired session, a verified auth identity, the session address matching that identity, the member being active, and the member carrying `isPlatformOperator`, which remains the actual grant. What changes is which member an address resolves to, and it now resolves more precisely than before.

Two behaviours are deliberately different. A member whose identity carries no invite marker can now be granted access, which is the point. And a stale marker pointing at another workspace is now ignored rather than blocking, because a marker left over from an invitation says nothing about who administers what today.

Rollback before merge is closing this pull request and deleting its branch. After merge, a revert restores the previous rule; no data written by this change needs undoing, because it writes none.
