### PR TITLE
feat(ui): give the entity detail custom fields section an empty state

### DIFF
--- a/components/entity-detail/__tests__/entity-detail-custom-fields-empty.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-custom-fields-empty.test.ts
@@ -1,0 +1,150 @@
+import type { Root } from "react-dom/client";
+import type { ComponentType, ReactNode } from "react";
+import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
+import type { EntityDetailPersonalizationConfig } from "../entity-detail-personalization";
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CustomColumnType, EntityType } from "@/generated/prisma";
+
+const upsertP13nAction = vi.hoisted(() => vi.fn());
+const customColumnModalStore = vi.hoisted(() => ({ initialize: vi.fn(), open: vi.fn() }));
+
+vi.mock("@/app/actions", () => ({ upsertP13nAction }));
+vi.mock("@/core/errors/report-application-error", () => ({
+  reportApplicationError: vi.fn(),
+}));
+vi.mock("@/core/utils/toast-zod-error-tree", () => ({
+  toastZodErrorTree: vi.fn(),
+}));
+vi.mock("@/core/stores/root-store.provider", () => ({
+  useRootStore: () => ({ customColumnModalStore }),
+}));
+vi.mock("@/components/data-view/custom-columns/custom-field-inputs", () => ({
+  CustomFieldInputs: () => createElement("div", { "data-custom-field-inputs": true }),
+}));
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import {
+  EntityDetailPersonalizationProvider,
+  resetEntityDetailPersonalizationPersistenceForTests,
+} from "../entity-detail-personalization";
+import { EntityDetailCustomFieldsSection } from "../entity-detail-custom-fields-section";
+import { EntityDetailSectionGroup } from "../entity-detail-section";
+
+const columnId = "10000000-0000-4000-8000-000000000001";
+const roots = new Set<Root>();
+const TestProvider = EntityDetailPersonalizationProvider as ComponentType<{
+  children?: ReactNode;
+  config: EntityDetailPersonalizationConfig;
+  customColumnIds?: string[];
+  persistenceScope: string;
+}>;
+const TestSectionGroup = EntityDetailSectionGroup as ComponentType<{ children?: ReactNode }>;
+const oneColumn: CustomColumnDto[] = [
+  { id: columnId, entityType: EntityType.contact, label: "Industry", type: CustomColumnType.plain },
+];
+
+function view({
+  canManage = true,
+  columns = [] as CustomColumnDto[],
+  isEditing = false,
+}: {
+  canManage?: boolean;
+  columns?: CustomColumnDto[];
+  isEditing?: boolean;
+}) {
+  return createElement(
+    TestProvider,
+    {
+      config: {
+        p13nId: "contact-detail",
+        defaultStarredFieldIds: [],
+        defaultCollapsedSectionIds: [],
+        sectionIds: ["customFields"],
+      },
+      customColumnIds: columns.map((column) => column.id),
+      persistenceScope: "user-1",
+    },
+    createElement(
+      TestSectionGroup,
+      null,
+      createElement(EntityDetailCustomFieldsSection, {
+        canManage,
+        columns,
+        entityType: EntityType.contact,
+        isEditing,
+        sectionId: "customFields",
+      }),
+    ),
+  );
+}
+
+function mount(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.add(root);
+  act(() => root.render(node));
+  return { container, root };
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  resetEntityDetailPersonalizationPersistenceForTests();
+  upsertP13nAction.mockReset();
+  upsertP13nAction.mockResolvedValue({ ok: true, data: {} });
+  customColumnModalStore.initialize.mockReset();
+  customColumnModalStore.open.mockReset();
+});
+
+afterEach(() => {
+  act(() => roots.forEach((root) => root.unmount()));
+  roots.clear();
+  document.body.replaceChildren();
+});
+
+describe("entity detail custom fields empty state", () => {
+  it("explains the absence and offers the first field without entering edit mode", () => {
+    const { container } = mount(view({}));
+    const emptyState = container.querySelector<HTMLElement>('[data-slot="empty-state"]');
+    const button = container.querySelector<HTMLButtonElement>("[data-entity-add-custom-field]");
+
+    expect(emptyState?.closest('[data-detail-section-content="customFields"]')).not.toBeNull();
+    expect(emptyState?.textContent).toContain("EntityDetail.customFieldsEmpty.title");
+    expect(emptyState?.textContent).toContain("EntityDetail.customFieldsEmpty.body");
+    expect(container.querySelector("[data-custom-field-inputs]")).toBeNull();
+    expect(button).not.toBeNull();
+    expect(button?.closest('[data-detail-section-content="customFields"]')).not.toBeNull();
+
+    act(() => button?.click());
+
+    expect(customColumnModalStore.initialize).toHaveBeenCalledWith(CustomColumnType.plain, EntityType.contact);
+    expect(customColumnModalStore.open).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the explanation but hides the action without manage permission", () => {
+    const { container } = mount(view({ canManage: false }));
+
+    expect(container.querySelector('[data-slot="empty-state"]')).not.toBeNull();
+    expect(container.querySelector("[data-entity-add-custom-field]")).toBeNull();
+  });
+
+  it("renders the fields instead of the empty state once a custom column exists", () => {
+    const { container } = mount(view({ columns: oneColumn }));
+
+    expect(container.querySelector('[data-slot="empty-state"]')).toBeNull();
+    expect(container.querySelector("[data-custom-field-inputs]")).not.toBeNull();
+    expect(container.querySelector("[data-entity-add-custom-field]")).toBeNull();
+  });
+
+  it("keeps the in-edit add action for a populated section", () => {
+    const { container } = mount(view({ columns: oneColumn, isEditing: true }));
+
+    expect(container.querySelector('[data-slot="empty-state"]')).toBeNull();
+    expect(container.querySelector("[data-entity-add-custom-field]")).not.toBeNull();
+  });
+});

