### PR TITLE
feat(data-view): make mass selection scoped and widen its actions

### DIFF
--- a/components/data-view/data-table.tsx
+++ b/components/data-view/data-table.tsx
@@ -207,10 +207,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
           <Checkbox
             aria-label={t("DataView.selectAllRows")}
             checked={allSelected ? true : someSelected ? "indeterminate" : false}
-            onCheckedChange={(checked) => {
-              if (checked) store.setSelectedIds("all");
-              else store.clearSelection();
-            }}
+            onCheckedChange={(checked) => store.setPageSelection(checked === true)}
           />
         );
       },
@@ -222,10 +219,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
           <Checkbox
             aria-label={t("DataView.selectRow", { id: row.index + 1 })}
             checked={store.selectedIds.has(id)}
-            onCheckedChange={(checked) => {
-              if (checked) store.selectedIds.add(id);
-              else store.selectedIds.delete(id);
-            }}
+            onCheckedChange={() => store.toggleItemSelection(id)}
             onClick={(e) => e.stopPropagation()}
           />
         );
@@ -393,8 +387,7 @@ export const DataTable = observer(function DataTable<E extends HasId>({
                 onClick={(e) => {
                   if (isInteractiveClick(e)) return;
                   if (store.selectedIds.size > 0 && canBulkAct) {
-                    if (store.selectedIds.has(row.original.id)) store.selectedIds.delete(row.original.id);
-                    else store.selectedIds.add(row.original.id);
+                    store.toggleItemSelection(row.original.id);
                     return;
                   }
                   if (onRowClick) {

--- a/components/data-view/mass-actions-bar.tsx
+++ b/components/data-view/mass-actions-bar.tsx
@@ -22,29 +22,55 @@ export const MassActionsBar = observer(function MassActionsBar<E extends HasId>(
   const entityType = store.entityType;
   if (!store.hasSelection || !entityType) return null;
 
+  const offView = store.selectedOffViewCount;
+
   return (
-    <div className="flex items-center gap-2 px-4 py-2 bg-card border-b border-border">
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-2 bg-card border-b border-border">
       <span className="text-sm font-medium whitespace-nowrap">
         {t("MassActions.selectedCount", { count: store.selectedCount })}
       </span>
 
+      {offView > 0 && (
+        <span className="text-muted-foreground text-xs whitespace-nowrap">
+          {t("MassActions.offView", { count: offView })}
+        </span>
+      )}
+
+      {store.isSelectionScopeStale && (
+        <>
+          <span className="text-muted-foreground text-xs whitespace-nowrap">{t("MassActions.scopeStale")}</span>
+
+          <Button
+            className="h-7 px-2 text-xs"
+            size="sm"
+            type="button"
+            variant="ghost"
+            onClick={() => store.keepSelectionInView()}
+          >
+            {t("MassActions.keepInView")}
+          </Button>
+        </>
+      )}
+
       <div className="grow" />
 
-      <MassUpdatePopover store={store} />
+      {store.canUpdateSelection && <MassUpdatePopover store={store} />}
 
-      <Button
-        className="h-8"
-        disabled={store.isBulkMutating}
-        id="mass-delete"
-        size="sm"
-        type="button"
-        variant="secondary"
-        onClick={() => showDeleteConfirmation(() => store.bulkDelete())}
-      >
-        <TrashIcon className="size-4 text-destructive" />
+      {store.canDeleteSelection && (
+        <Button
+          className="h-8"
+          disabled={store.isBulkMutating}
+          id="mass-delete"
+          size="sm"
+          type="button"
+          variant="secondary"
+          onClick={() => showDeleteConfirmation(() => store.bulkDelete())}
+        >
+          <TrashIcon className="size-4 text-destructive" />
 
-        {t("MassActions.delete")}
-      </Button>
+          {t("MassActions.delete")}
+        </Button>
+      )}
 
       <Button
         aria-label={t("Common.actions.clear")}

--- a/components/data-view/mass-update-form.store.ts
+++ b/components/data-view/mass-update-form.store.ts
@@ -1,0 +1,20 @@
+import type { RootStore } from "@/core/stores/root.store";
+
+import { BaseFormStore } from "@/core/base/base-form.store";
+
+export type MassUpdateFormState = {
+  customFieldValues: { columnId: string; value: string | undefined }[];
+};
+
+export const MASS_UPDATE_VALUE_PATH = "customFieldValues[0].value";
+
+export class MassUpdateFormStore extends BaseFormStore<MassUpdateFormState> {
+  constructor(rootStore: RootStore, columnId: string) {
+    super(rootStore, { customFieldValues: [{ columnId, value: undefined }] });
+    this.setWithUnsavedChangesGuard(false);
+  }
+
+  get value(): string | undefined {
+    return this.form.customFieldValues[0]?.value;
+  }
+}

--- a/components/data-view/mass-update-popover.tsx
+++ b/components/data-view/mass-update-popover.tsx
@@ -1,35 +1,101 @@
 "use client";
 
 import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store";
-import type { CustomColumnDto, CustomColumnOption } from "@/features/custom-column/custom-column.schema";
+import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
 
-import { ChevronDownIcon, SearchIcon } from "lucide-react";
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon, SearchIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import { CustomColumnType } from "@/generated/prisma";
 
-import { AppChip } from "@/components/chip/app-chip";
+import { AppForm } from "@/components/forms/form-context";
 import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/shared/icon";
 import { Input } from "@/components/ui/input";
 import { ResponsiveOverlay } from "@/components/modal";
 import { runUserAction } from "@/core/errors/report-application-error";
+import { useRootStore } from "@/core/stores/root-store.provider";
+
+import { CUSTOM_COLUMN_TYPE_ICON } from "./custom-columns/custom-column-type-icon";
+import { CustomFieldEditor } from "./custom-columns/custom-field-editor";
+import { MASS_UPDATE_VALUE_PATH, MassUpdateFormStore } from "./mass-update-form.store";
+
 type Props<E extends HasId> = {
   store: BaseDataViewStore<E>;
 };
 
+type EditorProps<E extends HasId> = {
+  column: CustomColumnDto;
+  store: BaseDataViewStore<E>;
+  onApplied: () => void;
+};
+
 const SEARCH_THRESHOLD = 6;
+
+const MassFieldEditor = observer(function MassFieldEditor<E extends HasId>({
+  column,
+  store,
+  onApplied,
+}: EditorProps<E>) {
+  const t = useTranslations();
+  const rootStore = useRootStore();
+  const formStore = useMemo(() => new MassUpdateFormStore(rootStore, column.id), [rootStore, column.id]);
+
+  async function applyValue(value: string) {
+    const ok = await store.bulkUpdateCustomField(column.id, value);
+    if (ok) onApplied();
+  }
+
+  const currentValue = formStore.value;
+
+  return (
+    <AppForm store={formStore}>
+      <div className="flex flex-col gap-3 px-3 py-2.5">
+        <CustomFieldEditor
+          column={column}
+          id={MASS_UPDATE_VALUE_PATH}
+          label={column.label}
+          value={currentValue}
+          onChange={(next) => formStore.onChange(MASS_UPDATE_VALUE_PATH, next)}
+        />
+
+        <div className="flex items-center gap-2">
+          <Button
+            className="h-8"
+            disabled={store.isBulkMutating}
+            size="sm"
+            type="button"
+            variant="secondary"
+            onClick={() => runUserAction(() => applyValue(""))}
+          >
+            {t("MassActions.clearField")}
+          </Button>
+
+          <div className="grow" />
+
+          <Button
+            className="h-8"
+            disabled={store.isBulkMutating || currentValue === undefined || currentValue === ""}
+            size="sm"
+            type="button"
+            onClick={() => runUserAction(() => applyValue(currentValue ?? ""))}
+          >
+            {t("MassActions.apply")}
+          </Button>
+        </div>
+      </div>
+    </AppForm>
+  );
+});
 
 export const MassUpdatePopover = observer(function MassUpdatePopover<E extends HasId>({ store }: Props<E>) {
   const t = useTranslations();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [activeColumnId, setActiveColumnId] = useState<string | undefined>(undefined);
 
   const entityType = store.entityType;
-  const columns = store.singleSelectCustomColumns.filter(
-    (c): c is Extract<CustomColumnDto, { type: typeof CustomColumnType.singleSelect }> =>
-      c.type === CustomColumnType.singleSelect && c.options.options.length > 0,
-  );
+  const columns = store.massEditableCustomColumns;
 
   const filtered = useMemo(() => {
     if (!query.trim()) return columns;
@@ -37,11 +103,14 @@ export const MassUpdatePopover = observer(function MassUpdatePopover<E extends H
     return columns.filter((c) => c.label.toLowerCase().includes(q));
   }, [columns, query]);
 
+  const activeColumn = columns.find((column) => column.id === activeColumnId);
+
   if (!entityType || columns.length === 0) return null;
 
-  async function applyOption(column: CustomColumnDto, option: CustomColumnOption) {
-    const ok = await store.bulkUpdateCustomField(column.id, option.value);
-    if (ok) setOpen(false);
+  function closeAndReset() {
+    setOpen(false);
+    setActiveColumnId(undefined);
+    setQuery("");
   }
 
   const showSearch = columns.length > SEARCH_THRESHOLD;
@@ -60,55 +129,72 @@ export const MassUpdatePopover = observer(function MassUpdatePopover<E extends H
     </Button>
   );
 
+  const title = activeColumn ? (
+    <button
+      className="flex cursor-pointer items-center gap-1.5 outline-none"
+      type="button"
+      onClick={() => setActiveColumnId(undefined)}
+    >
+      <ChevronLeftIcon className="size-3.5 opacity-60" />
+
+      <span className="truncate">{t("MassActions.update")}</span>
+    </button>
+  ) : (
+    t("MassActions.update")
+  );
+
   return (
     <ResponsiveOverlay
       open={open}
       popoverClassName="w-80"
-      title={t("MassActions.update")}
+      title={title}
       trigger={trigger}
-      onOpenChange={setOpen}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setActiveColumnId(undefined);
+      }}
     >
-      <div className="flex flex-col divide-y divide-border">
-        {showSearch && (
-          <div className="flex items-center gap-2 p-2">
-            <SearchIcon className="size-3.5 text-muted-foreground shrink-0" />
+      {activeColumn ? (
+        <MassFieldEditor column={activeColumn} store={store} onApplied={closeAndReset} />
+      ) : (
+        <div className="flex flex-col divide-y divide-border">
+          {showSearch && (
+            <div className="flex items-center gap-2 px-3 py-2">
+              <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
 
-            <Input
-              autoFocus
-              className="h-7 border-0 shadow-none focus-visible:ring-0 px-0"
-              placeholder={t("MassActions.searchFieldPlaceholder")}
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-          </div>
-        )}
-
-        {filtered.length === 0 ? (
-          <div className="px-3 py-6 text-center text-sm text-muted-foreground">{t("MassActions.noMatchingFields")}</div>
-        ) : (
-          filtered.map((column) => (
-            <div key={column.id} className="flex flex-col gap-1.5 p-2">
-              <span className="text-xs text-muted-foreground px-1">{column.label}</span>
-
-              <div className="flex flex-wrap gap-1">
-                {column.options.options.map((option) => (
-                  <button
-                    key={option.value}
-                    className="cursor-pointer outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled={store.isBulkMutating}
-                    type="button"
-                    onClick={() => runUserAction(() => applyOption(column, option))}
-                  >
-                    <AppChip interactive variant={option.color}>
-                      <span className="truncate">{option.label}</span>
-                    </AppChip>
-                  </button>
-                ))}
-              </div>
+              <Input
+                autoFocus
+                className="h-7 border-0 px-0 shadow-none focus-visible:ring-0"
+                placeholder={t("MassActions.searchFieldPlaceholder")}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
             </div>
-          ))
-        )}
-      </div>
+          )}
+
+          {filtered.length === 0 ? (
+            <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+              {t("MassActions.noMatchingFields")}
+            </div>
+          ) : (
+            filtered.map((column) => (
+              <button
+                key={column.id}
+                className="flex w-full cursor-pointer items-center gap-2 px-3 py-2.5 text-left text-sm outline-none hover:bg-accent focus-visible:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={store.isBulkMutating}
+                type="button"
+                onClick={() => setActiveColumnId(column.id)}
+              >
+                <Icon className="shrink-0 text-muted-foreground" icon={CUSTOM_COLUMN_TYPE_ICON[column.type]} />
+
+                <span className="min-w-0 flex-1 truncate">{column.label}</span>
+
+                <ChevronRightIcon className="size-3.5 shrink-0 opacity-60" />
+              </button>
+            ))
+          )}
+        </div>
+      )}
     </ResponsiveOverlay>
   );
 });

--- a/core/base/__tests__/base-data-view-selection.test.ts
+++ b/core/base/__tests__/base-data-view-selection.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Filter } from "../base-get.schema";
+import type { GetResult } from "../base-get.interactor";
+import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
+import type { RootStore } from "@/core/stores/root.store";
+
+import { Action, CustomColumnType, EntityType, Resource } from "@/generated/prisma";
+
+import { FilterOperatorKey } from "../base-query-builder";
+import { BaseDataViewStore, MAX_SELECTION_SIZE } from "../base-data-view.store";
+
+const { bulkDeleteEntitiesAction, bulkUpdateCustomFieldValuesAction, toastError } = vi.hoisted(() => ({
+  bulkDeleteEntitiesAction: vi.fn(),
+  bulkUpdateCustomFieldValuesAction: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/actions", () => ({
+  bulkDeleteEntitiesAction,
+  bulkUpdateCustomFieldValuesAction,
+  getCustomColumnsByEntityTypeAction: vi.fn(),
+  updateEntityCustomFieldValueAction: vi.fn(),
+  upsertP13nAction: vi.fn(),
+}));
+
+type Item = { id: string; system?: boolean };
+
+class TestStore extends BaseDataViewStore<Item> {
+  get columnsDefinition() {
+    return [];
+  }
+
+  protected refreshAction(): Promise<GetResult<Item>> {
+    return Promise.resolve({ items: this.items });
+  }
+
+  override isItemSelectable(item: Item): boolean {
+    return item.system !== true;
+  }
+}
+
+function makeStore(allowed: Action[] = [Action.create, Action.update, Action.delete], resource?: Resource) {
+  const granted = new Set(allowed);
+  const rootStore = {
+    localeStore: { getTranslation: (key: string) => key },
+    activityTimelines: { refreshForMany: vi.fn() },
+    userStore: {
+      user: {},
+      can: (_resource: Resource, action: Action) => granted.has(action),
+      canManage: () => [Action.create, Action.update, Action.delete].every((action) => granted.has(action)),
+    },
+  } as unknown as RootStore;
+
+  return new TestStore(rootStore, resource, EntityType.contact);
+}
+
+function page(ids: string[], extra: Partial<GetResult<Item>> = {}): GetResult<Item> {
+  return { items: ids.map((id) => ({ id })), ...extra };
+}
+
+function singleSelectColumn(id: string, optionCount: number): CustomColumnDto {
+  return {
+    id,
+    label: `single-${id}`,
+    entityType: EntityType.contact,
+    type: CustomColumnType.singleSelect,
+    options: {
+      options: Array.from({ length: optionCount }, (_, index) => ({
+        value: `opt-${index}`,
+        label: `Option ${index}`,
+        color: "info" as const,
+        isDefault: false,
+        index,
+      })),
+    },
+  } as CustomColumnDto;
+}
+
+function plainColumn(id: string): CustomColumnDto {
+  return { id, label: `plain-${id}`, entityType: EntityType.contact, type: CustomColumnType.plain } as CustomColumnDto;
+}
+
+describe("data view selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds the current page to the selection instead of replacing what was already selected", () => {
+    const store = makeStore();
+    store.setItems(page(["a", "b"]));
+    store.setPageSelection(true);
+
+    store.setItems(page(["c", "d"]));
+    store.setPageSelection(true);
+
+    expect([...store.selectedIds].sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("unchecking the page header removes only that page from the selection", () => {
+    const store = makeStore();
+    store.setItems(page(["a", "b"]));
+    store.setPageSelection(true);
+    store.setItems(page(["c", "d"]));
+    store.setPageSelection(true);
+
+    store.setPageSelection(false);
+
+    expect([...store.selectedIds].sort()).toEqual(["a", "b"]);
+  });
+
+  it("never selects a row the view marks unselectable", () => {
+    const store = makeStore();
+    store.setItems({ items: [{ id: "a" }, { id: "system", system: true }] });
+
+    store.setPageSelection(true);
+
+    expect([...store.selectedIds]).toEqual(["a"]);
+  });
+
+  it("stops the selection at the bulk write limit and says why", () => {
+    const store = makeStore();
+    const ids = Array.from({ length: MAX_SELECTION_SIZE + 5 }, (_, index) => `row-${index}`);
+    store.setItems(page(ids));
+
+    store.setPageSelection(true);
+
+    expect(store.selectedCount).toBe(MAX_SELECTION_SIZE);
+    expect(store.isSelectionAtLimit).toBe(true);
+    expect(toastError).toHaveBeenCalledWith("MassActions.limitReached", expect.anything());
+  });
+
+  it("refuses one more row once the limit is reached", () => {
+    const store = makeStore();
+    store.setItems(page(Array.from({ length: MAX_SELECTION_SIZE }, (_, index) => `row-${index}`)));
+    store.setPageSelection(true);
+    toastError.mockClear();
+
+    store.setItems(page(["extra"]));
+    store.toggleItemSelection("extra");
+
+    expect(store.selectedIds.has("extra")).toBe(false);
+    expect(toastError).toHaveBeenCalledWith("MassActions.limitReached", expect.anything());
+  });
+
+  it("still allows deselecting while at the limit", () => {
+    const store = makeStore();
+    const ids = Array.from({ length: MAX_SELECTION_SIZE }, (_, index) => `row-${index}`);
+    store.setItems(page(ids));
+    store.setPageSelection(true);
+
+    store.toggleItemSelection("row-0");
+
+    expect(store.selectedIds.has("row-0")).toBe(false);
+    expect(store.selectedCount).toBe(MAX_SELECTION_SIZE - 1);
+  });
+
+  it("counts selected rows that are no longer in the current view", () => {
+    const store = makeStore();
+    store.setItems(page(["a", "b"]));
+    store.setPageSelection(true);
+
+    store.setItems(page(["b", "c"]));
+
+    expect(store.selectedCount).toBe(2);
+    expect(store.selectedVisibleCount).toBe(1);
+    expect(store.selectedOffViewCount).toBe(1);
+  });
+
+  it("marks the selection stale when the filters change under it", () => {
+    const store = makeStore();
+    const filters: Filter[] = [{ field: "stage", operator: FilterOperatorKey.contains, value: "won" }];
+    store.setItems(page(["a"], { filters }));
+    store.setPageSelection(true);
+
+    expect(store.isSelectionScopeStale).toBe(false);
+
+    store.setItems(page(["a"], { filters: [] }));
+
+    expect(store.isSelectionScopeStale).toBe(true);
+  });
+
+  it("does not mark the selection stale when only the page changes", () => {
+    const store = makeStore();
+    store.setItems(page(["a"], { pagination: { page: 1, pageSize: 5, total: 2, totalPages: 2 } }));
+    store.setPageSelection(true);
+
+    store.setItems(page(["b"], { pagination: { page: 2, pageSize: 5, total: 2, totalPages: 2 } }));
+
+    expect(store.isSelectionScopeStale).toBe(false);
+  });
+
+  it("keeps only the rows still in view and clears the stale marker", () => {
+    const store = makeStore();
+    store.setItems(page(["a", "b"], { searchTerm: "acme" }));
+    store.setPageSelection(true);
+
+    store.setItems(page(["b", "c"], { searchTerm: "other" }));
+    expect(store.isSelectionScopeStale).toBe(true);
+
+    store.keepSelectionInView();
+
+    expect([...store.selectedIds]).toEqual(["b"]);
+    expect(store.isSelectionScopeStale).toBe(false);
+  });
+
+  it("keeps the stale marker when a row is added under the changed filters", () => {
+    const store = makeStore();
+    store.setItems(page(["a", "b"], { searchTerm: "acme" }));
+    store.setPageSelection(true);
+
+    store.setItems(page(["c"], { searchTerm: "other" }));
+    store.toggleItemSelection("c");
+
+    expect(store.selectedCount).toBe(3);
+    expect(store.isSelectionScopeStale).toBe(true);
+  });
+
+  it("re-baselines the scope once a fresh selection starts", () => {
+    const store = makeStore();
+    store.setItems(page(["a"], { searchTerm: "acme" }));
+    store.setPageSelection(true);
+    store.clearSelection();
+
+    store.setItems(page(["b"], { searchTerm: "other" }));
+    store.toggleItemSelection("b");
+
+    expect(store.isSelectionScopeStale).toBe(false);
+  });
+
+  it("forgets the scope when the selection is cleared", () => {
+    const store = makeStore();
+    store.setItems(page(["a"], { searchTerm: "acme" }));
+    store.setPageSelection(true);
+
+    store.clearSelection();
+
+    expect(store.selectedScopeKey).toBeUndefined();
+    expect(store.isSelectionScopeStale).toBe(false);
+  });
+
+  it("refuses a bulk delete larger than the server limit without calling the server", async () => {
+    const store = makeStore();
+    for (let index = 0; index <= MAX_SELECTION_SIZE; index += 1) store.selectedIds.add(`row-${index}`);
+
+    const result = await store.bulkDelete();
+
+    expect(result).toBe(false);
+    expect(bulkDeleteEntitiesAction).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith("MassActions.limitReached", expect.anything());
+  });
+
+  it("refuses a bulk field write larger than the server limit without calling the server", async () => {
+    const store = makeStore();
+    for (let index = 0; index <= MAX_SELECTION_SIZE; index += 1) store.selectedIds.add(`row-${index}`);
+
+    const result = await store.bulkUpdateCustomField("column", "value");
+
+    expect(result).toBe(false);
+    expect(bulkUpdateCustomFieldValuesAction).not.toHaveBeenCalled();
+  });
+
+  it("gates each mass verb on the permission its own interactor enforces", () => {
+    const readerOnly = makeStore([], Resource.contacts);
+    const updaterOnly = makeStore([Action.update], Resource.contacts);
+    const deleterOnly = makeStore([Action.delete], Resource.contacts);
+
+    expect([readerOnly.canUpdateSelection, readerOnly.canDeleteSelection]).toEqual([false, false]);
+    expect([updaterOnly.canUpdateSelection, updaterOnly.canDeleteSelection]).toEqual([true, false]);
+    expect([deleterOnly.canUpdateSelection, deleterOnly.canDeleteSelection]).toEqual([false, true]);
+  });
+
+  it("leaves both mass verbs available on a view that declares no resource", () => {
+    const store = makeStore([]);
+
+    expect([store.canUpdateSelection, store.canDeleteSelection]).toEqual([true, true]);
+  });
+
+  it("offers every custom column type for mass editing but drops a single select with no options", () => {
+    const store = makeStore();
+    store.setCustomColumns([plainColumn("plain"), singleSelectColumn("empty", 0), singleSelectColumn("full", 2)]);
+
+    expect(store.massEditableCustomColumns.map((column) => column.id)).toEqual(["plain", "full"]);
+    expect(store.singleSelectCustomColumns.map((column) => column.id)).toEqual(["empty", "full"]);
+  });
+});

--- a/core/base/base-data-view.store.ts
+++ b/core/base/base-data-view.store.ts
@@ -8,7 +8,7 @@ import type { SavedFilterPreset } from "@/features/p13n/prisma-p13n.repository";
 
 import { makeObservable, observable, computed, action, toJS, runInAction } from "mobx";
 import deepEqual from "fast-deep-equal/es6";
-import { CustomColumnType } from "@/generated/prisma";
+import { Action, CustomColumnType } from "@/generated/prisma";
 
 import type { Resource, EntityType } from "@/generated/prisma";
 
@@ -26,6 +26,8 @@ import {
   bulkUpdateCustomFieldValuesAction,
   updateEntityCustomFieldValueAction,
 } from "@/app/actions";
+
+export const MAX_SELECTION_SIZE = 100;
 
 export interface HasId {
   id: string;
@@ -81,6 +83,7 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
   viewMode: ViewMode = ViewMode.table;
   groupingColumnId?: string | null;
   selectedIds: ObservableSet<string> = observable.set();
+  selectedScopeKey: string | undefined = undefined;
 
   groupCounts: Record<string, number> = {};
   groupValueSums: Record<string, GroupValueSums> = {};
@@ -127,6 +130,7 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
       viewMode: observable,
       groupingColumnId: observable,
       selectedIds: observable,
+      selectedScopeKey: observable,
 
       groupCounts: observable,
       groupValueSums: observable,
@@ -138,10 +142,18 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
       sortableColumnIds: computed,
       canManage: computed,
       canExport: computed,
+      canUpdateSelection: computed,
+      canDeleteSelection: computed,
       isDisabled: computed,
       hasSelection: computed,
       selectedCount: computed,
+      selectedVisibleCount: computed,
+      selectedOffViewCount: computed,
+      isSelectionAtLimit: computed,
+      currentSelectionScopeKey: computed,
+      isSelectionScopeStale: computed,
       singleSelectCustomColumns: computed,
+      massEditableCustomColumns: computed,
       isKanbanMode: computed,
       kanbanGroupingKey: computed,
 
@@ -159,6 +171,9 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
       executeOnChanges: action,
       setItems: action,
       setSelectedIds: action,
+      toggleItemSelection: action,
+      setPageSelection: action,
+      keepSelectionInView: action,
       clearSelection: action,
       loadMoreInGroup: action,
       resetGroupedTakeOverrides: action,
@@ -191,6 +206,10 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
   bulkDelete = async (): Promise<boolean> => {
     const ids = Array.from(this.selectedIds);
     if (ids.length === 0 || !this.entityType) return false;
+    if (ids.length > MAX_SELECTION_SIZE) {
+      this.toastError("MassActions.limitReached", { values: { limit: MAX_SELECTION_SIZE } });
+      return false;
+    }
 
     this.setBulkMutating(true);
     try {
@@ -212,6 +231,10 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
   bulkUpdateCustomField = async (columnId: string, value: string): Promise<boolean> => {
     const entityIds = Array.from(this.selectedIds);
     if (entityIds.length === 0 || !this.entityType) return false;
+    if (entityIds.length > MAX_SELECTION_SIZE) {
+      this.toastError("MassActions.limitReached", { values: { limit: MAX_SELECTION_SIZE } });
+      return false;
+    }
 
     this.setBulkMutating(true);
     try {
@@ -327,6 +350,18 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
     return this.rootStore.userStore.canAccess(this.resource);
   }
 
+  get canUpdateSelection(): boolean {
+    if (!this.resource) return true;
+
+    return this.rootStore.userStore.can(this.resource, Action.update);
+  }
+
+  get canDeleteSelection(): boolean {
+    if (!this.resource) return true;
+
+    return this.rootStore.userStore.can(this.resource, Action.delete);
+  }
+
   get isDisabled(): boolean {
     if (!this.resource) return false;
 
@@ -341,24 +376,101 @@ export abstract class BaseDataViewStore<Entity extends HasId> extends BaseStore 
     return this.selectedIds.size;
   }
 
+  get selectedVisibleCount(): number {
+    return this.items.reduce((count, item) => (this.selectedIds.has(item.id) ? count + 1 : count), 0);
+  }
+
+  get selectedOffViewCount(): number {
+    return this.selectedCount - this.selectedVisibleCount;
+  }
+
+  get isSelectionAtLimit(): boolean {
+    return this.selectedIds.size >= MAX_SELECTION_SIZE;
+  }
+
+  get currentSelectionScopeKey(): string {
+    return JSON.stringify({ filters: toJS(this.filters) ?? null, searchTerm: this.searchTerm ?? null });
+  }
+
+  get isSelectionScopeStale(): boolean {
+    if (!this.hasSelection || this.selectedScopeKey === undefined) return false;
+
+    return this.selectedScopeKey !== this.currentSelectionScopeKey;
+  }
+
   get singleSelectCustomColumns(): CustomColumnDto[] {
     return this.customColumns.filter((col) => col.type === CustomColumnType.singleSelect);
+  }
+
+  get massEditableCustomColumns(): CustomColumnDto[] {
+    return this.customColumns.filter((col) =>
+      col.type === CustomColumnType.singleSelect ? col.options.options.length > 0 : true,
+    );
   }
 
   isItemSelectable(_item: Entity): boolean {
     return true;
   }
 
-  setSelectedIds = (keys: "all" | Set<string>) => {
+  setSelectedIds = (keys: Set<string>) => {
     this.selectedIds.clear();
-    if (keys === "all") {
-      for (const item of this.items) if (this.isItemSelectable(item)) this.selectedIds.add(item.id);
-    } else keys.forEach((id) => this.selectedIds.add(id));
+    this.selectedScopeKey = undefined;
+    [...keys].slice(0, MAX_SELECTION_SIZE).forEach((id) => this.selectedIds.add(id));
+    this.rememberSelectionScope();
+  };
+
+  toggleItemSelection = (id: string): void => {
+    if (this.selectedIds.has(id)) {
+      this.selectedIds.delete(id);
+      this.rememberSelectionScope();
+      return;
+    }
+
+    if (this.isSelectionAtLimit) {
+      this.toastError("MassActions.limitReached", { values: { limit: MAX_SELECTION_SIZE } });
+      return;
+    }
+
+    this.selectedIds.add(id);
+    this.rememberSelectionScope();
+  };
+
+  setPageSelection = (selected: boolean): void => {
+    const pageIds = this.items.filter((item) => this.isItemSelectable(item)).map((item) => item.id);
+
+    if (!selected) {
+      pageIds.forEach((id) => this.selectedIds.delete(id));
+      this.rememberSelectionScope();
+      return;
+    }
+
+    const missing = pageIds.filter((id) => !this.selectedIds.has(id));
+    const room = Math.max(0, MAX_SELECTION_SIZE - this.selectedIds.size);
+    missing.slice(0, room).forEach((id) => this.selectedIds.add(id));
+    this.rememberSelectionScope();
+
+    if (missing.length > room) this.toastError("MassActions.limitReached", { values: { limit: MAX_SELECTION_SIZE } });
+  };
+
+  keepSelectionInView = (): void => {
+    const visible = new Set(this.items.map((item) => item.id));
+    for (const id of [...this.selectedIds]) if (!visible.has(id)) this.selectedIds.delete(id);
+    this.selectedScopeKey = this.selectedIds.size > 0 ? this.currentSelectionScopeKey : undefined;
   };
 
   clearSelection = () => {
     this.selectedIds.clear();
+    this.selectedScopeKey = undefined;
   };
+
+  private rememberSelectionScope(): void {
+    if (this.selectedIds.size === 0) {
+      this.selectedScopeKey = undefined;
+      return;
+    }
+
+    if (this.selectedScopeKey === undefined) this.selectedScopeKey = this.currentSelectionScopeKey;
+  }
 
   get orderedColumns() {
     const columnMap = new Map(this.columnsDefinition.map((col) => [col.uid, col]));

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -2302,8 +2302,14 @@
     "text": "Laden..."
   },
   "MassActions": {
+    "apply": "Auf Auswahl anwenden",
+    "clearField": "Feld leeren",
     "delete": "Ausgewählte löschen",
+    "keepInView": "Nur sichtbare Zeilen behalten",
+    "limitReached": "Du kannst höchstens {limit} Datensätze gleichzeitig auswählen.",
     "noMatchingFields": "Keine Felder entsprechen deiner Suche.",
+    "offView": "{count, plural, one {# nicht in der aktuellen Ansicht} other {# nicht in der aktuellen Ansicht}}",
+    "scopeStale": "Die Filter haben sich seit dieser Auswahl geändert.",
     "searchFieldPlaceholder": "Felder suchen…",
     "selectedCount": "{count, plural, one {# Element ausgewählt} other {# Elemente ausgewählt}}",
     "update": "Aktualisieren"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2302,8 +2302,14 @@
     "text": "Loading..."
   },
   "MassActions": {
+    "apply": "Apply to selected",
+    "clearField": "Clear field",
     "delete": "Delete selected",
+    "keepInView": "Keep only rows in view",
+    "limitReached": "You can select up to {limit} records at a time.",
     "noMatchingFields": "No fields match your search.",
+    "offView": "{count, plural, one {# not in the current view} other {# not in the current view}}",
+    "scopeStale": "The filters changed since you made this selection.",
     "searchFieldPlaceholder": "Search fields…",
     "selectedCount": "{count, plural, one {# item selected} other {# items selected}}",
     "update": "Update"

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -2302,8 +2302,14 @@
     "text": "Cargando..."
   },
   "MassActions": {
+    "apply": "Aplicar a la selección",
+    "clearField": "Vaciar campo",
     "delete": "Eliminar la selección",
+    "keepInView": "Conservar solo las filas visibles",
+    "limitReached": "Puedes seleccionar hasta {limit} registros a la vez.",
     "noMatchingFields": "Ningún campo coincide con tu búsqueda.",
+    "offView": "{count, plural, one {# fuera de la vista actual} other {# fuera de la vista actual}}",
+    "scopeStale": "Los filtros han cambiado desde que hiciste esta selección.",
     "searchFieldPlaceholder": "Buscar campos…",
     "selectedCount": "{count, plural, one {# elemento seleccionado} other {# elementos seleccionados}}",
     "update": "Actualizar"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -2302,8 +2302,14 @@
     "text": "Chargement..."
   },
   "MassActions": {
+    "apply": "Appliquer à la sélection",
+    "clearField": "Vider le champ",
     "delete": "Supprimer la sélection",
+    "keepInView": "Conserver uniquement les lignes visibles",
+    "limitReached": "Vous pouvez sélectionner jusqu'à {limit} enregistrements à la fois.",
     "noMatchingFields": "Aucun champ ne correspond à votre recherche.",
+    "offView": "{count, plural, one {# hors de la vue actuelle} other {# hors de la vue actuelle}}",
+    "scopeStale": "Les filtres ont changé depuis cette sélection.",
     "searchFieldPlaceholder": "Rechercher des champs…",
     "selectedCount": "{count, plural, one {# élément sélectionné} other {# éléments sélectionnés}}",
     "update": "Mettre à jour"

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -2302,8 +2302,14 @@
     "text": "Caricamento..."
   },
   "MassActions": {
+    "apply": "Applica alla selezione",
+    "clearField": "Svuota campo",
     "delete": "Elimina gli elementi selezionati",
+    "keepInView": "Mantieni solo le righe visibili",
+    "limitReached": "Puoi selezionare fino a {limit} record alla volta.",
     "noMatchingFields": "Nessun campo corrisponde alla tua ricerca.",
+    "offView": "{count, plural, one {# non nella vista corrente} other {# non nella vista corrente}}",
+    "scopeStale": "I filtri sono cambiati da quando hai fatto questa selezione.",
     "searchFieldPlaceholder": "Cerca tra i campi…",
     "selectedCount": "{count, plural, one {# elemento selezionato} other {# elementi selezionati}}",
     "update": "Aggiorna"


### PR DESCRIPTION
## Summary

Makes a row selection a scoped object rather than a bare bag of ids, and widens what a selection can be used for.

- **Scoped selection.** A selection carries the filter and search fingerprint it was made under. The bar reports how many selected rows sit outside the current view, says so when the view changed underneath, and offers to keep only the rows still in view.
- **Non-destructive select-all.** The page header checkbox adds and removes the current page instead of replacing the whole selection.
- **Declared limit.** Selecting stops at the 100 record server bulk ceiling with a stated message, instead of a raw Zod rejection after the action is pressed.
- **Typed mass field write.** Mass editing covers every custom column type through the existing per-type editors, plus an explicit clear. Every column is one row in the same shape and opens the same editor panel.
- **Per-verb permissions.** Update and delete are each gated on the permission their own interactor enforces.

## Context

`selectedIds` was an `ObservableSet` that nothing ever cleared: `setQueryOptions`, `setItems` and the refresh paths all left it untouched. Ids picked under one filter were therefore shipped to the server under another. Combined with a hard cascading delete and no archive anywhere in the schema, the concrete failure was: filter, tick 30 rows, clear the filter, press delete, and 30 rows you can no longer see are gone with no undo.

Separately `setSelectedIds("all")` cleared the set before adding the current page, so ticking the header on page 2 silently discarded a page 1 selection while per-row clicks accumulated across pages. Two different accumulation semantics in one table.

The mass update surface offered only `singleSelect` columns. That restriction was purely client side: `bulkUpdateCustomFieldValuesAction` already accepts any `CustomFieldValueDto[]` and `validate-custom-field-values.ts` already dispatches a validator for all ten types. A workspace with no singleSelect column had no bulk field editing at all.

The table also mutated the observable set directly, bypassing the declared store actions, so scope and limit state had nowhere to live.

## Validation

Local, against a disposable seeded Postgres in `cloud` mode with a real signed-in session.

Gates on this exact tree, rebased onto `4a92547`:

- `yarn typecheck` pass
- `yarn lint` pass
- `RUN_DATABASE_TESTS=true yarn test` 4792 passed, 2 skipped, 545 files, zero failures
- `yarn build` pass

18 new unit tests in `core/base/__tests__/base-data-view-selection.test.ts`. Deliberate regressions were planted against them first to confirm they fail rather than pass vacuously.

Browser walkthrough:

- Page 1 select-all then page 2 select-all gives 20 selected with "10 not in the current view"; unchecking page 2 returns to 10.
- With 150 contacts, select-all caps at exactly 100 with "You can select up to 100 records at a time."
- Changing the search under a live selection raises the stale notice; "keep only rows in view" cut 11 to 1 and cleared it.
- Mass write of a `phone` column across 3 contacts and a `link` column across 2 organizations, both confirmed in the database with only the selected rows touched. Clear removed exactly 3 values and left the other 27 intact.
- `singleSelect` writes the correct option UUID through the drill-in editor.
- With only `contacts.readAll` the bar shows the count alone; granting `update` alone shows Update but not Delete.
- Re-verified after rebasing onto the export/import work: selection, mass update and the new Import and export control coexist.

Not verified: anything on a Vercel preview. A preview only exists after this push and its authenticated surfaces are not reachable from here.

## Impact and rollback

User visible on the five CRM list pages in table view. No schema change, no migration, no new dependency, no API or REST contract change. Server interactors are untouched; the 100 record ceiling is unchanged and is now declared client side rather than discovered.

Behaviour changes a reader should expect: the header checkbox no longer clears the selection, and Update and Delete are hidden from users lacking the matching permission where they were previously shown and then refused.

Rollback is a revert of the single squash merge. Nothing persists outside the client store.
