### PR TITLE
feat(operator): show the credit rate every workspace actually grants

### DIFF
--- a/app/[locale]/(protected)/operator/components/users/operator-user-modal.tsx
+++ b/app/[locale]/(protected)/operator/components/users/operator-user-modal.tsx
@@ -282,6 +282,12 @@ export const OperatorUserModal = observer(function OperatorUserModal({ user, onC
                       </Button>
                     </div>
 
+                    <p className="text-xs text-muted-foreground">
+                      {t("OperatorUsers.adjustment.expiresAt", {
+                        date: intlStore.formatNumericalShortDate(period.periodEnd),
+                      })}
+                    </p>
+
                     <div className="flex flex-col gap-2">
                       <Button
                         className="w-full"

--- a/app/[locale]/(protected)/operator/components/workspaces/operator-workspace-modal.tsx
+++ b/app/[locale]/(protected)/operator/components/workspaces/operator-workspace-modal.tsx
@@ -19,6 +19,7 @@ import { ClickableChip } from "@/components/chip/clickable-chip";
 import { InfoRow } from "@/components/shared/info-row";
 import { Button } from "@/components/ui/button";
 import { FormInputChips } from "@/components/forms/form-input-chips";
+import { FormIsoDatePicker } from "@/components/forms/form-iso-date-picker";
 import { FormLabel } from "@/components/forms/form-label";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -315,14 +316,14 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
             </div>
 
             <div className="flex items-end gap-2">
-              <div className="flex-1 space-y-1.5">
-                <FormLabel htmlFor="operator-modal-trial">{t("OperatorWorkspaces.terms.trialEnd")}</FormLabel>
-
-                <Input
+              <div className="flex-1">
+                <FormIsoDatePicker
+                  clearable={false}
+                  containerClassName="flex-1"
                   id="operator-modal-trial"
-                  type="date"
+                  label={t("OperatorWorkspaces.terms.trialEnd")}
                   value={trialEnd}
-                  onChange={(event) => setTrialEnd(event.target.value)}
+                  onValueChange={(value) => setTrialEnd(value ?? "")}
                 />
               </div>
 

--- a/app/[locale]/(protected)/operator/components/workspaces/use-operator-workspace-columns.tsx
+++ b/app/[locale]/(protected)/operator/components/workspaces/use-operator-workspace-columns.tsx
@@ -6,9 +6,10 @@ import type { OperatorWorkspaceRowDto } from "@/ee/operator/operator-lists.schem
 import { useMemo } from "react";
 import { useTranslations } from "next-intl";
 
-import { SubscriptionPlan } from "@/generated/prisma";
+import { SubscriptionPlan, SubscriptionStatus } from "@/generated/prisma";
 
 import { AppChip } from "@/components/chip/app-chip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { OperatorTagsCell } from "../tags/operator-tags-cell";
 import { SUBSCRIPTION_STATUS_COLOR_MAP } from "@/app/[locale]/(protected)/company/components/subscription/subscription-panel";
 import { useHydratedIntlStore } from "@/core/stores/use-hydrated-intl-store";
@@ -73,14 +74,39 @@ export function useOperatorWorkspaceColumns(): ColumnDef<OperatorWorkspaceRowDto
       {
         id: "allowance",
         header: t("Common.table.columns.allowance"),
-        cell: ({ row }) =>
-          row.original.plan === SubscriptionPlan.enterprise ? (
-            <span className="text-sm">
-              {row.original.enterpriseCreditsPerUser === null
-                ? t("OperatorWorkspaces.allowance.notSet")
-                : intlStore.formatNumber(row.original.enterpriseCreditsPerUser)}
-            </span>
-          ) : null,
+        cell: ({ row }) => {
+          const { plan, subscriptionStatus, creditsPerUser } = row.original;
+          if (!plan) return <span className="text-sm text-muted-foreground">-</span>;
+
+          const awaitingContract = plan === SubscriptionPlan.enterprise && creditsPerUser === null;
+          const onTrial = subscriptionStatus === SubscriptionStatus.trial;
+          const label = awaitingContract
+            ? t("OperatorWorkspaces.allowance.notSet")
+            : creditsPerUser === null
+              ? "-"
+              : intlStore.formatNumber(creditsPerUser);
+          const explanation = awaitingContract
+            ? t("OperatorWorkspaces.allowance.hintMissing")
+            : creditsPerUser === null
+              ? t("OperatorWorkspaces.allowance.hintUnavailable")
+              : onTrial
+                ? t("OperatorWorkspaces.allowance.hintTrial")
+                : plan === SubscriptionPlan.enterprise
+                  ? t("OperatorWorkspaces.allowance.hintContract")
+                  : t("OperatorWorkspaces.allowance.hintPlan", {
+                      plan: t(`Subscription.planNames.${row.original.plan}`),
+                    });
+
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className={awaitingContract ? "text-sm text-warning" : "text-sm"}>{label}</span>
+              </TooltipTrigger>
+
+              <TooltipContent className="max-w-72">{explanation}</TooltipContent>
+            </Tooltip>
+          );
+        },
       },
       {
         id: "trialEnd",

--- a/components/forms/form-iso-date-picker.tsx
+++ b/components/forms/form-iso-date-picker.tsx
@@ -29,6 +29,9 @@ type Props = {
   required?: boolean;
   displayFormat?: DateDisplayFormat;
   dateOnly?: boolean;
+  clearable?: boolean;
+  value?: string;
+  onValueChange?: (value: string | undefined) => void;
   className?: string;
   containerClassName?: string;
 };
@@ -41,6 +44,9 @@ export const FormIsoDatePicker = observer(
     required,
     displayFormat = "descriptiveLong",
     dateOnly = true,
+    clearable = true,
+    value: controlledValue,
+    onValueChange,
     className,
     containerClassName,
   }: Props) => {
@@ -49,8 +55,8 @@ export const FormIsoDatePicker = observer(
     const store = useAppForm();
     const intlStore = useHydratedIntlStore();
 
-    const raw = store?.getValue(id);
-    const isoValue = typeof raw === "string" ? raw : undefined;
+    const raw = controlledValue ?? store?.getValue(id);
+    const isoValue = typeof raw === "string" && raw !== "" ? raw : undefined;
     const parsed = parseIsoDate(isoValue);
     const { hasError } = useFormFieldErrors(id);
     const isLoading = store?.isLoading ?? false;
@@ -70,10 +76,14 @@ export const FormIsoDatePicker = observer(
       if (isReadOnly || isLoading) return;
 
       if (!date) {
-        store?.onChange(id, undefined);
+        if (onValueChange) onValueChange(undefined);
+        else store?.onChange(id, undefined);
         return;
       }
-      store?.onChange(id, toLocalIso(date, dateOnly));
+
+      const next = toLocalIso(date, dateOnly);
+      if (onValueChange) onValueChange(next);
+      else store?.onChange(id, next);
       setCurrentMonth(startOfMonth(date));
     }
 
@@ -138,7 +148,9 @@ export const FormIsoDatePicker = observer(
 
               <span className="truncate flex-1">{parsed ? formatter(parsed) : resolvedPlaceholder}</span>
 
-              {parsed && !isReadOnly && !isLoading ? <InputClearButton onClear={() => commit(undefined)} /> : null}
+              {parsed && clearable && !isReadOnly && !isLoading ? (
+                <InputClearButton onClear={() => commit(undefined)} />
+              ) : null}
             </Button>
           </PopoverTrigger>
 

--- a/core/validation/validation.types.ts
+++ b/core/validation/validation.types.ts
@@ -114,6 +114,7 @@ export enum CustomErrorCode {
   operatorUnavailable = "operatorUnavailable",
   operatorAllowanceMissing = "operatorAllowanceMissing",
   operatorConnectedAccountsActive = "operatorConnectedAccountsActive",
+  operatorTrialEndRequired = "operatorTrialEndRequired",
   generic = "generic",
 }
 

--- a/ee/agent-chat/__tests__/agent-credit-policy.test.ts
+++ b/ee/agent-chat/__tests__/agent-credit-policy.test.ts
@@ -8,6 +8,7 @@ import {
   agentCreditsForStartedProviderCost,
   prorateAgentCreditsForSeat,
   resolveAgentCreditEntitlement,
+  workspaceAgentCreditRate,
 } from "../agent-credit-policy";
 
 const ACTIVE = SubscriptionStatus.active;
@@ -167,6 +168,44 @@ describe("agent credit entitlements", () => {
 
     expect(business.limit).toBeGreaterThan(pro.limit);
     expect(starter.limit).toBeLessThan(pro.limit);
+  });
+});
+
+describe("workspace credit rate", () => {
+  function rate(overrides: Partial<Parameters<typeof workspaceAgentCreditRate>[0]> = {}) {
+    return workspaceAgentCreditRate({
+      plan: SubscriptionPlan.starter,
+      status: ACTIVE,
+      trialEndDate: null,
+      enterpriseCreditsPerUser: null,
+      now: NOW,
+      ...overrides,
+    });
+  }
+
+  it("reports the plan rate for a paid workspace", () => {
+    expect(rate({ plan: SubscriptionPlan.starter })).toBe(200);
+    expect(rate({ plan: SubscriptionPlan.pro })).toBe(500);
+    expect(rate({ plan: SubscriptionPlan.business })).toBe(1_200);
+  });
+
+  it("reports the trial rate whatever the plan says, until the trial ends", () => {
+    const live = { status: SubscriptionStatus.trial, trialEndDate: new Date("2026-08-20T12:00:00.000Z") };
+    expect(rate({ ...live, plan: SubscriptionPlan.starter })).toBe(TRIAL_HOSTED_AI_CREDITS_PER_ACTIVE_USER);
+    expect(rate({ ...live, plan: SubscriptionPlan.business })).toBe(TRIAL_HOSTED_AI_CREDITS_PER_ACTIVE_USER);
+    expect(rate({ ...live, plan: SubscriptionPlan.enterprise })).toBe(TRIAL_HOSTED_AI_CREDITS_PER_ACTIVE_USER);
+  });
+
+  it("reports nothing once the trial has lapsed or the subscription is not usable", () => {
+    expect(rate({ status: SubscriptionStatus.trial, trialEndDate: new Date("2026-08-01T12:00:00.000Z") })).toBeNull();
+    expect(rate({ status: SubscriptionStatus.cancelled })).toBeNull();
+    expect(rate({ status: SubscriptionStatus.pastDue })).toBeNull();
+  });
+
+  it("draws the Enterprise rate from the contracted value and reports nothing without one", () => {
+    expect(rate({ plan: SubscriptionPlan.enterprise, enterpriseCreditsPerUser: 750 })).toBe(750);
+    expect(rate({ plan: SubscriptionPlan.enterprise, enterpriseCreditsPerUser: null })).toBeNull();
+    expect(rate({ plan: SubscriptionPlan.enterprise, enterpriseCreditsPerUser: 0 })).toBeNull();
   });
 });
 

--- a/ee/agent-chat/agent-credit-policy.ts
+++ b/ee/agent-chat/agent-credit-policy.ts
@@ -119,6 +119,22 @@ function adjustedAllowance(baseAllowance: number, adjustmentCredits = 0): number
   return allowance;
 }
 
+export function workspaceAgentCreditRate(input: {
+  plan: SubscriptionPlan;
+  status: SubscriptionStatus;
+  trialEndDate: Date | null;
+  enterpriseCreditsPerUser: number | null;
+  now: Date;
+}): number | null {
+  const usableTrial =
+    input.status === SubscriptionStatus.trial &&
+    (input.trialEndDate === null || input.trialEndDate.getTime() >= input.now.getTime());
+  if (usableTrial) return TRIAL_HOSTED_AI_CREDITS_PER_ACTIVE_USER;
+  if (input.status !== SubscriptionStatus.active) return null;
+
+  return paidPlanAllowance(input.plan, input.enterpriseCreditsPerUser);
+}
+
 export function resolveAgentCreditEntitlement(input: AgentCreditEntitlementInput): AgentCreditEntitlement {
   const period = agentCreditPeriodForAnchor(input.creditAnchorAt, input.now);
 

--- a/ee/operator/__tests__/operator-user-administration.database.test.ts
+++ b/ee/operator/__tests__/operator-user-administration.database.test.ts
@@ -21,7 +21,14 @@ import { OPERATOR_AUDIT_ACTION } from "../operator.schema";
 import type { OperatorRefusal } from "../operator.repo";
 import { PrismaOperatorRepo } from "../prisma-operator.repository";
 
-const OPERATOR_REFUSALS: OperatorRefusal[] = ["conflict", "notFound", "unavailable"];
+const OPERATOR_REFUSALS: OperatorRefusal[] = [
+  "conflict",
+  "notFound",
+  "unavailable",
+  "allowanceMissing",
+  "connectedAccountsActive",
+  "trialEndRequired",
+];
 
 function assertAdmitted<T>(result: T | OperatorRefusal): asserts result is T {
   const refusal = OPERATOR_REFUSALS.find((candidate) => candidate === result);
@@ -769,5 +776,32 @@ describeDatabase("operator user administration against a real database", { timeo
       expect(second.next?.lemonSqueezyId).toBeNull();
       expect(second.billingBindingCleared).toBe(true);
     });
+  });
+
+  it("refuses to clear a trial end date that is already set, and leaves an absent one writable", async () => {
+    const repo = new PrismaOperatorRepo();
+    const companyId = await createCompany({ plan: "pro", status: "trial" });
+    const actor = operatorActor();
+
+    const refused = await runWithOperator(actor, () =>
+      repo.updateSubscriptionTermsUnscoped({ companyId, trialEndDate: null, lemonSqueezyId: null }, now),
+    );
+    expect(refused).toBe("trialEndRequired");
+
+    await runWithoutTenant(async () => {
+      const subscription = await prisma.subscription.findUniqueOrThrow({ where: { companyId } });
+      expect(subscription.trialEndDate).not.toBeNull();
+      expect(await prisma.operatorAuditEvent.count({ where: { actorUserId: actor.userId } })).toBe(0);
+    });
+
+    const perpetualId = await createCompany({ plan: "enterprise", status: "active" });
+    await runWithoutTenant(() =>
+      prisma.subscription.update({ where: { companyId: perpetualId }, data: { trialEndDate: null } }),
+    );
+
+    const stillWritable = await runWithOperator(actor, () =>
+      repo.updateSubscriptionTermsUnscoped({ companyId: perpetualId, trialEndDate: null, lemonSqueezyId: null }, now),
+    );
+    assertAdmitted(stillWritable);
   });
 });