--- a/components/entity-detail/__tests__/entity-detail-personalization.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-personalization.test.ts
@@ -454,7 +454,7 @@ describe("entity detail section", () => {
             defaultCollapsedSectionIds: [],
             sectionIds: ["customFields"],
           },
-          customColumnIds: [],
+          customColumnIds: [firstId],
           persistenceScope: "user-1",
         },
         createElement(
@@ -462,7 +462,7 @@ describe("entity detail section", () => {
           null,
           createElement(EntityDetailCustomFieldsSection, {
             canManage: true,
-            columns: [],
+            columns: [{ id: firstId, entityType: EntityType.contact, label: "Industry", type: CustomColumnType.plain }],
             entityType: EntityType.contact,
             isEditing: true,
             sectionId: "customFields",

--- a/components/entity-detail/entity-detail-custom-fields-section.tsx
+++ b/components/entity-detail/entity-detail-custom-fields-section.tsx
@@ -2,12 +2,13 @@
 
 import type { CustomColumnDto } from "@/features/custom-column/custom-column.schema";
 
-import { Plus } from "lucide-react";
+import { Plus, SlidersHorizontal } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback } from "react";
 import { CustomColumnType, type EntityType } from "@/generated/prisma";
 
 import { CustomFieldInputs } from "@/components/data-view/custom-columns/custom-field-inputs";
+import { DataViewEmptyState } from "@/components/data-view/data-view-empty-state";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/shared/icon";
 import { useRootStore } from "@/core/stores/root-store.provider";
@@ -29,15 +30,24 @@ export function EntityDetailCustomFieldsSection({ canManage, columns, entityType
     customColumnModalStore.initialize(CustomColumnType.plain, entityType);
     customColumnModalStore.open();
   }, [customColumnModalStore, entityType]);
+  const isEmpty = columns.length === 0;
 
   return (
     <EntityDetailSection label={t("EntityDetail.sections.customFields")} sectionId={sectionId}>
-      <CustomFieldInputs personalizable columns={columns} isEditing={isEditing} />
+      {isEmpty ? (
+        <DataViewEmptyState
+          body={t("EntityDetail.customFieldsEmpty.body")}
+          icon={SlidersHorizontal}
+          title={t("EntityDetail.customFieldsEmpty.title")}
+        />
+      ) : (
+        <CustomFieldInputs personalizable columns={columns} isEditing={isEditing} />
+      )}
 
-      {isEditing && canManage ? (
+      {canManage && (isEmpty || isEditing) ? (
         <Button
           data-entity-add-custom-field
-          className="w-full"
+          className={isEmpty ? "self-center" : "w-full"}
           id="entity-add-custom-field"
           size="sm"
           type="button"

--- a/content/docs/de/app-records.mdx
+++ b/content/docs/de/app-records.mdx
@@ -44,7 +44,7 @@ Diese Ids teilen sich alle Datensatztypen.
 | Speichern (Drawer) | Drawer-Footer | `#drawer-save` | Speichert Änderungen im Drawer |
 | Speichern / Zurücksetzen (Detail) | Detail-Topbar | `#entity-save` / `#entity-reset` | Speichert oder verwirft Änderungen |
 | Custom Fields bearbeiten | Detail-Topbar | `#entity-edit-fields` | Schaltet das Bearbeiten der Custom Fields um, nicht der eingebauten Felder |
-| Custom Field hinzufügen | Detail-Topbar | `#entity-add-custom-field` | Legt eine Custom Column an |
+| Custom Field hinzufügen | Abschnitt „Custom Fields“, beim Bearbeiten der Felder oder wenn der Abschnitt leer ist | `#entity-add-custom-field` | Legt eine Custom Column an |
 | Löschen | Detail-Topbar | `#entity-delete` | Öffnet das Bestätigungs-Modal |
 | Löschen bestätigen / abbrechen | Bestätigungs-Modal | `#confirm-delete` / `#confirm-delete-cancel` | Unwiderrufliches Löschen oder Abbruch |
 | Massenlöschung | Auswahlleiste nach Checkbox-Auswahl | `#mass-delete` | Löscht alle ausgewählten Zeilen |

--- a/content/docs/en/app-records.mdx
+++ b/content/docs/en/app-records.mdx
@@ -44,7 +44,7 @@ These ids are shared by every record type.
 | Save (drawer) | Drawer footer | `#drawer-save` | Persists edits made in the drawer |
 | Save / Reset (detail) | Detail topbar | `#entity-save` / `#entity-reset` | Persists or discards edits |
 | Edit custom fields | Detail topbar | `#entity-edit-fields` | Toggles editing of the custom fields, not the built-in ones |
-| Add custom field | Detail topbar | `#entity-add-custom-field` | Creates a custom column |
+| Add custom field | Custom fields section, while editing fields or when the section is empty | `#entity-add-custom-field` | Creates a custom column |
 | Delete | Detail topbar | `#entity-delete` | Opens the confirmation modal |
 | Confirm / cancel delete | Confirmation modal | `#confirm-delete` / `#confirm-delete-cancel` | Irreversible delete or abort |
 | Bulk delete | Selection bar after checkbox-select | `#mass-delete` | Deletes every selected row |

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1879,6 +1879,10 @@
       "weightedValue": "{dealValue} × {percent} % Abschlusswahrscheinlichkeit der aktuellen Phase ({stage}). Ändere „{services}“, Mengen oder die Phase; bearbeite Phasenwahrscheinlichkeiten unter „{company}“.",
       "weightedValueUnconfigured": "{dealValue} × Abschlusswahrscheinlichkeit der ausgewählten Phase. Richte unter „{company}“ Phasenwahrscheinlichkeiten ein und wähle eine Phase; ändere „{services}“ oder Mengen."
     },
+    "customFieldsEmpty": {
+      "body": "Benutzerdefinierte Felder enthalten die zusätzlichen Angaben, die dein Arbeitsbereich zu diesem Datensatztyp erfasst.",
+      "title": "Noch keine benutzerdefinierten Felder"
+    },
     "donePersonalizing": "Fertig",
     "fields": {
       "createdAt": "Erstellt am",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1879,6 +1879,10 @@
       "weightedValue": "{dealValue} × the {percent}% win probability for the current stage ({stage}). Change {services}, quantities, or the stage; manage stage probabilities in {company}.",
       "weightedValueUnconfigured": "{dealValue} × the selected stage’s win probability. Configure stage probabilities in {company} and select a stage; change {services} or quantities to update it."
     },
+    "customFieldsEmpty": {
+      "body": "Custom fields hold the extra details your workspace tracks on this record type.",
+      "title": "No custom fields yet"
+    },
     "donePersonalizing": "Done",
     "fields": {
       "createdAt": "Created at",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1879,6 +1879,10 @@
       "weightedValue": "{dealValue} × {percent} % de probabilidad de cierre de la etapa actual ({stage}). Edita «{services}», las cantidades o la etapa; gestiona las probabilidades en «{company}».",
       "weightedValueUnconfigured": "{dealValue} × probabilidad de cierre de la etapa seleccionada. Configura las probabilidades en «{company}» y selecciona una etapa; edita «{services}» o las cantidades."
     },
+    "customFieldsEmpty": {
+      "body": "Los campos personalizados contienen los datos adicionales que tu espacio de trabajo registra para este tipo de registro.",
+      "title": "Aún no hay campos personalizados"
+    },
     "donePersonalizing": "Listo",
     "fields": {
       "createdAt": "Creado el",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1879,6 +1879,10 @@
       "weightedValue": "{dealValue} × probabilité de conclusion de {percent} % pour l’étape actuelle ({stage}). Modifiez « {services} », les quantités ou l’étape ; gérez les probabilités dans « {company} ».",
       "weightedValueUnconfigured": "{dealValue} × probabilité de conclusion de l’étape sélectionnée. Configurez les probabilités dans « {company} » et sélectionnez une étape ; modifiez « {services} » ou les quantités."
     },
+    "customFieldsEmpty": {
+      "body": "Les champs personnalisés contiennent les informations supplémentaires que votre espace de travail suit pour ce type d’enregistrement.",
+      "title": "Aucun champ personnalisé pour le moment"
+    },
     "donePersonalizing": "Terminé",
     "fields": {
       "createdAt": "Créé le",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1879,6 +1879,10 @@
       "weightedValue": "{dealValue} × probabilità di chiusura del {percent}% per la fase corrente ({stage}). Modifica «{services}», quantità o fase; gestisci le probabilità in «{company}».",
       "weightedValueUnconfigured": "{dealValue} × probabilità di chiusura della fase selezionata. Configura le probabilità in «{company}» e seleziona una fase; modifica «{services}» o quantità."
     },
+    "customFieldsEmpty": {
+      "body": "I campi personalizzati contengono le informazioni aggiuntive che il tuo spazio di lavoro registra per questo tipo di record.",
+      "title": "Ancora nessun campo personalizzato"
+    },
     "donePersonalizing": "Fine",
     "fields": {
       "createdAt": "Creato il",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ const domTestFiles = [
   "components/data-view/__tests__/data-view-url-sync.test.ts",
   "components/data-view/__tests__/use-data-view-sync.test.ts",
   "components/data-view/filter-modal/inputs/__tests__/filter-input-number.test.ts",
+  "components/entity-detail/__tests__/entity-detail-custom-fields-empty.test.ts",
   "components/entity-detail/__tests__/entity-detail-personalization.test.ts",
   "components/entity-detail/__tests__/entity-detail-summary.test.ts",
   "components/entity-detail/__tests__/entity-detail-visibility.test.tsx",


### PR DESCRIPTION
## Summary

The Custom fields section on a record detail page rendered an empty panel when the workspace had no custom columns for that record type, and its `Add Field` action only appeared after the user found the Customize / Edit Field toggle in the top bar. Expanding the section now explains the absence and offers the first field directly.

## Context

Tracks [CUS-310](https://linear.app/customermates/issue/CUS-310/give-the-entity-detail-custom-fields-section-an-empty-state-with-a).

A fresh workspace shows the "Custom fields" header on all five detail pages, and expanding it revealed nothing at all: no explanation, and no way forward without first discovering an unrelated top-bar control. Every other true-empty surface in the product already answers this, through `DataViewEmptyState` and `PageState` (CUS-185, CUS-55).

CUS-64 is the broad entity-detail information-architecture epic and lists an empty state as one property of its planned field descriptors; it is in Backlog and does not own this gap. CUS-240 owns custom-column write authorization, which this change does not touch: the button keeps the same `canManage` predicate it already had, and the write is still authorized server-side in `upsert-custom-column.interactor.ts`.

The entity drawer renders `CustomFieldInputs` inline with no section header and no add action, so it makes no promise of a panel and is deliberately unchanged.

## Changes

- renders `DataViewEmptyState` in the Custom fields section when the record type has no custom columns, with a title and a one-line explanation
- shows the existing `Add Field` action in that empty case without requiring edit mode, still gated on `canManage`; the populated section keeps its previous in-edit behaviour exactly
- adds `EntityDetail.customFieldsEmpty` to all five application locale bundles
- adds `components/entity-detail/__tests__/entity-detail-custom-fields-empty.test.ts` covering the empty, empty-without-manage, populated, and populated-while-editing renders, and registers it in the vitest dom project
- makes the pre-existing "keeps Add field inside the open Custom fields section" case render a populated section, so it exercises the editing branch it names rather than the new empty branch
- corrects the `#entity-add-custom-field` anchor row in the EN and DE record docs, which said "Detail topbar"; the action has never rendered there

## Validation

Against `origin/main` `2690bd60`, Node 24.18, in an isolated worktree with a disposable local PostgreSQL 17 container:

- `yarn typecheck`
- `yarn lint` (`--max-warnings 0`)
- `yarn vitest run tests/conventions` — 75 files passed, 1 skipped; 635 tests passed, 2 skipped
- `yarn test` — 529 files passed, 34 skipped; 4,792 tests passed, 199 skipped
- `yarn build`
- `yarn openapi:generate && yarn raw-docs:generate` leave the tree clean

Both new branches were proven to discriminate rather than merely pass. Reverting the component to `origin/main` fails 2 of the 4 new cases; reducing the button condition to `canManage && isEmpty` fails the editing-branch case in both test files.

Browser acceptance against the locally served app (`APP_MODE=cloud`, synthetic seed, disposable local database):

- with every `CustomColumn` row removed, the empty state and the action render on the contact, organization, deal, service and task detail pages
- the action opens the Add Field modal pre-set to that entity type, and saving a field replaced the empty state with the new field, without entering edit mode first
- the populated section is unchanged: two seeded contact fields render as before, with no empty state and no add button outside edit mode
- German renders the translated copy; light and dark themes both read correctly

Independent read-only review returned no high or medium findings across two rounds. Four low findings were accepted with rationale: the empty state inherits `role="status"` from the shared primitive; read-only users see the same explanatory copy rather than permission-specific copy; the new test file repeats the sibling file's harness; and the CTA keeps the section's existing primary variant rather than the `secondary` other empty states use, because one element serves both states.

## Impact and rollback

Presentational only. No schema, migration, persisted preference, server behaviour or authorization change, and no new dependency. Rollback is reverting this pull request or its eventual merge commit; no data repair is possible or required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
