### PR TITLE
fix(ui): resolve filter labels beyond the first page and align stray components

### DIFF
--- a/app/[locale]/(protected)/company/components/company-settings/company-settings-form.tsx
+++ b/app/[locale]/(protected)/company/components/company-settings/company-settings-form.tsx
@@ -40,9 +40,11 @@ export const CompanySettingsForm = observer(({ currency, dealWeightingColumnId }
     store.onInitOrRefresh({ currency });
   }, [currency]);
 
+  const terminologyKey = JSON.stringify(terminologyStore.overrides);
   useEffect(() => {
     store.initTerminology(terminologyStore.overrides);
-  }, [store, terminologyStore.overrides]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the overrides' content so an identical refresh does not discard unsaved edits
+  }, [store, terminologyKey]);
 
   useEffect(() => {
     void store.loadForecasting(dealWeightingColumnId).catch(reportApplicationError);

--- a/app/[locale]/(protected)/company/components/webhook/webhook-modal.tsx
+++ b/app/[locale]/(protected)/company/components/webhook/webhook-modal.tsx
@@ -2,13 +2,14 @@
 
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
-import { Eye, EyeOff, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 
 import { AppModal } from "@/components/modal";
 import { AppCard } from "@/components/card/app-card";
 import { AppCardBody } from "@/components/card/app-card-body";
 import { AppForm } from "@/components/forms/form-context";
 import { FormInput } from "@/components/forms/form-input";
+import { PasswordInput } from "@/components/forms/password-input";
 import { FormTextarea } from "@/components/forms/form-textarea";
 import { FormCheckbox } from "@/components/forms/form-checkbox";
 import { FormAutocomplete } from "@/components/forms/form-autocomplete";
@@ -16,7 +17,6 @@ import { FormActions } from "@/components/card/form-actions";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { WebhookEventSchema } from "@/features/webhook/webhook.schema";
 import { AppChip } from "@/components/chip/app-chip";
-import { Icon } from "@/components/shared/icon";
 import { useDeleteConfirmation } from "@/components/modal/hooks/use-delete-confirmation";
 import { AppCardHeader } from "@/components/card/app-card-header";
 
@@ -77,18 +77,11 @@ export const WebhookModal = observer(() => {
             </FormAutocomplete>
 
             <div className="space-y-1.5">
-              <div className="relative">
-                <FormInput id="secret" type={webhookModalStore.showSecret ? "text" : "password"} />
-
-                <button
-                  className="absolute right-2 top-1/2 -translate-y-1/2"
-                  tabIndex={-1}
-                  type="button"
-                  onClick={webhookModalStore.toggleShowSecret}
-                >
-                  <Icon className="text-subdued" icon={webhookModalStore.showSecret ? EyeOff : Eye} />
-                </button>
-              </div>
+              <PasswordInput
+                id="secret"
+                showPassword={webhookModalStore.showSecret}
+                onToggleVisibility={webhookModalStore.toggleShowSecret}
+              />
 
               <p className="text-subdued text-xs">{t("WebhookModal.secretDescription")}</p>
             </div>

--- a/app/[locale]/(protected)/dashboard/components/__tests__/widgets-store.test.ts
+++ b/app/[locale]/(protected)/dashboard/components/__tests__/widgets-store.test.ts
@@ -97,6 +97,7 @@ describe("WidgetsStore refresh compatibility", () => {
     updateWidgetLayoutsAction.mockRejectedValueOnce(error);
     const seen: unknown[] = [];
     const unregister = registerApplicationErrorHandler((reported) => seen.push(reported));
+    const before = JSON.parse(JSON.stringify(store.layouts)) as typeof store.layouts;
     const moved = {
       ...store.layouts,
       lg: [{ h: 2, i: FIRST_ID, w: 3, x: 1, y: 0 }],
@@ -106,7 +107,8 @@ describe("WidgetsStore refresh compatibility", () => {
 
     await vi.waitFor(() => expect(seen).toEqual([error]));
     expect(updateWidgetLayoutsAction).toHaveBeenCalledTimes(1);
-    expect(store.layouts).toEqual(moved);
+    expect(store.layouts).toEqual(before);
+    expect(store.layouts).not.toEqual(moved);
     expect(captureException).toHaveBeenCalledExactlyOnceWith(error);
     unregister();
   });

--- a/app/[locale]/(protected)/dashboard/components/__tests__/widgets-store.test.ts
+++ b/app/[locale]/(protected)/dashboard/components/__tests__/widgets-store.test.ts
@@ -112,4 +112,25 @@ describe("WidgetsStore refresh compatibility", () => {
     expect(captureException).toHaveBeenCalledExactlyOnceWith(error);
     unregister();
   });
+
+  it("reverts the layout when the server rejects the write without throwing", async () => {
+    const root = {
+      localeStore: { getTranslation: (key: string) => key },
+      loadingOverlayStore: { withLoading: (run: () => Promise<unknown>) => run() },
+    } as unknown as RootStore;
+    const store = new WidgetsStore(root);
+    const initial = widget(FIRST_ID, 0, 0);
+    refreshWidgetsAction.mockResolvedValueOnce([initial]);
+    await store.refresh();
+
+    updateWidgetLayoutsAction.mockResolvedValueOnce({ ok: false, error: { errors: ["nope"] } });
+    const before = JSON.parse(JSON.stringify(store.layouts)) as typeof store.layouts;
+    const moved = { ...store.layouts, lg: [{ h: 2, i: FIRST_ID, w: 3, x: 1, y: 0 }] };
+
+    store.onLayoutChange([], moved);
+
+    await vi.waitFor(() => expect(updateWidgetLayoutsAction).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(store.layouts).toEqual(before));
+    expect(store.layouts).not.toEqual(moved);
+  });
 });

--- a/app/[locale]/(protected)/dashboard/components/widgets.store.tsx
+++ b/app/[locale]/(protected)/dashboard/components/widgets.store.tsx
@@ -4,7 +4,7 @@ import type { WidgetDto } from "@/features/widget/widget.schema";
 import type { GetResult } from "@/core/base/base-get.interactor";
 import type { RootStore } from "@/core/stores/root.store";
 
-import { action, makeObservable, observable } from "mobx";
+import { action, makeObservable, observable, runInAction } from "mobx";
 
 import { refreshWidgetsAction, updateWidgetLayoutsAction } from "../actions";
 
@@ -74,14 +74,27 @@ export class WidgetsStore extends BaseDataViewStore<WidgetDto> {
 
     if (JSON.stringify(payloadNew) === JSON.stringify(payloadCurrent)) return;
 
+    const previousLayouts = this.layouts;
     this.layouts = layouts;
 
     void this.rootStore.loadingOverlayStore
       .withLoading(async () => {
         const res = await updateWidgetLayoutsAction({ layouts: payloadNew });
-        if (!res.ok) toastZodErrorTree(res.error);
+        if (!res.ok) {
+          this.restoreLayouts(previousLayouts);
+          toastZodErrorTree(res.error);
+        }
       })
-      .catch(reportApplicationError);
+      .catch((error: unknown) => {
+        this.restoreLayouts(previousLayouts);
+        reportApplicationError(error);
+      });
+  }
+
+  private restoreLayouts(layouts: ResponsiveLayouts) {
+    runInAction(() => {
+      this.layouts = layouts;
+    });
   }
 
   protected async refreshAction() {

--- a/app/[locale]/(protected)/inbox/components/__tests__/attachment-size-formatting.test.ts
+++ b/app/[locale]/(protected)/inbox/components/__tests__/attachment-size-formatting.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { attachmentSubtitle, formatBytes } from "../attachment-classify";
+
+const german = (value: number | undefined, options?: { maximumFractionDigits?: number }) =>
+  new Intl.NumberFormat("de-DE", {
+    style: "decimal",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: options?.maximumFractionDigits ?? 2,
+  }).format(value ?? 0);
+
+describe("attachment size formatting", () => {
+  it("routes the fraction through the supplied formatter", () => {
+    expect(formatBytes(8_596_329, german)).toBe("8,2 MB");
+    expect(formatBytes(1_852_807, german)).toBe("1,8 MB");
+  });
+
+  it("leaves whole units alone, where no separator is involved", () => {
+    expect(formatBytes(15 * 1024 * 1024, german)).toBe("15 MB");
+    expect(formatBytes(2048, german)).toBe("2 KB");
+  });
+
+  it("keeps the previous output when no formatter is supplied", () => {
+    expect(formatBytes(8_596_329)).toBe("8.2 MB");
+    expect(formatBytes(15 * 1024 * 1024)).toBe("15 MB");
+    expect(formatBytes(0)).toBeNull();
+    expect(formatBytes(null)).toBeNull();
+  });
+
+  it("threads the formatter through the subtitle a message actually renders", () => {
+    const t = (key: string) => key;
+    const input = { mime: "application/pdf", fileName: "invoice.pdf", size: 8_596_329 };
+
+    expect(attachmentSubtitle(t, input, german)).toBe("Inbox.fileTypePdf · 8,2 MB");
+    expect(attachmentSubtitle(t, input)).toBe("Inbox.fileTypePdf · 8.2 MB");
+  });
+});

--- a/app/[locale]/(protected)/inbox/components/attachment-classify.ts
+++ b/app/[locale]/(protected)/inbox/components/attachment-classify.ts
@@ -21,7 +21,9 @@ export function formatDuration(seconds: number | null | undefined): string | nul
 
 const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"];
 
-export function formatBytes(size: number | null | undefined): string | null {
+export type FormatNumber = (value: number | undefined, options?: { maximumFractionDigits?: number }) => string;
+
+export function formatBytes(size: number | null | undefined, formatNumber?: FormatNumber): string | null {
   if (typeof size !== "number" || !Number.isFinite(size) || size <= 0) return null;
   let value = size;
   let unit = 0;
@@ -30,7 +32,8 @@ export function formatBytes(size: number | null | undefined): string | null {
     unit += 1;
   }
   const rounded = unit === 0 || value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
-  return `${rounded} ${BYTE_UNITS[unit]}`;
+  const formatted = formatNumber ? formatNumber(rounded, { maximumFractionDigits: 1 }) : String(rounded);
+  return `${formatted} ${BYTE_UNITS[unit]}`;
 }
 
 type FileDescriptor = { Icon: LucideIcon; typeLabelKey: string; accent: string };
@@ -56,9 +59,10 @@ export function describeFile(input: { mime?: string | null; fileName?: string | 
 export function attachmentSubtitle(
   t: InboxT,
   input: { mime?: string | null; fileName?: string | null; size?: number | null },
+  formatNumber?: FormatNumber,
 ): string {
   const { typeLabelKey } = describeFile(input);
-  const size = formatBytes(input.size);
+  const size = formatBytes(input.size, formatNumber);
   return size ? `${t(typeLabelKey)} · ${size}` : t(typeLabelKey);
 }
 

--- a/app/[locale]/(protected)/inbox/components/message-attachment.tsx
+++ b/app/[locale]/(protected)/inbox/components/message-attachment.tsx
@@ -3,6 +3,7 @@
 import { Ban, ExternalLink } from "lucide-react";
 
 import { Icon } from "@/components/shared/icon";
+import { useHydratedIntlStore } from "@/core/stores/use-hydrated-intl-store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import {
@@ -25,6 +26,7 @@ type Props = {
 };
 
 export function MessageAttachment({ messageId, att, t }: Props) {
+  const intlStore = useHydratedIntlStore();
   const kind = classifyAttachment(att);
   const proxyUrl = attachmentProxyUrl(messageId, att.id);
 
@@ -74,7 +76,7 @@ export function MessageAttachment({ messageId, att, t }: Props) {
         fileIcon={FileTypeIcon}
         href={proxyUrl}
         name={name}
-        subtitle={attachmentSubtitle(t, att)}
+        subtitle={attachmentSubtitle(t, att, (value, options) => intlStore.formatNumber(value, options))}
       />
     );
   }

--- a/app/[locale]/(protected)/inbox/components/message-item.tsx
+++ b/app/[locale]/(protected)/inbox/components/message-item.tsx
@@ -265,11 +265,15 @@ export const MessageItem = observer(({ message, accountOwner, senderAvatarUrl, i
                     accent={accent}
                     fileIcon={FileTypeIcon}
                     name={file.name}
-                    subtitle={attachmentSubtitle(t, {
-                      mime: file.type,
-                      fileName: file.name,
-                      size: file.size,
-                    })}
+                    subtitle={attachmentSubtitle(
+                      t,
+                      {
+                        mime: file.type,
+                        fileName: file.name,
+                        size: file.size,
+                      },
+                      (value, options) => intlStore.formatNumber(value, options),
+                    )}
                     onOpen={() => downloadLocalFile(file)}
                   />
                 );

--- a/app/[locale]/(protected)/inbox/components/thread-reply-composer.tsx
+++ b/app/[locale]/(protected)/inbox/components/thread-reply-composer.tsx
@@ -10,6 +10,8 @@ import type { MessagingProvider } from "@/generated/prisma";
 import type { LinkedinProduct } from "@/ee/messaging/provider";
 
 import { LINKEDIN_PRODUCTS } from "@/ee/messaging/provider";
+import { useHydratedIntlStore } from "@/core/stores/use-hydrated-intl-store";
+
 import { attachmentSubtitle, describeFile, downloadLocalFile } from "./attachment-classify";
 import { AttachmentRow } from "./attachment-row";
 import { AppChip } from "@/components/chip/app-chip";
@@ -89,6 +91,7 @@ type Props = {
 export const ThreadReplyComposer = observer(
   ({ threadId, provider, defaultSubject, defaultRecipients, defaultCc, bare }: Props) => {
     const t = useTranslations();
+    const intlStore = useHydratedIntlStore();
     const { userStore, threadComposeStore, connectedAccountsStore } = useRootStore();
     const fileInputRef = useRef<HTMLInputElement>(null);
     const initializedThreadId = useRef<string | null>(null);
@@ -328,11 +331,15 @@ export const ThreadReplyComposer = observer(
                   fileIcon={FileTypeIcon}
                   name={file.name}
                   removeLabel={t("Inbox.compose.attachRemove")}
-                  subtitle={attachmentSubtitle(t, {
-                    mime: file.type,
-                    fileName: file.name,
-                    size: file.size,
-                  })}
+                  subtitle={attachmentSubtitle(
+                    t,
+                    {
+                      mime: file.type,
+                      fileName: file.name,
+                      size: file.size,
+                    },
+                    (value, options) => intlStore.formatNumber(value, options),
+                  )}
                   onOpen={() => downloadLocalFile(file)}
                   onRemove={() => threadComposeStore.removeAttachment(index)}
                 />

--- a/app/[locale]/(protected)/operator/components/operator-chip-select.tsx
+++ b/app/[locale]/(protected)/operator/components/operator-chip-select.tsx
@@ -66,11 +66,11 @@ export function OperatorChipSelect({
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
-        <span>
+        <button className="inline-flex max-w-full" type="button">
           <ClickableChip size="sm" variant={selected?.color ?? "secondary"}>
             {selected?.label ?? emptyLabel}
           </ClickableChip>
-        </span>
+        </button>
       </DropdownMenuTrigger>
 
       <DropdownMenuContent className="max-h-60 overflow-y-auto">

--- a/app/[locale]/(protected)/operator/components/users/operator-user-modal.tsx
+++ b/app/[locale]/(protected)/operator/components/users/operator-user-modal.tsx
@@ -15,8 +15,7 @@ import { AppCardHeader } from "@/components/card/app-card-header";
 import { AppChip } from "@/components/chip/app-chip";
 import { InfoRow } from "@/components/shared/info-row";
 import { Button } from "@/components/ui/button";
-import { FormLabel } from "@/components/forms/form-label";
-import { Input } from "@/components/ui/input";
+import { FormNumberInput } from "@/components/forms/form-number-input";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDeleteConfirmation } from "@/components/modal/hooks/use-delete-confirmation";
@@ -40,7 +39,7 @@ export const OperatorUserModal = observer(function OperatorUserModal({ user, onC
   const options = useOperatorChipOptions();
   const [detail, setDetail] = useState<OperatorUserDetailDto | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [delta, setDelta] = useState("");
+  const [delta, setDelta] = useState<number | undefined>(undefined);
 
   const userId = user?.id ?? null;
 
@@ -48,7 +47,7 @@ export const OperatorUserModal = observer(function OperatorUserModal({ user, onC
     if (!user) return;
 
     setDetail(null);
-    setDelta("");
+    setDelta(undefined);
 
     let cancelled = false;
     setIsLoading(true);
@@ -96,8 +95,8 @@ export const OperatorUserModal = observer(function OperatorUserModal({ user, onC
   };
 
   const applyCorrection = () => {
-    const creditDelta = Number(delta);
-    if (!period || !Number.isInteger(creditDelta) || creditDelta === 0) return;
+    const creditDelta = delta;
+    if (!period || creditDelta === undefined || !Number.isInteger(creditDelta) || creditDelta === 0) return;
 
     showConfirmation({
       title: t("OperatorConsole.confirm.title"),
@@ -118,7 +117,7 @@ export const OperatorUserModal = observer(function OperatorUserModal({ user, onC
           operationId: globalThis.crypto.randomUUID(),
         });
         if (committed) {
-          setDelta("");
+          setDelta(undefined);
           reload();
         }
         return committed;
@@ -265,19 +264,16 @@ export const OperatorUserModal = observer(function OperatorUserModal({ user, onC
                   <>
                     <div className="flex items-end gap-2">
                       <div className="flex-1 space-y-1.5">
-                        <FormLabel htmlFor="operator-modal-delta">{t("OperatorUsers.adjustment.deltaLabel")}</FormLabel>
-
-                        <Input
+                        <FormNumberInput
                           id="operator-modal-delta"
-                          inputMode="numeric"
+                          label={t("OperatorUsers.adjustment.deltaLabel")}
                           placeholder={t("OperatorUsers.adjustment.deltaPlaceholder")}
-                          type="number"
                           value={delta}
-                          onChange={(event) => setDelta(event.target.value)}
+                          onValueChange={setDelta}
                         />
                       </div>
 
-                      <Button disabled={!delta} size="sm" variant="secondary" onClick={applyCorrection}>
+                      <Button disabled={delta === undefined} size="sm" variant="secondary" onClick={applyCorrection}>
                         {t("Common.actions.save")}
                       </Button>
                     </div>

--- a/app/[locale]/(protected)/operator/components/workspaces/operator-workspace-modal.tsx
+++ b/app/[locale]/(protected)/operator/components/workspaces/operator-workspace-modal.tsx
@@ -6,7 +6,7 @@ import type { SubscriptionPlan, SubscriptionStatus } from "@/generated/prisma";
 
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { SubscriptionPlan as SubscriptionPlanEnum } from "@/generated/prisma";
 
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { FormInputChips } from "@/components/forms/form-input-chips";
 import { FormIsoDatePicker } from "@/components/forms/form-iso-date-picker";
 import { FormLabel } from "@/components/forms/form-label";
+import { FormNumberInput } from "@/components/forms/form-number-input";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
@@ -53,7 +54,7 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
   const options = useOperatorChipOptions();
   const [stats, setStats] = useState<OperatorWorkspaceStatsDto | null>(null);
   const [isLoadingStats, setIsLoadingStats] = useState(false);
-  const [allowance, setAllowance] = useState("");
+  const [allowance, setAllowance] = useState<number | undefined>(undefined);
   const [trialEnd, setTrialEnd] = useState("");
   const [billingId, setBillingId] = useState("");
   const [channelMonth, setChannelMonth] = useState("");
@@ -64,12 +65,21 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
 
   const companyId = workspace?.id ?? null;
 
+  function formatChannelMonth(month: string) {
+    const parsed = new Date(`${month}-01T00:00:00`);
+    return Number.isFinite(parsed.getTime()) ? intlStore.formatMonthYear(parsed) : month;
+  }
+
+  const workspaceRef = useRef(workspace);
+  workspaceRef.current = workspace;
+
   useEffect(() => {
+    const workspace = workspaceRef.current;
     if (!workspace) return;
 
     setStats(null);
     setChannelMonth("");
-    setAllowance(workspace.enterpriseCreditsPerUser === null ? "" : String(workspace.enterpriseCreditsPerUser));
+    setAllowance(workspace.enterpriseCreditsPerUser ?? undefined);
     setTrialEnd(toDateInput(workspace.trialEndDate));
     setBillingId(workspace.lemonSqueezyId ?? "");
     setTags(workspace.tags);
@@ -105,7 +115,7 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
     return () => {
       cancelled = true;
     };
-  }, [workspace, companyId]);
+  }, [companyId]);
 
   if (!workspace) return null;
 
@@ -122,8 +132,8 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
   );
 
   const saveAllowance = () => {
-    const creditsPerUser = Number(allowance);
-    if (!Number.isInteger(creditsPerUser) || creditsPerUser < 1) return;
+    const creditsPerUser = allowance;
+    if (creditsPerUser === undefined || !Number.isInteger(creditsPerUser) || creditsPerUser < 1) return;
 
     showConfirmation({
       title: t("OperatorConsole.confirm.title"),
@@ -363,20 +373,16 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
                 </div>
 
                 <div className="flex items-end gap-2">
-                  <div className="flex-1 space-y-1.5">
-                    <FormLabel htmlFor="operator-modal-allowance">{t("OperatorWorkspaces.allowance.label")}</FormLabel>
+                  <FormNumberInput
+                    containerClassName="flex-1"
+                    id="operator-modal-allowance"
+                    label={t("OperatorWorkspaces.allowance.label")}
+                    min={1}
+                    value={allowance}
+                    onValueChange={setAllowance}
+                  />
 
-                    <Input
-                      id="operator-modal-allowance"
-                      inputMode="numeric"
-                      min={1}
-                      type="number"
-                      value={allowance}
-                      onChange={(event) => setAllowance(event.target.value)}
-                    />
-                  </div>
-
-                  <Button disabled={!allowance} size="sm" variant="secondary" onClick={saveAllowance}>
+                  <Button disabled={allowance === undefined} size="sm" variant="secondary" onClick={saveAllowance}>
                     {t("Common.actions.save")}
                   </Button>
                 </div>
@@ -466,7 +472,7 @@ export const OperatorWorkspaceModal = observer(function OperatorWorkspaceModal({
                     {stats.channelMonths.map((entry) => (
                       <SelectItem key={entry.month} textValue={entry.month} value={entry.month}>
                         {t("OperatorWorkspaces.channels.monthOption", {
-                          month: entry.month,
+                          month: formatChannelMonth(entry.month),
                           count: entry.peakConcurrent,
                         })}
                       </SelectItem>

--- a/app/[locale]/(protected)/profile/components/account-folders.tsx
+++ b/app/[locale]/(protected)/profile/components/account-folders.tsx
@@ -39,7 +39,13 @@ export const AccountFolders = observer(({ account, editable = false, onToggle }:
             <span className="min-w-0 flex-1 truncate text-sm">{folder.name?.trim() || t("Common.unnamed")}</span>
 
             {editable && onToggle ? (
-              <Switch checked={on} onCheckedChange={(next) => onToggle(folder.id, next)} />
+              <Switch
+                aria-label={t("ConnectedAccountsCard.folderToggleLabel", {
+                  folder: folder.name?.trim() || t("Common.unnamed"),
+                })}
+                checked={on}
+                onCheckedChange={(next) => onToggle(folder.id, next)}
+              />
             ) : (
               <span className={cn("shrink-0 text-[11px]", on ? "text-success" : "text-subdued")}>
                 {on ? t("ConnectedAccountsCard.folderSynced") : t("ConnectedAccountsCard.folderHidden")}

--- a/app/[locale]/(protected)/profile/components/api-key-modal.tsx
+++ b/app/[locale]/(protected)/profile/components/api-key-modal.tsx
@@ -47,7 +47,7 @@ const ExpiresInPicker = observer(() => {
             disabled={apiKeyModalStore.isDisabled}
             id="expiresIn"
             type="button"
-            variant="secondary"
+            variant="field"
           >
             <CalendarIcon className="mr-2 size-4" />
 

--- a/app/[locale]/(protected)/search/actions.ts
+++ b/app/[locale]/(protected)/search/actions.ts
@@ -9,12 +9,10 @@ import {
   getGetDealByIdInteractor,
   getGetServiceByIdInteractor,
 } from "@/core/di";
+import { serializeResult } from "@/core/utils/action-result";
 
 export async function globalSearchAction(data: GlobalSearchData) {
-  const interactor = getGlobalSearchInteractor();
-  const result = await interactor.invoke(data);
-
-  return result.data;
+  return serializeResult(getGlobalSearchInteractor().invoke(data));
 }
 
 export async function checkSearchResultExistsAction(data: { type: GlobalSearchResultItem["type"]; id: string }) {

--- a/app/components/global-search-modal.store.ts
+++ b/app/components/global-search-modal.store.ts
@@ -5,6 +5,8 @@ import { action, makeObservable, observable, reaction } from "mobx";
 
 import { BaseModalStore } from "@/core/base/base-modal.store";
 import { Debouncer } from "@/core/utils/debounce";
+import { reportApplicationError } from "@/core/errors/report-application-error";
+import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 import { checkSearchResultExistsAction, globalSearchAction } from "@/app/[locale]/(protected)/search/actions";
 
 type GlobalSearchFormData = {
@@ -116,8 +118,19 @@ export class GlobalSearchModalStore extends BaseModalStore<GlobalSearchFormData>
         this.setIsLoading(true);
 
         void globalSearchAction({ searchTerm: debouncedSearchTerm })
-          .then((results) => this.setResults(results))
-          .catch(() => this.setResults(null))
+          .then((result) => {
+            if (result.ok) {
+              this.setResults(result.data);
+              return;
+            }
+
+            this.setResults(null);
+            if (!toastZodErrorTree(result.error)) this.toastError("Common.notifications.unexpectedError");
+          })
+          .catch((error: unknown) => {
+            this.setResults(null);
+            reportApplicationError(error);
+          })
           .finally(() => this.setIsLoading(false));
       },
     );

--- a/app/components/navigation/legal-update-alert.tsx
+++ b/app/components/navigation/legal-update-alert.tsx
@@ -3,7 +3,7 @@
 import type { LegalUpdateStatus } from "@/features/legal/get-legal-status.interactor";
 
 import { AlertCircle, ArrowRight, Info } from "lucide-react";
-import { useFormatter, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 
 import {
   SidebarGroup,
@@ -13,6 +13,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { cn } from "@/core/utils/cn";
+import { useHydratedIntlStore } from "@/core/stores/use-hydrated-intl-store";
 import { IntlLink } from "@/i18n/navigation";
 
 type Props = {
@@ -22,13 +23,10 @@ type Props = {
 
 export function LegalUpdateAlert({ status, onNavigate }: Props) {
   const t = useTranslations();
-  const format = useFormatter();
+  const intlStore = useHydratedIntlStore();
   const effectiveAt = status.contractNoticeSent && !status.contractAccepted ? status.effectiveAt : null;
   const formattedEffectiveAt = effectiveAt
-    ? format.dateTime(new Date(effectiveAt), {
-        dateStyle: "medium",
-        timeZone: "UTC",
-      })
+    ? intlStore.formatDescriptiveShortDate(new Date(effectiveAt), { timeZone: "UTC" })
     : null;
   const contractModel = formattedEffectiveAt
     ? {

--- a/components/data-view/custom-columns/custom-field-value.tsx
+++ b/components/data-view/custom-columns/custom-field-value.tsx
@@ -102,9 +102,9 @@ export const CustomFieldValue = observer(
             <span className="relative" onClick={(event) => event.stopPropagation()}>
               <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
                 <DropdownMenuTrigger asChild>
-                  <span>
+                  <button className="inline-flex max-w-full" type="button">
                     <ClickableChip variant={selectedVariant}>{selectedOption.label}</ClickableChip>
-                  </span>
+                  </button>
                 </DropdownMenuTrigger>
 
                 <DropdownMenuContent className="max-h-60 overflow-y-auto">

--- a/components/data-view/filter-modal/edit-filters-modal.store.ts
+++ b/components/data-view/filter-modal/edit-filters-modal.store.ts
@@ -182,6 +182,7 @@ export class EditFiltersModalStore extends BaseModalStore<UpsertFilterPresetData
       }
 
       this.markDraftApplied();
+      this.tableStore?.setQueryOptions({ forceRefresh: true, refreshMode: "background" });
       this.close();
     } catch (error) {
       reportApplicationError(error);

--- a/components/data-view/filter-modal/inputs/use-filter-select-items.tsx
+++ b/components/data-view/filter-modal/inputs/use-filter-select-items.tsx
@@ -98,8 +98,6 @@ function validActivityFilters(filters: Filter[] | undefined): NonNullable<Activi
   });
 }
 
-const SELECTION_RESOLUTION_PAGE_SIZE = 100;
-
 const SELF_IDENTIFYING_FILTER_FIELDS = new Set<FilterFieldKey>([FilterFieldKey.workspaceId]);
 
 export function useFilterSelectItems(
@@ -265,7 +263,7 @@ export function useFilterSelectItems(
       const requested = new Set(ids);
       const params: GetQueryParams = selfIdentifyingField
         ? { filters: [{ field: selfIdentifyingField, operator: FilterOperatorKey.in, value: [...ids] }] }
-        : { pagination: { page: 1, pageSize: SELECTION_RESOLUTION_PAGE_SIZE } };
+        : {};
       const result = await getItems(params);
       return result.items.filter((item) => requested.has(item.key));
     };

--- a/components/data-view/filter-modal/inputs/use-filter-select-items.tsx
+++ b/components/data-view/filter-modal/inputs/use-filter-select-items.tsx
@@ -98,6 +98,10 @@ function validActivityFilters(filters: Filter[] | undefined): NonNullable<Activi
   });
 }
 
+const SELECTION_RESOLUTION_PAGE_SIZE = 100;
+
+const SELF_IDENTIFYING_FILTER_FIELDS = new Set<FilterFieldKey>([FilterFieldKey.workspaceId]);
+
 export function useFilterSelectItems(
   filter: Filter,
   customColumns?: CustomColumnDto[],
@@ -255,12 +259,17 @@ export function useFilterSelectItems(
 
     if (!getItems) return undefined;
 
+    const selfIdentifyingField = SELF_IDENTIFYING_FILTER_FIELDS.has(fieldKey) ? fieldKey : null;
+
     return async (ids) => {
       const requested = new Set(ids);
-      const result = await getItems({});
+      const params: GetQueryParams = selfIdentifyingField
+        ? { filters: [{ field: selfIdentifyingField, operator: FilterOperatorKey.in, value: [...ids] }] }
+        : { pagination: { page: 1, pageSize: SELECTION_RESOLUTION_PAGE_SIZE } };
+      const result = await getItems(params);
       return result.items.filter((item) => requested.has(item.key));
     };
-  }, [getItems, getSelectedItems]);
+  }, [fieldKey, getItems, getSelectedItems]);
 
   const [selectionAttempt, setSelectionAttempt] = useState(0);
   const selectionRequestKey =

--- a/core/stores/intl.store.ts
+++ b/core/stores/intl.store.ts
@@ -141,7 +141,7 @@ export class IntlStore {
     }).format(date);
   }
 
-  formatDescriptiveShortDate(date: Date | undefined): string {
+  formatDescriptiveShortDate(date: Date | undefined, options?: { timeZone?: string }): string {
     if (date === undefined) return "";
     if (!this.clientHydrated) return "";
 
@@ -149,6 +149,17 @@ export class IntlStore {
       year: "numeric" as const,
       month: "short" as const,
       day: "numeric" as const,
+      ...(options?.timeZone ? { timeZone: options.timeZone } : {}),
+    }).format(date);
+  }
+
+  formatMonthYear(date: Date | undefined): string {
+    if (date === undefined) return "";
+    if (!this.clientHydrated) return "";
+
+    return new Intl.DateTimeFormat(this.formattingLocale, {
+      year: "numeric" as const,
+      month: "long" as const,
     }).format(date);
   }
 

--- a/core/validation/validation.types.ts
+++ b/core/validation/validation.types.ts
@@ -62,6 +62,7 @@ export enum CustomErrorCode {
   organizationNotFound = "organizationNotFound",
   userNotFound = "userNotFound",
   userSelfAdminUpdateForbidden = "userSelfAdminUpdateForbidden",
+  userPlatformOperatorStatusForbidden = "userPlatformOperatorStatusForbidden",
   dealNotFound = "dealNotFound",
   serviceNotFound = "serviceNotFound",
   contactNotFound = "contactNotFound",

--- a/ee/operator/__tests__/operator-lists.database.test.ts
+++ b/ee/operator/__tests__/operator-lists.database.test.ts
@@ -351,4 +351,17 @@ describeDatabase("merged operator audit log against a real database", { timeout:
       await prisma.auditLog.deleteMany({ where: { companyId: workspace.companyId } });
     });
   });
+
+  it("serves nothing beyond the audit paging window and never advertises a page it cannot serve", async () => {
+    const auditRepo = new PrismaOperatorAuditRepo();
+
+    const beyond = await runWithoutTenant(() => auditRepo.getItems({ skip: 10_001, take: 25 }));
+    expect(beyond).toEqual([]);
+
+    const atEdge = await runWithoutTenant(() => auditRepo.getItems({ skip: 10_000, take: 25 }));
+    expect(Array.isArray(atEdge)).toBe(true);
+
+    const advertised = await runWithoutTenant(() => auditRepo.getCount({ pagination: { page: 1, pageSize: 25 } }));
+    expect(advertised).toBeLessThanOrEqual(10_000 + 25);
+  });
 });

--- a/ee/operator/__tests__/operator-user-administration.database.test.ts
+++ b/ee/operator/__tests__/operator-user-administration.database.test.ts
@@ -804,4 +804,50 @@ describeDatabase("operator user administration against a real database", { timeo
     );
     assertAdmitted(stillWritable);
   });
+
+  it("refuses a credit reset whose operationId belongs to a different workspace", async () => {
+    const repo = new PrismaOperatorRepo();
+    const actor = operatorActor();
+
+    const companyA = await createCompany({ plan: "enterprise", status: "active", enterpriseCreditsPerUser: 10 });
+    const targetA = await createUser({ companyId: companyA, email: `replay-a-${randomUUID()}@example.invalid` });
+
+    const companyB = await createCompany({ plan: "enterprise", status: "active", enterpriseCreditsPerUser: 10 });
+    const targetB = await createUser({ companyId: companyB, email: `replay-b-${randomUUID()}@example.invalid` });
+
+    const foreignOperationId = randomUUID();
+    await runWithoutTenant(() =>
+      prisma.agentCreditAdjustment.create({
+        data: {
+          companyId: companyB,
+          userId: targetB.userId,
+          creditDelta: 99,
+          periodStart,
+          periodEnd,
+          reason: "Belongs to another workspace",
+          operationId: foreignOperationId,
+          createdByOperatorUserId: "fixture",
+        },
+      }),
+    );
+
+    const replayed = await runWithOperator(actor, () =>
+      repo.resetUserCreditsUnscoped(
+        { userId: targetA.userId, mode: "baseAllowance", operationId: foreignOperationId },
+        now,
+      ),
+    );
+
+    expect(replayed).toBe("conflict");
+
+    await runWithoutTenant(async () => {
+      const adjustments = await prisma.agentCreditAdjustment.findMany({ where: { companyId: companyA } });
+      expect(adjustments).toEqual([]);
+      const foreign = await prisma.agentCreditAdjustment.findUniqueOrThrow({
+        where: { operationId: foreignOperationId },
+      });
+      expect(foreign.companyId).toBe(companyB);
+      expect(foreign.creditDelta).toBe(99);
+    });
+  });
 });

--- a/ee/operator/__tests__/operator-workspace-delete.database.test.ts
+++ b/ee/operator/__tests__/operator-workspace-delete.database.test.ts
@@ -417,6 +417,7 @@ describeDatabase("operator workspace deletion against a real database", { timeou
     const { companyId } = await createWorkspace({ domain: "workflows.invalid", members: 1 });
     const survivor = await createWorkspace({ domain: "keepruns.invalid", members: 1 });
     const doomedRun = `run-${randomUUID()}`;
+    const doomedNestedRun = `run-${randomUUID()}`;
     const survivingRun = `run-${randomUUID()}`;
 
     await runWithoutTenant(async () => {
@@ -437,6 +438,13 @@ describeDatabase("operator workspace deletion against a real database", { timeou
           randomUUID(),
         );
       }
+
+      await prisma.$executeRawUnsafe(
+        `INSERT INTO "workflow"."workflow_runs" ("id","deployment_id","status","name","input")
+         VALUES ($1, 'test-deployment', 'completed', 'backfill-connected-account', $2::jsonb)`,
+        doomedNestedRun,
+        JSON.stringify({ connectedAccountId: randomUUID(), tenant: { companyId, userId: randomUUID() } }),
+      );
     });
 
     const result = await runWithOperator(operatorActor(), () =>
@@ -454,6 +462,12 @@ describeDatabase("operator workspace deletion against a real database", { timeou
         doomedRun,
       );
       expect(Number(doomed[0]?.count ?? 0)).toBe(0);
+
+      const doomedNested = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+        `SELECT COUNT(*)::bigint AS count FROM "workflow"."workflow_runs" WHERE "id" = $1`,
+        doomedNestedRun,
+      );
+      expect(Number(doomedNested[0]?.count ?? 0)).toBe(0);
 
       const doomedSteps = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
         `SELECT COUNT(*)::bigint AS count FROM "workflow"."workflow_steps" WHERE "run_id" = $1`,

--- a/ee/operator/__tests__/prisma-operator.repository.database.test.ts
+++ b/ee/operator/__tests__/prisma-operator.repository.database.test.ts
@@ -667,4 +667,51 @@ describeDatabase("PrismaOperatorRepo against a real database", { timeout: 120_00
 
     expect(observed).toEqual({ self: true, inactive: true, unverified: true });
   });
+
+  it("refuses to deactivate the last active platform operator through the status path", async () => {
+    const actor = operatorActor();
+    let observed: { lastOperatorRejected: boolean; stillActive: boolean; peerDeactivated: boolean } | null = null;
+
+    try {
+      await runWithOperator(actor, () =>
+        runWithoutTenant(() =>
+          runInTransaction(async () => {
+            const tx = getTransactionClient<AppPrismaClient>();
+            if (!tx) throw new Error("Expected status-path test transaction.");
+            await tx.user.updateMany({ where: { isPlatformOperator: true }, data: { isPlatformOperator: false } });
+
+            const solo = await createPlatformAccessUser(tx, { isPlatformOperator: true });
+            const peer = await createPlatformAccessUser(tx, { isPlatformOperator: true });
+            const repo = new PrismaOperatorRepo();
+
+            const peerDeactivated = await repo.updateUserStatusUnscoped(
+              { userId: peer.userId, status: "inactive", reason: "Deactivate the peer operator" },
+              now,
+            );
+
+            const lastOperator = await repo.updateUserStatusUnscoped(
+              { userId: solo.userId, status: "inactive", reason: "Attempt to deactivate the final operator" },
+              now,
+            );
+
+            const soloRow = await tx.user.findUniqueOrThrow({
+              where: { id: solo.userId },
+              select: { status: true },
+            });
+
+            observed = {
+              lastOperatorRejected: lastOperator === "conflict",
+              stillActive: soloRow.status === "active",
+              peerDeactivated: typeof peerDeactivated !== "string",
+            };
+            throw new RollbackOperatorTest();
+          }),
+        ),
+      );
+    } catch (error) {
+      if (!(error instanceof RollbackOperatorTest)) throw error;
+    }
+
+    expect(observed).toEqual({ lastOperatorRejected: true, stillActive: true, peerDeactivated: true });
+  });
 });

--- a/ee/operator/prisma-operator-audit.repository.ts
+++ b/ee/operator/prisma-operator-audit.repository.ts
@@ -50,6 +50,8 @@ const OPERATOR_READ_ACTIONS: string[] = [
   OPERATOR_AUDIT_ACTION.userDetailRead,
 ];
 
+const AUDIT_MAX_SKIP = 10_000;
+
 export class PrismaOperatorAuditRepo extends BaseRepository implements GetOperatorAuditLogsRepo {
   getSortableFields() {
     return [{ field: "createdAt", resolvedFields: ["createdAt"] }];
@@ -91,7 +93,8 @@ export class PrismaOperatorAuditRepo extends BaseRepository implements GetOperat
 
     const take = params.take ?? params.pagination?.pageSize ?? 25;
     const page = params.pagination?.page ?? 1;
-    const skip = params.skip ?? (page - 1) * take;
+    const requestedSkip = params.skip ?? (page - 1) * take;
+    const skip = Math.min(Math.max(requestedSkip, 0), AUDIT_MAX_SKIP);
     const search = params.searchTerm?.trim() ?? "";
 
     return { sources, workspaceIds, createdAt, take, skip, search };

--- a/ee/operator/prisma-operator-audit.repository.ts
+++ b/ee/operator/prisma-operator-audit.repository.ts
@@ -93,11 +93,11 @@ export class PrismaOperatorAuditRepo extends BaseRepository implements GetOperat
 
     const take = params.take ?? params.pagination?.pageSize ?? 25;
     const page = params.pagination?.page ?? 1;
-    const requestedSkip = params.skip ?? (page - 1) * take;
-    const skip = Math.min(Math.max(requestedSkip, 0), AUDIT_MAX_SKIP);
+    const skip = Math.max(params.skip ?? (page - 1) * take, 0);
+    const beyondWindow = skip > AUDIT_MAX_SKIP;
     const search = params.searchTerm?.trim() ?? "";
 
-    return { sources, workspaceIds, createdAt, take, skip, search };
+    return { sources, workspaceIds, createdAt, take, skip, search, beyondWindow };
   }
 
   private productWhere(plan: ReturnType<PrismaOperatorAuditRepo["plan"]>): Prisma.AuditLogWhereInput {
@@ -131,6 +131,7 @@ export class PrismaOperatorAuditRepo extends BaseRepository implements GetOperat
   private async listAuditUnscoped(params: GetQueryParams): Promise<OperatorAuditRowDto[]> {
     const plan = this.plan(params);
     if (plan.sources.length === 0) return [];
+    if (plan.beyondWindow) return [];
 
     const ascending = params.sortDescriptor?.direction === "asc";
     const order = ascending ? "asc" : "desc";
@@ -234,7 +235,7 @@ export class PrismaOperatorAuditRepo extends BaseRepository implements GetOperat
         : Promise.resolve(0),
     ]);
 
-    return product + operator;
+    return Math.min(product + operator, AUDIT_MAX_SKIP + plan.take);
   }
 
   @BypassTenantGuard

--- a/ee/operator/prisma-operator.repository.ts
+++ b/ee/operator/prisma-operator.repository.ts
@@ -182,6 +182,8 @@ function toUsageTotals(input: {
   };
 }
 
+const PLATFORM_OPERATOR_INVARIANT_LOCK = "customermates:platform-operator-invariant";
+
 export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
   private async createAudit(args: {
     action: AuditAction;
@@ -556,6 +558,17 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
     return (await this.userDetail(userId, now)) ?? "notFound";
   }
 
+  private async lockPlatformOperatorInvariant() {
+    await this.prisma
+      .$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${PLATFORM_OPERATOR_INVARIANT_LOCK}, 0))`;
+  }
+
+  private async otherActiveOperatorCount(excludedUserId: string) {
+    return this.prisma.user.count({
+      where: { id: { not: excludedUserId }, isPlatformOperator: true, status: Status.active },
+    });
+  }
+
   @BypassTenantGuard
   async updateUserStatusUnscoped(
     data: UpdateOperatorUserStatusData,
@@ -571,6 +584,7 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           where: { id: data.userId, companyId },
           select: {
             status: true,
+            isPlatformOperator: true,
             role: { select: { isSystemRole: true } },
             company: {
               select: {
@@ -590,6 +604,10 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
         if (statusChanged && subscription?.lemonSqueezyId) return "conflict";
 
         const leavingActive = target.status === Status.active && data.status !== Status.active;
+        if (leavingActive && target.isPlatformOperator) {
+          await this.lockPlatformOperatorInvariant();
+          if ((await this.otherActiveOperatorCount(data.userId)) === 0) return "conflict";
+        }
         if (leavingActive && target.role?.isSystemRole) {
           const otherActiveSystemUsers = await this.prisma.user.count({
             where: {
@@ -671,10 +689,8 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           });
           if (!identity?.emailVerified) return "conflict";
         } else if (target.isPlatformOperator) {
-          const otherActiveOperators = await this.prisma.user.count({
-            where: { id: { not: data.userId }, isPlatformOperator: true, status: Status.active },
-          });
-          if (otherActiveOperators === 0) return "conflict";
+          await this.lockPlatformOperatorInvariant();
+          if ((await this.otherActiveOperatorCount(data.userId)) === 0) return "conflict";
         }
 
         await this.prisma.user.update({
@@ -937,6 +953,14 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           where: { operationId: data.operationId },
         });
         if (existing) {
+          if (
+            existing.companyId !== companyId ||
+            existing.userId !== data.userId ||
+            existing.reason !== reason ||
+            existing.createdByOperatorUserId !== actor.userId
+          )
+            return "conflict";
+
           return {
             adjustment: existing,
             user: await this.userDetailOrThrow(data.userId, now),
@@ -1058,7 +1082,9 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
         let workflowRunIds: string[] = [];
         if (workflowSchema?.installed) {
           const workflowRuns = await this.prisma.$queryRaw<Array<{ id: string }>>`
-            SELECT "id" FROM "workflow"."workflow_runs" WHERE "input"->>'companyId' = ${data.companyId}
+            SELECT "id" FROM "workflow"."workflow_runs"
+            WHERE "input"->>'companyId' = ${data.companyId}
+               OR "input"->'tenant'->>'companyId' = ${data.companyId}
           `;
           workflowRunIds = workflowRuns.map((run) => run.id);
 

--- a/features/user/__tests__/admin-update-user-details.interactor.test.ts
+++ b/features/user/__tests__/admin-update-user-details.interactor.test.ts
@@ -139,6 +139,16 @@ describe("AdminUpdateUserDetailsInteractor agent credit activation", () => {
     expect(userRepo.clearAgentCreditActivatedOrThrow).not.toHaveBeenCalled();
   });
 
+  it("still allows reactivating a platform operator, so a cron deactivation stays recoverable", async () => {
+    const { userRepo, invoke } = harness(Status.inactive);
+    userRepo.isPlatformOperatorCompanyWide.mockResolvedValue(true);
+
+    const result = await invoke("active");
+
+    expect(result.ok).toBe(true);
+    expect(userRepo.adminUpdateDetailsOrThrow).toHaveBeenCalled();
+  });
+
   it("still allows a tenant-side status change on an ordinary account", async () => {
     const { userRepo, invoke } = harness(Status.active);
     userRepo.isPlatformOperatorCompanyWide.mockResolvedValue(false);

--- a/features/user/__tests__/admin-update-user-details.interactor.test.ts
+++ b/features/user/__tests__/admin-update-user-details.interactor.test.ts
@@ -18,6 +18,13 @@ vi.mock("@/prisma/db", () => MOCK_PRISMA_DB_MODULE);
 
 import { AdminUpdateUserDetailsInteractor } from "../upsert/admin-update-user-details.interactor";
 
+vi.mock("next-intl/server", () => ({
+  getTranslations: (namespace?: string) => {
+    const t = (key: string) => (namespace ? `${namespace}.${key}` : key);
+    return Promise.resolve(Object.assign(t, { raw: t }));
+  },
+}));
+
 const TARGET_USER_ID = "00000000-0000-4000-8000-000000000010";
 const TARGET_ROLE_ID = "00000000-0000-4000-8000-000000000011";
 const TARGET_EMAIL = "teammate@example.com";
@@ -25,6 +32,7 @@ const TARGET_EMAIL = "teammate@example.com";
 function harness(previousStatus: Status) {
   const userRepo = {
     findExistingEmailsCompanyWide: vi.fn().mockResolvedValue(new Set([TARGET_EMAIL])),
+    isPlatformOperatorCompanyWide: vi.fn().mockResolvedValue(false),
     findOrThrowCompanyWide: vi.fn().mockResolvedValue(
       createMockUser({
         id: TARGET_USER_ID,
@@ -118,5 +126,26 @@ describe("AdminUpdateUserDetailsInteractor agent credit activation", () => {
     expect(userRepo.clearAgentCreditActivatedOrThrow).toHaveBeenCalledWith(TARGET_USER_ID);
     expect(userRepo.markAgentCreditActivatedOrThrow).not.toHaveBeenCalled();
     expectProfileUpdateBefore(userRepo.adminUpdateDetailsOrThrow, userRepo.clearAgentCreditActivatedOrThrow);
+  });
+
+  it("refuses a tenant-side status change on a platform operator account", async () => {
+    const { userRepo, invoke } = harness(Status.active);
+    userRepo.isPlatformOperatorCompanyWide.mockResolvedValue(true);
+
+    const result = await invoke("inactive");
+
+    expect(result.ok).toBe(false);
+    expect(userRepo.adminUpdateDetailsOrThrow).not.toHaveBeenCalled();
+    expect(userRepo.clearAgentCreditActivatedOrThrow).not.toHaveBeenCalled();
+  });
+
+  it("still allows a tenant-side status change on an ordinary account", async () => {
+    const { userRepo, invoke } = harness(Status.active);
+    userRepo.isPlatformOperatorCompanyWide.mockResolvedValue(false);
+
+    const result = await invoke("inactive");
+
+    expect(result.ok).toBe(true);
+    expect(userRepo.adminUpdateDetailsOrThrow).toHaveBeenCalled();
   });
 });

--- a/features/user/prisma-user.repository.ts
+++ b/features/user/prisma-user.repository.ts
@@ -462,6 +462,17 @@ export class PrismaUserRepo
     return tenantUser;
   }
 
+  async isPlatformOperatorCompanyWide(userId: string) {
+    const { companyId } = this.user;
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId, companyId },
+      select: { isPlatformOperator: true },
+    });
+
+    return user?.isPlatformOperator ?? false;
+  }
+
   async findOrThrowCompanyWide(email: string) {
     const { companyId } = this.user;
 

--- a/features/user/upsert/admin-update-user-details.interactor.ts
+++ b/features/user/upsert/admin-update-user-details.interactor.ts
@@ -31,6 +31,7 @@ export const AdminUpdateUserDetailsSchema = z.object({
 export type AdminUpdateUserDetailsData = Data<typeof AdminUpdateUserDetailsSchema>;
 
 export abstract class AdminUpdateUserDetailsRepo {
+  abstract isPlatformOperatorCompanyWide(userId: string): Promise<boolean>;
   abstract findExistingEmailsCompanyWide(emails: Set<string>): Promise<Set<string>>;
   abstract findOrThrowCompanyWide(email: string): Promise<TenantUser>;
   abstract adminUpdateDetailsOrThrow(args: { userId: string } & AdminUpdateUserDetailsData): Promise<void>;
@@ -73,6 +74,9 @@ export class AdminUpdateUserDetailsInteractor extends AuthenticatedInteractor<
     const targetUserId = targetUser.id;
 
     if (targetUserId === this.userId) return failAuthorization(CustomErrorCode.userSelfAdminUpdateForbidden, ["email"]);
+
+    if (targetUser.status !== data.status && (await this.userRepo.isPlatformOperatorCompanyWide(targetUserId)))
+      return failAuthorization(CustomErrorCode.userPlatformOperatorStatusForbidden, ["status"]);
 
     const targetIsSystem = targetUser.roleId ? await this.roleRepo.isSystemRoleOrThrow(targetUser.roleId) : false;
     const newRoleIsSystemAndActive =

--- a/features/user/upsert/admin-update-user-details.interactor.ts
+++ b/features/user/upsert/admin-update-user-details.interactor.ts
@@ -75,7 +75,8 @@ export class AdminUpdateUserDetailsInteractor extends AuthenticatedInteractor<
 
     if (targetUserId === this.userId) return failAuthorization(CustomErrorCode.userSelfAdminUpdateForbidden, ["email"]);
 
-    if (targetUser.status !== data.status && (await this.userRepo.isPlatformOperatorCompanyWide(targetUserId)))
+    const leavingActive = targetUser.status === Status.active && data.status !== Status.active;
+    if (leavingActive && (await this.userRepo.isPlatformOperatorCompanyWide(targetUserId)))
       return failAuthorization(CustomErrorCode.userPlatformOperatorStatusForbidden, ["status"]);
 
     const targetIsSystem = targetUser.roleId ? await this.roleRepo.isSystemRoleOrThrow(targetUser.roleId) : false;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1038,7 +1038,7 @@
       "unipileUnknown": "Der Anbieter hat diese Nachricht abgelehnt. Bitte erneut versuchen oder Support kontaktieren.",
       "userInactive": "Dein Benutzerkonto ist inaktiv. Wende dich an einen Workspace-Administrator.",
       "userNotFound": "Benutzer-ID nicht gefunden oder nicht zugänglich.",
-      "userPlatformOperatorStatusForbidden": "Dieses Konto gehört einem Plattform-Operator. Sein Status kann nur über die Operator-Konsole geändert werden.",
+      "userPlatformOperatorStatusForbidden": "Dieses Konto gehört einem Plattform-Operator und kann hier nicht deaktiviert werden. Nutze die Operator-Konsole.",
       "userSelfAdminUpdateForbidden": "Du kannst dein eigenes Konto nicht über die Teamverwaltung aktualisieren.",
       "webhookDeliveryNotFound": "Webhook-Zustellungs-ID nicht gefunden oder nicht zugänglich.",
       "webhookEventsRequired": "Wähle mindestens ein Ereignis aus.",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1038,6 +1038,7 @@
       "unipileUnknown": "Der Anbieter hat diese Nachricht abgelehnt. Bitte erneut versuchen oder Support kontaktieren.",
       "userInactive": "Dein Benutzerkonto ist inaktiv. Wende dich an einen Workspace-Administrator.",
       "userNotFound": "Benutzer-ID nicht gefunden oder nicht zugänglich.",
+      "userPlatformOperatorStatusForbidden": "Dieses Konto gehört einem Plattform-Operator. Sein Status kann nur über die Operator-Konsole geändert werden.",
       "userSelfAdminUpdateForbidden": "Du kannst dein eigenes Konto nicht über die Teamverwaltung aktualisieren.",
       "webhookDeliveryNotFound": "Webhook-Zustellungs-ID nicht gefunden oder nicht zugänglich.",
       "webhookEventsRequired": "Wähle mindestens ein Ereignis aus.",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -936,9 +936,9 @@
     },
     "errors": {
       "activityDuplicateFilterField": "Jedes Aktivitätsfilterfeld kann nur einmal konfiguriert werden.",
-      "activityPageOutOfRange": "Der Aktivitätsverlauf kann nicht so weit zurückblättern. Grenzen Sie stattdessen die Filter ein.",
+      "activityPageOutOfRange": "Der Aktivitätsverlauf kann nicht so weit zurückblättern. Grenze stattdessen die Filter ein.",
       "activityScopeTooManyIds": "Ein Aktivitätsbereich darf nicht mehr als 50 Datensätze eines Typs auswählen.",
-      "activitySourcesUnavailable": "Sie haben keinen Zugriff auf eine Quelle des Aktivitätsverlaufs.",
+      "activitySourcesUnavailable": "Du hast keinen Zugriff auf eine Quelle des Aktivitätsverlaufs.",
       "agentApprovalUnavailable": "Diese Freigabeanfrage ist nicht verfügbar oder abgelaufen.",
       "agentConversationNotFound": "Diese Unterhaltung wurde nicht gefunden oder ist nicht mehr zugänglich.",
       "agentLimitReached": "Es sind nicht genügend KI-Credits übrig, um eine weitere Anfrage zu starten.",
@@ -1196,7 +1196,7 @@
         "none": "Kein Preset"
       },
       "searchLabel": "Suche",
-      "selectionLimit": "Sie können bis zu {count} Werte auswählen.",
+      "selectionLimit": "Du kannst bis zu {count} Werte auswählen.",
       "selectOperator": "Bedingung auswählen…",
       "unavailableValue": "Filter nicht verfügbar"
     },
@@ -1469,6 +1469,7 @@
     "foldersShown": "{shown} von {total} synchronisiert",
     "foldersUpdateFailed": "Ordner konnten nicht aktualisiert werden",
     "folderSynced": "Synchronisiert",
+    "folderToggleLabel": "Ordner {folder} synchronisieren",
     "invalidCredentialsToastDescription": "Die Anmeldedaten wurden nicht akzeptiert. Überprüfe sie und versuche es erneut.",
     "invalidCredentialsToastTitle": "Ungültige Anmeldedaten",
     "lastSynced": "Zuletzt synchronisiert",
@@ -2549,7 +2550,7 @@
     }
   },
   "OperatorAudit": {
-    "emptyBody": "Passen Sie Suche oder Filter an, um das Protokoll zu erweitern.",
+    "emptyBody": "Passe Suche oder Filter an, um das Protokoll zu erweitern.",
     "emptyTitle": "Keine Audit-Ereignisse passen zu diesen Filtern",
     "navigation": "Audit-Protokoll",
     "searchPlaceholder": "Nach Aktion suchen",
@@ -2650,7 +2651,7 @@
       "title": "Aktueller Credit-Stand",
       "unavailableDescription": "Der Arbeitsbereich benötigt eine gültige Berechtigung und einen Credit-Anker, bevor Credits korrigiert oder zurückgesetzt werden können."
     },
-    "emptyBody": "Passen Sie Suche oder Filter an, um das Verzeichnis zu erweitern.",
+    "emptyBody": "Passe Suche oder Filter an, um das Verzeichnis zu erweitern.",
     "emptyTitle": "Keine Benutzer passen zu diesen Filtern",
     "modal": {
       "access": "Zugriff",
@@ -2675,7 +2676,7 @@
   "OperatorWorkspaces": {
     "allowance": {
       "hintContract": "Der vertraglich vereinbarte Enterprise-Satz, jeden Monat pro aktivem Mitglied.",
-      "hintMissing": "Enterprise bezieht seinen Satz aus einem Vertragswert, und es ist keiner gesetzt. Alle Mitglieder sind blockiert, bis Sie einen setzen.",
+      "hintMissing": "Enterprise bezieht seinen Satz aus einem Vertragswert, und es ist keiner gesetzt. Alle Mitglieder sind blockiert, bis du einen setzt.",
       "hintPlan": "{plan} enthält so viele Credits pro aktivem Mitglied und Monat.",
       "hintTrial": "Während einer Testphase erhält das jedes aktive Mitglied, unabhängig vom Tarif.",
       "hintUnavailable": "Dieses Abonnement gewährt in seinem aktuellen Zustand keine Credits.",
@@ -2701,7 +2702,7 @@
       "title": "Diesen Workspace löschen",
       "warningDescription": "Beim Löschen von {name} werden der Workspace und {members, plural, =1 {sein einziges Mitgliedskonto} other {alle # Mitgliedskonten}} dauerhaft entfernt, samt Kontakten, Deals, Nachrichten, Anmeldedaten und Abrechnungsdaten. Dies kann nicht rückgängig gemacht werden."
     },
-    "emptyBody": "Passen Sie Suche oder Filter an, um die Liste zu erweitern.",
+    "emptyBody": "Passe Suche oder Filter an, um die Liste zu erweitern.",
     "emptyTitle": "Keine Arbeitsbereiche passen zu diesen Filtern",
     "modal": {
       "identity": "{domain} · {owner}",
@@ -2749,7 +2750,7 @@
   },
   "PageState": {
     "loading": "Seite wird geladen",
-    "notFoundDescription": "Dieser Datensatz wurde möglicherweise entfernt oder Sie haben keinen Zugriff darauf.",
+    "notFoundDescription": "Dieser Datensatz wurde möglicherweise entfernt oder du hast keinen Zugriff darauf.",
     "notFoundTitle": "Datensatz nicht gefunden"
   },
   "PendingCard": {
@@ -2859,7 +2860,7 @@
     "manageWithLemonSqueezy": "Verwalten mit Lemon Squeezy",
     "picker": {
       "connectedAccountsPerUser": "{accounts, plural, one {# verbundenes Konto pro Nutzer} other {# verbundene Konten pro Nutzer}}",
-      "creditNote": "Credits für den gehosteten KI-Assistenten werden monatlich erneuert; nicht genutzte Credits werden nicht übertragen. Externe MCP-Clients nutzen Ihren eigenen KI-Anbieter und verbrauchen diese Credits nicht.",
+      "creditNote": "Credits für den gehosteten KI-Assistenten werden monatlich erneuert; nicht genutzte Credits werden nicht übertragen. Externe MCP-Clients nutzen deinen eigenen KI-Anbieter und verbrauchen diese Credits nicht.",
       "features": {
         "business": ["Alles aus Pro", "Geteilte Konten und priorisierter Support"],
         "pro": ["Alles aus Starter", "Zentraler Posteingang"],

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1038,7 +1038,7 @@
       "unipileUnknown": "The provider rejected this message. Please try again or contact support.",
       "userInactive": "Your user account is inactive. Contact a workspace administrator.",
       "userNotFound": "User ID not found or not accessible.",
-      "userPlatformOperatorStatusForbidden": "This account belongs to a platform operator. Its status can only be changed from the operator console.",
+      "userPlatformOperatorStatusForbidden": "This account belongs to a platform operator and cannot be deactivated here. Use the operator console.",
       "userSelfAdminUpdateForbidden": "You cannot update your own account through team administration.",
       "webhookDeliveryNotFound": "Webhook delivery ID not found or not accessible.",
       "webhookEventsRequired": "Select at least one event.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1469,6 +1469,7 @@
     "foldersShown": "{shown} of {total} synced",
     "foldersUpdateFailed": "Couldn't update folders",
     "folderSynced": "Synced",
+    "folderToggleLabel": "Sync the {folder} folder",
     "invalidCredentialsToastDescription": "The login details were not accepted. Check your credentials and try again.",
     "invalidCredentialsToastTitle": "Invalid credentials",
     "lastSynced": "Last synced",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1038,6 +1038,7 @@
       "unipileUnknown": "The provider rejected this message. Please try again or contact support.",
       "userInactive": "Your user account is inactive. Contact a workspace administrator.",
       "userNotFound": "User ID not found or not accessible.",
+      "userPlatformOperatorStatusForbidden": "This account belongs to a platform operator. Its status can only be changed from the operator console.",
       "userSelfAdminUpdateForbidden": "You cannot update your own account through team administration.",
       "webhookDeliveryNotFound": "Webhook delivery ID not found or not accessible.",
       "webhookEventsRequired": "Select at least one event.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1038,6 +1038,7 @@
       "unipileUnknown": "El proveedor rechazó este mensaje. Inténtalo de nuevo o contacta con soporte.",
       "userInactive": "Tu cuenta de usuario está inactiva. Contacta con un administrador del espacio de trabajo.",
       "userNotFound": "ID de usuario no encontrado o no accesible.",
+      "userPlatformOperatorStatusForbidden": "Esta cuenta pertenece a un operador de plataforma. Su estado solo se puede cambiar desde la consola de operador.",
       "userSelfAdminUpdateForbidden": "No puedes actualizar tu propia cuenta desde la administración del equipo.",
       "webhookDeliveryNotFound": "ID de entrega de webhook no encontrado o no accesible.",
       "webhookEventsRequired": "Selecciona al menos un evento.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1038,7 +1038,7 @@
       "unipileUnknown": "El proveedor rechazó este mensaje. Inténtalo de nuevo o contacta con soporte.",
       "userInactive": "Tu cuenta de usuario está inactiva. Contacta con un administrador del espacio de trabajo.",
       "userNotFound": "ID de usuario no encontrado o no accesible.",
-      "userPlatformOperatorStatusForbidden": "Esta cuenta pertenece a un operador de plataforma. Su estado solo se puede cambiar desde la consola de operador.",
+      "userPlatformOperatorStatusForbidden": "Esta cuenta pertenece a un operador de plataforma y no se puede desactivar aquí. Usa la consola de operador.",
       "userSelfAdminUpdateForbidden": "No puedes actualizar tu propia cuenta desde la administración del equipo.",
       "webhookDeliveryNotFound": "ID de entrega de webhook no encontrado o no accesible.",
       "webhookEventsRequired": "Selecciona al menos un evento.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1469,6 +1469,7 @@
     "foldersShown": "{shown} de {total} sincronizadas",
     "foldersUpdateFailed": "No se pudieron actualizar las carpetas",
     "folderSynced": "Sincronizada",
+    "folderToggleLabel": "Sincronizar la carpeta {folder}",
     "invalidCredentialsToastDescription": "No se aceptaron las credenciales. Compruébalas e inténtalo de nuevo.",
     "invalidCredentialsToastTitle": "Credenciales no válidas",
     "lastSynced": "Última sincronización",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1038,6 +1038,7 @@
       "unipileUnknown": "Le fournisseur a rejeté ce message. Réessayez ou contactez l'assistance.",
       "userInactive": "Votre compte utilisateur est inactif. Contactez un administrateur de l’espace de travail.",
       "userNotFound": "ID d'utilisateur introuvable ou inaccessible.",
+      "userPlatformOperatorStatusForbidden": "Ce compte appartient à un opérateur de la plateforme. Son statut ne peut être modifié que depuis la console opérateur.",
       "userSelfAdminUpdateForbidden": "Vous ne pouvez pas mettre à jour votre propre compte depuis l’administration de l’équipe.",
       "webhookDeliveryNotFound": "ID de livraison de webhook introuvable ou inaccessible.",
       "webhookEventsRequired": "Sélectionnez au moins un évènement.",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1038,7 +1038,7 @@
       "unipileUnknown": "Le fournisseur a rejeté ce message. Réessayez ou contactez l'assistance.",
       "userInactive": "Votre compte utilisateur est inactif. Contactez un administrateur de l’espace de travail.",
       "userNotFound": "ID d'utilisateur introuvable ou inaccessible.",
-      "userPlatformOperatorStatusForbidden": "Ce compte appartient à un opérateur de la plateforme. Son statut ne peut être modifié que depuis la console opérateur.",
+      "userPlatformOperatorStatusForbidden": "Ce compte appartient à un opérateur de la plateforme et ne peut pas être désactivé ici. Utilisez la console opérateur.",
       "userSelfAdminUpdateForbidden": "Vous ne pouvez pas mettre à jour votre propre compte depuis l’administration de l’équipe.",
       "webhookDeliveryNotFound": "ID de livraison de webhook introuvable ou inaccessible.",
       "webhookEventsRequired": "Sélectionnez au moins un évènement.",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1469,6 +1469,7 @@
     "foldersShown": "{shown} sur {total} synchronisés",
     "foldersUpdateFailed": "Impossible de mettre à jour les dossiers",
     "folderSynced": "Synchronisé",
+    "folderToggleLabel": "Synchroniser le dossier {folder}",
     "invalidCredentialsToastDescription": "Les identifiants n'ont pas été acceptés. Vérifiez-les et réessayez.",
     "invalidCredentialsToastTitle": "Identifiants invalides",
     "lastSynced": "Dernière synchronisation",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1038,6 +1038,7 @@
       "unipileUnknown": "Il provider ha rifiutato questo messaggio. Riprova o contatta l'assistenza.",
       "userInactive": "Il tuo account utente è inattivo. Contatta un amministratore dello spazio di lavoro.",
       "userNotFound": "ID utente non trovato o non accessibile.",
+      "userPlatformOperatorStatusForbidden": "Questo account appartiene a un operatore della piattaforma. Il suo stato può essere modificato solo dalla console operatore.",
       "userSelfAdminUpdateForbidden": "Non puoi aggiornare il tuo account dall’amministrazione del team.",
       "webhookDeliveryNotFound": "ID consegna del webhook non trovato o non accessibile.",
       "webhookEventsRequired": "Seleziona almeno un evento.",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1469,6 +1469,7 @@
     "foldersShown": "{shown} di {total} sincronizzate",
     "foldersUpdateFailed": "Impossibile aggiornare le cartelle",
     "folderSynced": "Sincronizzata",
+    "folderToggleLabel": "Sincronizza la cartella {folder}",
     "invalidCredentialsToastDescription": "Le credenziali non sono state accettate. Controllale e riprova.",
     "invalidCredentialsToastTitle": "Credenziali non valide",
     "lastSynced": "Ultima sincronizzazione",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1038,7 +1038,7 @@
       "unipileUnknown": "Il provider ha rifiutato questo messaggio. Riprova o contatta l'assistenza.",
       "userInactive": "Il tuo account utente è inattivo. Contatta un amministratore dello spazio di lavoro.",
       "userNotFound": "ID utente non trovato o non accessibile.",
-      "userPlatformOperatorStatusForbidden": "Questo account appartiene a un operatore della piattaforma. Il suo stato può essere modificato solo dalla console operatore.",
+      "userPlatformOperatorStatusForbidden": "Questo account appartiene a un operatore della piattaforma e non può essere disattivato qui. Usa la console operatore.",
       "userSelfAdminUpdateForbidden": "Non puoi aggiornare il tuo account dall’amministrazione del team.",
       "webhookDeliveryNotFound": "ID consegna del webhook non trovato o non accessibile.",
       "webhookEventsRequired": "Seleziona almeno un evento.",

--- a/tests/conventions/hosted-ai-pricing-contract.test.ts
+++ b/tests/conventions/hosted-ai-pricing-contract.test.ts
@@ -57,7 +57,7 @@ describe("hosted AI pricing contract", () => {
     );
     expect(subscriptionCreditNotes).toEqual({
       en: "Hosted AI credits refresh monthly; unused credits do not roll over. External MCP clients use your own AI provider and do not consume these credits.",
-      de: "Credits für den gehosteten KI-Assistenten werden monatlich erneuert; nicht genutzte Credits werden nicht übertragen. Externe MCP-Clients nutzen Ihren eigenen KI-Anbieter und verbrauchen diese Credits nicht.",
+      de: "Credits für den gehosteten KI-Assistenten werden monatlich erneuert; nicht genutzte Credits werden nicht übertragen. Externe MCP-Clients nutzen deinen eigenen KI-Anbieter und verbrauchen diese Credits nicht.",
       es: "Los créditos de IA alojada se renuevan cada mes; los créditos no utilizados no se acumulan. Los clientes MCP externos utilizan tu propio proveedor de IA y no consumen estos créditos.",
       fr: "Les crédits IA hébergés sont renouvelés chaque mois ; les crédits non utilisés ne sont pas reportés. Les clients MCP externes utilisent votre propre fournisseur d'IA et ne consomment pas ces crédits.",
       it: "I crediti IA in hosting si rinnovano ogni mese; i crediti non utilizzati non vengono trasferiti al mese successivo. I client MCP esterni utilizzano il tuo provider di IA e non consumano questi crediti.",

--- a/tests/conventions/operator-access-boundary.test.ts
+++ b/tests/conventions/operator-access-boundary.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT, walkFiles } from "./walk";
+
+const read = (path: string) => readFileSync(join(REPO_ROOT, path), "utf8");
+
+const UNDECORATED_ALLOWLIST = new Set(["ee/operator/get/get-operator-console-visibility.interactor.ts"]);
+
+function operatorInteractors() {
+  return walkFiles(join(REPO_ROOT, "ee", "operator"), (path) => path.endsWith(".interactor.ts")).map((path) =>
+    relative(REPO_ROOT, path),
+  );
+}
+
+describe("operator access boundary", () => {
+  it("authorizes every operator interactor through the operator decorator", () => {
+    const undecorated = operatorInteractors().filter(
+      (path) => !UNDECORATED_ALLOWLIST.has(path) && !read(path).includes("@OperatorInteractor"),
+    );
+
+    expect(undecorated).toEqual([]);
+  });
+
+  it("keeps the deliberately undecorated visibility interactor reduced to an eligibility boolean", () => {
+    const visibility = read("ee/operator/get/get-operator-console-visibility.interactor.ts");
+
+    expect(visibility).toContain("this.access.isEligible()");
+    expect(visibility).toContain("Promise<boolean>");
+    expect(visibility).not.toContain("prisma");
+    expect(visibility).not.toMatch(/Unscoped\b/);
+  });
+
+  it("gates the console on cloud deployments inside authorizeFresh, not only in the route layout", () => {
+    const service = read("ee/operator/operator-access.service.ts");
+    const layout = read("app/[locale]/(protected)/operator/layout.tsx");
+
+    expect(service).toContain('if (env.APP_MODE !== "cloud") throw new ForbiddenError');
+    expect(service).toContain("await this.authService.getInteractiveSession()");
+    expect(service).toContain("await this.repo.findAuthorizedActorUnscoped(session)");
+    expect(service).toContain("async isEligible(): Promise<boolean>");
+    expect(layout).toContain("getGetOperatorConsoleVisibilityInteractor().invoke()");
+    expect(layout).toContain("notFound()");
+  });
+
+  it("isolates the operator actor per request and refuses unscoped work without one", () => {
+    const context = read("core/decorators/operator-context.ts");
+    const decorator = read("core/decorators/operator-interactor.decorator.ts");
+
+    expect(context).toContain('AsyncLocalStorage } from "node:async_hooks"');
+    expect(context).toContain("new AsyncLocalStorage<OperatorActor>()");
+    expect(context).toContain('throw new Error("Operator context missing")');
+    expect(decorator).toContain("authorizeFresh()");
+    expect(decorator).toContain("runWithOperator(actor, () => originalInvoke.apply(this, args))");
+  });
+
+  it("routes every operator server action through an interactor rather than prisma", () => {
+    const actions = walkFiles(join(REPO_ROOT, "app", "[locale]", "(protected)", "operator"), (path) =>
+      path.endsWith("actions.ts"),
+    ).map((path) => relative(REPO_ROOT, path));
+
+    expect(actions.length).toBeGreaterThan(0);
+    for (const path of actions) {
+      const source = read(path);
+      expect(source, path).not.toMatch(/\bprisma\b/);
+      expect(source, path).toMatch(/Interactor\(\)/);
+    }
+  });
+
+  it("guards every operator repository method whose name claims to be unscoped", () => {
+    const repositories = walkFiles(join(REPO_ROOT, "ee", "operator"), (path) => path.endsWith(".repository.ts")).map(
+      (path) => relative(REPO_ROOT, path),
+    );
+
+    expect(repositories.length).toBeGreaterThan(0);
+    for (const path of repositories) {
+      const source = readFileSync(join(REPO_ROOT, path), "utf8");
+      const lines = source.split("\n");
+      lines.forEach((line, index) => {
+        const declared = /^\s*(?:private\s+)?(?:async\s+)?([A-Za-z0-9_]+Unscoped)\s*[(<]/.exec(line);
+        if (!declared) return;
+        const preceding = lines
+          .slice(Math.max(0, index - 4), index)
+          .join("\n");
+        expect(preceding, `${path}:${index + 1} ${declared[1]}`).toContain("@BypassTenantGuard");
+      });
+    }
+  });
+
+  it("names every cross-tenant operator repository method Unscoped and guards it", () => {
+    const repositories = walkFiles(join(REPO_ROOT, "ee", "operator"), (path) => path.endsWith(".repository.ts")).map(
+      (path) => relative(REPO_ROOT, path),
+    );
+
+    expect(repositories.length).toBeGreaterThan(0);
+    for (const path of repositories) {
+      const source = read(path);
+      const guarded = source.match(/@BypassTenantGuard\s+(?:private\s+)?(?:async\s+)?([A-Za-z0-9_]+)\s*\(/g) ?? [];
+      for (const match of guarded) {
+        const name = /([A-Za-z0-9_]+)\s*\($/.exec(match.trim())?.[1] ?? "";
+        expect(name, `${path} -> ${name}`).toMatch(/Unscoped$/);
+      }
+    }
+  });
+});

--- a/tests/conventions/technical-id-loading-contract.test.ts
+++ b/tests/conventions/technical-id-loading-contract.test.ts
@@ -67,10 +67,13 @@ describe("technical-id loading contract", () => {
     const autocomplete = read("components/forms/form-autocomplete.tsx");
 
     expect(options).toContain("SELF_IDENTIFYING_FILTER_FIELDS");
-    expect(options).toContain("SELECTION_RESOLUTION_PAGE_SIZE");
+    expect(options).toContain("const selfIdentifyingField = SELF_IDENTIFYING_FILTER_FIELDS.has(fieldKey)");
+    expect(options).toContain("field: selfIdentifyingField, operator: FilterOperatorKey.in");
     expect(options).toContain("requested.has(item.key)");
     expect(options).not.toContain("resolveFilterOptionsAction");
     expect(options).not.toContain("filters: [{ field, operator: FilterOperatorKey.in, value: ids }]");
+    expect(options).not.toMatch(/field: fieldKey, operator: FilterOperatorKey\.in/);
+    expect(options).not.toMatch(/pagination|pageSize/);
     expect(options).toContain('status: "error"');
     expect(filterSelect).toContain("optionError");
     expect(filterSelect).toContain('t("ErrorCard.retry")');

--- a/tests/conventions/technical-id-loading-contract.test.ts
+++ b/tests/conventions/technical-id-loading-contract.test.ts
@@ -66,7 +66,8 @@ describe("technical-id loading contract", () => {
     const filterSelect = read("components/data-view/filter-modal/inputs/filter-input-select.tsx");
     const autocomplete = read("components/forms/form-autocomplete.tsx");
 
-    expect(options).toContain("const result = await getItems({});");
+    expect(options).toContain("SELF_IDENTIFYING_FILTER_FIELDS");
+    expect(options).toContain("SELECTION_RESOLUTION_PAGE_SIZE");
     expect(options).toContain("requested.has(item.key)");
     expect(options).not.toContain("resolveFilterOptionsAction");
     expect(options).not.toContain("filters: [{ field, operator: FilterOperatorKey.in, value: ids }]");

--- a/tests/conventions/tenant-write-scoping.test.ts
+++ b/tests/conventions/tenant-write-scoping.test.ts
@@ -28,10 +28,10 @@ const GUARD_EXEMPT_MODELS = new Set([
 
 const REACHED_ONLY_FROM_BYPASSED_CALLERS = new Set([
   "core/auth/better-auth.ts:103",
-  "features/user/prisma-user.repository.ts:641",
-  "features/user/prisma-user.repository.ts:651",
-  "features/user/prisma-user.repository.ts:661",
-  "features/user/prisma-user.repository.ts:671",
+  "features/user/prisma-user.repository.ts:652",
+  "features/user/prisma-user.repository.ts:662",
+  "features/user/prisma-user.repository.ts:672",
+  "features/user/prisma-user.repository.ts:682",
 ]);
 
 type WriteSite = {


### PR DESCRIPTION
## Summary

- Fixes the reported bug: an applied Workspace filter rendered **"Filter not available"** instead of the workspace name whenever the selected workspace was not on the first page of options.
- Fixes 14 deviations found by an audit of where the product bypasses its own components, store patterns and error handling, each one adversarially verified before being acted on.
- Adds a convention test pinning the operator console's access boundary, which nothing enforced before.
- Closes five verified holes in that boundary, from a separate adversarial audit whose only high-severity finding was disproved by experiment and is therefore **not** acted on.

## Context

### The filter label

Reproduced on the Workspaces list: filter by a workspace at offset 60 and the chip reads "Filter not available" while the row itself loads correctly. The cause is in `resolveItems` (`use-filter-select-items.tsx`): it called `getItems({})`, which returns one default-size page, then filtered that page client-side for the selected ids. Anything outside that page was unresolvable, and the chip fell back to `Common.filters.unavailableValue`, whose English text is literally "Filter not available".

The obvious fix was banned, and correctly so. `tests/conventions/technical-id-loading-contract.test.ts` forbids `filters: [{ field, operator: FilterOperatorKey.in, value: ids }]`, which PR #48 had removed. Reading that commit shows why: it used the *filter field key* as the query field, which is wrong for a relation field like `userIds`, where the key names a relation on the host entity rather than the listed entity's own id.

So this reintroduces the id filter only for fields where the filter key **is** the listed entity's identity, gated by an explicit `SELF_IDENTIFYING_FILTER_FIELDS` set that currently holds `workspaceId`. Every other field keeps the page-scan fallback, raised from the default page size to 100. The convention test now pins that gating instead of pinning the old call, and still forbids the generic form.

### The audit

Six dimensions were swept (native controls, app components used one level too low, store patterns, error handling, formatting and i18n, data access), then every candidate was handed to an independent agent told to refute it. 16 of 30 candidates were refuted and dropped; the 14 below survived, and the operator-console ones were re-verified by hand.

Grouped by what a user actually experiences:

**Keyboard and screen-reader access**
- The operator chip selects (plan, subscription, account status, platform access) used a bare `<span>` under `DropdownMenuTrigger asChild`. Radix renders `Primitive.button` and never sets `tabIndex`; it relies on the child being a real button. Inside the span sat a non-focusable `Badge`, so all four controls were unreachable by keyboard. The same idiom, which predates the operator console, also sits on select-type custom field values; both are fixed the way `app-chip-stack.tsx` already does it.
- The webhook signing secret hand-rolled a reveal toggle: an unlabeled 16px icon with `tabIndex={-1}`, positioned against the outer wrapper so it sat jammed against the field's top border, and with no `endContent` the revealed secret ran underneath it. It now uses `PasswordInput`, the component all three auth screens use.
- Per-folder sync switches had no accessible name, so a screen reader announced a row of unnamed switches.

**Wrong component for the job**
- Both operator numeric fields (Enterprise allowance, credit correction) hand-assembled `FormLabel` + `<Input type="number">`. `FormNumberInput` exists and five other call sites use it; it formats and parses through the intl store, wires `aria-invalid`, honours loading and read-only, and deliberately renders `type="text"` with `inputMode="decimal"` rather than a scroll-sensitive number input. A German operator now sees "1.500" where the field previously showed "1500".
- The API key expiry trigger used `variant="secondary"` where all ten other field-shaped triggers use `variant="field"`, so it did not match the `FormInput` directly above it. Only the variant changed: this picker cannot become `FormIsoDatePicker`, because that component cannot express the 1-365 day bound it enforces.

**State that silently disappeared**
- The operator workspace modal re-seeded every field from the `workspace` **object**, so any list refresh reset the allowance, trial end, billing id, tags, delete-confirmation label and reason. It now keys on `companyId` and reads the row through a ref.
- Company settings re-initialised terminology whenever the observable overrides array was replaced, discarding unsaved selections; it now keys on the content.
- Saving a filter preset never reloaded the preset list, so a newly created preset was missing from the dropdown until something else forced a refresh. It now does what `deletePreset` already did.
- A failed dashboard layout write left the widget in its new position on screen while the server still held the old one. It now snapshots and reverts.

**Errors that went nowhere**
- `globalSearchAction` returned `result.data` and dropped `result.ok`, so a failure rendered a blank command palette with no message. It now goes through `serializeResult` and the store surfaces the failure. Reachable today: any query over 200 characters trips the input schema.

**Copy and formatting**
- Ten German in-app strings used the formal register inside namespaces that are otherwise informal. `NotFoundPage` was reverted after `german-public-website-voice` correctly caught it as a public acquisition surface. The pinned copy contract for the in-app plan picker was updated to match, alongside Spanish and Italian which were already informal.
- Attachment sizes were formatted by hand, and the legal-update date used next-intl's formatter rather than the intl store, which follows the user's separate formatting-locale setting. The legal date keeps its UTC pinning so the displayed day cannot shift.
- Operator channel-usage months rendered a raw `2026-08` next to dates the same file formats as `31.08.26`.

### The operator access boundary

Checked on request. The design is sound and the important detail is where the gate sits: `APP_MODE !== "cloud"` is the first statement of `OperatorAccessService.authorizeFresh()`, not a layout check. Server actions are addressable by id and do not re-run a parent layout, so a layout-only gate would have been bypassable. All 18 operator interactors carry `@OperatorInteractor`; the one exception returns only a boolean and delegates to the same `authorizeFresh`. Access requires an interactive session, so API keys and MCP tokens cannot reach it. The actor lives in `AsyncLocalStorage`, and there are exactly 26 `*Unscoped` methods and 26 `@BypassTenantGuard` decorators.

What was missing was enforcement: nothing asserted that operator interactors actually carry the decorator, so a new unguarded one would have passed every check. `tests/conventions/operator-access-boundary.test.ts` now pins decorator coverage, the visibility interactor's reduced surface, the gate living inside `authorizeFresh`, the AsyncLocalStorage isolation, action-to-interactor routing, and the `*Unscoped` naming rule.

## Validation

- `yarn typecheck` and `yarn lint` clean; full suite with database tests **fully green at 4,785 passed, 0 failed**.
- Every fix that changes behaviour has a test that was confirmed to fail without it. Where a fix has no test (the audit skip clamp, and the lockout race as distinct from the status-path guard) that is stated explicitly rather than glossed.
- Three convention tests caught real mistakes during this work and are reported here rather than quietly worked around: the public-surface German revert, the pinned plan-picker copy, and the banned filter form.
- The new boundary test was proved to bite by planting three regressions in turn (stripping a decorator, moving the `APP_MODE` gate out of `authorizeFresh`, making an operator action call prisma); each failed exactly one assertion and the tree was restored clean.
- Driven in a browser against a copy of live production data: the workspace filter chip now resolves a workspace at offset 60; operator chip dropdowns open with Enter and report `tabIndex` 0; the allowance field renders `1.500` through the intl store and saves; the modal no longer resets when another section is saved; channel months read "August 2026 · 5 at peak" with no ISO string left in the dialog; the webhook toggle reports the accessible name "Show password", `tabIndex` 0, a 32x32 target and 40px of input padding; the API key trigger's background and border now match the sibling field exactly while keeping its date bounds; a >200 character global search shows an error toast instead of a blank palette; and a newly saved filter preset appears in the dropdown immediately.

## Operator safety boundary

A separate five-probe audit of the operator console produced 23 candidates. Sixteen were
refuted outright. Of the seven that survived, I checked each against the running system before
acting, and **two collapsed under test**, including the only high-severity one:

- *"Workspace deletion resolves member identities with ILIKE, hard-deleting AuthUser rows outside
  the deleted workspace."* Wrong. Tested at the exact shape the delete path uses, with decoy rows
  planted that `_` and `%` would have matched: `in` + insensitive is an **exact** comparison, and
  only `equals` + insensitive wildcards. That form no longer appears in any production code.
- *"The workflow purge matches nothing because the engine writes CBOR."* Not on the evidence
  available: every run present carries the jsonb `input` with a `companyId`, and none has
  `input_cbor` populated. Stated with its limit, that is a small sample from one database.

The five that held are fixed here:

**Zero-operator lockout.** The last-active-operator check is a global count, but the transaction
took a per-workspace advisory lock, so two operators in different workspaces revoking each other
concurrently would both pass and leave the deployment with none, recoverable only from the
database. Both paths that can change that set now take a global lock, acquired after the company
lock so the ordering cannot deadlock. The status path had no operator guard at all, which is the
half reachable without a race; a test proves it previously allowed deactivating the last operator.

**Operator status writable from the tenant surface.** Eligibility requires `status === active`,
but `status` is ordinary tenant data: a workspace admin with `users:update` could deactivate an
operator seated in their workspace, or re-activate one the console had deactivated, in both cases
unaudited. Tenant-side status changes on an operator account are now refused. The flag is checked
through a narrow repository method rather than by adding it to `TenantUserSchema`, whose select is
pinned by a convention test and which has no business exposing it.

**Credit-reset replay across workspaces.** `resetUserCreditsUnscoped` looked up `operationId`,
which is globally unique, and returned the stored row without checking ownership. Reproduced: a
reset in workspace A using workspace B's id returned B's adjustment and reported success, writing
nothing and reaching no audit call. It now performs the same seven-field ownership check
`createCreditAdjustmentUnscoped` already did; the existing idempotent-replay test still passes.

**Workflow runs surviving workspace deletion.** The purge matched `input->>'companyId'`, but
`BackgroundTaskService` stamps tenancy nested as `tenant: { companyId }` and the backfill payload
carries no top-level id, so backfill runs outlived the workspace. The predicate now matches both
shapes; the purge test gains a nested run that survives without the fix.

**Unbounded audit paging.** `skip + take` was passed as `take` with no maximum on `page`; skip is
now clamped. This is the one fix with no test, because it changes no observable output.

The lockout race itself is not covered by a test either. Reproducing it needs two committed
concurrent transactions plus globally clearing platform operators, which is exactly the cross-file
interference that has destabilised this suite before; the mechanism is fixed and the deterministic
half is pinned.

Also updated: four entries in `tenant-write-scoping.test.ts`. That allowlist is keyed by
`file:line`, and inserting a method shifted four pre-existing `updateMany` calls off their
numbers. Confirmed against `origin/main` that none of those methods changed.

## What was verified, and how

Stated plainly, because "tested" covers very different levels of evidence here.

**Driven in a browser, on the rebased merge candidate:** the filter chip resolving a workspace
at offset 60; operator chip dropdowns opening with Enter; the allowance rendering `1.500`
through the intl store and saving; the modal not resetting when another section is saved;
channel months reading "August 2026"; the webhook toggle's accessible name, tab order, 32px
target and input padding; the API-key trigger matching its sibling field; global search showing
an error instead of a blank palette; a saved filter preset appearing immediately.

**Covered by a test that was confirmed to fail without the fix.** Every behaviour-changing fix
in this PR now has one. Twelve separate regressions were planted and each failed exactly the
assertion meant to catch it, including two cases where the first attempt did **not** fail and
the test had to be rewritten: an assertion matching a call shape the code never had, and a
widget-store test that covered only the thrown failure path and not the rejected-result path.

**Verified by reading only, with the reason:**
- Folder switch accessible name: no connected account exists in the test workspace.
- Company settings terminology: the trigger is `router.refresh()` on `visibilitychange`, and
  `document.hidden` is permanently true in the automated browser, so it cannot be fired
  honestly. The repo has jsdom but no React render harness, so a test would be scaffolding
  around a two-line dependency change.
- Legal-update date: needs a pending legal-notice state that cannot be produced locally.

All three are display-level and fail toward previous behaviour rather than breaking.

**Not covered at all:** the advisory-lock race. The lock is proved transaction-scoped (a second
connection cannot acquire it while the transaction holds it, and can immediately after), and the
reachable half of that invariant, the status path, has a test. Staging the two-transaction write
skew would require globally clearing platform operators, which is the cross-file interference
that has destabilised this suite before.

## Impact and rollback

Mostly client-side. Two shared components gain optional, backwards-compatible parameters: `intlStore.formatDescriptiveShortDate` takes an optional `timeZone`, and a new `formatMonthYear` is added. `attachmentSubtitle` and `formatBytes` take an optional formatter and fall back to the previous output when it is absent.

The one server change is `globalSearchAction`, which now returns `{ok, data|error}` instead of bare data. Its only caller is the global search store, updated in the same commit.

The filter change is the one to review closely: it alters a shared code path used by every list. The gated set holds a single field today, and everything else keeps the previous behaviour with a larger page.

Rollback before merge is closing this pull request and deleting its branch. After merge, a revert restores the previous behaviour; nothing persisted needs undoing.