--- a/ee/operator/__tests__/operator-workspace-channels.database.test.ts
+++ b/ee/operator/__tests__/operator-workspace-channels.database.test.ts
@@ -26,6 +26,7 @@ const OPERATOR_REFUSALS: OperatorRefusal[] = [
   "unavailable",
   "allowanceMissing",
   "connectedAccountsActive",
+  "trialEndRequired",
 ];
 
 function assertAdmitted<T>(result: T | OperatorRefusal): asserts result is T {

--- a/ee/operator/__tests__/operator-workspace-tags.database.test.ts
+++ b/ee/operator/__tests__/operator-workspace-tags.database.test.ts
@@ -36,6 +36,7 @@ const OPERATOR_REFUSALS: OperatorRefusal[] = [
   "unavailable",
   "allowanceMissing",
   "connectedAccountsActive",
+  "trialEndRequired",
 ];
 
 function assertAdmitted<T>(result: T | OperatorRefusal): asserts result is T {

--- a/ee/operator/correct-operator-subscription-snapshot.interactor.ts
+++ b/ee/operator/correct-operator-subscription-snapshot.interactor.ts
@@ -20,6 +20,7 @@ export class CorrectOperatorSubscriptionSnapshotInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/create-agent-credit-adjustment.interactor.ts
+++ b/ee/operator/create-agent-credit-adjustment.interactor.ts
@@ -20,6 +20,7 @@ export class CreateAgentCreditAdjustmentInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/delete-operator-workspace.interactor.ts
+++ b/ee/operator/delete-operator-workspace.interactor.ts
@@ -20,6 +20,7 @@ export class DeleteOperatorWorkspaceInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/get/get-operator-user-detail.interactor.ts
+++ b/ee/operator/get/get-operator-user-detail.interactor.ts
@@ -20,6 +20,7 @@ export class GetOperatorUserDetailInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/get/get-operator-workspace-stats.interactor.ts
+++ b/ee/operator/get/get-operator-workspace-stats.interactor.ts
@@ -20,6 +20,7 @@ export class GetOperatorWorkspaceStatsInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/operator-lists.schema.ts
+++ b/ee/operator/operator-lists.schema.ts
@@ -40,6 +40,7 @@ export const OperatorWorkspaceRowDtoSchema = z.object({
   subscriptionStatus: z.enum(SubscriptionStatus).nullable(),
   seats: z.number().nullable(),
   enterpriseCreditsPerUser: z.number().nullable(),
+  creditsPerUser: z.number().nullable(),
   trialEndDate: z.date().nullable(),
   lemonSqueezyId: z.string().nullable(),
   subscriptionUpdatedAt: z.date().nullable(),

--- a/ee/operator/operator.repo.ts
+++ b/ee/operator/operator.repo.ts
@@ -20,7 +20,13 @@ import type {
   OperatorWorkspaceTagsDto,
 } from "./operator.schema";
 
-export type OperatorRefusal = "conflict" | "notFound" | "unavailable" | "allowanceMissing" | "connectedAccountsActive";
+export type OperatorRefusal =
+  | "conflict"
+  | "notFound"
+  | "unavailable"
+  | "allowanceMissing"
+  | "connectedAccountsActive"
+  | "trialEndRequired";
 
 export abstract class OperatorRepo {
   abstract getOverviewUnscoped(now?: Date): Promise<HostedAiOperatorOverviewDto | OperatorRefusal>;

--- a/ee/operator/prisma-operator-workspaces.repository.ts
+++ b/ee/operator/prisma-operator-workspaces.repository.ts
@@ -10,6 +10,8 @@ import { BypassTenantGuard } from "@/core/decorators/bypass-tenant.decorator";
 import { FilterFieldKey } from "@/core/types/filter-field-key";
 import { FILTER_FIELD_DEFAULT_OPERATORS } from "@/core/types/filter-field-operators";
 
+import { workspaceAgentCreditRate } from "@/ee/agent-chat/agent-credit-policy";
+
 import { filterValues, negated } from "./operator-list-filters";
 
 type WorkspaceAggregate = {
@@ -191,9 +193,11 @@ export class PrismaOperatorWorkspacesRepo
     });
 
     const aggregates = await this.aggregatesUnscoped(companies.map((company) => company.id));
+    const now = new Date();
 
     return companies.map((company) => {
       const aggregate = aggregates.get(company.id);
+      const subscription = company.subscription;
 
       return {
         id: company.id,
@@ -206,6 +210,15 @@ export class PrismaOperatorWorkspacesRepo
         subscriptionStatus: company.subscription?.status ?? null,
         seats: company.subscription?.quantity ?? null,
         enterpriseCreditsPerUser: company.subscription?.enterpriseAgentCreditsPerUser ?? null,
+        creditsPerUser: subscription
+          ? workspaceAgentCreditRate({
+              plan: subscription.plan,
+              status: subscription.status,
+              trialEndDate: subscription.trialEndDate,
+              enterpriseCreditsPerUser: subscription.enterpriseAgentCreditsPerUser,
+              now,
+            })
+          : null,
         trialEndDate: company.subscription?.trialEndDate ?? null,
         lemonSqueezyId: company.subscription?.lemonSqueezyId ?? null,
         subscriptionUpdatedAt: company.subscription?.updatedAt ?? null,

--- a/ee/operator/prisma-operator.repository.ts
+++ b/ee/operator/prisma-operator.repository.ts
@@ -1118,6 +1118,7 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
 
         const trialEndDate = data.trialEndDate === null ? null : new Date(data.trialEndDate);
         if (trialEndDate && !Number.isFinite(trialEndDate.getTime())) return "conflict";
+        if (trialEndDate === null && subscription.trialEndDate !== null) return "trialEndRequired";
 
         const previous = {
           trialEndDate: subscription.trialEndDate?.toISOString() ?? null,

--- a/ee/operator/reset-operator-user-credits.interactor.ts
+++ b/ee/operator/reset-operator-user-credits.interactor.ts
@@ -20,6 +20,7 @@ export class ResetOperatorUserCreditsInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/update-hosted-ai-enterprise-allowance.interactor.ts
+++ b/ee/operator/update-hosted-ai-enterprise-allowance.interactor.ts
@@ -20,6 +20,7 @@ export class UpdateHostedAiEnterpriseAllowanceInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/update-operator-subscription-terms.interactor.ts
+++ b/ee/operator/update-operator-subscription-terms.interactor.ts
@@ -18,6 +18,7 @@ export class UpdateOperatorSubscriptionTermsInteractor {
   async invoke(data: UpdateOperatorSubscriptionTermsData): Validated<HostedAiOperatorCompanyDto> {
     const result = await this.repo.updateSubscriptionTermsUnscoped(data);
 
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);

--- a/ee/operator/update-operator-user-platform-access.interactor.ts
+++ b/ee/operator/update-operator-user-platform-access.interactor.ts
@@ -20,6 +20,7 @@ export class UpdateOperatorUserPlatformAccessInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/update-operator-user-status.interactor.ts
+++ b/ee/operator/update-operator-user-status.interactor.ts
@@ -20,6 +20,7 @@ export class UpdateOperatorUserStatusInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/ee/operator/update-operator-workspace-tags.interactor.ts
+++ b/ee/operator/update-operator-workspace-tags.interactor.ts
@@ -20,6 +20,7 @@ export class UpdateOperatorWorkspaceTagsInteractor {
 
     if (result === "connectedAccountsActive") return failConflict(CustomErrorCode.operatorConnectedAccountsActive);
     if (result === "allowanceMissing") return failConflict(CustomErrorCode.operatorAllowanceMissing);
+    if (result === "trialEndRequired") return failConflict(CustomErrorCode.operatorTrialEndRequired);
     if (result === "conflict") return failConflict(CustomErrorCode.operatorConflict);
     if (result === "notFound") return failNotFound(CustomErrorCode.userNotFound);
     if (result === "unavailable") return failUnavailable(CustomErrorCode.operatorUnavailable);

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1001,6 +1001,7 @@
       "operatorAllowanceMissing": "Für diesen Workspace ist noch kein vertraglich vereinbartes Enterprise-Kontingent hinterlegt, daher lassen sich Credits nicht korrigieren. Hinterlege das Kontingent zuerst in der Workspace-Liste.",
       "operatorConflict": "Die Änderung wurde abgelehnt. Der Datensatz hat sich seit dem Laden der Liste möglicherweise geändert, oder der Workspace lässt sie derzeit nicht zu. Lade neu und prüfe den aktuellen Stand.",
       "operatorConnectedAccountsActive": "Dieser Workspace hat noch verbundene Messaging-Konten. Trenne sie zuerst, damit die Anbieterkonten freigegeben werden, und lösche den Workspace dann.",
+      "operatorTrialEndRequired": "Ein Testende kann nicht entfernt, sondern nur verschoben werden. Ein Löschen würde den Arbeitsbereich in einer Testphase belassen, die nie abläuft.",
       "operatorUnavailable": "Die gewünschte Korrektur ist für die aktuelle Kontokonfiguration nicht verfügbar.",
       "organizationNotFound": "Organisations-ID nicht gefunden oder nicht zugänglich.",
       "passwordInvalid": "Das Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Zahl und ein Sonderzeichen enthalten.",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -2560,7 +2560,8 @@
   "OperatorUsers": {
     "adjustment": {
       "deltaLabel": "Vorzeichenbehaftete Credit-Korrektur",
-      "deltaPlaceholder": "Zum Beispiel 500 oder -100"
+      "deltaPlaceholder": "Zum Beispiel 500 oder -100",
+      "expiresAt": "Diese Korrektur gilt nur für die aktuelle Periode und verfällt am {date}."
     },
     "confirm": {
       "operator": "Den Plattform-Operator-Zugriff für {name} auf {value} setzen?",
@@ -2604,6 +2605,11 @@
   },
   "OperatorWorkspaces": {
     "allowance": {
+      "hintContract": "Der vertraglich vereinbarte Enterprise-Satz, jeden Monat pro aktivem Mitglied.",
+      "hintMissing": "Enterprise bezieht seinen Satz aus einem Vertragswert, und es ist keiner gesetzt. Alle Mitglieder sind blockiert, bis Sie einen setzen.",
+      "hintPlan": "{plan} enthält so viele Credits pro aktivem Mitglied und Monat.",
+      "hintTrial": "Während einer Testphase erhält das jedes aktive Mitglied, unabhängig vom Tarif.",
+      "hintUnavailable": "Dieses Abonnement gewährt in seinem aktuellen Zustand keine Credits.",
       "label": "Credits pro Benutzer",
       "notSet": "Nicht gesetzt",
       "title": "Enterprise-Kontingent",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2560,7 +2560,8 @@
   "OperatorUsers": {
     "adjustment": {
       "deltaLabel": "Signed credit correction",
-      "deltaPlaceholder": "For example, 500 or -100"
+      "deltaPlaceholder": "For example, 500 or -100",
+      "expiresAt": "This correction applies to the current period only and lapses on {date}."
     },
     "confirm": {
       "operator": "Set platform operator access for {name} to {value}?",
@@ -2604,6 +2605,11 @@
   },
   "OperatorWorkspaces": {
     "allowance": {
+      "hintContract": "The contracted Enterprise rate, granted to each active member every month.",
+      "hintMissing": "Enterprise draws its rate from a contracted value, and none is set. Every member is blocked until you set one.",
+      "hintPlan": "{plan} includes this many credits for each active member every month.",
+      "hintTrial": "Every active member gets this during a trial, whatever the plan says.",
+      "hintUnavailable": "This subscription grants no credits in its current state.",
       "label": "Credits per user",
       "notSet": "Not set",
       "title": "Enterprise allowance",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1001,6 +1001,7 @@
       "operatorAllowanceMissing": "This workspace has no contracted Enterprise allowance yet, so credits cannot be corrected. Set the allowance on the Workspaces list first.",
       "operatorConflict": "That change was refused. The record may have changed since the list loaded, or the workspace may not allow it right now. Reload and check the current state.",
       "operatorConnectedAccountsActive": "This workspace still has connected messaging accounts. Disconnect them first so the provider accounts are released, then delete the workspace.",
+      "operatorTrialEndRequired": "A trial end date cannot be removed, only moved. Clearing it would leave the workspace on a trial that never expires.",
       "operatorUnavailable": "The requested correction is not available for the current account configuration.",
       "organizationNotFound": "Organization ID not found or not accessible.",
       "passwordInvalid": "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1001,6 +1001,7 @@
       "operatorAllowanceMissing": "Este espacio de trabajo aún no tiene un cupo Enterprise contratado, por lo que no se pueden corregir los créditos. Define primero el cupo en la lista de espacios de trabajo.",
       "operatorConflict": "El cambio fue rechazado. Puede que el registro haya cambiado desde que se cargó la lista, o que el espacio de trabajo no lo permita ahora mismo. Recarga y revisa el estado actual.",
       "operatorConnectedAccountsActive": "Este espacio de trabajo todavía tiene cuentas de mensajería conectadas. Desconéctalas primero para liberar las cuentas del proveedor y elimina después el espacio de trabajo.",
+      "operatorTrialEndRequired": "La fecha de fin de prueba no se puede quitar, solo mover. Borrarla dejaría el espacio de trabajo en una prueba que nunca caduca.",
       "operatorUnavailable": "La corrección solicitada no está disponible para la configuración actual de la cuenta.",
       "organizationNotFound": "ID de organización no encontrado o no accesible.",
       "passwordInvalid": "La contraseña debe tener al menos 8 caracteres e incluir al menos una mayúscula, una minúscula, un número y un carácter especial.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -2560,7 +2560,8 @@
   "OperatorUsers": {
     "adjustment": {
       "deltaLabel": "Corrección de créditos con signo",
-      "deltaPlaceholder": "Por ejemplo, 500 o -100"
+      "deltaPlaceholder": "Por ejemplo, 500 o -100",
+      "expiresAt": "Esta corrección se aplica solo al periodo actual y caduca el {date}."
     },
     "confirm": {
       "operator": "¿Establecer el acceso de operador de plataforma de {name} en {value}?",
@@ -2604,6 +2605,11 @@
   },
   "OperatorWorkspaces": {
     "allowance": {
+      "hintContract": "La tarifa Enterprise contratada, concedida a cada miembro activo cada mes.",
+      "hintMissing": "Enterprise toma su tarifa de un valor contratado, y no hay ninguno. Todos los miembros están bloqueados hasta que definas uno.",
+      "hintPlan": "{plan} incluye esta cantidad de créditos por cada miembro activo al mes.",
+      "hintTrial": "Durante una prueba, cada miembro activo recibe esto, sea cual sea el plan.",
+      "hintUnavailable": "Esta suscripción no concede créditos en su estado actual.",
       "label": "Créditos por usuario",
       "notSet": "Sin definir",
       "title": "Asignación Enterprise",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -2560,7 +2560,8 @@
   "OperatorUsers": {
     "adjustment": {
       "deltaLabel": "Correction de crédits signée",
-      "deltaPlaceholder": "Par exemple, 500 ou -100"
+      "deltaPlaceholder": "Par exemple, 500 ou -100",
+      "expiresAt": "Cette correction ne vaut que pour la période en cours et expire le {date}."
     },
     "confirm": {
       "operator": "Définir l’accès opérateur de plateforme de {name} sur {value} ?",
@@ -2604,6 +2605,11 @@
   },
   "OperatorWorkspaces": {
     "allowance": {
+      "hintContract": "Le tarif Enterprise contractuel, accordé à chaque membre actif chaque mois.",
+      "hintMissing": "Enterprise tire son tarif d'une valeur contractuelle, et aucune n'est définie. Tous les membres sont bloqués tant que vous n'en définissez pas une.",
+      "hintPlan": "{plan} inclut ce nombre de crédits pour chaque membre actif chaque mois.",
+      "hintTrial": "Pendant un essai, chaque membre actif reçoit ceci, quel que soit le forfait.",
+      "hintUnavailable": "Cet abonnement n'accorde aucun crédit dans son état actuel.",
       "label": "Crédits par utilisateur",
       "notSet": "Non défini",
       "title": "Allocation Enterprise",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1001,6 +1001,7 @@
       "operatorAllowanceMissing": "Cet espace de travail n'a pas encore d'allocation Enterprise contractuelle, les crédits ne peuvent donc pas être corrigés. Définissez d'abord l'allocation dans la liste des espaces de travail.",
       "operatorConflict": "La modification a été refusée. L’enregistrement a peut-être changé depuis le chargement de la liste, ou l’espace de travail ne l’autorise pas actuellement. Rechargez et vérifiez l’état actuel.",
       "operatorConnectedAccountsActive": "Cet espace de travail a encore des comptes de messagerie connectés. Déconnectez-les d'abord pour libérer les comptes chez le prestataire, puis supprimez l'espace de travail.",
+      "operatorTrialEndRequired": "Une date de fin d'essai ne peut pas être supprimée, seulement déplacée. L'effacer laisserait l'espace de travail sur un essai qui n'expire jamais.",
       "operatorUnavailable": "La correction demandée n’est pas disponible pour la configuration actuelle du compte.",
       "organizationNotFound": "ID d'organisation introuvable ou inaccessible.",
       "passwordInvalid": "Le mot de passe doit comporter au moins 8 caractères et contenir au moins une majuscule, une minuscule, un chiffre et un caractère spécial.",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -2560,7 +2560,8 @@
   "OperatorUsers": {
     "adjustment": {
       "deltaLabel": "Correzione crediti con segno",
-      "deltaPlaceholder": "Ad esempio, 500 o -100"
+      "deltaPlaceholder": "Ad esempio, 500 o -100",
+      "expiresAt": "Questa correzione vale solo per il periodo corrente e decade il {date}."
     },
     "confirm": {
       "operator": "Impostare l’accesso operatore di piattaforma di {name} su {value}?",
@@ -2604,6 +2605,11 @@
   },
   "OperatorWorkspaces": {
     "allowance": {
+      "hintContract": "La tariffa Enterprise concordata, assegnata a ogni membro attivo ogni mese.",
+      "hintMissing": "Enterprise ricava la tariffa da un valore contrattuale, e non ne è impostato nessuno. Tutti i membri sono bloccati finché non ne imposti uno.",
+      "hintPlan": "{plan} include questi crediti per ogni membro attivo ogni mese.",
+      "hintTrial": "Durante una prova ogni membro attivo riceve questo, qualunque sia il piano.",
+      "hintUnavailable": "Questo abbonamento non concede crediti nel suo stato attuale.",
       "label": "Crediti per utente",
       "notSet": "Non impostato",
       "title": "Dotazione Enterprise",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1001,6 +1001,7 @@
       "operatorAllowanceMissing": "Questo spazio di lavoro non ha ancora un contingente Enterprise contrattuale, quindi i crediti non possono essere corretti. Imposta prima il contingente nell'elenco degli spazi di lavoro.",
       "operatorConflict": "La modifica è stata rifiutata. Il record potrebbe essere cambiato dal caricamento dell’elenco, oppure lo spazio di lavoro al momento non la consente. Ricarica e verifica lo stato attuale.",
       "operatorConnectedAccountsActive": "Questo spazio di lavoro ha ancora account di messaggistica collegati. Scollegali prima per liberare gli account del fornitore, poi elimina lo spazio di lavoro.",
+      "operatorTrialEndRequired": "La data di fine prova non può essere rimossa, solo spostata. Cancellarla lascerebbe l'area di lavoro su una prova che non scade mai.",
       "operatorUnavailable": "La correzione richiesta non è disponibile per la configurazione corrente dell’account.",
       "organizationNotFound": "ID organizzazione non trovato o non accessibile.",
       "passwordInvalid": "La password deve contenere almeno 8 caratteri e includere almeno una lettera maiuscola, una minuscola, un numero e un carattere speciale.",


### PR DESCRIPTION
## Summary

- Shows the hosted-AI credit rate for **every** workspace in the Allowance column, not only Enterprise ones.
- Shows the rate that actually applies rather than the plan's catalogue figure, because during a trial those differ.
- Explains the number in a tooltip, saying which of four situations produced it.
- States in the user modal that a manual credit correction lasts only until the period rolls, and names the date.
- Replaces the trial end field with the product's own date picker, and refuses to clear a trial end that is already set.

## Context

The Allowance column rendered a number for Enterprise and nothing at all for anyone else, so the rate most workspaces run on was invisible.

Printing the plan's catalogue number would have been the obvious fix and would have been wrong. A trial grants every active member the flat trial credits whatever the plan says, so a Starter workspace on trial runs on **500**, not 200. A lapsed trial or a cancelled subscription grants nothing. Verified on a copy of live data: an active Starter shows 200, a live Starter trial shows 500, and a lapsed trial shows a dash.

So the column reports the effective rate, from a new exported helper that sits beside the entitlement resolver and shares `paidPlanAllowance` with it. The console cannot drift from the policy it is reporting, which is how the original outage happened: the fact sheet described a fallback that the code had already removed.

The Enterprise workspace still awaiting a contracted rate keeps its "Not set" wording, now in the warning colour, because every member of that workspace is blocked until it is filled in.

Separately, the user modal now says a correction applies to the current period only and names the date it lapses. That was already true, and nowhere on screen. A correction is stamped with the period it was made in and simply stops matching once the period rolls, so an operator granting a top-up had no way to see it was temporary. The two reset buttons are corrections too and lapse the same way, which is worth knowing before using "Set remaining balance to zero" as though it were a lasting block.

### The trial end field

The workspace modal held the only native `<input type="date">` left in the application. Every other date in the product is a `FormIsoDatePicker`, a popover with a calendar and shortcuts, which is why this one field behaved unlike anything else and would not open a picker. It now uses that component. The picker gained a controlled mode, so a caller holding its own state can use it without the form store, and a `clearable` flag; both default to the previous behaviour, so the two custom-field editors that already use it are untouched.

Clearing the date was also worth removing rather than fixing. A null trial end does not end a trial: it makes it perpetual, and the list then labels the workspace "No trial" while it quietly keeps granting the flat trial rate to every active member. Nothing on screen said so. The picker no longer offers a clear control, and the repository refuses a set-to-null transition with its own message rather than the generic conflict toast, so the rule holds even for a request the UI cannot produce. A workspace that legitimately has no trial end, such as a contracted Enterprise one, stays writable.

## Validation

- `yarn typecheck`, `yarn lint`, full suite with database tests at **4,602 passed, 2 skipped across 525 files**.
- Four cases pin the rate rules directly: plan rates for paid workspaces, the trial rate overriding every plan while the trial is live, nothing once it lapses or the subscription is unusable, and the Enterprise contracted value including the zero and null cases.
- A database test pins both halves of the trial end rule: clearing a date that is set is refused with `trialEndRequired`, writes nothing and audits nothing; a subscription whose date is already null stays writable. Removing the guard fails that test, which was checked.
- Driven in a browser against a copy of live production data: active Starter renders 200, live Starter trial renders 500, lapsed trial renders a dash, contracted Enterprise renders its value, the tooltip reads "Starter includes this many credits for each active member every month", and the user modal reads "This correction applies to the current period only and lapses on 15.09.26".
- The trial end field was driven end to end in the same browser session: the calendar opens on the stored date, a new date saves and the toast confirms it, the row and the database both show the new value, and the trigger renders no clear control.

## Impact and rollback

The allowance work is display only. No schema change, no migration, no environment variable.

The trial end work touches one write path, `updateSubscriptionTermsUnscoped`, and only to reject an input the UI can no longer send. Widening the operator refusal union makes every operator interactor handle the new member, which is the bulk of the diff and is mechanical.

The one behavioural nuance worth a reviewer's eye is that the allowance number is now situational rather than a static plan figure, so the same Starter workspace legitimately shows 500 on Monday and 200 after its trial ends. That is the point, but it will look like a change to anyone who reads the column as "the plan's allowance".

Rollback before merge is closing this pull request and deleting its branch. After merge, a revert restores the previous column and the previous field; nothing persisted needs undoing.
