### PR TITLE
fix(onboarding): preserve invites and require workspace choice

### DIFF
--- a/app/[locale]/(protected)/data-transfer/__tests__/actions.test.ts
+++ b/app/[locale]/(protected)/data-transfer/__tests__/actions.test.ts
@@ -1,80 +1,58 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { EntityType } from "@/generated/prisma";
+import { createZodError } from "@/core/validation/validation.utils";
 
-const di = vi.hoisted(() => ({
-  getCreateManyContactsInteractor: vi.fn(),
-  getCreateManyDealsInteractor: vi.fn(),
-  getCreateManyOrganizationsInteractor: vi.fn(),
-  getCreateManyServicesInteractor: vi.fn(),
-  getCreateManyTasksInteractor: vi.fn(),
-  getDryRunImportContactsInteractor: vi.fn(),
-  getDryRunImportDealsInteractor: vi.fn(),
-  getDryRunImportOrganizationsInteractor: vi.fn(),
-  getDryRunImportServicesInteractor: vi.fn(),
-  getDryRunImportTasksInteractor: vi.fn(),
-  getGetImportRelationIndexInteractor: vi.fn(),
-  getUpdateManyContactsInteractor: vi.fn(),
-  getUpdateManyDealsInteractor: vi.fn(),
-  getUpdateManyOrganizationsInteractor: vi.fn(),
-  getUpdateManyServicesInteractor: vi.fn(),
-  getUpdateManyTasksInteractor: vi.fn(),
+const mocks = vi.hoisted(() => ({ commit: vi.fn(), dryRun: vi.fn(), relationIndex: vi.fn() }));
+vi.mock("@/core/di", () => ({
+  getCommitImportChunkInteractor: () => ({ invoke: mocks.commit }),
+  getDryRunImportChunkInteractor: () => ({ invoke: mocks.dryRun }),
+  getGetImportRelationIndexInteractor: () => ({ invoke: mocks.relationIndex }),
 }));
-
-vi.mock("@/core/di", () => di);
-
-import { commitImportChunkAction, dryRunImportChunkAction } from "../actions";
-
-function useInteractor(getter: ReturnType<typeof vi.fn>, result: unknown) {
-  const invoke = vi.fn().mockResolvedValue(result);
-  getter.mockReturnValue({ invoke });
-  return invoke;
-}
+import { commitImportChunkAction, dryRunImportChunkAction, getImportRelationIndexAction } from "../actions";
 
 describe("data transfer server actions", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("rejects an entity type outside the enum instead of dereferencing undefined", async () => {
-    const rows = [{ firstName: "Ada" }];
-
-    await expect(
-      commitImportChunkAction({ entityType: "companies" as EntityType, mode: "create", rows }),
-    ).rejects.toThrow("Unknown entity type");
-
-    await expect(
-      dryRunImportChunkAction({ entityType: "companies" as EntityType, mode: "create", rows }),
-    ).rejects.toThrow("Unknown entity type");
+  it("forwards commit input and serializes record ids", async () => {
+    const input = { entityType: EntityType.deal, mode: "create" as const, rows: [{ name: "Renewal" }] };
+    mocks.commit.mockResolvedValue({ ok: true, data: [{ id: "deal-1" }] });
+    await expect(commitImportChunkAction(input)).resolves.toEqual({ ok: true, ids: ["deal-1"] });
+    expect(mocks.commit).toHaveBeenCalledExactlyOnceWith(input);
   });
 
-  it("sends rows under the collection key the write interactor expects", async () => {
-    const invoke = useInteractor(di.getCreateManyDealsInteractor, { ok: true, data: [{ id: "deal-1" }] });
-    const rows = [{ name: "Renewal" }];
+  it("forwards update mode unchanged", async () => {
+    const input = {
+      entityType: EntityType.contact,
+      mode: "update" as const,
+      rows: [{ id: "contact-1", firstName: "Ada" }],
+    };
+    mocks.commit.mockResolvedValue({ ok: true, data: [{ id: "contact-1" }] });
+    await expect(commitImportChunkAction(input)).resolves.toEqual({ ok: true, ids: ["contact-1"] });
+    expect(mocks.commit).toHaveBeenCalledExactlyOnceWith(input);
+  });
 
-    await expect(commitImportChunkAction({ entityType: EntityType.deal, mode: "create", rows })).resolves.toEqual({
-      ok: true,
-      ids: ["deal-1"],
+  it("forwards a dry run and reports no created ids", async () => {
+    const input = { entityType: EntityType.task, mode: "update" as const, rows: [{ name: "Call" }] };
+    mocks.dryRun.mockResolvedValue({ ok: true, data: null });
+    await expect(dryRunImportChunkAction(input)).resolves.toEqual({ ok: true, ids: [] });
+    expect(mocks.dryRun).toHaveBeenCalledExactlyOnceWith(input);
+  });
+
+  it.each(["commit", "dryRun"] as const)("serializes %s validation failures without throwing", async (operation) => {
+    const error = createZodError("Invalid entity", ["entityType"]);
+    mocks[operation].mockResolvedValue({ ok: false, error });
+    const action = operation === "commit" ? commitImportChunkAction : dryRunImportChunkAction;
+    await expect(action({ entityType: "companies" as EntityType, mode: "create", rows: [{}] })).resolves.toMatchObject({
+      ok: false,
+      failure: { kind: "validation", issues: [{ path: ["entityType"], message: "Invalid entity" }] },
     });
-    expect(invoke).toHaveBeenCalledWith({ deals: rows });
   });
 
-  it("routes update mode to the update interactor", async () => {
-    const create = useInteractor(di.getCreateManyContactsInteractor, { ok: true, data: [] });
-    const update = useInteractor(di.getUpdateManyContactsInteractor, { ok: true, data: [{ id: "contact-1" }] });
-    const rows = [{ id: "contact-1", firstName: "Ada" }];
-
-    await expect(commitImportChunkAction({ entityType: EntityType.contact, mode: "update", rows })).resolves.toEqual({
-      ok: true,
-      ids: ["contact-1"],
-    });
-    expect(update).toHaveBeenCalledWith({ contacts: rows });
-    expect(create).not.toHaveBeenCalled();
-  });
-
-  it("reports a dry run success as no created ids", async () => {
-    useInteractor(di.getDryRunImportTasksInteractor, { ok: true, data: null });
-
-    await expect(
-      dryRunImportChunkAction({ entityType: EntityType.task, mode: "create", rows: [{ name: "Call" }] }),
-    ).resolves.toEqual({ ok: true, ids: [] });
+  it("forwards relation-index requests unchanged", async () => {
+    const input = { entityTypes: [EntityType.contact], includeUsers: true };
+    const data = { index: {}, truncated: [] };
+    mocks.relationIndex.mockResolvedValue({ ok: true, data });
+    await expect(getImportRelationIndexAction(input)).resolves.toEqual({ ok: true, data });
+    expect(mocks.relationIndex).toHaveBeenCalledExactlyOnceWith(input);
   });
 });

--- a/app/[locale]/(protected)/data-transfer/actions.ts
+++ b/app/[locale]/(protected)/data-transfer/actions.ts
@@ -2,110 +2,24 @@
 
 import type {
   GetImportRelationIndexData,
-  ImportMode,
+  ImportChunkData,
   RelationIndexResult,
 } from "@/features/data-transfer/data-transfer.schema";
 import type { RowActionResult } from "@/core/utils/action-result";
-import type { Validated } from "@/core/validation/validation.utils";
 
-import { z } from "zod";
-import { EntityType } from "@/generated/prisma";
-
-import { IMPORT_ENTITIES } from "@/features/data-transfer/import/import-entity.registry";
 import { serializeResult, serializeRowResult } from "@/core/utils/action-result";
 import {
-  getCreateManyContactsInteractor,
-  getCreateManyDealsInteractor,
-  getCreateManyOrganizationsInteractor,
-  getCreateManyServicesInteractor,
-  getCreateManyTasksInteractor,
-  getDryRunImportContactsInteractor,
-  getDryRunImportDealsInteractor,
-  getDryRunImportOrganizationsInteractor,
-  getDryRunImportServicesInteractor,
-  getDryRunImportTasksInteractor,
+  getCommitImportChunkInteractor,
+  getDryRunImportChunkInteractor,
   getGetImportRelationIndexInteractor,
-  getUpdateManyContactsInteractor,
-  getUpdateManyDealsInteractor,
-  getUpdateManyOrganizationsInteractor,
-  getUpdateManyServicesInteractor,
-  getUpdateManyTasksInteractor,
 } from "@/core/di";
 
-type ImportChunkInput = { entityType: EntityType; mode: ImportMode; rows: unknown[] };
-
-type RowsInvoker = (rows: unknown[]) => Validated<Array<{ id: string }>>;
-
-type DryRunInvoker = (data: { mode: ImportMode; rows: unknown[] }) => Validated<null>;
-
-const UNKNOWN_ENTITY_TYPE = "Unknown entity type";
-
-function entityTypeOrThrow(value: EntityType): EntityType {
-  const parsed = z.enum(EntityType).safeParse(value);
-  if (!parsed.success) throw new Error(UNKNOWN_ENTITY_TYPE);
-
-  return parsed.data;
+export async function dryRunImportChunkAction(data: ImportChunkData): Promise<RowActionResult> {
+  return await serializeRowResult(getDryRunImportChunkInteractor().invoke(data));
 }
 
-function dryRunInvoker(entityType: EntityType): DryRunInvoker {
-  switch (entityType) {
-    case EntityType.contact:
-      return (data) => getDryRunImportContactsInteractor().invoke(data);
-    case EntityType.organization:
-      return (data) => getDryRunImportOrganizationsInteractor().invoke(data);
-    case EntityType.deal:
-      return (data) => getDryRunImportDealsInteractor().invoke(data);
-    case EntityType.service:
-      return (data) => getDryRunImportServicesInteractor().invoke(data);
-    case EntityType.task:
-      return (data) => getDryRunImportTasksInteractor().invoke(data);
-  }
-}
-
-function collectionPayload<T>(entityType: EntityType, rows: unknown[]): T {
-  return { [IMPORT_ENTITIES[entityType].collectionKey]: rows } as T;
-}
-
-function commitInvoker(entityType: EntityType, mode: ImportMode): RowsInvoker {
-  switch (entityType) {
-    case EntityType.contact:
-      return (rows) =>
-        mode === "create"
-          ? getCreateManyContactsInteractor().invoke(collectionPayload(entityType, rows))
-          : getUpdateManyContactsInteractor().invoke(collectionPayload(entityType, rows));
-    case EntityType.organization:
-      return (rows) =>
-        mode === "create"
-          ? getCreateManyOrganizationsInteractor().invoke(collectionPayload(entityType, rows))
-          : getUpdateManyOrganizationsInteractor().invoke(collectionPayload(entityType, rows));
-    case EntityType.deal:
-      return (rows) =>
-        mode === "create"
-          ? getCreateManyDealsInteractor().invoke(collectionPayload(entityType, rows))
-          : getUpdateManyDealsInteractor().invoke(collectionPayload(entityType, rows));
-    case EntityType.service:
-      return (rows) =>
-        mode === "create"
-          ? getCreateManyServicesInteractor().invoke(collectionPayload(entityType, rows))
-          : getUpdateManyServicesInteractor().invoke(collectionPayload(entityType, rows));
-    case EntityType.task:
-      return (rows) =>
-        mode === "create"
-          ? getCreateManyTasksInteractor().invoke(collectionPayload(entityType, rows))
-          : getUpdateManyTasksInteractor().invoke(collectionPayload(entityType, rows));
-  }
-}
-
-export async function dryRunImportChunkAction(data: ImportChunkInput): Promise<RowActionResult> {
-  const entityType = entityTypeOrThrow(data.entityType);
-
-  return await serializeRowResult(dryRunInvoker(entityType)({ mode: data.mode, rows: data.rows }));
-}
-
-export async function commitImportChunkAction(data: ImportChunkInput): Promise<RowActionResult> {
-  const entityType = entityTypeOrThrow(data.entityType);
-
-  return await serializeRowResult(commitInvoker(entityType, data.mode)(data.rows));
+export async function commitImportChunkAction(data: ImportChunkData): Promise<RowActionResult> {
+  return await serializeRowResult(getCommitImportChunkInteractor().invoke(data));
 }
 
 export async function getImportRelationIndexAction(data: GetImportRelationIndexData) {

--- a/app/[locale]/(protected)/inbox/__tests__/actions.test.ts
+++ b/app/[locale]/(protected)/inbox/__tests__/actions.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createZodError } from "@/core/validation/validation.utils";
+
+const mocks = vi.hoisted(() => ({ link: vi.fn(), unlink: vi.fn() }));
+vi.mock("@/core/di", () => ({
+  getLinkContactIdentifierInteractor: () => ({ invoke: mocks.link }),
+  getUnlinkContactIdentifierInteractor: () => ({ invoke: mocks.unlink }),
+}));
+import { linkContactToThreadAction, unlinkContactFromThreadAction } from "../actions";
+
+describe("inbox contact-link action adapters", () => {
+  beforeEach(() => vi.clearAllMocks());
+  it.each(["link", "unlink"] as const)("forwards the complete %s command to its interactor", async (operation) => {
+    const input = {
+      contactId: "10000000-0000-4000-8000-000000000001",
+      provider: "mail" as const,
+      identifier: "ada@example.com",
+    };
+    const data = { id: input.contactId };
+    mocks[operation].mockResolvedValue({ ok: true, data });
+    const action = operation === "link" ? linkContactToThreadAction : unlinkContactFromThreadAction;
+    await expect(action(input)).resolves.toEqual({ ok: true, data });
+    expect(mocks[operation]).toHaveBeenCalledExactlyOnceWith(input);
+  });
+
+  it("serializes the localized missing-contact error", async () => {
+    mocks.link.mockResolvedValue({ ok: false, error: createZodError("Contact not found", ["contactId"]) });
+    await expect(
+      linkContactToThreadAction({
+        contactId: "10000000-0000-4000-8000-000000000001",
+        provider: "mail",
+        identifier: "ada@example.com",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: { errors: [], properties: { contactId: { errors: ["Contact not found"] } } },
+    });
+  });
+});

--- a/app/[locale]/(protected)/inbox/actions.ts
+++ b/app/[locale]/(protected)/inbox/actions.ts
@@ -1,8 +1,10 @@
 "use server";
 
 import type { GetQueryParams } from "@/core/base/base-get.schema";
-import type { MessagingProvider } from "@/generated/prisma";
-import type { ContactDto, ContactIdentifierDto, IdentifierInput } from "@/features/contacts/contact.schema";
+import type {
+  LinkContactIdentifierData,
+  UnlinkContactIdentifierData,
+} from "@/features/contacts/upsert/contact-identifier";
 import type { UpdateThreadData } from "@/ee/messaging/thread-state/update-thread.interactor";
 import type { SendChatMessageData } from "@/ee/messaging/outbound/send-chat-message.interactor";
 import type { SendEmailData } from "@/ee/messaging/outbound/send-email.interactor";
@@ -11,13 +13,11 @@ import type { DiscardDraftData } from "@/ee/messaging/outbound/discard-draft.int
 import type { StartChatData } from "@/ee/messaging/outbound/start-chat.interactor";
 import type { ResolveProviderProfileData } from "@/ee/messaging/outbound/resolve-provider-profile.interactor";
 
-import { z } from "zod";
-
 import {
   getGetMessagingThreadsInteractor,
   getGetMessagingThreadInteractor,
-  getGetContactByIdInteractor,
-  getUpdateContactInteractor,
+  getLinkContactIdentifierInteractor,
+  getUnlinkContactIdentifierInteractor,
   getUpdateThreadInteractor,
   getResyncThreadInteractor,
   getSendChatMessageInteractor,
@@ -28,7 +28,6 @@ import {
   getResolveProviderProfileInteractor,
   getRefreshInboxInteractor,
 } from "@/core/di";
-import { channelClass, isHandleProvider } from "@/ee/messaging/provider";
 import { serializeResult } from "@/core/utils/action-result";
 import { unwrapValidated } from "@/core/validation/validation.utils";
 
@@ -45,50 +44,12 @@ export async function refreshInboxAction() {
   return serializeResult(getRefreshInboxInteractor().invoke());
 }
 
-export async function linkContactToThreadAction(data: {
-  contactId: string;
-  provider: MessagingProvider;
-  identifier: string;
-  displayName?: string;
-  profileUrl?: string;
-}) {
-  const contactResult = await getGetContactByIdInteractor().invoke({ id: data.contactId });
-  if (!contactResult.ok) return serializeResult(contactResult);
-  const contact = contactResult.data.contact;
-  if (!contact) return { ok: false as const, error: z.treeifyError(new z.ZodError([])) };
-
-  const linked: IdentifierInput = {
-    provider: data.provider,
-    value: data.identifier,
-    messagingId: isHandleProvider(data.provider) ? data.identifier : undefined,
-    displayName: data.displayName,
-    profileUrl: data.profileUrl,
-  };
-
-  return serializeResult(
-    getUpdateContactInteractor().invoke({
-      id: data.contactId,
-      identifiers: [...identifiersExcept(contact, data.provider, data.identifier), linked],
-    }),
-  );
+export async function linkContactToThreadAction(data: LinkContactIdentifierData) {
+  return serializeResult(getLinkContactIdentifierInteractor().invoke(data));
 }
 
-export async function unlinkContactFromThreadAction(data: {
-  contactId: string;
-  provider: MessagingProvider;
-  identifier: string;
-}) {
-  const contactResult = await getGetContactByIdInteractor().invoke({ id: data.contactId });
-  if (!contactResult.ok) return serializeResult(contactResult);
-  const contact = contactResult.data.contact;
-  if (!contact) return { ok: false as const, error: z.treeifyError(new z.ZodError([])) };
-
-  return serializeResult(
-    getUpdateContactInteractor().invoke({
-      id: data.contactId,
-      identifiers: identifiersExcept(contact, data.provider, data.identifier),
-    }),
-  );
+export async function unlinkContactFromThreadAction(data: UnlinkContactIdentifierData) {
+  return serializeResult(getUnlinkContactIdentifierInteractor().invoke(data));
 }
 
 export async function updateThreadAction(data: UpdateThreadData) {
@@ -121,23 +82,4 @@ export async function startChatAction(data: StartChatData) {
 
 export async function resolveProviderProfileAction(data: ResolveProviderProfileData) {
   return serializeResult(getResolveProviderProfileInteractor().invoke(data));
-}
-
-function identifiersExcept(contact: ContactDto, provider: MessagingProvider, value: string): IdentifierInput[] {
-  const targetClass = channelClass(provider);
-  return contact.identifiers
-    .filter(
-      (dto) => !(channelClass(dto.provider) === targetClass && (dto.value === value || dto.messagingId === value)),
-    )
-    .map(toIdentifierInput);
-}
-
-function toIdentifierInput(dto: ContactIdentifierDto): IdentifierInput {
-  return {
-    provider: dto.provider,
-    value: dto.value,
-    messagingId: dto.messagingId ?? undefined,
-    displayName: dto.displayName ?? undefined,
-    profileUrl: dto.profileUrl ?? undefined,
-  };
 }

--- a/app/[locale]/(protected)/onboarding/__tests__/actions.test.ts
+++ b/app/[locale]/(protected)/onboarding/__tests__/actions.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearInviteTokenCookie: vi.fn(),
+  issueCreateCompanyOnboardingIntent: vi.fn(),
+  redirect: vi.fn(),
+  requireAccountState: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
+vi.mock("@/features/auth/next/require", () => ({
+  requireAccountState: mocks.requireAccountState,
+}));
+vi.mock("@/features/company/next/invite-token-cookie", () => ({
+  clearInviteTokenCookie: mocks.clearInviteTokenCookie,
+}));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  issueCreateCompanyOnboardingIntent: mocks.issueCreateCompanyOnboardingIntent,
+}));
+
+import { chooseCreateWorkspaceAction, chooseJoinWorkspaceAction, chooseWorkspaceAction } from "../actions";
+
+describe("onboarding workspace choice actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAccountState.mockResolvedValue({
+      state: "unregistered",
+      sessionUser: { id: "user-one" },
+    });
+    mocks.clearInviteTokenCookie.mockResolvedValue(undefined);
+    mocks.issueCreateCompanyOnboardingIntent.mockReturnValue("signed-create-intent");
+  });
+
+  it("binds an explicit create decision to the current identity and URL", async () => {
+    await chooseCreateWorkspaceAction();
+
+    expect(mocks.requireAccountState).toHaveBeenCalledWith("unregistered");
+    expect(mocks.clearInviteTokenCookie).toHaveBeenCalledOnce();
+    expect(mocks.issueCreateCompanyOnboardingIntent).toHaveBeenCalledWith("user-one");
+    expect(mocks.clearInviteTokenCookie.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.issueCreateCompanyOnboardingIntent.mock.invocationCallOrder[0],
+    );
+    expect(mocks.redirect).toHaveBeenCalledWith("/en/onboarding/wizard?intent=signed-create-intent");
+  });
+
+  it("clears ambient invitation state before showing join instructions", async () => {
+    await chooseJoinWorkspaceAction();
+
+    expect(mocks.requireAccountState).toHaveBeenCalledWith("unregistered");
+    expect(mocks.clearInviteTokenCookie).toHaveBeenCalledOnce();
+    expect(mocks.issueCreateCompanyOnboardingIntent).not.toHaveBeenCalled();
+    expect(mocks.redirect).toHaveBeenCalledWith("/en/onboarding/join");
+  });
+
+  it.each([
+    ["create", "/en/onboarding/wizard?intent=signed-create-intent"],
+    ["join", "/en/onboarding/join"],
+  ])("dispatches the %s form choice", async (choice, target) => {
+    const formData = new FormData();
+    formData.set("workspaceChoice", choice);
+
+    await chooseWorkspaceAction(null, formData);
+
+    expect(mocks.redirect).toHaveBeenCalledWith(target);
+  });
+
+  it("ignores an unknown form choice", async () => {
+    const formData = new FormData();
+    formData.set("workspaceChoice", "unknown");
+
+    await expect(chooseWorkspaceAction(null, formData)).resolves.toBeNull();
+
+    expect(mocks.requireAccountState).not.toHaveBeenCalled();
+    expect(mocks.clearInviteTokenCookie).not.toHaveBeenCalled();
+    expect(mocks.issueCreateCompanyOnboardingIntent).not.toHaveBeenCalled();
+    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/app/[locale]/(protected)/onboarding/__tests__/actions.test.ts
+++ b/app/[locale]/(protected)/onboarding/__tests__/actions.test.ts
@@ -1,79 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  clearInviteTokenCookie: vi.fn(),
-  issueCreateCompanyOnboardingIntent: vi.fn(),
-  redirect: vi.fn(),
-  requireAccountState: vi.fn(),
-}));
+const mocks = vi.hoisted(() => ({ chooseWorkspace: vi.fn(), redirect: vi.fn() }));
 
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
 vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
-vi.mock("@/features/auth/next/require", () => ({
-  requireAccountState: mocks.requireAccountState,
-}));
-vi.mock("@/features/company/next/invite-token-cookie", () => ({
-  clearInviteTokenCookie: mocks.clearInviteTokenCookie,
-}));
-vi.mock("@/features/company/next/onboarding-intent", () => ({
-  issueCreateCompanyOnboardingIntent: mocks.issueCreateCompanyOnboardingIntent,
-}));
+vi.mock("@/core/di", () => ({ getChooseWorkspaceOnboardingInteractor: () => ({ invoke: mocks.chooseWorkspace }) }));
 
-import { chooseCreateWorkspaceAction, chooseJoinWorkspaceAction, chooseWorkspaceAction } from "../actions";
+import { chooseWorkspaceAction } from "../actions";
 
-describe("onboarding workspace choice actions", () => {
+describe("onboarding workspace choice action", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.requireAccountState.mockResolvedValue({
-      state: "unregistered",
-      sessionUser: { id: "user-one" },
-    });
-    mocks.clearInviteTokenCookie.mockResolvedValue(undefined);
-    mocks.issueCreateCompanyOnboardingIntent.mockReturnValue("signed-create-intent");
   });
 
-  it("binds an explicit create decision to the current identity and URL", async () => {
-    await chooseCreateWorkspaceAction();
-
-    expect(mocks.requireAccountState).toHaveBeenCalledWith("unregistered");
-    expect(mocks.clearInviteTokenCookie).toHaveBeenCalledOnce();
-    expect(mocks.issueCreateCompanyOnboardingIntent).toHaveBeenCalledWith("user-one");
-    expect(mocks.clearInviteTokenCookie.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.issueCreateCompanyOnboardingIntent.mock.invocationCallOrder[0],
-    );
-    expect(mocks.redirect).toHaveBeenCalledWith("/en/onboarding/wizard?intent=signed-create-intent");
-  });
-
-  it("clears ambient invitation state before showing join instructions", async () => {
-    await chooseJoinWorkspaceAction();
-
-    expect(mocks.requireAccountState).toHaveBeenCalledWith("unregistered");
-    expect(mocks.clearInviteTokenCookie).toHaveBeenCalledOnce();
-    expect(mocks.issueCreateCompanyOnboardingIntent).not.toHaveBeenCalled();
-    expect(mocks.redirect).toHaveBeenCalledWith("/en/onboarding/join");
-  });
-
-  it.each([
-    ["create", "/en/onboarding/wizard?intent=signed-create-intent"],
-    ["join", "/en/onboarding/join"],
-  ])("dispatches the %s form choice", async (choice, target) => {
+  it("adapts the submitted choice and localizes the interactor redirect", async () => {
+    mocks.chooseWorkspace.mockResolvedValue({ redirect: "/onboarding/join" });
     const formData = new FormData();
-    formData.set("workspaceChoice", choice);
+    formData.set("workspaceChoice", "join");
 
     await chooseWorkspaceAction(null, formData);
 
-    expect(mocks.redirect).toHaveBeenCalledWith(target);
+    expect(mocks.chooseWorkspace).toHaveBeenCalledExactlyOnceWith({ choice: "join" });
+    expect(mocks.redirect).toHaveBeenCalledExactlyOnceWith("/en/onboarding/join");
   });
 
-  it("ignores an unknown form choice", async () => {
+  it("returns without redirecting when the interactor rejects the choice", async () => {
+    mocks.chooseWorkspace.mockResolvedValue(null);
     const formData = new FormData();
     formData.set("workspaceChoice", "unknown");
 
     await expect(chooseWorkspaceAction(null, formData)).resolves.toBeNull();
 
-    expect(mocks.requireAccountState).not.toHaveBeenCalled();
-    expect(mocks.clearInviteTokenCookie).not.toHaveBeenCalled();
-    expect(mocks.issueCreateCompanyOnboardingIntent).not.toHaveBeenCalled();
+    expect(mocks.chooseWorkspace).toHaveBeenCalledExactlyOnceWith({ choice: "unknown" });
     expect(mocks.redirect).not.toHaveBeenCalled();
   });
 });

--- a/app/[locale]/(protected)/onboarding/__tests__/onboarding-ui.test.ts
+++ b/app/[locale]/(protected)/onboarding/__tests__/onboarding-ui.test.ts
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react";
+import type { AiConnectionStore } from "@/components/ai-connection/ai-connection.store";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { AiConnectionClaudeSetup } from "@/components/ai-connection/ai-connection-claude-setup";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/core/stores/root-store.provider", () => ({
+  useRootStore: () => ({ appMode: "cloud" }),
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  IntlLink: ({ children, href }: { children: ReactNode; href: string }) => createElement("a", { href }, children),
+}));
+
+vi.mock("../actions", () => ({
+  chooseWorkspaceAction: vi.fn(),
+}));
+
+import { JoinWorkspaceCard } from "../join/join-workspace-card";
+import { OnboardingChoiceCard } from "../onboarding-choice-card";
+
+function buttonContaining(markup: string, content: string) {
+  const button = (markup.match(/<button\b[\s\S]*?<\/button>/gu) ?? []).find((candidate) => candidate.includes(content));
+
+  expect(button).toBeDefined();
+  return button ?? "";
+}
+
+function classTokens(element: string) {
+  const className = element.match(/\bclass="([^"]*)"/u)?.[1] ?? "";
+  return className.split(/\s+/u).filter(Boolean).sort();
+}
+
+function groupTag(markup: string) {
+  const group = (markup.match(/<div\b[^>]*>/gu) ?? []).find((candidate) => candidate.includes('role="group"'));
+
+  expect(group).toBeDefined();
+  return group ?? "";
+}
+
+describe("onboarding workspace UI", () => {
+  it("uses the established large secondary selection buttons", () => {
+    const markup = renderToStaticMarkup(
+      createElement(OnboardingChoiceCard, { email: "person@example.com", trialDays: 7 }),
+    );
+    const claudeMarkup = renderToStaticMarkup(
+      createElement(AiConnectionClaudeSetup, {
+        baseUrl: "http://localhost:4000",
+        disabled: false,
+        mcpUrl: "http://localhost:4000/api/mcp",
+        onCreate: vi.fn(),
+        resultHeadingRef: { current: null },
+        store: {
+          claudeMethod: null,
+          selectClaudeMethod: vi.fn(),
+        } as unknown as AiConnectionStore,
+      }),
+    );
+    const createButton = buttonContaining(markup, "OnboardingChoice.create.title");
+    const joinButton = buttonContaining(markup, "OnboardingChoice.join.title");
+    const claudeAccountButton = buttonContaining(claudeMarkup, "OnboardingWizard.ai.methods.account.title");
+    const claudeLocalButton = buttonContaining(claudeMarkup, "OnboardingWizard.ai.methods.local.title");
+
+    expect(markup.match(/data-variant="secondary"/gu)).toHaveLength(2);
+    expect(createButton).toContain('name="workspaceChoice"');
+    expect(createButton).toContain('type="submit"');
+    expect(createButton).toContain('value="create"');
+    expect(joinButton).toContain('name="workspaceChoice"');
+    expect(joinButton).toContain('type="submit"');
+    expect(joinButton).toContain('value="join"');
+    expect(classTokens(createButton)).toEqual(classTokens(claudeAccountButton));
+    expect(classTokens(joinButton)).toEqual(classTokens(claudeLocalButton));
+    expect(classTokens(groupTag(markup))).toEqual(classTokens(groupTag(claudeMarkup)));
+  });
+
+  it("uses the shared Markdown process steps for joining", () => {
+    const markup = renderToStaticMarkup(createElement(JoinWorkspaceCard, { email: "person@example.com" }));
+
+    expect(markup).toContain('data-process-steps="true"');
+    expect(markup.match(/data-process-step="true"/gu)).toHaveLength(3);
+    expect(markup).toContain("<ol");
+    const steps = markup.match(/<li\b[\s\S]*?<\/li>/gu) ?? [];
+
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toContain("JoinWorkspace.steps.request.title");
+    expect(steps[0]).toContain("JoinWorkspace.steps.request.body");
+    expect(steps[1]).toContain("JoinWorkspace.steps.open.title");
+    expect(steps[1]).toContain("JoinWorkspace.steps.open.body");
+    expect(steps[2]).toContain("JoinWorkspace.steps.complete.title");
+    expect(steps[2]).toContain("JoinWorkspace.steps.complete.body");
+  });
+});

--- a/app/[locale]/(protected)/onboarding/actions.ts
+++ b/app/[locale]/(protected)/onboarding/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
+import { requireAccountState } from "@/features/auth/next/require";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { issueCreateCompanyOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { clearInviteTokenCookie } from "@/features/company/next/invite-token-cookie";
+import { buildLocalePath } from "@/i18n/locale-registry";
+
+export async function chooseCreateWorkspaceAction(): Promise<void> {
+  const { sessionUser } = await requireAccountState("unregistered");
+  const locale = await getLocale();
+  if (!sessionUser) redirect(buildLocalePath(locale, "/auth/signin"));
+
+  await clearInviteTokenCookie();
+  const onboardingIntent = issueCreateCompanyOnboardingIntent(sessionUser.id);
+  redirect(buildLocalePath(locale, pathWithOnboardingIntent("/onboarding/wizard", onboardingIntent)));
+}
+
+export async function chooseJoinWorkspaceAction(): Promise<void> {
+  await requireAccountState("unregistered");
+  await clearInviteTokenCookie();
+  redirect(buildLocalePath(await getLocale(), "/onboarding/join"));
+}
+
+export async function chooseWorkspaceAction(_state: null, formData: FormData): Promise<null> {
+  const choice = formData.get("workspaceChoice");
+
+  if (choice === "create") await chooseCreateWorkspaceAction();
+  if (choice === "join") await chooseJoinWorkspaceAction();
+
+  return null;
+}

--- a/app/[locale]/(protected)/onboarding/actions.ts
+++ b/app/[locale]/(protected)/onboarding/actions.ts
@@ -3,33 +3,12 @@
 import { redirect } from "next/navigation";
 import { getLocale } from "next-intl/server";
 
-import { requireAccountState } from "@/features/auth/next/require";
-import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
-import { issueCreateCompanyOnboardingIntent } from "@/features/company/next/onboarding-intent";
-import { clearInviteTokenCookie } from "@/features/company/next/invite-token-cookie";
+import { getChooseWorkspaceOnboardingInteractor } from "@/core/di";
 import { buildLocalePath } from "@/i18n/locale-registry";
 
-export async function chooseCreateWorkspaceAction(): Promise<void> {
-  const { sessionUser } = await requireAccountState("unregistered");
-  const locale = await getLocale();
-  if (!sessionUser) redirect(buildLocalePath(locale, "/auth/signin"));
-
-  await clearInviteTokenCookie();
-  const onboardingIntent = issueCreateCompanyOnboardingIntent(sessionUser.id);
-  redirect(buildLocalePath(locale, pathWithOnboardingIntent("/onboarding/wizard", onboardingIntent)));
-}
-
-export async function chooseJoinWorkspaceAction(): Promise<void> {
-  await requireAccountState("unregistered");
-  await clearInviteTokenCookie();
-  redirect(buildLocalePath(await getLocale(), "/onboarding/join"));
-}
-
 export async function chooseWorkspaceAction(_state: null, formData: FormData): Promise<null> {
-  const choice = formData.get("workspaceChoice");
-
-  if (choice === "create") await chooseCreateWorkspaceAction();
-  if (choice === "join") await chooseJoinWorkspaceAction();
+  const result = await getChooseWorkspaceOnboardingInteractor().invoke({ choice: formData.get("workspaceChoice") });
+  if (result) redirect(buildLocalePath(await getLocale(), result.redirect));
 
   return null;
 }

--- a/app/[locale]/(protected)/onboarding/join/join-workspace-card.tsx
+++ b/app/[locale]/(protected)/onboarding/join/join-workspace-card.tsx
@@ -1,0 +1,86 @@
+import { Mail, ShieldCheck } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { AppCard } from "@/components/card/app-card";
+import { AppCardBody } from "@/components/card/app-card-body";
+import { AppCardFooter } from "@/components/card/app-card-footer";
+import { CardHeroHeader } from "@/components/card/card-hero-header";
+import { Step, Steps } from "@/components/marketing/process-steps";
+import { CopyableCode } from "@/components/shared/copyable-code";
+import { IconContainer } from "@/components/shared/icon-container";
+import { Button } from "@/components/ui/button";
+import { IntlLink } from "@/i18n/navigation";
+
+type Props = {
+  email: string;
+};
+
+export function JoinWorkspaceCard({ email }: Props) {
+  const t = useTranslations();
+  const steps = [
+    {
+      body: t("JoinWorkspace.steps.request.body"),
+      title: t("JoinWorkspace.steps.request.title"),
+    },
+    {
+      body: t("JoinWorkspace.steps.open.body"),
+      title: t("JoinWorkspace.steps.open.title"),
+    },
+    {
+      body: t("JoinWorkspace.steps.complete.body"),
+      title: t("JoinWorkspace.steps.complete.title"),
+    },
+  ];
+
+  return (
+    <AppCard className="max-w-lg">
+      <CardHeroHeader
+        alt=""
+        subtitle={<span className="[overflow-wrap:anywhere]">{t("JoinWorkspace.subtitle", { email })}</span>}
+        title={t("JoinWorkspace.title")}
+      />
+
+      <AppCardBody className="gap-5 pt-2">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Mail aria-hidden className="size-4 text-primary" />
+
+            <h2 className="text-sm font-medium">{t("JoinWorkspace.emailLabel")}</h2>
+          </div>
+
+          <CopyableCode value={email} />
+        </div>
+
+        <section aria-labelledby="join-workspace-steps-title">
+          <h2 className="sr-only" id="join-workspace-steps-title">
+            {t("JoinWorkspace.stepsTitle")}
+          </h2>
+
+          <Steps className="my-0">
+            {steps.map((step) => (
+              <Step key={step.title} title={step.title}>
+                <p>{step.body}</p>
+              </Step>
+            ))}
+          </Steps>
+        </section>
+
+        <div className="flex gap-3 rounded-lg border border-primary/20 bg-primary/5 p-3.5">
+          <IconContainer className="shrink-0" icon={ShieldCheck} size="sm" />
+
+          <div className="space-y-1">
+            <h2 className="text-sm font-medium">{t("JoinWorkspace.safeTitle")}</h2>
+
+            <p className="text-xs leading-relaxed text-muted-foreground">{t("JoinWorkspace.safeBody")}</p>
+          </div>
+        </div>
+      </AppCardBody>
+
+      <AppCardFooter>
+        <Button asChild className="w-full" variant="secondary">
+          <IntlLink href="/onboarding">{t("JoinWorkspace.backAction")}</IntlLink>
+        </Button>
+      </AppCardFooter>
+    </AppCard>
+  );
+}

--- a/app/[locale]/(protected)/onboarding/join/loading.tsx
+++ b/app/[locale]/(protected)/onboarding/join/loading.tsx
@@ -1,0 +1,70 @@
+import { getTranslations } from "next-intl/server";
+
+import { PageState } from "@/components/page-state/page-state";
+import { SkeletonShape as Shape } from "@/components/page-state/skeleton-shape";
+import { CenteredCardPageSkeleton } from "@/components/shared/centered-card-page-skeleton";
+import { GridPattern } from "@/components/shared/grid-pattern";
+
+function JoinSkeleton() {
+  return (
+    <div className="relative size-full min-h-0 bg-background isolate">
+      <GridPattern />
+
+      <div className="relative size-full min-h-0">
+        <CenteredCardPageSkeleton maxWidth="lg">
+          <div className="flex flex-col items-center gap-2 p-6 pb-0 text-center">
+            <Shape animated className="size-12 rounded-lg" />
+
+            <Shape animated breathe className="mt-4 h-7 w-3/4" motionPhase={1} />
+
+            <Shape animated className="h-3 w-5/6" motionPhase={2} />
+          </div>
+
+          <div className="flex flex-col gap-5 p-6 pt-2">
+            <div className="space-y-2">
+              <Shape animated className="h-4 w-40" motionPhase={1} />
+
+              <Shape animated className="h-9 w-full rounded-md" motionPhase={2} />
+            </div>
+
+            <div className="relative ms-2 border-s border-border ps-6 sm:ms-4 sm:ps-7">
+              {[0, 1, 2].map((index) => (
+                <div key={index} className="relative pb-10 ps-1 last:pb-0">
+                  <Shape
+                    animated
+                    className="absolute -start-10 size-8 rounded-full sm:-start-11"
+                    motionPhase={index === 0 ? 1 : 2}
+                  />
+
+                  <Shape animated breathe className="h-5 w-2/3" motionPhase={index === 0 ? 1 : 2} />
+
+                  <Shape animated className="mt-3 h-3 w-full" motionPhase={index === 2 ? 3 : 2} />
+                </div>
+              ))}
+            </div>
+
+            <div className="flex gap-3 rounded-lg border border-primary/20 bg-primary/5 p-3.5">
+              <Shape animated className="size-8 shrink-0 rounded-lg" motionPhase={2} />
+
+              <div className="flex-1 space-y-2">
+                <Shape animated breathe className="h-4 w-1/2" motionPhase={2} />
+
+                <Shape animated className="h-3 w-full" motionPhase={3} />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex w-full p-6 pt-0">
+            <Shape animated className="h-9 w-full rounded-md" motionPhase={3} />
+          </div>
+        </CenteredCardPageSkeleton>
+      </div>
+    </div>
+  );
+}
+
+export default async function Loading() {
+  const t = await getTranslations("PageState");
+
+  return <PageState background={<JoinSkeleton />} className="h-full flex-1" label={t("loading")} state="loading" />;
+}

--- a/app/[locale]/(protected)/onboarding/join/page.tsx
+++ b/app/[locale]/(protected)/onboarding/join/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
+import { JoinWorkspaceCard } from "./join-workspace-card";
+
+import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { NOINDEX_METADATA } from "@/core/seo/noindex-metadata";
+import { requireAccountState } from "@/features/auth/next/require";
+import {
+  ONBOARDING_INTENT_QUERY_PARAM,
+  onboardingIntentAuthRedirects,
+  pathWithOnboardingIntent,
+} from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
+
+export const metadata = NOINDEX_METADATA;
+
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function JoinWorkspacePage({ searchParams }: Props) {
+  const params = await searchParams;
+  const invitation = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  const locale = await getLocale();
+  if (invitation.status === "invalid" && invitation.source === "explicit")
+    redirect(buildLocalePath(locale, `/auth/error?type=${invitation.errorMessage}`));
+  if (invitation.status === "valid" && invitation.type !== "invitation")
+    redirect(buildLocalePath(locale, "/auth/error?type=invalidOnboardingIntent"));
+  const activeIntent = invitation.status === "valid" ? invitation : null;
+  const resolution = await requireAccountState(
+    "unregistered",
+    "/",
+    activeIntent ? onboardingIntentAuthRedirects(activeIntent.intent) : undefined,
+  );
+  const sessionUser = resolution.sessionUser;
+  if (!sessionUser) redirect(buildLocalePath(locale, "/auth/signin"));
+
+  if (invitation.status === "valid")
+    redirect(buildLocalePath(locale, pathWithOnboardingIntent("/onboarding/wizard", invitation.intent)));
+  if (sessionUser.companyId) redirect(buildLocalePath(locale, "/onboarding/wizard"));
+
+  return (
+    <CenteredCardPage className="animate-page-result-in motion-reduce:animate-none">
+      <JoinWorkspaceCard email={sessionUser.email} />
+    </CenteredCardPage>
+  );
+}

--- a/app/[locale]/(protected)/onboarding/loading.tsx
+++ b/app/[locale]/(protected)/onboarding/loading.tsx
@@ -1,0 +1,55 @@
+import { getTranslations } from "next-intl/server";
+
+import { PageState } from "@/components/page-state/page-state";
+import { SkeletonShape as Shape } from "@/components/page-state/skeleton-shape";
+import { CenteredCardPageSkeleton } from "@/components/shared/centered-card-page-skeleton";
+import { GridPattern } from "@/components/shared/grid-pattern";
+
+function ChoiceSkeleton() {
+  return (
+    <div className="relative size-full min-h-0 bg-background isolate">
+      <GridPattern />
+
+      <div className="relative size-full min-h-0">
+        <CenteredCardPageSkeleton>
+          <div className="flex flex-col items-center gap-2 p-6 pb-0 text-center">
+            <Shape animated className="size-12 rounded-lg" />
+
+            <Shape animated breathe className="mt-4 h-7 w-2/3 max-w-72" motionPhase={1} />
+
+            <Shape animated className="h-3 w-4/5 max-w-md" motionPhase={2} />
+          </div>
+
+          <div className="flex flex-col gap-5 p-6 pt-2">
+            <Shape animated className="mx-auto h-7 w-48 max-w-full rounded-full" motionPhase={2} />
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {[0, 1].map((index) => (
+                <div
+                  key={index}
+                  className="flex min-h-36 flex-col gap-2 rounded-xl border border-border bg-secondary p-4"
+                >
+                  <Shape animated breathe className="h-4 w-3/4" motionPhase={1} />
+
+                  <Shape animated className="h-3 w-full" motionPhase={2} />
+
+                  <Shape animated className="h-3 w-4/5" motionPhase={2} />
+
+                  <Shape animated className="mt-auto h-3 w-1/2" motionPhase={3} />
+                </div>
+              ))}
+            </div>
+
+            <Shape animated className="mx-auto h-3 w-3/4 max-w-sm" motionPhase={3} />
+          </div>
+        </CenteredCardPageSkeleton>
+      </div>
+    </div>
+  );
+}
+
+export default async function Loading() {
+  const t = await getTranslations("PageState");
+
+  return <PageState background={<ChoiceSkeleton />} className="h-full flex-1" label={t("loading")} state="loading" />;
+}

--- a/app/[locale]/(protected)/onboarding/onboarding-choice-card.tsx
+++ b/app/[locale]/(protected)/onboarding/onboarding-choice-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useActionState } from "react";
+
+import { chooseWorkspaceAction } from "./actions";
+
+import { AppCard } from "@/components/card/app-card";
+import { AppCardBody } from "@/components/card/app-card-body";
+import { CardHeroHeader } from "@/components/card/card-hero-header";
+import { Button } from "@/components/ui/button";
+import { useRootStore } from "@/core/stores/root-store.provider";
+
+type ChoiceProps = {
+  choice: "create" | "join";
+  description: string;
+  isPending: boolean;
+  note?: string;
+  title: string;
+};
+
+function WorkspaceChoice({ choice, description, isPending, note, title }: ChoiceProps) {
+  return (
+    <Button
+      className="relative h-auto min-h-36 w-full flex-col items-start justify-start whitespace-normal rounded-xl p-4 text-left"
+      disabled={isPending}
+      name="workspaceChoice"
+      type="submit"
+      value={choice}
+      variant="secondary"
+    >
+      <span className="flex w-full items-start justify-between gap-2">
+        <span className="text-sm font-medium">{title}</span>
+      </span>
+
+      <span className="text-xs font-normal leading-relaxed text-muted-foreground">{description}</span>
+
+      {note ? (
+        <span className="mt-auto pt-2 text-[11px] font-normal leading-relaxed text-muted-foreground">{note}</span>
+      ) : null}
+    </Button>
+  );
+}
+
+type Props = {
+  email: string;
+  trialDays: number;
+};
+
+export function OnboardingChoiceCard({ email, trialDays }: Props) {
+  const t = useTranslations();
+  const { appMode } = useRootStore();
+  const [, formAction, isPending] = useActionState(chooseWorkspaceAction, null);
+
+  return (
+    <AppCard className="max-w-2xl">
+      <CardHeroHeader alt="" subtitle={t("OnboardingChoice.subtitle")} title={t("OnboardingChoice.title")} />
+
+      <AppCardBody className="gap-5 pt-2">
+        <p className="mx-auto max-w-full rounded-full border border-border bg-muted/40 px-3 py-1.5 text-center text-xs text-muted-foreground [overflow-wrap:anywhere]">
+          {t("OnboardingChoice.signedInAs", { email })}
+        </p>
+
+        <form action={formAction} aria-busy={isPending}>
+          <div
+            aria-label={t("OnboardingChoice.optionsLabel")}
+            className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+            role="group"
+          >
+            <WorkspaceChoice
+              choice="create"
+              description={t("OnboardingChoice.create.description")}
+              isPending={isPending}
+              note={appMode === "cloud" ? t("OnboardingChoice.create.note", { days: trialDays }) : undefined}
+              title={t("OnboardingChoice.create.title")}
+            />
+
+            <WorkspaceChoice
+              choice="join"
+              description={t("OnboardingChoice.join.description")}
+              isPending={isPending}
+              note={t("OnboardingChoice.join.note")}
+              title={t("OnboardingChoice.join.title")}
+            />
+          </div>
+
+          <span aria-live="polite" className="sr-only" role="status">
+            {isPending ? t("PageState.loading") : ""}
+          </span>
+        </form>
+
+        <p className="text-center text-xs leading-relaxed text-muted-foreground">{t("OnboardingChoice.footnote")}</p>
+      </AppCardBody>
+    </AppCard>
+  );
+}

--- a/app/[locale]/(protected)/onboarding/page.tsx
+++ b/app/[locale]/(protected)/onboarding/page.tsx
@@ -1,0 +1,50 @@
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
+import { OnboardingChoiceCard } from "./onboarding-choice-card";
+
+import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { CLOUD_TRIAL } from "@/core/commercial/plan-catalog";
+import { NOINDEX_METADATA } from "@/core/seo/noindex-metadata";
+import { requireAccountState } from "@/features/auth/next/require";
+import {
+  ONBOARDING_INTENT_QUERY_PARAM,
+  onboardingIntentAuthRedirects,
+  pathWithOnboardingIntent,
+} from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
+
+export const metadata = NOINDEX_METADATA;
+
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function OnboardingPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const onboardingIntent = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  const locale = await getLocale();
+  if (onboardingIntent.status === "invalid" && onboardingIntent.source === "explicit")
+    redirect(buildLocalePath(locale, `/auth/error?type=${onboardingIntent.errorMessage}`));
+  const activeIntent = onboardingIntent.status === "valid" ? onboardingIntent : null;
+  const resolution = await requireAccountState(
+    "unregistered",
+    "/",
+    activeIntent ? onboardingIntentAuthRedirects(activeIntent.intent) : undefined,
+  );
+  const sessionUser = resolution.sessionUser;
+  if (!sessionUser) redirect(buildLocalePath(locale, "/auth/signin"));
+
+  if (activeIntent?.type === "createCompany" && activeIntent.authUserId !== sessionUser.id)
+    redirect(buildLocalePath(locale, "/auth/error?type=invalidOnboardingIntent"));
+  if (activeIntent)
+    redirect(buildLocalePath(locale, pathWithOnboardingIntent("/onboarding/wizard", activeIntent.intent)));
+  if (sessionUser.companyId) redirect(buildLocalePath(locale, "/onboarding/wizard"));
+
+  return (
+    <CenteredCardPage className="animate-page-result-in motion-reduce:animate-none">
+      <OnboardingChoiceCard email={sessionUser.email} trialDays={CLOUD_TRIAL.days} />
+    </CenteredCardPage>
+  );
+}

--- a/app/[locale]/(protected)/onboarding/wizard/__tests__/actions.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/__tests__/actions.test.ts
@@ -1,21 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  clearInviteCookie: vi.fn(),
   clearRegisteredClick: vi.fn(),
   complete: vi.fn(),
-  deleteCookie: vi.fn(),
+  getSession: vi.fn(),
   readAttribution: vi.fn(),
-  redirect: vi.fn(),
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
   refresh: vi.fn(),
   register: vi.fn(),
+  resolveOnboardingIntent: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({ refresh: mocks.refresh }));
-vi.mock("next/headers", () => ({
-  cookies: vi.fn().mockResolvedValue({ delete: mocks.deleteCookie }),
-}));
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
 vi.mock("@/core/di", () => ({
+  getAuthService: () => ({ getSession: mocks.getSession }),
   getCompleteOnboardingWizardInteractor: () => ({ invoke: mocks.complete }),
   getRegisterUserInteractor: () => ({ invoke: mocks.register }),
 }));
@@ -26,64 +29,177 @@ vi.mock("@/features/acquisition/next/ad-attribution-cookie", () => ({
   clearRegisteredAdClicksFromCookie: mocks.clearRegisteredClick,
   readRegistrationAdAttribution: mocks.readAttribution,
 }));
+vi.mock("@/features/company/next/invite-token-cookie", () => ({
+  clearInviteTokenCookie: mocks.clearInviteCookie,
+}));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
+}));
 
 import { registerProfileAction } from "../actions";
 
 const registration = {
+  agreeToTerms: true,
+  avatarUrl: null,
+  country: "de" as const,
   email: "owner@example.com",
   firstName: "Owner",
   lastName: "Example",
-  country: "de" as const,
-  avatarUrl: null,
-  agreeToTerms: true,
 };
 
 const attribution = [
   {
-    provider: "google_ads" as const,
-    identifierKind: "gclid" as const,
-    identifierValue: "Case-Sensitive_GCLID",
-    clickedAt: new Date("2026-08-31T09:55:00.000Z"),
     capturedAt: new Date("2026-08-31T10:00:00.000Z"),
+    clickedAt: new Date("2026-08-31T09:55:00.000Z"),
     consentedAt: new Date("2026-08-31T09:59:00.000Z"),
     consentNoticeVersion: "2026-09-02",
     expiresAt: new Date("2026-11-28T10:00:00.000Z"),
+    identifierKind: "gclid" as const,
+    identifierValue: "Case-Sensitive_GCLID",
+    provider: "google_ads" as const,
   },
 ];
 
-describe("onboarding registration ad attribution boundary", () => {
+const invitation = {
+  companyId: "company-invited",
+  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  intent: "signed-invitation-a",
+  inviterName: "Invite Admin",
+  source: "explicit",
+  status: "valid",
+  token: "invite-a",
+  type: "invitation",
+} as const;
+
+describe("onboarding registration boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.clearRegisteredClick.mockResolvedValue(undefined);
+    mocks.clearInviteCookie.mockResolvedValue(undefined);
+    mocks.getSession.mockResolvedValue({ user: { id: "user-one" } });
     mocks.readAttribution.mockResolvedValue(attribution);
+    mocks.resolveOnboardingIntent.mockResolvedValue(invitation);
     mocks.register.mockResolvedValue({
+      data: { redirectTo: "/auth/pending" },
       ok: true,
-      data: { redirectTo: "/onboarding/wizard" },
     });
   });
 
-  it("reads the signed click before registration and clears it only after success", async () => {
-    await registerProfileAction(registration);
+  it("uses the explicit invitation even when ambient state could point elsewhere", async () => {
+    await expect(registerProfileAction(registration, "signed-invitation-a")).rejects.toThrow("REDIRECT:/auth/pending");
 
-    expect(mocks.register).toHaveBeenCalledWith(registration, { adAttribution: attribution });
+    expect(mocks.resolveOnboardingIntent).toHaveBeenCalledWith("signed-invitation-a");
+    expect(mocks.register).toHaveBeenCalledWith(registration, {
+      adAttribution: attribution,
+      target: { companyId: "company-invited", type: "invitation" },
+    });
+    expect(mocks.getSession).not.toHaveBeenCalled();
+  });
+
+  it("uses a create decision only for the identity that made it", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      authUserId: "user-one",
+      intent: "signed-create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+
+    await expect(registerProfileAction(registration, "signed-create")).rejects.toThrow("REDIRECT:/auth/pending");
+
+    expect(mocks.register).toHaveBeenCalledWith(registration, {
+      adAttribution: attribution,
+      target: { type: "createCompany" },
+    });
+  });
+
+  it("rejects a create decision made by a different identity before registration", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      authUserId: "user-two",
+      intent: "signed-create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+
+    await expect(registerProfileAction(registration, "signed-create")).rejects.toThrow(
+      "REDIRECT:/en/auth/error?type=invalidOnboardingIntent",
+    );
+
+    expect(mocks.register).not.toHaveBeenCalled();
+    expect(mocks.clearInviteCookie).toHaveBeenCalledOnce();
+  });
+
+  it.each(["invalidOnboardingIntent", "onboardingSessionExpired"] as const)(
+    "fails closed for an explicit %s intent",
+    async (errorMessage) => {
+      mocks.resolveOnboardingIntent.mockResolvedValue({
+        errorMessage,
+        source: "explicit",
+        status: "invalid",
+      });
+
+      await expect(registerProfileAction(registration, "bad-intent")).rejects.toThrow(
+        `REDIRECT:/en/auth/error?type=${errorMessage}`,
+      );
+
+      expect(mocks.register).not.toHaveBeenCalled();
+      expect(mocks.clearInviteCookie).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("retains the legacy identity binding only when no explicit intent exists", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({ status: "absent" });
+
+    await expect(registerProfileAction(registration)).rejects.toThrow("REDIRECT:/auth/pending");
+
+    expect(mocks.register).toHaveBeenCalledWith(registration, {
+      adAttribution: attribution,
+      target: { type: "legacyAuthBinding" },
+    });
+  });
+
+  it("clears an invalid rollout cookie and continues with a live identity binding", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      errorMessage: "inviteLinkExpired",
+      source: "legacy",
+      status: "invalid",
+    });
+
+    await expect(registerProfileAction(registration)).rejects.toThrow("REDIRECT:/auth/pending");
+
+    expect(mocks.clearInviteCookie).toHaveBeenCalled();
+    expect(mocks.register).toHaveBeenCalledWith(registration, {
+      adAttribution: attribution,
+      target: { type: "legacyAuthBinding" },
+    });
+  });
+
+  it("clears attribution and the legacy invite only after registration succeeds", async () => {
+    await expect(registerProfileAction(registration, "signed-invitation-a")).rejects.toThrow("REDIRECT:/auth/pending");
+
     expect(mocks.readAttribution.mock.invocationCallOrder[0]).toBeLessThan(mocks.register.mock.invocationCallOrder[0]);
     expect(mocks.register.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.clearRegisteredClick.mock.invocationCallOrder[0],
     );
-    expect(mocks.deleteCookie).toHaveBeenCalledWith("inviteToken");
-    expect(mocks.redirect).toHaveBeenCalledWith("/onboarding/wizard");
+    expect(mocks.clearRegisteredClick).toHaveBeenCalledOnce();
+    expect(mocks.clearInviteCookie).toHaveBeenCalledOnce();
+    expect(mocks.refresh).toHaveBeenCalledOnce();
   });
 
-  it("keeps the signed click available when registration fails", async () => {
+  it("keeps recoverable state when registration fails", async () => {
     mocks.register.mockResolvedValue({
+      error: { fieldErrors: {}, formErrors: [] },
       ok: false,
-      error: { formErrors: [], fieldErrors: {} },
     });
 
-    await registerProfileAction(registration);
+    await expect(registerProfileAction(registration, "signed-invitation-a")).resolves.toEqual({
+      error: { fieldErrors: {}, formErrors: [] },
+      ok: false,
+    });
 
     expect(mocks.clearRegisteredClick).not.toHaveBeenCalled();
-    expect(mocks.deleteCookie).not.toHaveBeenCalled();
+    expect(mocks.clearInviteCookie).not.toHaveBeenCalled();
     expect(mocks.refresh).not.toHaveBeenCalled();
     expect(mocks.redirect).not.toHaveBeenCalled();
   });

--- a/app/[locale]/(protected)/onboarding/wizard/__tests__/actions.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/__tests__/actions.test.ts
@@ -1,39 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  clearInviteCookie: vi.fn(),
   clearRegisteredClick: vi.fn(),
   complete: vi.fn(),
-  getSession: vi.fn(),
   readAttribution: vi.fn(),
   redirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
   refresh: vi.fn(),
   register: vi.fn(),
-  resolveOnboardingIntent: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({ refresh: mocks.refresh }));
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
 vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
 vi.mock("@/core/di", () => ({
-  getAuthService: () => ({ getSession: mocks.getSession }),
   getCompleteOnboardingWizardInteractor: () => ({ invoke: mocks.complete }),
-  getRegisterUserInteractor: () => ({ invoke: mocks.register }),
+  getRegisterOnboardingProfileInteractor: () => ({ invoke: mocks.register }),
 }));
-vi.mock("@/core/utils/action-result", () => ({
-  serializeResult: async (result: unknown) => await result,
-}));
+vi.mock("@/core/utils/action-result", () => ({ serializeResult: async (result: unknown) => await result }));
 vi.mock("@/features/acquisition/next/ad-attribution-cookie", () => ({
   clearRegisteredAdClicksFromCookie: mocks.clearRegisteredClick,
   readRegistrationAdAttribution: mocks.readAttribution,
-}));
-vi.mock("@/features/company/next/invite-token-cookie", () => ({
-  clearInviteTokenCookie: mocks.clearInviteCookie,
-}));
-vi.mock("@/features/company/next/onboarding-intent", () => ({
-  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
 }));
 
 import { registerProfileAction } from "../actions";
@@ -45,6 +33,7 @@ const registration = {
   email: "owner@example.com",
   firstName: "Owner",
   lastName: "Example",
+  onboardingIntent: "signed-invitation-a",
 };
 
 const attribution = [
@@ -60,147 +49,40 @@ const attribution = [
   },
 ];
 
-const invitation = {
-  companyId: "company-invited",
-  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-  intent: "signed-invitation-a",
-  inviterName: "Invite Admin",
-  source: "explicit",
-  status: "valid",
-  token: "invite-a",
-  type: "invitation",
-} as const;
-
-describe("onboarding registration boundary", () => {
+describe("onboarding registration action", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.clearRegisteredClick.mockResolvedValue(undefined);
-    mocks.clearInviteCookie.mockResolvedValue(undefined);
-    mocks.getSession.mockResolvedValue({ user: { id: "user-one" } });
     mocks.readAttribution.mockResolvedValue(attribution);
-    mocks.resolveOnboardingIntent.mockResolvedValue(invitation);
-    mocks.register.mockResolvedValue({
-      data: { redirectTo: "/auth/pending" },
-      ok: true,
-    });
   });
 
-  it("uses the explicit invitation even when ambient state could point elsewhere", async () => {
-    await expect(registerProfileAction(registration, "signed-invitation-a")).rejects.toThrow("REDIRECT:/auth/pending");
+  it("passes form and request attribution to the onboarding interactor", async () => {
+    mocks.register.mockResolvedValue({ ok: false, error: { fieldErrors: {}, formErrors: [] } });
 
-    expect(mocks.resolveOnboardingIntent).toHaveBeenCalledWith("signed-invitation-a");
-    expect(mocks.register).toHaveBeenCalledWith(registration, {
-      adAttribution: attribution,
-      target: { companyId: "company-invited", type: "invitation" },
-    });
-    expect(mocks.getSession).not.toHaveBeenCalled();
-  });
-
-  it("uses a create decision only for the identity that made it", async () => {
-    mocks.resolveOnboardingIntent.mockResolvedValue({
-      authUserId: "user-one",
-      intent: "signed-create",
-      source: "explicit",
-      status: "valid",
-      type: "createCompany",
-    });
-
-    await expect(registerProfileAction(registration, "signed-create")).rejects.toThrow("REDIRECT:/auth/pending");
-
-    expect(mocks.register).toHaveBeenCalledWith(registration, {
-      adAttribution: attribution,
-      target: { type: "createCompany" },
-    });
-  });
-
-  it("rejects a create decision made by a different identity before registration", async () => {
-    mocks.resolveOnboardingIntent.mockResolvedValue({
-      authUserId: "user-two",
-      intent: "signed-create",
-      source: "explicit",
-      status: "valid",
-      type: "createCompany",
-    });
-
-    await expect(registerProfileAction(registration, "signed-create")).rejects.toThrow(
-      "REDIRECT:/en/auth/error?type=invalidOnboardingIntent",
-    );
-
-    expect(mocks.register).not.toHaveBeenCalled();
-    expect(mocks.clearInviteCookie).toHaveBeenCalledOnce();
-  });
-
-  it.each(["invalidOnboardingIntent", "onboardingSessionExpired"] as const)(
-    "fails closed for an explicit %s intent",
-    async (errorMessage) => {
-      mocks.resolveOnboardingIntent.mockResolvedValue({
-        errorMessage,
-        source: "explicit",
-        status: "invalid",
-      });
-
-      await expect(registerProfileAction(registration, "bad-intent")).rejects.toThrow(
-        `REDIRECT:/en/auth/error?type=${errorMessage}`,
-      );
-
-      expect(mocks.register).not.toHaveBeenCalled();
-      expect(mocks.clearInviteCookie).toHaveBeenCalledOnce();
-    },
-  );
-
-  it("retains the legacy identity binding only when no explicit intent exists", async () => {
-    mocks.resolveOnboardingIntent.mockResolvedValue({ status: "absent" });
-
-    await expect(registerProfileAction(registration)).rejects.toThrow("REDIRECT:/auth/pending");
-
-    expect(mocks.register).toHaveBeenCalledWith(registration, {
-      adAttribution: attribution,
-      target: { type: "legacyAuthBinding" },
-    });
-  });
-
-  it("clears an invalid rollout cookie and continues with a live identity binding", async () => {
-    mocks.resolveOnboardingIntent.mockResolvedValue({
-      errorMessage: "inviteLinkExpired",
-      source: "legacy",
-      status: "invalid",
-    });
-
-    await expect(registerProfileAction(registration)).rejects.toThrow("REDIRECT:/auth/pending");
-
-    expect(mocks.clearInviteCookie).toHaveBeenCalled();
-    expect(mocks.register).toHaveBeenCalledWith(registration, {
-      adAttribution: attribution,
-      target: { type: "legacyAuthBinding" },
-    });
-  });
-
-  it("clears attribution and the legacy invite only after registration succeeds", async () => {
-    await expect(registerProfileAction(registration, "signed-invitation-a")).rejects.toThrow("REDIRECT:/auth/pending");
-
-    expect(mocks.readAttribution.mock.invocationCallOrder[0]).toBeLessThan(mocks.register.mock.invocationCallOrder[0]);
-    expect(mocks.register.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.clearRegisteredClick.mock.invocationCallOrder[0],
-    );
-    expect(mocks.clearRegisteredClick).toHaveBeenCalledOnce();
-    expect(mocks.clearInviteCookie).toHaveBeenCalledOnce();
-    expect(mocks.refresh).toHaveBeenCalledOnce();
-  });
-
-  it("keeps recoverable state when registration fails", async () => {
-    mocks.register.mockResolvedValue({
-      error: { fieldErrors: {}, formErrors: [] },
+    await expect(registerProfileAction(registration)).resolves.toEqual({
       ok: false,
-    });
-
-    await expect(registerProfileAction(registration, "signed-invitation-a")).resolves.toEqual({
       error: { fieldErrors: {}, formErrors: [] },
-      ok: false,
     });
 
+    expect(mocks.register).toHaveBeenCalledExactlyOnceWith(registration, { adAttribution: attribution });
     expect(mocks.clearRegisteredClick).not.toHaveBeenCalled();
-    expect(mocks.clearInviteCookie).not.toHaveBeenCalled();
-    expect(mocks.refresh).not.toHaveBeenCalled();
-    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+
+  it("localizes redirects returned by the onboarding interactor", async () => {
+    mocks.register.mockResolvedValue({ redirect: "/auth/signin?intent=signed-invitation-a" });
+
+    await expect(registerProfileAction(registration)).rejects.toThrow(
+      "REDIRECT:/en/auth/signin?intent=signed-invitation-a",
+    );
+    expect(mocks.clearRegisteredClick).not.toHaveBeenCalled();
+  });
+
+  it("clears consumed ad attribution and refreshes only after registration succeeds", async () => {
+    mocks.register.mockResolvedValue({ data: { redirectTo: "/auth/pending" }, ok: true });
+
+    await expect(registerProfileAction(registration)).rejects.toThrow("REDIRECT:/auth/pending");
+
+    expect(mocks.clearRegisteredClick).toHaveBeenCalledOnce();
+    expect(mocks.refresh).toHaveBeenCalledOnce();
   });
 });

--- a/app/[locale]/(protected)/onboarding/wizard/__tests__/page.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/__tests__/page.test.ts
@@ -25,6 +25,28 @@ describe("OnboardingWizardPage authentication detours", () => {
     vi.clearAllMocks();
   });
 
+  it.each([
+    { name: "registered creator", user: { companyId: "company-a" }, intent: null, isInvited: false },
+    { name: "explicit invitee", user: null, intent: { type: "invitation", intent: "signed.invite" }, isInvited: true },
+    { name: "pre-tenant binding", user: null, intent: null, isInvited: true },
+    {
+      name: "explicit creator with an old binding",
+      user: null,
+      intent: { type: "createCompany", authUserId: "user-a", intent: "signed.create" },
+      isInvited: false,
+    },
+  ])("uses the correct progress presentation for a $name", async ({ user, intent, isInvited }) => {
+    mocks.resolveOnboardingIntent.mockResolvedValue(intent ? { ...intent, status: "valid" } : { status: "absent" });
+    mocks.requireAccountState.mockResolvedValue({
+      sessionUser: { id: "user-a", email: "owner@example.com", companyId: "company-a" },
+      user,
+    });
+
+    const page = await OnboardingWizardPage({ searchParams: Promise.resolve({}) });
+
+    expect(page.props.children.props).toMatchObject({ isInvited, profileCompleted: Boolean(user) });
+  });
+
   it("preserves an invitation when a cached session loses its identity", async () => {
     mocks.resolveOnboardingIntent.mockResolvedValue({
       companyId: "company-a",

--- a/app/[locale]/(protected)/onboarding/wizard/__tests__/page.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/__tests__/page.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAccountState: vi.fn(),
+  resolveOnboardingIntent: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => {
+    throw new Error(`REDIRECT:${path}`);
+  },
+}));
+vi.mock("next-intl/server", () => ({ getLocale: vi.fn().mockResolvedValue("en") }));
+vi.mock("@/features/auth/next/require", () => ({ requireAccountState: mocks.requireAccountState }));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
+}));
+vi.mock("@/components/shared/centered-card-page", () => ({ CenteredCardPage: "centered-card-page" }));
+vi.mock("../components/onboarding-wizard", () => ({ OnboardingWizard: "onboarding-wizard" }));
+
+import OnboardingWizardPage from "../page";
+
+describe("OnboardingWizardPage authentication detours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves an invitation when a cached session loses its identity", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      companyId: "company-a",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      intent: "signed.intent",
+      inviterName: "Invite Admin",
+      source: "explicit",
+      status: "valid",
+      token: "invite-a",
+      type: "invitation",
+    });
+    mocks.requireAccountState.mockImplementation((_expected, _fallback, redirects) => {
+      throw new Error(`REDIRECT:${redirects.unauthenticated}`);
+    });
+
+    await expect(OnboardingWizardPage({ searchParams: Promise.resolve({ intent: "signed.intent" }) })).rejects.toThrow(
+      "REDIRECT:/auth/signin?intent=signed.intent",
+    );
+    expect(mocks.requireAccountState).toHaveBeenCalledWith(
+      ["unregistered", "onboarding"],
+      "/",
+      expect.objectContaining({ unauthenticated: "/auth/signin?intent=signed.intent" }),
+    );
+  });
+});

--- a/app/[locale]/(protected)/onboarding/wizard/actions.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/actions.ts
@@ -1,61 +1,27 @@
 "use server";
 
-import type { RegisterUserData, RegistrationTarget } from "@/features/user/register/register-user.interactor";
+import type { RegisterOnboardingProfileData } from "@/features/user/register/register-onboarding-profile.interactor";
 
 import { refresh } from "next/cache";
 import { redirect } from "next/navigation";
 import { getLocale } from "next-intl/server";
 
-import { getAuthService, getCompleteOnboardingWizardInteractor, getRegisterUserInteractor } from "@/core/di";
+import { getCompleteOnboardingWizardInteractor, getRegisterOnboardingProfileInteractor } from "@/core/di";
 import { serializeResult } from "@/core/utils/action-result";
 import { isRedirect } from "@/features/auth/auth-outcome";
 import {
   clearRegisteredAdClicksFromCookie,
   readRegistrationAdAttribution,
 } from "@/features/acquisition/next/ad-attribution-cookie";
-import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
-import { clearInviteTokenCookie } from "@/features/company/next/invite-token-cookie";
-import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 import { buildLocalePath } from "@/i18n/locale-registry";
 
-export async function registerProfileAction(data: RegisterUserData, onboardingIntentValue?: string) {
+export async function registerProfileAction(data: RegisterOnboardingProfileData) {
   const adAttribution = await readRegistrationAdAttribution();
-  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
-  if (onboardingIntent.status === "invalid") {
-    await clearInviteTokenCookie();
-    if (onboardingIntent.source === "explicit")
-      redirect(buildLocalePath(await getLocale(), `/auth/error?type=${onboardingIntent.errorMessage}`));
-  }
-
-  let target: RegistrationTarget = { type: "legacyAuthBinding" };
-  if (onboardingIntent.status === "valid" && onboardingIntent.type === "invitation")
-    target = { type: "invitation", companyId: onboardingIntent.companyId } as const;
-  if (onboardingIntent.status === "valid" && onboardingIntent.type === "createCompany") {
-    const session = await getAuthService().getSession();
-    if (!session)
-      redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent)));
-
-    if (onboardingIntent.authUserId !== session?.user.id) {
-      await clearInviteTokenCookie();
-      redirect(buildLocalePath(await getLocale(), "/auth/error?type=invalidOnboardingIntent"));
-    }
-    target = { type: "createCompany" } as const;
-  }
-  const registrationResult = await getRegisterUserInteractor().invoke(data, {
-    adAttribution,
-    target,
-  });
-  if (isRedirect(registrationResult) && onboardingIntent.status === "valid") {
-    if (registrationResult.redirect === "/auth/signin")
-      redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent)));
-
-    if (registrationResult.redirect === "/auth/signup" && onboardingIntent.type === "invitation")
-      redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/signup", onboardingIntent.intent)));
-  }
+  const registrationResult = await getRegisterOnboardingProfileInteractor().invoke(data, { adAttribution });
+  if (isRedirect(registrationResult)) redirect(buildLocalePath(await getLocale(), registrationResult.redirect));
   const result = await serializeResult(registrationResult);
   if (result.ok) {
     await clearRegisteredAdClicksFromCookie();
-    await clearInviteTokenCookie();
     refresh();
     redirect(result.data.redirectTo);
   }

--- a/app/[locale]/(protected)/onboarding/wizard/actions.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/actions.ts
@@ -1,25 +1,61 @@
 "use server";
 
-import type { RegisterUserData } from "@/features/user/register/register-user.interactor";
+import type { RegisterUserData, RegistrationTarget } from "@/features/user/register/register-user.interactor";
 
 import { refresh } from "next/cache";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
 
-import { getCompleteOnboardingWizardInteractor, getRegisterUserInteractor } from "@/core/di";
+import { getAuthService, getCompleteOnboardingWizardInteractor, getRegisterUserInteractor } from "@/core/di";
 import { serializeResult } from "@/core/utils/action-result";
+import { isRedirect } from "@/features/auth/auth-outcome";
 import {
   clearRegisteredAdClicksFromCookie,
   readRegistrationAdAttribution,
 } from "@/features/acquisition/next/ad-attribution-cookie";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { clearInviteTokenCookie } from "@/features/company/next/invite-token-cookie";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
-export async function registerProfileAction(data: RegisterUserData) {
+export async function registerProfileAction(data: RegisterUserData, onboardingIntentValue?: string) {
   const adAttribution = await readRegistrationAdAttribution();
-  const result = await serializeResult(getRegisterUserInteractor().invoke(data, { adAttribution }));
+  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
+  if (onboardingIntent.status === "invalid") {
+    await clearInviteTokenCookie();
+    if (onboardingIntent.source === "explicit")
+      redirect(buildLocalePath(await getLocale(), `/auth/error?type=${onboardingIntent.errorMessage}`));
+  }
+
+  let target: RegistrationTarget = { type: "legacyAuthBinding" };
+  if (onboardingIntent.status === "valid" && onboardingIntent.type === "invitation")
+    target = { type: "invitation", companyId: onboardingIntent.companyId } as const;
+  if (onboardingIntent.status === "valid" && onboardingIntent.type === "createCompany") {
+    const session = await getAuthService().getSession();
+    if (!session)
+      redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent)));
+
+    if (onboardingIntent.authUserId !== session?.user.id) {
+      await clearInviteTokenCookie();
+      redirect(buildLocalePath(await getLocale(), "/auth/error?type=invalidOnboardingIntent"));
+    }
+    target = { type: "createCompany" } as const;
+  }
+  const registrationResult = await getRegisterUserInteractor().invoke(data, {
+    adAttribution,
+    target,
+  });
+  if (isRedirect(registrationResult) && onboardingIntent.status === "valid") {
+    if (registrationResult.redirect === "/auth/signin")
+      redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent)));
+
+    if (registrationResult.redirect === "/auth/signup" && onboardingIntent.type === "invitation")
+      redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/signup", onboardingIntent.intent)));
+  }
+  const result = await serializeResult(registrationResult);
   if (result.ok) {
     await clearRegisteredAdClicksFromCookie();
-    const cookieStore = await cookies();
-    cookieStore.delete("inviteToken");
+    await clearInviteTokenCookie();
     refresh();
     redirect(result.data.redirectTo);
   }

--- a/app/[locale]/(protected)/onboarding/wizard/components/__tests__/onboarding-wizard.store.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/__tests__/onboarding-wizard.store.test.ts
@@ -52,6 +52,17 @@ describe("OnboardingWizardStore", () => {
     expect(store.currentStep).toBe("ai");
   });
 
+  it("resets progress when a different account starts at an earlier step", () => {
+    const store = new OnboardingWizardStore(rootStore);
+    store.setInitialStep(1);
+    store.next();
+
+    store.setInitialStep(0);
+
+    expect(store.currentStep).toBe("profile");
+    expect(store.isFirstStep).toBe(true);
+  });
+
   it("preserves the existing completion action", async () => {
     const store = new OnboardingWizardStore(rootStore);
 

--- a/app/[locale]/(protected)/onboarding/wizard/components/__tests__/onboarding-wizard.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/__tests__/onboarding-wizard.test.ts
@@ -2,7 +2,6 @@ import type { RootStore } from "@/core/stores/root.store";
 
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { runInAction } from "mobx";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const testContext = vi.hoisted(() => ({ rootStore: null as RootStore | null }));
@@ -35,16 +34,13 @@ vi.mock("../step-ai", () => ({
 import { OnboardingWizardStore } from "../onboarding-wizard.store";
 import { OnboardingWizard } from "../onboarding-wizard";
 
-function renderStep(index: number): string {
+function renderWizard(profileCompleted: boolean): string {
   const store = new OnboardingWizardStore({} as RootStore);
-  runInAction(() => {
-    store.currentStepIndex = index;
-  });
   testContext.rootStore = {
     onboardingWizardStore: store,
   } as unknown as RootStore;
 
-  return renderToStaticMarkup(createElement(OnboardingWizard, { profileCompleted: false }));
+  return renderToStaticMarkup(createElement(OnboardingWizard, { profileCompleted }));
 }
 
 beforeEach(() => {
@@ -53,11 +49,10 @@ beforeEach(() => {
 
 describe("OnboardingWizard", () => {
   it.each([
-    [0, "profile", 1],
-    [1, "invite", 2],
-    [2, "ai", 3],
-  ] as const)("renders only the %s step at the correct three-step progress", (index, step, current) => {
-    const html = renderStep(index);
+    [false, "profile", 1],
+    [true, "invite", 2],
+  ] as const)("initializes profileCompleted=%s at the %s step", (profileCompleted, step, current) => {
+    const html = renderWizard(profileCompleted);
 
     expect(html).toContain(`data-step="${step}"`);
     expect(html).toContain(`OnboardingWizard.progress current=${current} total=3`);
@@ -66,11 +61,9 @@ describe("OnboardingWizard", () => {
     expect(html).not.toContain("OnboardingWizard.steps.terminology");
   });
 
-  it("keeps shared Back and Next navigation on Invite only", () => {
-    expect(renderStep(0)).not.toContain('id="onboarding-next"');
-    expect(renderStep(1)).toContain('id="onboarding-back"');
-    expect(renderStep(1)).toContain('id="onboarding-next"');
-    expect(renderStep(2)).not.toContain('id="onboarding-next"');
-    expect(renderStep(2)).toContain('data-step-footer="ai"');
+  it("keeps shared Back and Next navigation on the initial Invite step only", () => {
+    expect(renderWizard(false)).not.toContain('id="onboarding-next"');
+    expect(renderWizard(true)).toContain('id="onboarding-back"');
+    expect(renderWizard(true)).toContain('id="onboarding-next"');
   });
 });

--- a/app/[locale]/(protected)/onboarding/wizard/components/__tests__/onboarding-wizard.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/__tests__/onboarding-wizard.test.ts
@@ -66,4 +66,13 @@ describe("OnboardingWizard", () => {
     expect(renderWizard(true)).toContain('id="onboarding-back"');
     expect(renderWizard(true)).toContain('id="onboarding-next"');
   });
+
+  it("does not mutate the shared wizard store during render", () => {
+    const store = new OnboardingWizardStore({} as RootStore);
+    testContext.rootStore = { onboardingWizardStore: store } as unknown as RootStore;
+
+    renderToStaticMarkup(createElement(OnboardingWizard, { profileCompleted: true }));
+
+    expect(store.currentStep).toBe("profile");
+  });
 });

--- a/app/[locale]/(protected)/onboarding/wizard/components/__tests__/step-profile.store.test.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/__tests__/step-profile.store.test.ts
@@ -1,0 +1,43 @@
+import type { RootStore } from "@/core/stores/root.store";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const actions = vi.hoisted(() => ({ registerProfileAction: vi.fn() }));
+
+vi.mock("../../actions", () => actions);
+
+import { StepProfileStore } from "../step-profile.store";
+
+const rootStore = {} as RootStore;
+
+describe("StepProfileStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actions.registerProfileAction.mockResolvedValue({ data: { redirectTo: "/onboarding/wizard" }, ok: true });
+  });
+
+  it("keeps onboarding intent in the form submitted for registration", async () => {
+    const store = new StepProfileStore(rootStore);
+    store.onInitOrRefresh({
+      avatarUrl: null,
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+      onboardingIntent: "signed.create.intent",
+    });
+    store.onChange("agreeToTerms", true);
+
+    await store.onSubmit();
+
+    expect(store.form.onboardingIntent).toBe("signed.create.intent");
+    expect(actions.registerProfileAction).toHaveBeenCalledExactlyOnceWith({
+      agreeToTerms: true,
+      avatarUrl: null,
+      country: "de",
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+      onboardingIntent: "signed.create.intent",
+    });
+  });
+});

--- a/app/[locale]/(protected)/onboarding/wizard/components/onboarding-wizard.store.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/onboarding-wizard.store.ts
@@ -31,7 +31,7 @@ export class OnboardingWizardStore {
 
   setInitialStep = (index: number) => {
     this.minStepIndex = index;
-    if (this.currentStepIndex < index) this.currentStepIndex = index;
+    this.currentStepIndex = index;
   };
 
   setMinStepIndex = (index: number) => {

--- a/app/[locale]/(protected)/onboarding/wizard/components/onboarding-wizard.tsx
+++ b/app/[locale]/(protected)/onboarding/wizard/components/onboarding-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
 
@@ -17,6 +17,8 @@ import { StepInvite } from "./step-invite";
 
 type Props = {
   profileCompleted: boolean;
+  onboardingIntent?: string;
+  inviterName?: string;
   isInvited?: boolean;
   sessionEmail?: string;
   sessionFirstName?: string;
@@ -27,6 +29,8 @@ type Props = {
 export const OnboardingWizard = observer(
   ({
     profileCompleted,
+    onboardingIntent,
+    inviterName,
     isInvited = false,
     sessionEmail = "",
     sessionFirstName,
@@ -35,6 +39,7 @@ export const OnboardingWizard = observer(
   }: Props) => {
     const t = useTranslations();
     const { onboardingWizardStore } = useRootStore();
+    useState(() => onboardingWizardStore.setInitialStep(profileCompleted ? 1 : 0));
     const { currentStep, currentStepIndex, totalSteps, isFirstStep, isSubmitting, next, back } = onboardingWizardStore;
     const headingRef = useRef<HTMLHeadingElement>(null);
     const previousStep = useRef(currentStep);
@@ -56,8 +61,10 @@ export const OnboardingWizard = observer(
               avatarUrl={sessionAvatarUrl}
               email={sessionEmail}
               firstName={sessionFirstName}
+              inviterName={inviterName}
               isInvited={isInvited}
               lastName={sessionLastName}
+              onboardingIntent={onboardingIntent}
             />
           );
         case "ai":
@@ -86,7 +93,11 @@ export const OnboardingWizard = observer(
               {t(`OnboardingWizard.steps.${currentStep}.title`)}
             </h1>
 
-            <p className="text-sm text-muted-foreground">{t(`OnboardingWizard.steps.${currentStep}.subtitle`)}</p>
+            <p className="text-sm text-muted-foreground">
+              {currentStep === "profile" && isInvited
+                ? t("OnboardingWizard.steps.profile.invitedSubtitle")
+                : t(`OnboardingWizard.steps.${currentStep}.subtitle`)}
+            </p>
           </div>
 
           {!isInvited && (

--- a/app/[locale]/(protected)/onboarding/wizard/components/onboarding-wizard.tsx
+++ b/app/[locale]/(protected)/onboarding/wizard/components/onboarding-wizard.tsx
@@ -39,14 +39,24 @@ export const OnboardingWizard = observer(
   }: Props) => {
     const t = useTranslations();
     const { onboardingWizardStore } = useRootStore();
-    useState(() => onboardingWizardStore.setInitialStep(profileCompleted ? 1 : 0));
-    const { currentStep, currentStepIndex, totalSteps, isFirstStep, isSubmitting, next, back } = onboardingWizardStore;
+    const initialStepIndex = profileCompleted ? 1 : 0;
+    const [initializedProfileCompleted, setInitializedProfileCompleted] = useState<boolean | null>(null);
+    const isStepSynchronized = initializedProfileCompleted === profileCompleted;
+    const currentStep = isStepSynchronized
+      ? onboardingWizardStore.currentStep
+      : profileCompleted
+        ? "invite"
+        : "profile";
+    const currentStepIndex = isStepSynchronized ? onboardingWizardStore.currentStepIndex : initialStepIndex;
+    const isFirstStep = isStepSynchronized ? onboardingWizardStore.isFirstStep : true;
+    const { totalSteps, isSubmitting, next, back } = onboardingWizardStore;
     const headingRef = useRef<HTMLHeadingElement>(null);
     const previousStep = useRef(currentStep);
 
     useEffect(() => {
-      onboardingWizardStore.setInitialStep(profileCompleted ? 1 : 0);
-    }, [onboardingWizardStore, profileCompleted]);
+      onboardingWizardStore.setInitialStep(initialStepIndex);
+      setInitializedProfileCompleted(profileCompleted);
+    }, [initialStepIndex, onboardingWizardStore, profileCompleted]);
 
     useEffect(() => {
       if (previousStep.current !== currentStep) headingRef.current?.focus();

--- a/app/[locale]/(protected)/onboarding/wizard/components/step-profile.store.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/step-profile.store.ts
@@ -2,7 +2,7 @@ import type { FormEvent } from "react";
 import type { RegisterUserData } from "@/features/user/register/register-user.interactor";
 import type { RootStore } from "@/core/stores/root.store";
 
-import { action, makeObservable, toJS } from "mobx";
+import { action, makeObservable, observable, toJS } from "mobx";
 import { CountryCode } from "@/generated/prisma";
 
 import { registerProfileAction } from "../actions";
@@ -10,6 +10,8 @@ import { registerProfileAction } from "../actions";
 import { BaseFormStore } from "@/core/base/base-form.store";
 
 export class StepProfileStore extends BaseFormStore<RegisterUserData> {
+  onboardingIntent?: string;
+
   constructor(rootStore: RootStore) {
     super(rootStore, {
       firstName: "",
@@ -21,16 +23,22 @@ export class StepProfileStore extends BaseFormStore<RegisterUserData> {
     });
 
     makeObservable(this, {
+      onboardingIntent: observable,
       onSubmit: action,
+      setOnboardingIntent: action,
     });
   }
+
+  setOnboardingIntent = (onboardingIntent?: string) => {
+    this.onboardingIntent = onboardingIntent;
+  };
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await registerProfileAction(toJS(this.form));
+      const res = await registerProfileAction(toJS(this.form), this.onboardingIntent);
 
       if (!res.ok) this.setError(res.error);
       else this.setError(undefined);

--- a/app/[locale]/(protected)/onboarding/wizard/components/step-profile.store.ts
+++ b/app/[locale]/(protected)/onboarding/wizard/components/step-profile.store.ts
@@ -1,17 +1,15 @@
 import type { FormEvent } from "react";
-import type { RegisterUserData } from "@/features/user/register/register-user.interactor";
+import type { RegisterOnboardingProfileData } from "@/features/user/register/register-onboarding-profile.interactor";
 import type { RootStore } from "@/core/stores/root.store";
 
-import { action, makeObservable, observable, toJS } from "mobx";
+import { action, makeObservable, toJS } from "mobx";
 import { CountryCode } from "@/generated/prisma";
 
 import { registerProfileAction } from "../actions";
 
 import { BaseFormStore } from "@/core/base/base-form.store";
 
-export class StepProfileStore extends BaseFormStore<RegisterUserData> {
-  onboardingIntent?: string;
-
+export class StepProfileStore extends BaseFormStore<RegisterOnboardingProfileData> {
   constructor(rootStore: RootStore) {
     super(rootStore, {
       firstName: "",
@@ -20,25 +18,20 @@ export class StepProfileStore extends BaseFormStore<RegisterUserData> {
       avatarUrl: null,
       email: "",
       agreeToTerms: false,
+      onboardingIntent: undefined,
     });
 
     makeObservable(this, {
-      onboardingIntent: observable,
       onSubmit: action,
-      setOnboardingIntent: action,
     });
   }
-
-  setOnboardingIntent = (onboardingIntent?: string) => {
-    this.onboardingIntent = onboardingIntent;
-  };
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await registerProfileAction(toJS(this.form), this.onboardingIntent);
+      const res = await registerProfileAction(toJS(this.form));
 
       if (!res.ok) this.setError(res.error);
       else this.setError(undefined);

--- a/app/[locale]/(protected)/onboarding/wizard/components/step-profile.tsx
+++ b/app/[locale]/(protected)/onboarding/wizard/components/step-profile.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 
 import { observer } from "mobx-react-lite";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 
@@ -14,77 +14,93 @@ import { FormInput } from "@/components/forms/form-input";
 import { AppLink } from "@/components/shared/app-link";
 import { Button } from "@/components/ui/button";
 import { useRootStore } from "@/core/stores/root-store.provider";
+import { Alert } from "@/components/shared/alert";
 
 type Props = {
   email: string;
   firstName?: string;
   lastName?: string;
   avatarUrl?: string;
+  onboardingIntent?: string;
+  inviterName?: string;
   isInvited?: boolean;
 };
 
-export const StepProfile = observer(({ email, firstName, lastName, avatarUrl, isInvited = false }: Props) => {
-  const t = useTranslations();
-  const { stepProfileStore: store, appMode } = useRootStore();
-  const { isLoading } = store;
+export const StepProfile = observer(
+  ({ email, firstName, lastName, avatarUrl, onboardingIntent, inviterName, isInvited = false }: Props) => {
+    const t = useTranslations();
+    const { stepProfileStore: store, appMode } = useRootStore();
+    useState(() => {
+      store.onInitOrRefresh({ email, firstName, lastName, avatarUrl });
+      store.setOnboardingIntent(onboardingIntent);
+      store.setWithUnsavedChangesGuard(false);
+    });
+    const { isLoading } = store;
 
-  useEffect(
-    () => store.onInitOrRefresh({ email, firstName, lastName, avatarUrl }),
-    [email, firstName, lastName, avatarUrl],
-  );
+    useEffect(
+      () => store.onInitOrRefresh({ email, firstName, lastName, avatarUrl }),
+      [avatarUrl, email, firstName, lastName, store],
+    );
 
-  useEffect(() => {
-    store.setWithUnsavedChangesGuard(false);
-  }, []);
+    useEffect(() => {
+      store.setOnboardingIntent(onboardingIntent);
+    }, [onboardingIntent, store]);
 
-  const legalDocumentLinks = {
-    dataPrivacyLink: (chunks: ReactNode) => (
-      <AppLink inheritSize appearance="inline" href="/privacy" target="_blank">
-        {chunks}
-      </AppLink>
-    ),
-    dpaLink: (chunks: ReactNode) => (
-      <AppLink inheritSize appearance="inline" href="/dpa" target="_blank">
-        {chunks}
-      </AppLink>
-    ),
-    termsOfServiceLink: (chunks: ReactNode) => (
-      <AppLink inheritSize appearance="inline" href="/terms" target="_blank">
-        {chunks}
-      </AppLink>
-    ),
-  };
+    const legalDocumentLinks = {
+      dataPrivacyLink: (chunks: ReactNode) => (
+        <AppLink inheritSize appearance="inline" href="/privacy" target="_blank">
+          {chunks}
+        </AppLink>
+      ),
+      dpaLink: (chunks: ReactNode) => (
+        <AppLink inheritSize appearance="inline" href="/dpa" target="_blank">
+          {chunks}
+        </AppLink>
+      ),
+      termsOfServiceLink: (chunks: ReactNode) => (
+        <AppLink inheritSize appearance="inline" href="/terms" target="_blank">
+          {chunks}
+        </AppLink>
+      ),
+    };
 
-  return (
-    <AppForm store={store}>
-      <div className="flex flex-col gap-3">
-        <FormInput readOnly autoComplete="email" id="email" name="email" type="email" />
+    return (
+      <AppForm store={store}>
+        <div className="flex flex-col gap-3">
+          {isInvited && inviterName ? (
+            <Alert role="note">
+              <p className="text-x-sm">{t("OnboardingForm.invitationFrom", { inviterName })}</p>
+            </Alert>
+          ) : null}
 
-        <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
-          <FormInput required autoComplete="given-name" id="firstName" name="given-name" />
+          <FormInput readOnly autoComplete="email" id="email" name="email" type="email" />
 
-          <FormInput required autoComplete="family-name" id="lastName" name="family-name" />
+          <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
+            <FormInput required autoComplete="given-name" id="firstName" name="given-name" />
+
+            <FormInput required autoComplete="family-name" id="lastName" name="family-name" />
+          </div>
+
+          <FormAutocompleteCountry required id="country" />
+
+          {appMode === "cloud" ? (
+            <FormCheckbox
+              required
+              id="agreeToTerms"
+              label={t.rich(
+                isInvited ? "OnboardingForm.invitedAgreeToTerms" : "OnboardingForm.agreeToTerms",
+                legalDocumentLinks,
+              )}
+            />
+          ) : null}
+
+          <Button className="self-end mt-2" disabled={isLoading} type="submit">
+            {isLoading && <Loader2 className="size-4 animate-spin" />}
+
+            {t("OnboardingWizard.continue")}
+          </Button>
         </div>
-
-        <FormAutocompleteCountry required id="country" />
-
-        {appMode === "cloud" ? (
-          <FormCheckbox
-            required
-            id="agreeToTerms"
-            label={t.rich(
-              isInvited ? "OnboardingForm.invitedAgreeToTerms" : "OnboardingForm.agreeToTerms",
-              legalDocumentLinks,
-            )}
-          />
-        ) : null}
-
-        <Button className="self-end mt-2" disabled={isLoading} type="submit">
-          {isLoading && <Loader2 className="size-4 animate-spin" />}
-
-          {t("OnboardingWizard.continue")}
-        </Button>
-      </div>
-    </AppForm>
-  );
-});
+      </AppForm>
+    );
+  },
+);

--- a/app/[locale]/(protected)/onboarding/wizard/components/step-profile.tsx
+++ b/app/[locale]/(protected)/onboarding/wizard/components/step-profile.tsx
@@ -31,20 +31,15 @@ export const StepProfile = observer(
     const t = useTranslations();
     const { stepProfileStore: store, appMode } = useRootStore();
     useState(() => {
-      store.onInitOrRefresh({ email, firstName, lastName, avatarUrl });
-      store.setOnboardingIntent(onboardingIntent);
+      store.onInitOrRefresh({ email, firstName, lastName, avatarUrl, onboardingIntent });
       store.setWithUnsavedChangesGuard(false);
     });
     const { isLoading } = store;
 
     useEffect(
-      () => store.onInitOrRefresh({ email, firstName, lastName, avatarUrl }),
-      [avatarUrl, email, firstName, lastName, store],
+      () => store.onInitOrRefresh({ email, firstName, lastName, avatarUrl, onboardingIntent }),
+      [avatarUrl, email, firstName, lastName, onboardingIntent, store],
     );
-
-    useEffect(() => {
-      store.setOnboardingIntent(onboardingIntent);
-    }, [onboardingIntent, store]);
 
     const legalDocumentLinks = {
       dataPrivacyLink: (chunks: ReactNode) => (

--- a/app/[locale]/(protected)/onboarding/wizard/page.tsx
+++ b/app/[locale]/(protected)/onboarding/wizard/page.tsx
@@ -33,7 +33,7 @@ export default async function OnboardingWizardPage({ searchParams }: Props) {
 
   const invitation = effectiveIntent?.type === "invitation" ? effectiveIntent : null;
   const hasExplicitCreateIntent = effectiveIntent?.type === "createCompany";
-  const isInvited = Boolean(invitation || (!hasExplicitCreateIntent && sessionUser.companyId));
+  const isInvited = Boolean(!user && (invitation || (!hasExplicitCreateIntent && sessionUser.companyId)));
   const canCreateCompany = Boolean(
     effectiveIntent?.type === "createCompany" && effectiveIntent.authUserId === sessionUser.id,
   );

--- a/app/[locale]/(protected)/onboarding/wizard/page.tsx
+++ b/app/[locale]/(protected)/onboarding/wizard/page.tsx
@@ -1,28 +1,43 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
 
 import { OnboardingWizard } from "./components/onboarding-wizard";
 
-import { getInviteTokenValidationInteractor } from "@/core/di";
 import { requireAccountState } from "@/features/auth/next/require";
 import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { ONBOARDING_INTENT_QUERY_PARAM, onboardingIntentAuthRedirects } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
-export default async function OnboardingWizardPage() {
-  const resolution = await requireAccountState(["unregistered", "onboarding"]);
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function OnboardingWizardPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const onboardingIntent = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  if (onboardingIntent.status === "invalid" && onboardingIntent.source === "explicit")
+    redirect(buildLocalePath(await getLocale(), `/auth/error?type=${onboardingIntent.errorMessage}`));
+  const activeIntent = onboardingIntent.status === "valid" ? onboardingIntent : null;
+  const resolution = await requireAccountState(
+    ["unregistered", "onboarding"],
+    "/",
+    activeIntent ? onboardingIntentAuthRedirects(activeIntent.intent) : undefined,
+  );
   const { sessionUser, user } = resolution;
   if (!sessionUser) redirect("/auth/signin");
 
-  let isInvited = Boolean(sessionUser.companyId);
-  if (!user && !isInvited) {
-    const cookieStore = await cookies();
-    const inviteTokenValue = cookieStore.get("inviteToken")?.value;
-    if (inviteTokenValue) {
-      const validation = await getInviteTokenValidationInteractor().invoke({
-        token: inviteTokenValue,
-      });
-      isInvited = validation.ok && validation.data.valid;
-    }
-  }
+  const effectiveIntent = user ? null : activeIntent;
+  if (effectiveIntent?.type === "createCompany" && effectiveIntent.authUserId !== sessionUser.id)
+    redirect(buildLocalePath(await getLocale(), "/auth/error?type=invalidOnboardingIntent"));
+
+  const invitation = effectiveIntent?.type === "invitation" ? effectiveIntent : null;
+  const hasExplicitCreateIntent = effectiveIntent?.type === "createCompany";
+  const isInvited = Boolean(invitation || (!hasExplicitCreateIntent && sessionUser.companyId));
+  const canCreateCompany = Boolean(
+    effectiveIntent?.type === "createCompany" && effectiveIntent.authUserId === sessionUser.id,
+  );
+  if (!user && !isInvited && !canCreateCompany) redirect(buildLocalePath(await getLocale(), "/onboarding"));
 
   const sessionName = sessionUser.name ?? "";
   const isEmail = sessionName.includes("@");
@@ -38,7 +53,9 @@ export default async function OnboardingWizardPage() {
   return (
     <CenteredCardPage className="animate-page-result-in motion-reduce:animate-none">
       <OnboardingWizard
+        inviterName={invitation?.inviterName}
         isInvited={isInvited}
+        onboardingIntent={effectiveIntent?.intent}
         profileCompleted={Boolean(user)}
         sessionAvatarUrl={sessionAvatarUrl}
         sessionEmail={sessionUser.email}

--- a/app/[locale]/(protected)/services/actions.ts
+++ b/app/[locale]/(protected)/services/actions.ts
@@ -10,6 +10,7 @@ import {
   getGetServicesInteractor,
   getGetServiceByIdInteractor,
   getCreateServiceInteractor,
+  getCreateServiceByNameInteractor,
   getUpdateServiceInteractor,
   getDeleteServiceInteractor,
 } from "@/core/di";
@@ -38,15 +39,5 @@ export async function getServiceByIdAction(data: GetServiceByIdData) {
 }
 
 export async function createServiceByNameAction(name: string, userId: string | null | undefined) {
-  const result = await createServiceAction({
-    name,
-    amount: 100,
-    notes: null,
-    userIds: userId ? [userId] : [],
-    dealIds: [],
-    taskIds: [],
-    customFieldValues: [],
-  });
-
-  return result;
+  return serializeResult(getCreateServiceByNameInteractor().invoke({ name, userId }));
 }

--- a/app/[locale]/(public)/auth/__tests__/actions.test.ts
+++ b/app/[locale]/(public)/auth/__tests__/actions.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  decideMcp: vi.fn(),
+  requestPasswordReset: vi.fn(),
+  resendVerification: vi.fn(),
+  resetPassword: vi.fn(),
+  resolveOnboardingIntent: vi.fn(),
+  signIn: vi.fn(),
+  signUp: vi.fn(),
+  social: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
+vi.mock("@/core/di", () => ({
+  getContinueWithSocialsInteractor: () => ({ invoke: mocks.social }),
+  getDecideMcpConsentInteractor: () => ({ invoke: mocks.decideMcp }),
+  getRequestPasswordResetInteractor: () => ({ invoke: mocks.requestPasswordReset }),
+  getResendVerificationEmailInteractor: () => ({ invoke: mocks.resendVerification }),
+  getResetPasswordInteractor: () => ({ invoke: mocks.resetPassword }),
+  getSignInWithEmailInteractor: () => ({ invoke: mocks.signIn }),
+  getSignUpWithEmailInteractor: () => ({ invoke: mocks.signUp }),
+}));
+vi.mock("@/core/utils/action-result", () => ({
+  serializeResult: async (result: unknown) => await result,
+}));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
+}));
+
+import {
+  requestPasswordResetAction,
+  resendVerificationEmailFromAuthAction,
+  resetPasswordAction,
+  signUpWithEmailAction,
+} from "../actions";
+
+const invitation = {
+  companyId: "company-a",
+  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  intent: "signed.intent",
+  inviterName: "Invite Admin",
+  source: "explicit",
+  status: "valid",
+  token: "invite-a",
+  type: "invitation",
+} as const;
+const createIntent = {
+  authUserId: "auth-user-one",
+  intent: "signed.create",
+  source: "explicit",
+  status: "valid",
+  type: "createCompany",
+} as const;
+
+describe("authentication actions preserve onboarding intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveOnboardingIntent.mockResolvedValue(invitation);
+    mocks.requestPasswordReset.mockResolvedValue({ ok: true, data: null });
+    mocks.resendVerification.mockResolvedValue({ ok: true });
+    mocks.resetPassword.mockResolvedValue({ ok: true, data: null });
+    mocks.signUp.mockResolvedValue({ ok: true, data: null });
+  });
+
+  it.each([
+    [invitation, "signed.intent"],
+    [createIntent, "signed.create"],
+  ])("keeps a valid invitation or create choice in password reset", async (resolved, intent) => {
+    mocks.resolveOnboardingIntent.mockResolvedValue(resolved);
+    const data = { confirmEmail: "user@example.com", email: "user@example.com" };
+
+    await requestPasswordResetAction(data, intent);
+
+    expect(mocks.requestPasswordReset).toHaveBeenCalledWith(data, `/auth/reset-password?intent=${intent}`);
+  });
+
+  it("keeps the same intent through reset success and invalid-token recovery", async () => {
+    const data = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "reset-token" };
+
+    await resetPasswordAction(data, "signed.intent");
+
+    expect(mocks.resetPassword).toHaveBeenCalledWith(data, {
+      error: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
+      success: "/auth/signin?intent=signed.intent",
+    });
+  });
+
+  it.each([
+    [invitation, "/auth/invitation?intent=signed.intent"],
+    [createIntent, "/onboarding/wizard?intent=signed.create"],
+  ])("sends verification back to the exact onboarding destination", async (resolved, callbackURL) => {
+    mocks.resolveOnboardingIntent.mockResolvedValue(resolved);
+
+    await resendVerificationEmailFromAuthAction(resolved.intent);
+
+    expect(mocks.resendVerification).toHaveBeenCalledWith(callbackURL);
+  });
+
+  it("does not let an expired onboarding intent block account recovery", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      errorMessage: "onboardingSessionExpired",
+      source: "explicit",
+      status: "invalid",
+    });
+
+    const data = { confirmEmail: "a@b.co", email: "a@b.co" };
+    await requestPasswordResetAction(data, "expired");
+
+    expect(mocks.requestPasswordReset).toHaveBeenCalledWith(data);
+
+    const resetData = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "valid-reset" };
+    await resetPasswordAction(resetData, "expired");
+    expect(mocks.resetPassword).toHaveBeenCalledWith(resetData);
+  });
+
+  it("does not allow a create-company intent on the account-signup route", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue(createIntent);
+
+    await expect(
+      signUpWithEmailAction(
+        {
+          confirmEmail: "user@example.com",
+          confirmPassword: "ValidPass1!",
+          email: "user@example.com",
+          password: "ValidPass1!",
+        },
+        "signed.create",
+      ),
+    ).rejects.toThrow("REDIRECT:/en/auth/error?type=invalidOnboardingIntent");
+    expect(mocks.signUp).not.toHaveBeenCalled();
+  });
+});

--- a/app/[locale]/(public)/auth/__tests__/actions.test.ts
+++ b/app/[locale]/(public)/auth/__tests__/actions.test.ts
@@ -46,11 +46,12 @@ describe("authentication action adapters", () => {
       confirmPassword: "ValidPass1!",
       email: "user@example.com",
       password: "ValidPass1!",
+      onboardingIntent: "signed.intent",
     };
 
-    await signUpWithEmailAction(data, "signed.intent");
+    await signUpWithEmailAction(data);
 
-    expect(mocks.signUp).toHaveBeenCalledExactlyOnceWith(data, "signed.intent");
+    expect(mocks.signUp).toHaveBeenCalledExactlyOnceWith(data);
   });
 
   it("localizes a signup redirect returned by the interactor", async () => {
@@ -62,21 +63,26 @@ describe("authentication action adapters", () => {
     };
     mocks.signUp.mockResolvedValue({ redirect: "/auth/error?type=invalidOnboardingIntent" });
 
-    await signUpWithEmailAction(data, "invalid.intent");
+    await signUpWithEmailAction({ ...data, onboardingIntent: "invalid.intent" });
 
     expect(mocks.redirect).toHaveBeenCalledExactlyOnceWith("/en/auth/error?type=invalidOnboardingIntent");
   });
 
   it("passes password recovery data and onboarding intent to their interactors", async () => {
-    const request = { confirmEmail: "user@example.com", email: "user@example.com" };
-    const reset = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "reset-token" };
+    const request = { confirmEmail: "user@example.com", email: "user@example.com", onboardingIntent: "signed.intent" };
+    const reset = {
+      confirmPassword: "ValidPass1!",
+      password: "ValidPass1!",
+      token: "reset-token",
+      onboardingIntent: "signed.intent",
+    };
 
-    await requestPasswordResetAction(request, "signed.intent");
-    await resetPasswordAction(reset, "signed.intent");
+    await requestPasswordResetAction(request);
+    await resetPasswordAction(reset);
     await resendVerificationEmailFromAuthAction("signed.intent");
 
-    expect(mocks.requestPasswordReset).toHaveBeenCalledExactlyOnceWith(request, "signed.intent");
-    expect(mocks.resetPassword).toHaveBeenCalledExactlyOnceWith(reset, "signed.intent");
+    expect(mocks.requestPasswordReset).toHaveBeenCalledExactlyOnceWith(request);
+    expect(mocks.resetPassword).toHaveBeenCalledExactlyOnceWith(reset);
     expect(mocks.resendVerification).toHaveBeenCalledExactlyOnceWith("signed.intent");
   });
 });

--- a/app/[locale]/(public)/auth/__tests__/actions.test.ts
+++ b/app/[locale]/(public)/auth/__tests__/actions.test.ts
@@ -2,20 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   decideMcp: vi.fn(),
+  redirect: vi.fn(),
   requestPasswordReset: vi.fn(),
   resendVerification: vi.fn(),
   resetPassword: vi.fn(),
-  resolveOnboardingIntent: vi.fn(),
   signIn: vi.fn(),
   signUp: vi.fn(),
   social: vi.fn(),
 }));
 
-vi.mock("next/navigation", () => ({
-  redirect: (url: string) => {
-    throw new Error(`REDIRECT:${url}`);
-  },
-}));
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
 vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
 vi.mock("@/core/di", () => ({
   getContinueWithSocialsInteractor: () => ({ invoke: mocks.social }),
@@ -26,12 +22,7 @@ vi.mock("@/core/di", () => ({
   getSignInWithEmailInteractor: () => ({ invoke: mocks.signIn }),
   getSignUpWithEmailInteractor: () => ({ invoke: mocks.signUp }),
 }));
-vi.mock("@/core/utils/action-result", () => ({
-  serializeResult: async (result: unknown) => await result,
-}));
-vi.mock("@/features/company/next/onboarding-intent", () => ({
-  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
-}));
+vi.mock("@/core/utils/action-result", () => ({ serializeResult: async (result: unknown) => await result }));
 
 import {
   requestPasswordResetAction,
@@ -40,99 +31,52 @@ import {
   signUpWithEmailAction,
 } from "../actions";
 
-const invitation = {
-  companyId: "company-a",
-  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-  intent: "signed.intent",
-  inviterName: "Invite Admin",
-  source: "explicit",
-  status: "valid",
-  token: "invite-a",
-  type: "invitation",
-} as const;
-const createIntent = {
-  authUserId: "auth-user-one",
-  intent: "signed.create",
-  source: "explicit",
-  status: "valid",
-  type: "createCompany",
-} as const;
-
-describe("authentication actions preserve onboarding intent", () => {
+describe("authentication action adapters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveOnboardingIntent.mockResolvedValue(invitation);
     mocks.requestPasswordReset.mockResolvedValue({ ok: true, data: null });
     mocks.resendVerification.mockResolvedValue({ ok: true });
     mocks.resetPassword.mockResolvedValue({ ok: true, data: null });
     mocks.signUp.mockResolvedValue({ ok: true, data: null });
   });
 
-  it.each([
-    [invitation, "signed.intent"],
-    [createIntent, "signed.create"],
-  ])("keeps a valid invitation or create choice in password reset", async (resolved, intent) => {
-    mocks.resolveOnboardingIntent.mockResolvedValue(resolved);
-    const data = { confirmEmail: "user@example.com", email: "user@example.com" };
+  it("passes signup data and invitation intent to the interactor", async () => {
+    const data = {
+      confirmEmail: "user@example.com",
+      confirmPassword: "ValidPass1!",
+      email: "user@example.com",
+      password: "ValidPass1!",
+    };
 
-    await requestPasswordResetAction(data, intent);
+    await signUpWithEmailAction(data, "signed.intent");
 
-    expect(mocks.requestPasswordReset).toHaveBeenCalledWith(data, `/auth/reset-password?intent=${intent}`);
+    expect(mocks.signUp).toHaveBeenCalledExactlyOnceWith(data, "signed.intent");
   });
 
-  it("keeps the same intent through reset success and invalid-token recovery", async () => {
-    const data = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "reset-token" };
+  it("localizes a signup redirect returned by the interactor", async () => {
+    const data = {
+      confirmEmail: "user@example.com",
+      confirmPassword: "ValidPass1!",
+      email: "user@example.com",
+      password: "ValidPass1!",
+    };
+    mocks.signUp.mockResolvedValue({ redirect: "/auth/error?type=invalidOnboardingIntent" });
 
-    await resetPasswordAction(data, "signed.intent");
+    await signUpWithEmailAction(data, "invalid.intent");
 
-    expect(mocks.resetPassword).toHaveBeenCalledWith(data, {
-      error: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
-      success: "/auth/signin?intent=signed.intent",
-    });
+    expect(mocks.redirect).toHaveBeenCalledExactlyOnceWith("/en/auth/error?type=invalidOnboardingIntent");
   });
 
-  it.each([
-    [invitation, "/auth/invitation?intent=signed.intent"],
-    [createIntent, "/onboarding/wizard?intent=signed.create"],
-  ])("sends verification back to the exact onboarding destination", async (resolved, callbackURL) => {
-    mocks.resolveOnboardingIntent.mockResolvedValue(resolved);
+  it("passes password recovery data and onboarding intent to their interactors", async () => {
+    const request = { confirmEmail: "user@example.com", email: "user@example.com" };
+    const reset = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "reset-token" };
 
-    await resendVerificationEmailFromAuthAction(resolved.intent);
+    await requestPasswordResetAction(request, "signed.intent");
+    await resetPasswordAction(reset, "signed.intent");
+    await resendVerificationEmailFromAuthAction("signed.intent");
 
-    expect(mocks.resendVerification).toHaveBeenCalledWith(callbackURL);
-  });
-
-  it("does not let an expired onboarding intent block account recovery", async () => {
-    mocks.resolveOnboardingIntent.mockResolvedValue({
-      errorMessage: "onboardingSessionExpired",
-      source: "explicit",
-      status: "invalid",
-    });
-
-    const data = { confirmEmail: "a@b.co", email: "a@b.co" };
-    await requestPasswordResetAction(data, "expired");
-
-    expect(mocks.requestPasswordReset).toHaveBeenCalledWith(data);
-
-    const resetData = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "valid-reset" };
-    await resetPasswordAction(resetData, "expired");
-    expect(mocks.resetPassword).toHaveBeenCalledWith(resetData);
-  });
-
-  it("does not allow a create-company intent on the account-signup route", async () => {
-    mocks.resolveOnboardingIntent.mockResolvedValue(createIntent);
-
-    await expect(
-      signUpWithEmailAction(
-        {
-          confirmEmail: "user@example.com",
-          confirmPassword: "ValidPass1!",
-          email: "user@example.com",
-          password: "ValidPass1!",
-        },
-        "signed.create",
-      ),
-    ).rejects.toThrow("REDIRECT:/en/auth/error?type=invalidOnboardingIntent");
-    expect(mocks.signUp).not.toHaveBeenCalled();
+    expect(mocks.requestPasswordReset).toHaveBeenCalledExactlyOnceWith(request, "signed.intent");
+    expect(mocks.resetPassword).toHaveBeenCalledExactlyOnceWith(reset, "signed.intent");
+    expect(mocks.resendVerification).toHaveBeenCalledExactlyOnceWith("signed.intent");
   });
 });

--- a/app/[locale]/(public)/auth/actions.ts
+++ b/app/[locale]/(public)/auth/actions.ts
@@ -15,8 +15,14 @@ import {
   getResendVerificationEmailInteractor,
   getDecideMcpConsentInteractor,
 } from "@/core/di";
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
 import { serializeResult } from "@/core/utils/action-result";
 import { isRedirect } from "@/features/auth/auth-outcome";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function signInWithEmailAction(data: EmailSignInData) {
   const result = await getSignInWithEmailInteractor().invoke(data);
@@ -61,22 +67,62 @@ export async function continueWithMicrosoftAction(callbackURL?: string, errorCal
   return { ok: true as const, data: { url: null } };
 }
 
-export async function signUpWithEmailAction(data: EmailSignUpData) {
-  return serializeResult(getSignUpWithEmailInteractor().invoke(data));
+export async function signUpWithEmailAction(data: EmailSignUpData, invitationIntent?: string) {
+  if (!invitationIntent) return serializeResult(getSignUpWithEmailInteractor().invoke(data));
+
+  const invitation = await resolveOnboardingIntent(invitationIntent);
+  if (invitation.status !== "valid" || invitation.type !== "invitation") {
+    const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
+    return redirect(buildLocalePath(await getLocale(), `/auth/error?type=${errorMessage}`));
+  }
+
+  const callbackURL = pathWithOnboardingIntent("/auth/invitation", invitation.intent);
+  const result = await getSignUpWithEmailInteractor().invoke({ ...data, callbackURL });
+  if (isRedirect(result)) return redirect(buildLocalePath(await getLocale(), result.redirect));
+
+  return serializeResult(result);
 }
 
-export async function requestPasswordResetAction(data: RequestPasswordResetData) {
-  return serializeResult(getRequestPasswordResetInteractor().invoke(data));
+export async function requestPasswordResetAction(data: RequestPasswordResetData, onboardingIntentValue?: string) {
+  if (!onboardingIntentValue) return serializeResult(getRequestPasswordResetInteractor().invoke(data));
+
+  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
+  if (onboardingIntent.status !== "valid") return serializeResult(getRequestPasswordResetInteractor().invoke(data));
+
+  return serializeResult(
+    getRequestPasswordResetInteractor().invoke(
+      data,
+      pathWithOnboardingIntent("/auth/reset-password", onboardingIntent.intent),
+    ),
+  );
 }
 
-export async function resetPasswordAction(data: ResetPasswordData) {
-  return serializeResult(getResetPasswordInteractor().invoke(data));
+export async function resetPasswordAction(data: ResetPasswordData, onboardingIntentValue?: string) {
+  if (!onboardingIntentValue) return serializeResult(getResetPasswordInteractor().invoke(data));
+
+  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
+  if (onboardingIntent.status !== "valid") return serializeResult(getResetPasswordInteractor().invoke(data));
+
+  return serializeResult(
+    getResetPasswordInteractor().invoke(data, {
+      error: pathWithOnboardingIntent("/auth/forgot-password?info=RESET_LINK_INVALID", onboardingIntent.intent),
+      success: pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent),
+    }),
+  );
 }
 
-export async function resendVerificationEmailFromAuthAction(): Promise<{
+export async function resendVerificationEmailFromAuthAction(onboardingIntentValue?: string): Promise<{
   ok: boolean;
 }> {
-  return await getResendVerificationEmailInteractor().invoke();
+  if (!onboardingIntentValue) return await getResendVerificationEmailInteractor().invoke();
+
+  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
+  if (onboardingIntent.status !== "valid") return await getResendVerificationEmailInteractor().invoke();
+
+  const destination = onboardingIntent.type === "invitation" ? "/auth/invitation" : "/onboarding/wizard";
+  return await getResendVerificationEmailInteractor().invoke(
+    pathWithOnboardingIntent(destination, onboardingIntent.intent),
+  );
 }
 
 export async function decideMcpConsentAction(data: DecideMcpConsentData) {

--- a/app/[locale]/(public)/auth/actions.ts
+++ b/app/[locale]/(public)/auth/actions.ts
@@ -65,19 +65,19 @@ export async function continueWithMicrosoftAction(callbackURL?: string, errorCal
   return { ok: true as const, data: { url: null } };
 }
 
-export async function signUpWithEmailAction(data: EmailSignUpData, invitationIntent?: string) {
-  const result = await getSignUpWithEmailInteractor().invoke(data, invitationIntent);
+export async function signUpWithEmailAction(data: EmailSignUpData) {
+  const result = await getSignUpWithEmailInteractor().invoke(data);
   if (isRedirect(result)) redirect(buildLocalePath(await getLocale(), result.redirect));
 
   return serializeResult(result);
 }
 
-export async function requestPasswordResetAction(data: RequestPasswordResetData, onboardingIntentValue?: string) {
-  return serializeResult(getRequestPasswordResetInteractor().invoke(data, onboardingIntentValue));
+export async function requestPasswordResetAction(data: RequestPasswordResetData) {
+  return serializeResult(getRequestPasswordResetInteractor().invoke(data));
 }
 
-export async function resetPasswordAction(data: ResetPasswordData, onboardingIntentValue?: string) {
-  return serializeResult(getResetPasswordInteractor().invoke(data, onboardingIntentValue));
+export async function resetPasswordAction(data: ResetPasswordData) {
+  return serializeResult(getResetPasswordInteractor().invoke(data));
 }
 
 export async function resendVerificationEmailFromAuthAction(onboardingIntentValue?: string): Promise<{

--- a/app/[locale]/(public)/auth/actions.ts
+++ b/app/[locale]/(public)/auth/actions.ts
@@ -20,8 +20,6 @@ import { getLocale } from "next-intl/server";
 
 import { serializeResult } from "@/core/utils/action-result";
 import { isRedirect } from "@/features/auth/auth-outcome";
-import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
-import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
 import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function signInWithEmailAction(data: EmailSignInData) {
@@ -68,61 +66,24 @@ export async function continueWithMicrosoftAction(callbackURL?: string, errorCal
 }
 
 export async function signUpWithEmailAction(data: EmailSignUpData, invitationIntent?: string) {
-  if (!invitationIntent) return serializeResult(getSignUpWithEmailInteractor().invoke(data));
-
-  const invitation = await resolveOnboardingIntent(invitationIntent);
-  if (invitation.status !== "valid" || invitation.type !== "invitation") {
-    const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
-    return redirect(buildLocalePath(await getLocale(), `/auth/error?type=${errorMessage}`));
-  }
-
-  const callbackURL = pathWithOnboardingIntent("/auth/invitation", invitation.intent);
-  const result = await getSignUpWithEmailInteractor().invoke({ ...data, callbackURL });
-  if (isRedirect(result)) return redirect(buildLocalePath(await getLocale(), result.redirect));
+  const result = await getSignUpWithEmailInteractor().invoke(data, invitationIntent);
+  if (isRedirect(result)) redirect(buildLocalePath(await getLocale(), result.redirect));
 
   return serializeResult(result);
 }
 
 export async function requestPasswordResetAction(data: RequestPasswordResetData, onboardingIntentValue?: string) {
-  if (!onboardingIntentValue) return serializeResult(getRequestPasswordResetInteractor().invoke(data));
-
-  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
-  if (onboardingIntent.status !== "valid") return serializeResult(getRequestPasswordResetInteractor().invoke(data));
-
-  return serializeResult(
-    getRequestPasswordResetInteractor().invoke(
-      data,
-      pathWithOnboardingIntent("/auth/reset-password", onboardingIntent.intent),
-    ),
-  );
+  return serializeResult(getRequestPasswordResetInteractor().invoke(data, onboardingIntentValue));
 }
 
 export async function resetPasswordAction(data: ResetPasswordData, onboardingIntentValue?: string) {
-  if (!onboardingIntentValue) return serializeResult(getResetPasswordInteractor().invoke(data));
-
-  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
-  if (onboardingIntent.status !== "valid") return serializeResult(getResetPasswordInteractor().invoke(data));
-
-  return serializeResult(
-    getResetPasswordInteractor().invoke(data, {
-      error: pathWithOnboardingIntent("/auth/forgot-password?info=RESET_LINK_INVALID", onboardingIntent.intent),
-      success: pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent),
-    }),
-  );
+  return serializeResult(getResetPasswordInteractor().invoke(data, onboardingIntentValue));
 }
 
 export async function resendVerificationEmailFromAuthAction(onboardingIntentValue?: string): Promise<{
   ok: boolean;
 }> {
-  if (!onboardingIntentValue) return await getResendVerificationEmailInteractor().invoke();
-
-  const onboardingIntent = await resolveOnboardingIntent(onboardingIntentValue);
-  if (onboardingIntent.status !== "valid") return await getResendVerificationEmailInteractor().invoke();
-
-  const destination = onboardingIntent.type === "invitation" ? "/auth/invitation" : "/onboarding/wizard";
-  return await getResendVerificationEmailInteractor().invoke(
-    pathWithOnboardingIntent(destination, onboardingIntent.intent),
-  );
+  return await getResendVerificationEmailInteractor().invoke(onboardingIntentValue);
 }
 
 export async function decideMcpConsentAction(data: DecideMcpConsentData) {

--- a/app/[locale]/(public)/auth/error/__tests__/page.test.ts
+++ b/app/[locale]/(public)/auth/error/__tests__/page.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAccountState: vi.fn(),
+  resolveAccountState: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
+vi.mock("@/features/auth/next/require", () => ({
+  requireAccountState: mocks.requireAccountState,
+}));
+vi.mock("@/features/auth/next/resolve-account-state", () => ({
+  resolveRequestAccountState: mocks.resolveAccountState,
+}));
+vi.mock("../error-page-content", () => ({ ErrorPageContent: "error-page-content" }));
+
+import ErrorPage from "../page";
+
+describe("ErrorPage restricted account handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveAccountState.mockResolvedValue({ state: "pending" });
+  });
+
+  it.each(["invalidInviteLink", "invalidOnboardingIntent", "inviteLinkExpired", "onboardingSessionExpired"])(
+    "lets a restricted user see the %s onboarding error",
+    async (errorKey) => {
+      const result = await ErrorPage({ searchParams: Promise.resolve({ type: errorKey }) });
+
+      expect(mocks.requireAccountState).not.toHaveBeenCalled();
+      expect(result.props).toMatchObject({ errorKey, isInactive: false });
+    },
+  );
+
+  it("keeps the inactive-account error canonical", async () => {
+    mocks.resolveAccountState.mockResolvedValue({ state: "inactive" });
+
+    await expect(ErrorPage({ searchParams: Promise.resolve({ type: "inviteLinkExpired" }) })).rejects.toThrow(
+      "REDIRECT:/en/auth/error?type=inactiveUser",
+    );
+  });
+});

--- a/app/[locale]/(public)/auth/error/error-page-content.tsx
+++ b/app/[locale]/(public)/auth/error/error-page-content.tsx
@@ -4,7 +4,12 @@ import { useTranslations } from "next-intl";
 
 import { ErrorPageView } from "@/components/shared/error-page-view";
 
-export type ErrorPageKey = "inactiveUser" | "invalidInviteLink" | "inviteLinkExpired";
+export type ErrorPageKey =
+  | "inactiveUser"
+  | "invalidInviteLink"
+  | "invalidOnboardingIntent"
+  | "inviteLinkExpired"
+  | "onboardingSessionExpired";
 
 export function ErrorPageContent({ errorKey, isInactive }: { errorKey: ErrorPageKey | null; isInactive: boolean }) {
   const t = useTranslations();

--- a/app/[locale]/(public)/auth/error/page.tsx
+++ b/app/[locale]/(public)/auth/error/page.tsx
@@ -13,7 +13,12 @@ import { NOINDEX_METADATA } from "@/core/seo/noindex-metadata";
 
 export const metadata = NOINDEX_METADATA;
 
-const ERROR_KEYS = new Set<ErrorPageKey>(["invalidInviteLink", "inviteLinkExpired"]);
+const ERROR_KEYS = new Set<ErrorPageKey>([
+  "invalidInviteLink",
+  "invalidOnboardingIntent",
+  "inviteLinkExpired",
+  "onboardingSessionExpired",
+]);
 
 type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -24,18 +29,19 @@ export default async function ErrorPage({ searchParams }: Props) {
   const requestedErrorKey = typeof params.type === "string" ? params.type : null;
   const resolution = await resolveRequestAccountState();
   const isInactive = resolution.state === "inactive";
+  const isOnboardingError = Boolean(requestedErrorKey && ERROR_KEYS.has(requestedErrorKey as ErrorPageKey));
 
   if (isInactive && !isCanonicalInactiveErrorType(params.type))
     redirect(buildLocalePath(await getLocale(), "/auth/error?type=inactiveUser"));
 
-  if (!isInactive && (requestedErrorKey === "inactiveUser" || isRestrictedAccountState(resolution.state)))
+  if (
+    !isInactive &&
+    !isOnboardingError &&
+    (requestedErrorKey === "inactiveUser" || isRestrictedAccountState(resolution.state))
+  )
     await requireAccountState("inactive");
 
-  const errorKey = isInactive
-    ? "inactiveUser"
-    : requestedErrorKey && ERROR_KEYS.has(requestedErrorKey as ErrorPageKey)
-      ? (requestedErrorKey as ErrorPageKey)
-      : null;
+  const errorKey = isInactive ? "inactiveUser" : isOnboardingError ? (requestedErrorKey as ErrorPageKey) : null;
 
   return <ErrorPageContent errorKey={errorKey} isInactive={isInactive} />;
 }

--- a/app/[locale]/(public)/auth/forgot-password/__tests__/forgot-password.store.test.ts
+++ b/app/[locale]/(public)/auth/forgot-password/__tests__/forgot-password.store.test.ts
@@ -19,17 +19,41 @@ describe("ForgotPasswordStore", () => {
     actions.requestPasswordResetAction.mockResolvedValue({ ok: true, data: null });
   });
 
+  it("refreshes, resets and clears intent within the submitted form snapshot", async () => {
+    actions.requestPasswordResetAction.mockResolvedValue({ ok: true, data: null });
+    const store = new ForgotPasswordStore(rootStore);
+    store.onInitOrRefresh({ onboardingIntent: "invite-a" });
+    store.onChange("email", "invited@example.com");
+    store.onInitOrRefresh({ onboardingIntent: "invite-b" });
+    store.onChange("onboardingIntent", "unsaved-intent");
+    store.resetForm();
+
+    await store.onSubmit();
+
+    expect(actions.requestPasswordResetAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ email: "invited@example.com", onboardingIntent: "invite-b" }),
+    );
+    store.onInitOrRefresh({ onboardingIntent: undefined });
+    await store.onSubmit();
+
+    expect(actions.requestPasswordResetAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ email: "invited@example.com", onboardingIntent: undefined }),
+    );
+    expect(store.savedState.onboardingIntent).toBeUndefined();
+  });
+
   it("submits the active onboarding intent with the email", async () => {
     const store = new ForgotPasswordStore(rootStore);
     store.onChange("email", "invited@example.com");
     store.onChange("confirmEmail", "invited@example.com");
-    store.setOnboardingIntent("signed.intent");
+    store.onInitOrRefresh({ onboardingIntent: "signed.intent" });
 
     await store.onSubmit();
 
-    expect(actions.requestPasswordResetAction).toHaveBeenCalledWith(
-      { confirmEmail: "invited@example.com", email: "invited@example.com" },
-      "signed.intent",
-    );
+    expect(actions.requestPasswordResetAction).toHaveBeenCalledWith({
+      confirmEmail: "invited@example.com",
+      email: "invited@example.com",
+      onboardingIntent: "signed.intent",
+    });
   });
 });

--- a/app/[locale]/(public)/auth/forgot-password/__tests__/forgot-password.store.test.ts
+++ b/app/[locale]/(public)/auth/forgot-password/__tests__/forgot-password.store.test.ts
@@ -1,0 +1,35 @@
+import type { RootStore } from "@/core/stores/root.store";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const actions = vi.hoisted(() => ({ requestPasswordResetAction: vi.fn() }));
+
+vi.mock("@/app/[locale]/(public)/auth/actions", () => actions);
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { ForgotPasswordStore } from "../forgot-password.store";
+
+const rootStore = {
+  localeStore: { getTranslation: (key: string) => key },
+} as unknown as RootStore;
+
+describe("ForgotPasswordStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actions.requestPasswordResetAction.mockResolvedValue({ ok: true, data: null });
+  });
+
+  it("submits the active onboarding intent with the email", async () => {
+    const store = new ForgotPasswordStore(rootStore);
+    store.onChange("email", "invited@example.com");
+    store.onChange("confirmEmail", "invited@example.com");
+    store.setOnboardingIntent("signed.intent");
+
+    await store.onSubmit();
+
+    expect(actions.requestPasswordResetAction).toHaveBeenCalledWith(
+      { confirmEmail: "invited@example.com", email: "invited@example.com" },
+      "signed.intent",
+    );
+  });
+});

--- a/app/[locale]/(public)/auth/forgot-password/forgot-password-form.tsx
+++ b/app/[locale]/(public)/auth/forgot-password/forgot-password-form.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { observer } from "mobx-react-lite";
 import { Button } from "@/components/ui/button";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { AppForm } from "@/components/forms/form-context";
 import { FormInput } from "@/components/forms/form-input";
@@ -16,27 +16,42 @@ import { Alert } from "@/components/shared/alert";
 import { AppCardFooter } from "@/components/card/app-card-footer";
 import { CardHeroHeader } from "@/components/card/card-hero-header";
 import { Reveal } from "@/components/shared/reveal";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
-export const ForgotPasswordForm = observer(() => {
+type Props = {
+  inviterName?: string;
+  onboardingIntent?: string;
+};
+
+export const ForgotPasswordForm = observer(({ inviterName, onboardingIntent }: Props) => {
   const t = useTranslations();
 
   const searchParams = useSearchParams();
   const info = searchParams.get("info");
 
   const { forgotPasswordStore } = useRootStore();
+  useState(() => {
+    forgotPasswordStore.setOnboardingIntent(onboardingIntent);
+    forgotPasswordStore.setWithUnsavedChangesGuard(false);
+  });
   const { form, isLoading } = forgotPasswordStore;
 
   useEffect(() => {
-    forgotPasswordStore.setWithUnsavedChangesGuard(false);
-  }, []);
+    forgotPasswordStore.setOnboardingIntent(onboardingIntent);
+  }, [forgotPasswordStore, onboardingIntent]);
 
   return (
     <AppForm store={forgotPasswordStore}>
       <AppCard className="max-w-md">
         <CardHeroHeader
+          alt=""
           subtitle={t.rich("ForgotPasswordForm.backToSignIn", {
             backToSignInLink: (chunks) => (
-              <AppLink inheritSize appearance="inline" href="/auth/signin">
+              <AppLink
+                inheritSize
+                appearance="inline"
+                href={onboardingIntent ? pathWithOnboardingIntent("/auth/signin", onboardingIntent) : "/auth/signin"}
+              >
                 {chunks}
               </AppLink>
             ),
@@ -45,6 +60,12 @@ export const ForgotPasswordForm = observer(() => {
         />
 
         <AppCardBody>
+          {inviterName ? (
+            <Alert className="mb-4" role="note">
+              <p className="text-x-sm">{t("InvitationCard.inviter", { inviterName })}</p>
+            </Alert>
+          ) : null}
+
           {info === "RESET_LINK_INVALID" && (
             <Alert className="mb-4" color="warning">
               <p className="text-x-sm">{t("ForgotPasswordForm.resetLinkInvalid")}</p>

--- a/app/[locale]/(public)/auth/forgot-password/forgot-password-form.tsx
+++ b/app/[locale]/(public)/auth/forgot-password/forgot-password-form.tsx
@@ -31,13 +31,14 @@ export const ForgotPasswordForm = observer(({ inviterName, onboardingIntent }: P
 
   const { forgotPasswordStore } = useRootStore();
   useState(() => {
-    forgotPasswordStore.setOnboardingIntent(onboardingIntent);
+    forgotPasswordStore.onInitOrRefresh({ onboardingIntent });
     forgotPasswordStore.setWithUnsavedChangesGuard(false);
   });
   const { form, isLoading } = forgotPasswordStore;
 
   useEffect(() => {
-    forgotPasswordStore.setOnboardingIntent(onboardingIntent);
+    if (forgotPasswordStore.form.onboardingIntent !== onboardingIntent)
+      forgotPasswordStore.onInitOrRefresh({ onboardingIntent });
   }, [forgotPasswordStore, onboardingIntent]);
 
   return (

--- a/app/[locale]/(public)/auth/forgot-password/forgot-password.store.tsx
+++ b/app/[locale]/(public)/auth/forgot-password/forgot-password.store.tsx
@@ -2,26 +2,34 @@ import type { FormEvent } from "react";
 import type { RootStore } from "@/core/stores/root.store";
 import type { RequestPasswordResetData } from "@/features/auth/request-password-reset.interactor";
 
-import { action, makeObservable, toJS } from "mobx";
+import { action, makeObservable, observable, toJS } from "mobx";
 
 import { BaseFormStore } from "@/core/base/base-form.store";
 import { requestPasswordResetAction } from "@/app/[locale]/(public)/auth/actions";
 
 export class ForgotPasswordStore extends BaseFormStore<RequestPasswordResetData> {
+  onboardingIntent?: string;
+
   constructor(rootStore: RootStore) {
     super(rootStore, { email: "", confirmEmail: "" });
 
     makeObservable(this, {
+      onboardingIntent: observable,
       onSubmit: action,
+      setOnboardingIntent: action,
     });
   }
+
+  setOnboardingIntent = (onboardingIntent?: string) => {
+    this.onboardingIntent = onboardingIntent;
+  };
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await requestPasswordResetAction(toJS(this.form));
+      const res = await requestPasswordResetAction(toJS(this.form), this.onboardingIntent);
       if (res.ok) this.toastSuccess("ForgotPasswordForm.resetLinkSent");
       else this.setError(res.error);
     } finally {

--- a/app/[locale]/(public)/auth/forgot-password/forgot-password.store.tsx
+++ b/app/[locale]/(public)/auth/forgot-password/forgot-password.store.tsx
@@ -2,34 +2,26 @@ import type { FormEvent } from "react";
 import type { RootStore } from "@/core/stores/root.store";
 import type { RequestPasswordResetData } from "@/features/auth/request-password-reset.interactor";
 
-import { action, makeObservable, observable, toJS } from "mobx";
+import { action, makeObservable, toJS } from "mobx";
 
 import { BaseFormStore } from "@/core/base/base-form.store";
 import { requestPasswordResetAction } from "@/app/[locale]/(public)/auth/actions";
 
 export class ForgotPasswordStore extends BaseFormStore<RequestPasswordResetData> {
-  onboardingIntent?: string;
-
   constructor(rootStore: RootStore) {
-    super(rootStore, { email: "", confirmEmail: "" });
+    super(rootStore, { email: "", confirmEmail: "", onboardingIntent: undefined });
 
     makeObservable(this, {
-      onboardingIntent: observable,
       onSubmit: action,
-      setOnboardingIntent: action,
     });
   }
-
-  setOnboardingIntent = (onboardingIntent?: string) => {
-    this.onboardingIntent = onboardingIntent;
-  };
 
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await requestPasswordResetAction(toJS(this.form), this.onboardingIntent);
+      const res = await requestPasswordResetAction(toJS(this.form));
       if (res.ok) this.toastSuccess("ForgotPasswordForm.resetLinkSent");
       else this.setError(res.error);
     } finally {

--- a/app/[locale]/(public)/auth/forgot-password/page.tsx
+++ b/app/[locale]/(public)/auth/forgot-password/page.tsx
@@ -1,22 +1,56 @@
 import type { Metadata } from "next";
 
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
 import { ForgotPasswordForm } from "./forgot-password-form";
 
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { requireUnauthenticated } from "@/features/auth/next/require";
+import { resolveRequestAccountState } from "@/features/auth/next/resolve-account-state";
 import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { ONBOARDING_INTENT_QUERY_PARAM, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   return generateMetadataFromMeta({ locale, route: "/auth/forgot-password" });
 }
 
-export default async function ForgotPasswordPage() {
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function ForgotPasswordPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const onboardingIntent = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  const activeIntent = onboardingIntent.status === "valid" ? onboardingIntent : null;
+  const invitation =
+    onboardingIntent.status === "valid" && onboardingIntent.type === "invitation" ? onboardingIntent : null;
+  if (activeIntent) {
+    const resolution = await resolveRequestAccountState();
+    if (resolution.sessionUser) {
+      if (activeIntent.type === "createCompany" && activeIntent.authUserId !== resolution.sessionUser.id)
+        redirect(buildLocalePath(await getLocale(), "/auth/error?type=invalidOnboardingIntent"));
+
+      redirect(
+        buildLocalePath(
+          await getLocale(),
+          pathWithOnboardingIntent(
+            activeIntent.type === "invitation" ? "/auth/invitation" : "/onboarding/wizard",
+            activeIntent.intent,
+          ),
+        ),
+      );
+    }
+  }
+
   await requireUnauthenticated();
 
   return (
     <CenteredCardPage>
-      <ForgotPasswordForm />
+      <ForgotPasswordForm inviterName={invitation?.inviterName} onboardingIntent={activeIntent?.intent} />
     </CenteredCardPage>
   );
 }

--- a/app/[locale]/(public)/auth/invitation/__tests__/page.test.ts
+++ b/app/[locale]/(public)/auth/invitation/__tests__/page.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  resolveAccountState: vi.fn(),
+  resolveOnboardingIntent: vi.fn(),
+}));
+
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("@/components/shared/centered-card-page", () => ({ CenteredCardPage: () => null }));
+vi.mock("@/features/auth/next/resolve-account-state", () => ({
+  resolveRequestAccountState: mocks.resolveAccountState,
+}));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
+}));
+vi.mock("../invitation-card", () => ({ InvitationCard: () => null }));
+
+import InvitationPage from "../page";
+
+describe("InvitationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      companyId: "invited-company",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      intent: "signed-intent",
+      inviterName: "Invite Admin",
+      source: "explicit",
+      status: "valid",
+      token: "invite-token",
+      type: "invitation",
+    });
+  });
+
+  it("sends an overdue unverified identity without a tenant user through verification", async () => {
+    mocks.resolveAccountState.mockResolvedValue({
+      state: "overdueVerification",
+      sessionUser: { email: "invited@example.com" },
+      user: null,
+    });
+
+    await InvitationPage({ searchParams: Promise.resolve({ intent: "signed-intent" }) });
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/en/auth/verify-email?intent=signed-intent");
+  });
+
+  it("keeps the invitation decision for an overdue identity that already has a tenant user", async () => {
+    mocks.resolveAccountState.mockResolvedValue({
+      state: "overdueVerification",
+      sessionUser: { email: "member@example.com" },
+      user: { id: "tenant-user" },
+    });
+
+    await InvitationPage({ searchParams: Promise.resolve({ intent: "signed-intent" }) });
+
+    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/app/[locale]/(public)/auth/invitation/invitation-card.tsx
+++ b/app/[locale]/(public)/auth/invitation/invitation-card.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { LogOut } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { AppCard } from "@/components/card/app-card";
+import { AppCardBody } from "@/components/card/app-card-body";
+import { AppCardFooter } from "@/components/card/app-card-footer";
+import { CardHeroHeader } from "@/components/card/card-hero-header";
+import { Button } from "@/components/ui/button";
+import { IntlLink } from "@/i18n/navigation";
+import { runUserAction } from "@/core/errors/report-application-error";
+import { signOutForInvitationAction } from "@/app/[locale]/actions";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+
+type Props = {
+  canJoin: boolean;
+  email: string;
+  invitationIntent: string;
+  inviterName: string;
+};
+
+export function InvitationCard({ canJoin, email, invitationIntent, inviterName }: Props) {
+  const t = useTranslations();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  async function handleSignOut() {
+    if (isSigningOut) return;
+    setIsSigningOut(true);
+    try {
+      await signOutForInvitationAction(invitationIntent);
+    } catch (error) {
+      setIsSigningOut(false);
+      throw error;
+    }
+  }
+
+  const signOutButton = (
+    <Button
+      className="w-full"
+      disabled={isSigningOut}
+      variant={canJoin ? "ghost" : "default"}
+      onClick={() => runUserAction(handleSignOut)}
+    >
+      <LogOut aria-hidden className="size-4" />
+
+      {t("UserAvatar.signOut")}
+    </Button>
+  );
+
+  if (!canJoin) {
+    return (
+      <AppCard className="max-w-md">
+        <CardHeroHeader
+          alt=""
+          subtitle={t("InvitationCard.switchSubtitle", { email })}
+          title={t("InvitationCard.switchTitle")}
+        />
+
+        <AppCardBody>
+          <p className="text-center text-sm font-medium [overflow-wrap:anywhere]">
+            {t("InvitationCard.inviter", { inviterName })}
+          </p>
+
+          <p className="text-x-sm text-center">{t("InvitationCard.switchBody")}</p>
+        </AppCardBody>
+
+        <AppCardFooter>{signOutButton}</AppCardFooter>
+      </AppCard>
+    );
+  }
+
+  return (
+    <AppCard className="max-w-md">
+      <CardHeroHeader
+        alt=""
+        subtitle={t("InvitationCard.joinSubtitle", { email })}
+        title={t("InvitationCard.joinTitle")}
+      />
+
+      <AppCardBody>
+        <p className="text-center text-sm font-medium [overflow-wrap:anywhere]">
+          {t("InvitationCard.inviter", { inviterName })}
+        </p>
+
+        <p className="text-x-sm text-center">{t("InvitationCard.joinBody")}</p>
+      </AppCardBody>
+
+      <AppCardFooter className="flex-col gap-2">
+        <Button asChild className="w-full">
+          <IntlLink href={pathWithOnboardingIntent("/onboarding/wizard", invitationIntent)}>
+            {t("InvitationCard.joinAction")}
+          </IntlLink>
+        </Button>
+
+        {signOutButton}
+      </AppCardFooter>
+    </AppCard>
+  );
+}

--- a/app/[locale]/(public)/auth/invitation/invitation-card.tsx
+++ b/app/[locale]/(public)/auth/invitation/invitation-card.tsx
@@ -11,7 +11,7 @@ import { CardHeroHeader } from "@/components/card/card-hero-header";
 import { Button } from "@/components/ui/button";
 import { IntlLink } from "@/i18n/navigation";
 import { runUserAction } from "@/core/errors/report-application-error";
-import { signOutForInvitationAction } from "@/app/[locale]/actions";
+import { signOutWithOnboardingIntentAction } from "@/app/[locale]/actions";
 import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 type Props = {
@@ -29,7 +29,7 @@ export function InvitationCard({ canJoin, email, invitationIntent, inviterName }
     if (isSigningOut) return;
     setIsSigningOut(true);
     try {
-      await signOutForInvitationAction(invitationIntent);
+      await signOutWithOnboardingIntentAction(invitationIntent);
     } catch (error) {
       setIsSigningOut(false);
       throw error;

--- a/app/[locale]/(public)/auth/invitation/page.tsx
+++ b/app/[locale]/(public)/auth/invitation/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
+import { InvitationCard } from "./invitation-card";
+
+import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { NOINDEX_METADATA } from "@/core/seo/noindex-metadata";
+import { ONBOARDING_INTENT_QUERY_PARAM, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { resolveRequestAccountState } from "@/features/auth/next/resolve-account-state";
+import { buildLocalePath } from "@/i18n/locale-registry";
+
+export const metadata = NOINDEX_METADATA;
+
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function InvitationPage({ searchParams }: Props) {
+  const locale = await getLocale();
+  const params = await searchParams;
+  const invitation = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  if (invitation.status !== "valid" || invitation.type !== "invitation") {
+    const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
+    redirect(buildLocalePath(locale, `/auth/error?type=${errorMessage}`));
+  }
+
+  const resolution = await resolveRequestAccountState();
+  if (!resolution.sessionUser) {
+    redirect(
+      buildLocalePath(locale, `/auth/signup?${ONBOARDING_INTENT_QUERY_PARAM}=${encodeURIComponent(invitation.intent)}`),
+    );
+  }
+  if (resolution.state === "overdueVerification" && !resolution.user)
+    redirect(buildLocalePath(locale, pathWithOnboardingIntent("/auth/verify-email", invitation.intent)));
+
+  return (
+    <CenteredCardPage>
+      <InvitationCard
+        canJoin={resolution.state === "unregistered"}
+        email={resolution.sessionUser.email}
+        invitationIntent={invitation.intent}
+        inviterName={invitation.inviterName}
+      />
+    </CenteredCardPage>
+  );
+}

--- a/app/[locale]/(public)/auth/reset-password/__tests__/reset-password-form.test.ts
+++ b/app/[locale]/(public)/auth/reset-password/__tests__/reset-password-form.test.ts
@@ -1,0 +1,177 @@
+import type { Context, ReactNode } from "react";
+import type { Root } from "react-dom/client";
+import type { RootStore } from "@/core/stores/root.store";
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  rootStore: undefined as RootStore | undefined,
+  searchContext: undefined as Context<string> | undefined,
+  token: "reset-a",
+  resetPasswordAction: vi.fn(),
+}));
+
+vi.mock("../../actions", () => ({ resetPasswordAction: harness.resetPasswordAction }));
+vi.mock("next/navigation", async () => {
+  const { createContext, useContext } = await import("react");
+  const searchContext = createContext("");
+  harness.searchContext = searchContext;
+  return { useSearchParams: () => new URLSearchParams({ token: useContext(searchContext) }) };
+});
+vi.mock("next-intl", () => ({
+  useTranslations: () =>
+    Object.assign((key: string) => key, {
+      rich: (key: string, values: { backToSignInLink: (children: ReactNode) => ReactNode }) =>
+        values.backToSignInLink(key),
+    }),
+}));
+vi.mock("@/core/stores/root-store.provider", () => ({ useRootStore: () => harness.rootStore }));
+vi.mock("@/components/modal/use-navigation-guard", () => ({ useNavigationGuard: vi.fn() }));
+vi.mock("@/components/shared/app-image", () => ({ AppImage: () => null }));
+vi.mock("@/components/shared/app-link", () => ({
+  AppLink: ({ href, children }: { href: string; children?: ReactNode }) => createElement("a", { href }, children),
+}));
+
+import { ResetPasswordForm } from "../reset-password-form";
+import { ResetPasswordStore } from "../reset-password.store";
+
+let container: HTMLDivElement;
+let root: Root;
+let store: ResetPasswordStore;
+
+function render(onboardingIntent?: string) {
+  const searchContext = harness.searchContext;
+  if (!searchContext) throw new Error("Router context did not initialize");
+  act(() =>
+    root.render(
+      createElement(
+        searchContext.Provider,
+        { value: harness.token },
+        createElement(ResetPasswordForm, { onboardingIntent }),
+      ),
+    ),
+  );
+}
+
+function setPasswords(password: string) {
+  act(() => {
+    store.onChange("password", password);
+    store.onChange("confirmPassword", password);
+  });
+}
+
+function expectPasswords(password: string) {
+  expect(container.querySelector<HTMLInputElement>("#password")?.value).toBe(password);
+  expect(container.querySelector<HTMLInputElement>("#confirmPassword")?.value).toBe(password);
+  expect(store.form.password).toBe(password);
+  expect(store.form.confirmPassword).toBe(password);
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+  harness.token = "reset-a";
+  harness.resetPasswordAction.mockResolvedValue({ ok: true, data: null });
+  const rootStore = { terminologyStore: { overrides: [] } } as unknown as RootStore;
+  store = new ResetPasswordStore(rootStore);
+  Object.assign(rootStore, { resetPasswordStore: store });
+  harness.rootStore = rootStore;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  harness.rootStore = undefined;
+});
+
+describe("ResetPasswordForm context lifecycle", () => {
+  it("initializes the token and intent and clears credentials from a previous mount", () => {
+    store.onInitOrRefresh({
+      token: "old-reset",
+      onboardingIntent: "old-intent",
+      password: "OldPass1!",
+      confirmPassword: "OldPass1!",
+    });
+    render("invite-a");
+    expectPasswords("");
+    expect(store.form).toEqual({
+      token: "reset-a",
+      onboardingIntent: "invite-a",
+      password: "",
+      confirmPassword: "",
+    });
+    expect(store.savedState).toEqual(store.form);
+    expect(store.withUnsavedChangesGuard).toBe(false);
+  });
+
+  it("preserves credentials while refreshing and clearing only the intent", () => {
+    render("invite-a");
+    setPasswords("ValidPass1!");
+    render("invite-b");
+    expectPasswords("ValidPass1!");
+    expect(store.form.token).toBe("reset-a");
+    expect(store.form.onboardingIntent).toBe("invite-b");
+    expect(store.savedState).toEqual(store.form);
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/auth/signin?intent=invite-b");
+
+    render();
+    expectPasswords("ValidPass1!");
+    expect(store.form.token).toBe("reset-a");
+    expect(store.form.onboardingIntent).toBeUndefined();
+    expect(store.savedState.onboardingIntent).toBeUndefined();
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("/auth/signin");
+  });
+
+  it("clears credentials when token and intent change together and submits the new context", async () => {
+    render("invite-a");
+    setPasswords("FirstPass1!");
+    harness.token = "reset-b";
+    render("invite-b");
+    expectPasswords("");
+    expect(store.form).toEqual({
+      token: "reset-b",
+      onboardingIntent: "invite-b",
+      password: "",
+      confirmPassword: "",
+    });
+    expect(store.savedState).toEqual(store.form);
+
+    setPasswords("SecondPass1!");
+    const form = container.querySelector("form");
+    if (!form) throw new Error("Reset form did not render");
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    expect(harness.resetPasswordAction).toHaveBeenCalledExactlyOnceWith({
+      token: "reset-b",
+      onboardingIntent: "invite-b",
+      password: "SecondPass1!",
+      confirmPassword: "SecondPass1!",
+    });
+  });
+
+  it("clears credentials for a token-only change without losing intent", () => {
+    render("invite-a");
+    setPasswords("ValidPass1!");
+    harness.token = "reset-b";
+    render("invite-a");
+    expectPasswords("");
+    expect(store.form.token).toBe("reset-b");
+    expect(store.form.onboardingIntent).toBe("invite-a");
+    expect(store.savedState).toEqual(store.form);
+  });
+
+  it("does not reinitialize credentials on an unrelated rerender", () => {
+    render("invite-a");
+    setPasswords("ValidPass1!");
+    render("invite-a");
+    expectPasswords("ValidPass1!");
+    expect(store.savedState.password).toBe("");
+  });
+});

--- a/app/[locale]/(public)/auth/reset-password/__tests__/reset-password.store.test.ts
+++ b/app/[locale]/(public)/auth/reset-password/__tests__/reset-password.store.test.ts
@@ -16,22 +16,43 @@ describe("ResetPasswordStore", () => {
     actions.resetPasswordAction.mockResolvedValue({ ok: true, data: null });
   });
 
+  it("refreshes, resets and clears intent within the submitted form snapshot", async () => {
+    actions.resetPasswordAction.mockResolvedValue({ ok: true, data: null });
+    const store = new ResetPasswordStore(rootStore);
+    store.onInitOrRefresh({ onboardingIntent: "invite-a" });
+    store.onChange("token", "reset-token");
+    store.onInitOrRefresh({ onboardingIntent: "invite-b" });
+    store.onChange("onboardingIntent", "unsaved-intent");
+    store.resetForm();
+
+    await store.onSubmit();
+
+    expect(actions.resetPasswordAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ token: "reset-token", onboardingIntent: "invite-b" }),
+    );
+    store.onInitOrRefresh({ onboardingIntent: undefined });
+    await store.onSubmit();
+
+    expect(actions.resetPasswordAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ token: "reset-token", onboardingIntent: undefined }),
+    );
+    expect(store.savedState.onboardingIntent).toBeUndefined();
+  });
+
   it("submits the active onboarding intent with the reset token", async () => {
     const store = new ResetPasswordStore(rootStore);
     store.onInitOrRefresh({ token: "reset-token" });
     store.onChange("password", "ValidPass1!");
     store.onChange("confirmPassword", "ValidPass1!");
-    store.setOnboardingIntent("signed.intent");
+    store.onInitOrRefresh({ onboardingIntent: "signed.intent" });
 
     await store.onSubmit();
 
-    expect(actions.resetPasswordAction).toHaveBeenCalledWith(
-      {
-        confirmPassword: "ValidPass1!",
-        password: "ValidPass1!",
-        token: "reset-token",
-      },
-      "signed.intent",
-    );
+    expect(actions.resetPasswordAction).toHaveBeenCalledWith({
+      confirmPassword: "ValidPass1!",
+      password: "ValidPass1!",
+      token: "reset-token",
+      onboardingIntent: "signed.intent",
+    });
   });
 });

--- a/app/[locale]/(public)/auth/reset-password/__tests__/reset-password.store.test.ts
+++ b/app/[locale]/(public)/auth/reset-password/__tests__/reset-password.store.test.ts
@@ -1,0 +1,37 @@
+import type { RootStore } from "@/core/stores/root.store";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const actions = vi.hoisted(() => ({ resetPasswordAction: vi.fn() }));
+
+vi.mock("../../actions", () => actions);
+
+import { ResetPasswordStore } from "../reset-password.store";
+
+const rootStore = {} as RootStore;
+
+describe("ResetPasswordStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actions.resetPasswordAction.mockResolvedValue({ ok: true, data: null });
+  });
+
+  it("submits the active onboarding intent with the reset token", async () => {
+    const store = new ResetPasswordStore(rootStore);
+    store.onInitOrRefresh({ token: "reset-token" });
+    store.onChange("password", "ValidPass1!");
+    store.onChange("confirmPassword", "ValidPass1!");
+    store.setOnboardingIntent("signed.intent");
+
+    await store.onSubmit();
+
+    expect(actions.resetPasswordAction).toHaveBeenCalledWith(
+      {
+        confirmPassword: "ValidPass1!",
+        password: "ValidPass1!",
+        token: "reset-token",
+      },
+      "signed.intent",
+    );
+  });
+});

--- a/app/[locale]/(public)/auth/reset-password/page.tsx
+++ b/app/[locale]/(public)/auth/reset-password/page.tsx
@@ -7,6 +7,8 @@ import { ResetPasswordForm } from "./reset-password-form";
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { requireUnauthenticated } from "@/features/auth/next/require";
 import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { ONBOARDING_INTENT_QUERY_PARAM, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
 
 type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -18,15 +20,26 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 }
 
 export default async function ResetPasswordPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const onboardingIntent = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  const activeIntent = onboardingIntent.status === "valid" ? onboardingIntent : null;
+  const invitation =
+    onboardingIntent.status === "valid" && onboardingIntent.type === "invitation" ? onboardingIntent : null;
+
   await requireUnauthenticated();
 
-  const params = await searchParams;
   const error = params.error;
-  if (error === "INVALID_TOKEN") redirect("/auth/forgot-password?info=RESET_LINK_INVALID");
+  if (error === "INVALID_TOKEN") {
+    redirect(
+      activeIntent
+        ? pathWithOnboardingIntent("/auth/forgot-password?info=RESET_LINK_INVALID", activeIntent.intent)
+        : "/auth/forgot-password?info=RESET_LINK_INVALID",
+    );
+  }
 
   return (
     <CenteredCardPage>
-      <ResetPasswordForm />
+      <ResetPasswordForm inviterName={invitation?.inviterName} onboardingIntent={activeIntent?.intent} />
     </CenteredCardPage>
   );
 }

--- a/app/[locale]/(public)/auth/reset-password/reset-password-form.tsx
+++ b/app/[locale]/(public)/auth/reset-password/reset-password-form.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { observer } from "mobx-react-lite";
 import { Button } from "@/components/ui/button";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { AppCard } from "@/components/card/app-card";
@@ -15,29 +15,47 @@ import { AppForm } from "@/components/forms/form-context";
 import { FormInput } from "@/components/forms/form-input";
 import { PasswordInput } from "@/components/forms/password-input";
 import { AppLink } from "@/components/shared/app-link";
+import { Alert } from "@/components/shared/alert";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
-export const ResetPasswordForm = observer(() => {
+type Props = {
+  inviterName?: string;
+  onboardingIntent?: string;
+};
+
+export const ResetPasswordForm = observer(({ inviterName, onboardingIntent }: Props) => {
   const t = useTranslations();
   const { resetPasswordStore } = useRootStore();
-  const { isLoading, showPassword } = resetPasswordStore;
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
-
-  useEffect(() => {
-    if (token && resetPasswordStore.form.token !== token) resetPasswordStore.onInitOrRefresh({ token });
-  }, [token]);
-
-  useEffect(() => {
+  useState(() => {
+    resetPasswordStore.onInitOrRefresh({ confirmPassword: "", password: "", token });
+    resetPasswordStore.setOnboardingIntent(onboardingIntent);
     resetPasswordStore.setWithUnsavedChangesGuard(false);
-  }, []);
+  });
+  const { isLoading, showPassword } = resetPasswordStore;
+
+  useEffect(() => {
+    if (resetPasswordStore.form.token !== token)
+      resetPasswordStore.onInitOrRefresh({ confirmPassword: "", password: "", token });
+  }, [resetPasswordStore, token]);
+
+  useEffect(() => {
+    resetPasswordStore.setOnboardingIntent(onboardingIntent);
+  }, [onboardingIntent, resetPasswordStore]);
 
   return (
     <AppForm store={resetPasswordStore}>
       <AppCard className="max-w-md">
         <CardHeroHeader
+          alt=""
           subtitle={t.rich("ResetPasswordForm.backToSignIn", {
             backToSignInLink: (chunks) => (
-              <AppLink inheritSize appearance="inline" href="/auth/signin">
+              <AppLink
+                inheritSize
+                appearance="inline"
+                href={onboardingIntent ? pathWithOnboardingIntent("/auth/signin", onboardingIntent) : "/auth/signin"}
+              >
                 {chunks}
               </AppLink>
             ),
@@ -46,6 +64,12 @@ export const ResetPasswordForm = observer(() => {
         />
 
         <AppCardBody>
+          {inviterName ? (
+            <Alert className="mb-4" role="note">
+              <p className="text-x-sm">{t("InvitationCard.inviter", { inviterName })}</p>
+            </Alert>
+          ) : null}
+
           <PasswordInput
             required
             id="password"

--- a/app/[locale]/(public)/auth/reset-password/reset-password-form.tsx
+++ b/app/[locale]/(public)/auth/reset-password/reset-password-form.tsx
@@ -29,20 +29,17 @@ export const ResetPasswordForm = observer(({ inviterName, onboardingIntent }: Pr
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
   useState(() => {
-    resetPasswordStore.onInitOrRefresh({ confirmPassword: "", password: "", token });
-    resetPasswordStore.setOnboardingIntent(onboardingIntent);
+    resetPasswordStore.onInitOrRefresh({ confirmPassword: "", password: "", token, onboardingIntent });
     resetPasswordStore.setWithUnsavedChangesGuard(false);
   });
   const { isLoading, showPassword } = resetPasswordStore;
 
   useEffect(() => {
     if (resetPasswordStore.form.token !== token)
-      resetPasswordStore.onInitOrRefresh({ confirmPassword: "", password: "", token });
-  }, [resetPasswordStore, token]);
-
-  useEffect(() => {
-    resetPasswordStore.setOnboardingIntent(onboardingIntent);
-  }, [onboardingIntent, resetPasswordStore]);
+      resetPasswordStore.onInitOrRefresh({ confirmPassword: "", password: "", token, onboardingIntent });
+    else if (resetPasswordStore.form.onboardingIntent !== onboardingIntent)
+      resetPasswordStore.onInitOrRefresh({ token, onboardingIntent });
+  }, [onboardingIntent, resetPasswordStore, token]);
 
   return (
     <AppForm store={resetPasswordStore}>

--- a/app/[locale]/(public)/auth/reset-password/reset-password.store.tsx
+++ b/app/[locale]/(public)/auth/reset-password/reset-password.store.tsx
@@ -9,17 +9,14 @@ import { resetPasswordAction } from "../actions";
 import { BaseFormStore } from "@/core/base/base-form.store";
 
 export class ResetPasswordStore extends BaseFormStore<ResetPasswordData> {
-  onboardingIntent?: string;
   showPassword = false;
 
   constructor(rootStore: RootStore) {
-    super(rootStore, { password: "", confirmPassword: "", token: "" });
+    super(rootStore, { password: "", confirmPassword: "", token: "", onboardingIntent: undefined });
 
     makeObservable(this, {
       showPassword: observable,
-      onboardingIntent: observable,
       onSubmit: action,
-      setOnboardingIntent: action,
       toggleShowPassword: action,
     });
   }
@@ -28,16 +25,12 @@ export class ResetPasswordStore extends BaseFormStore<ResetPasswordData> {
     this.showPassword = !this.showPassword;
   };
 
-  setOnboardingIntent = (onboardingIntent?: string) => {
-    this.onboardingIntent = onboardingIntent;
-  };
-
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await resetPasswordAction(toJS(this.form), this.onboardingIntent);
+      const res = await resetPasswordAction(toJS(this.form));
 
       if (!res.ok) this.setError(res.error);
     } finally {

--- a/app/[locale]/(public)/auth/reset-password/reset-password.store.tsx
+++ b/app/[locale]/(public)/auth/reset-password/reset-password.store.tsx
@@ -9,6 +9,7 @@ import { resetPasswordAction } from "../actions";
 import { BaseFormStore } from "@/core/base/base-form.store";
 
 export class ResetPasswordStore extends BaseFormStore<ResetPasswordData> {
+  onboardingIntent?: string;
   showPassword = false;
 
   constructor(rootStore: RootStore) {
@@ -16,7 +17,9 @@ export class ResetPasswordStore extends BaseFormStore<ResetPasswordData> {
 
     makeObservable(this, {
       showPassword: observable,
+      onboardingIntent: observable,
       onSubmit: action,
+      setOnboardingIntent: action,
       toggleShowPassword: action,
     });
   }
@@ -25,12 +28,16 @@ export class ResetPasswordStore extends BaseFormStore<ResetPasswordData> {
     this.showPassword = !this.showPassword;
   };
 
+  setOnboardingIntent = (onboardingIntent?: string) => {
+    this.onboardingIntent = onboardingIntent;
+  };
+
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await resetPasswordAction(toJS(this.form));
+      const res = await resetPasswordAction(toJS(this.form), this.onboardingIntent);
 
       if (!res.ok) this.setError(res.error);
     } finally {

--- a/app/[locale]/(public)/auth/signin/__tests__/page.test.ts
+++ b/app/[locale]/(public)/auth/signin/__tests__/page.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireUnauthenticated: vi.fn(),
+  resolveAccountState: vi.fn(),
+  resolveOnboardingIntent: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
+vi.mock("@/core/auth/better-auth", () => ({
+  enabledSocialProviders: { google: false, microsoft: false },
+}));
+vi.mock("@/core/fumadocs/metadata", () => ({ generateMetadataFromMeta: vi.fn() }));
+vi.mock("@/features/auth/next/require", () => ({
+  requireUnauthenticated: mocks.requireUnauthenticated,
+}));
+vi.mock("@/features/auth/next/resolve-account-state", () => ({
+  resolveRequestAccountState: mocks.resolveAccountState,
+}));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
+}));
+vi.mock("@/components/shared/centered-card-page", () => ({ CenteredCardPage: "centered-card-page" }));
+vi.mock("../sign-in-form", () => ({ SignInForm: "sign-in-form" }));
+
+import SignInPage from "../page";
+
+const invitation = {
+  companyId: "company-a",
+  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  intent: "signed.intent",
+  inviterName: "Invite Admin",
+  source: "explicit",
+  status: "valid",
+  token: "invite-a",
+  type: "invitation",
+} as const;
+
+describe("SignInPage onboarding intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireUnauthenticated.mockResolvedValue(undefined);
+    mocks.resolveAccountState.mockResolvedValue({ sessionUser: null, state: "unauthenticated" });
+    mocks.resolveOnboardingIntent.mockResolvedValue({ status: "absent" });
+  });
+
+  it("recovers an invitation nested in a proxy callback URL", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue(invitation);
+
+    const result = await SignInPage({
+      searchParams: Promise.resolve({ callbackURL: "/onboarding/wizard?intent=signed.intent" }),
+    });
+    const form = result.props.children;
+
+    expect(mocks.resolveOnboardingIntent).toHaveBeenCalledWith("signed.intent");
+    expect(form.props).toMatchObject({
+      callbackURL: "/auth/invitation?intent=signed.intent",
+      inviterName: "Invite Admin",
+      onboardingIntent: "signed.intent",
+    });
+  });
+
+  it("fails closed on duplicate nested intents instead of consulting legacy state", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      errorMessage: "invalidOnboardingIntent",
+      source: "explicit",
+      status: "invalid",
+    });
+
+    await expect(
+      SignInPage({
+        searchParams: Promise.resolve({ callbackURL: "/auth/invitation?intent=one&intent=two" }),
+      }),
+    ).rejects.toThrow("REDIRECT:/en/auth/error?type=invalidOnboardingIntent");
+    expect(mocks.resolveOnboardingIntent).toHaveBeenCalledWith([]);
+    expect(mocks.requireUnauthenticated).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on duplicate callback parameters instead of consulting legacy state", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      errorMessage: "invalidOnboardingIntent",
+      source: "explicit",
+      status: "invalid",
+    });
+
+    await expect(
+      SignInPage({ searchParams: Promise.resolve({ callbackURL: ["/auth/signin", "/auth/invitation"] }) }),
+    ).rejects.toThrow("REDIRECT:/en/auth/error?type=invalidOnboardingIntent");
+    expect(mocks.resolveOnboardingIntent).toHaveBeenCalledWith([]);
+  });
+
+  it("routes an already signed-in visitor to the invitation explanation", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue(invitation);
+    mocks.resolveAccountState.mockResolvedValue({
+      sessionUser: { id: "auth-user-one" },
+      state: "registered",
+    });
+
+    await expect(SignInPage({ searchParams: Promise.resolve({ intent: "signed.intent" }) })).rejects.toThrow(
+      "REDIRECT:/en/auth/invitation?intent=signed.intent",
+    );
+    expect(mocks.requireUnauthenticated).not.toHaveBeenCalled();
+  });
+
+  it("resumes a signed create decision after authentication", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      authUserId: "auth-user-one",
+      intent: "signed.create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+
+    const result = await SignInPage({ searchParams: Promise.resolve({ intent: "signed.create" }) });
+    const form = result.props.children;
+
+    expect(form.props).toMatchObject({
+      callbackURL: "/onboarding/wizard?intent=signed.create",
+      onboardingIntent: "signed.create",
+    });
+    expect(form.props.inviterName).toBeUndefined();
+  });
+
+  it("rejects a create decision when a different identity is already signed in", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      authUserId: "auth-user-one",
+      intent: "signed.create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+    mocks.resolveAccountState.mockResolvedValue({
+      sessionUser: { id: "auth-user-two" },
+      state: "unregistered",
+    });
+
+    await expect(SignInPage({ searchParams: Promise.resolve({ intent: "signed.create" }) })).rejects.toThrow(
+      "REDIRECT:/en/auth/error?type=invalidOnboardingIntent",
+    );
+  });
+});

--- a/app/[locale]/(public)/auth/signin/__tests__/sign-in.store.test.ts
+++ b/app/[locale]/(public)/auth/signin/__tests__/sign-in.store.test.ts
@@ -23,6 +23,28 @@ beforeEach(() => {
 });
 
 describe("SignInStore", () => {
+  it("refreshes and clears callbacks in the form and provider continuation together", async () => {
+    authActions.continueWithGoogleAction.mockResolvedValue({ ok: true, data: { url: null } });
+    const store = new SignInStore(rootStore);
+    store.onInitOrRefresh({ callbackURL: "/auth/invitation?intent=invite-a" });
+    store.onChange("email", "invited@example.com");
+    store.onInitOrRefresh({ callbackURL: "/auth/invitation?intent=invite-b" });
+    store.onChange("callbackURL", "/unsaved");
+    store.resetForm();
+    await store.continueWithProvider("google");
+
+    expect(authActions.continueWithGoogleAction).toHaveBeenLastCalledWith(
+      "/auth/invitation?intent=invite-b",
+      "/auth/signin?intent=invite-b",
+    );
+    expect(store.form.email).toBe("invited@example.com");
+
+    store.onInitOrRefresh({ callbackURL: undefined });
+    await store.continueWithProvider("google");
+    expect(authActions.continueWithGoogleAction).toHaveBeenLastCalledWith(undefined, "/auth/signin");
+    expect(store.savedState.callbackURL).toBeUndefined();
+  });
+
   it("hard-navigates to the validated callback after the session cookie is committed", async () => {
     authActions.signInWithEmailAction.mockResolvedValue({
       ok: true,
@@ -31,7 +53,7 @@ describe("SignInStore", () => {
     const store = new SignInStore(rootStore);
     store.onChange("email", "synthetic@example.com");
     store.onChange("password", "local-demo-password");
-    store.setCallbackURLs("/en/onboarding/wizard");
+    store.onInitOrRefresh({ callbackURL: "/en/onboarding/wizard" });
 
     await store.onSubmit();
 
@@ -68,7 +90,7 @@ describe("SignInStore", () => {
       data: { url: "https://accounts.google.test/authorize" },
     });
     const store = new SignInStore(rootStore);
-    store.setCallbackURLs("/en/dashboard");
+    store.onInitOrRefresh({ callbackURL: "/en/dashboard" });
 
     await store.continueWithProvider("google");
     await store.continueWithProvider("google");
@@ -84,7 +106,7 @@ describe("SignInStore", () => {
       data: { url: "https://accounts.google.test/authorize" },
     });
     const store = new SignInStore(rootStore);
-    store.setCallbackURLs("/auth/invitation?intent=signed.intent", "/auth/signin?intent=signed.intent");
+    store.onInitOrRefresh({ callbackURL: "/auth/invitation?intent=signed.intent" });
 
     await store.continueWithProvider("google");
 

--- a/app/[locale]/(public)/auth/signin/__tests__/sign-in.store.test.ts
+++ b/app/[locale]/(public)/auth/signin/__tests__/sign-in.store.test.ts
@@ -31,7 +31,7 @@ describe("SignInStore", () => {
     const store = new SignInStore(rootStore);
     store.onChange("email", "synthetic@example.com");
     store.onChange("password", "local-demo-password");
-    store.setCallbackURL("/en/onboarding/wizard");
+    store.setCallbackURLs("/en/onboarding/wizard");
 
     await store.onSubmit();
 
@@ -68,7 +68,7 @@ describe("SignInStore", () => {
       data: { url: "https://accounts.google.test/authorize" },
     });
     const store = new SignInStore(rootStore);
-    store.setCallbackURL("/en/dashboard");
+    store.setCallbackURLs("/en/dashboard");
 
     await store.continueWithProvider("google");
     await store.continueWithProvider("google");
@@ -76,6 +76,22 @@ describe("SignInStore", () => {
     expect(authActions.continueWithGoogleAction).toHaveBeenCalledExactlyOnceWith("/en/dashboard", "/auth/signin");
     expect(assign).toHaveBeenCalledExactlyOnceWith("https://accounts.google.test/authorize");
     expect(store.isLoading).toBe(true);
+  });
+
+  it("preserves the onboarding intent in a provider error callback", async () => {
+    authActions.continueWithGoogleAction.mockResolvedValue({
+      ok: true,
+      data: { url: "https://accounts.google.test/authorize" },
+    });
+    const store = new SignInStore(rootStore);
+    store.setCallbackURLs("/auth/invitation?intent=signed.intent", "/auth/signin?intent=signed.intent");
+
+    await store.continueWithProvider("google");
+
+    expect(authActions.continueWithGoogleAction).toHaveBeenCalledWith(
+      "/auth/invitation?intent=signed.intent",
+      "/auth/signin?intent=signed.intent",
+    );
   });
 
   it("releases the social-provider lock when the action fails before navigation", async () => {

--- a/app/[locale]/(public)/auth/signin/page.tsx
+++ b/app/[locale]/(public)/auth/signin/page.tsx
@@ -1,29 +1,87 @@
 import type { Metadata } from "next";
 
-import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
 
 import { SignInForm } from "./sign-in-form";
 
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
 import { requireUnauthenticated } from "@/features/auth/next/require";
+import { resolveRequestAccountState } from "@/features/auth/next/resolve-account-state";
 import { enabledSocialProviders } from "@/core/auth/better-auth";
 import { CenteredCardPage } from "@/components/shared/centered-card-page";
-import { getInviteTokenValidationInteractor } from "@/core/di";
+import {
+  ONBOARDING_INTENT_QUERY_PARAM,
+  onboardingIntentFromPath,
+  pathWithOnboardingIntent,
+} from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   return generateMetadataFromMeta({ locale, route: "/auth/signin" });
 }
 
-export default async function SignInPage() {
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function SignInPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const callbackURLValue = params.callbackURL;
+  const callbackURL = typeof callbackURLValue === "string" ? callbackURLValue : undefined;
+  const callbackIntent =
+    callbackURLValue === undefined
+      ? { status: "absent" as const }
+      : typeof callbackURLValue === "string"
+        ? onboardingIntentFromPath(callbackURLValue)
+        : { status: "invalid" as const };
+  const intentValue =
+    params[ONBOARDING_INTENT_QUERY_PARAM] !== undefined
+      ? params[ONBOARDING_INTENT_QUERY_PARAM]
+      : callbackIntent.status === "valid"
+        ? callbackIntent.intent
+        : callbackIntent.status === "invalid"
+          ? []
+          : undefined;
+  const onboardingIntent = await resolveOnboardingIntent(intentValue);
+  if (onboardingIntent.status === "invalid" && onboardingIntent.source === "explicit")
+    redirect(buildLocalePath(await getLocale(), `/auth/error?type=${onboardingIntent.errorMessage}`));
+  const activeIntent = onboardingIntent.status === "valid" ? onboardingIntent : null;
+  const invitation =
+    onboardingIntent.status === "valid" && onboardingIntent.type === "invitation" ? onboardingIntent : null;
+  if (activeIntent) {
+    const resolution = await resolveRequestAccountState();
+    if (resolution.sessionUser) {
+      if (activeIntent.type === "createCompany" && activeIntent.authUserId !== resolution.sessionUser.id)
+        redirect(buildLocalePath(await getLocale(), "/auth/error?type=invalidOnboardingIntent"));
+
+      const destination =
+        activeIntent.type === "invitation"
+          ? pathWithOnboardingIntent("/auth/invitation", activeIntent.intent)
+          : pathWithOnboardingIntent("/onboarding/wizard", activeIntent.intent);
+      redirect(buildLocalePath(await getLocale(), destination));
+    }
+  }
+
   await requireUnauthenticated();
-  const cookiesStore = await cookies();
-  const token = cookiesStore.get("inviteToken")?.value;
-  const result = await getInviteTokenValidationInteractor().invoke({ token });
 
   return (
     <CenteredCardPage>
-      <SignInForm isInvited={result.ok && result.data.valid} socialProviders={enabledSocialProviders} />
+      <SignInForm
+        callbackURL={
+          activeIntent
+            ? pathWithOnboardingIntent(
+                activeIntent.type === "invitation" ? "/auth/invitation" : "/onboarding/wizard",
+                activeIntent.intent,
+              )
+            : callbackURL
+        }
+        inviterName={invitation?.inviterName}
+        onboardingIntent={activeIntent?.intent}
+        socialProviders={enabledSocialProviders}
+      />
     </CenteredCardPage>
   );
 }

--- a/app/[locale]/(public)/auth/signin/sign-in-form.tsx
+++ b/app/[locale]/(public)/auth/signin/sign-in-form.tsx
@@ -39,17 +39,17 @@ export const SignInForm = observer(({ callbackURL, inviterName, onboardingIntent
 
   const { signInStore, appMode } = useRootStore();
   const resolvedCallbackURL = callbackURL ?? searchParams.get("callbackURL") ?? undefined;
-  const errorCallbackURL = onboardingIntent ? pathWithOnboardingIntent("/auth/signin", onboardingIntent) : undefined;
   useState(() => {
-    signInStore.setCallbackURLs(resolvedCallbackURL, errorCallbackURL);
+    signInStore.onInitOrRefresh({ callbackURL: resolvedCallbackURL });
     signInStore.setWithUnsavedChangesGuard(false);
   });
   const { isLoading } = signInStore;
   const isInvited = Boolean(onboardingIntent && inviterName);
 
   useEffect(() => {
-    signInStore.setCallbackURLs(resolvedCallbackURL, errorCallbackURL);
-  }, [errorCallbackURL, resolvedCallbackURL, signInStore]);
+    if (signInStore.form.callbackURL !== resolvedCallbackURL)
+      signInStore.onInitOrRefresh({ callbackURL: resolvedCallbackURL });
+  }, [resolvedCallbackURL, signInStore]);
 
   return (
     <AppForm store={signInStore}>

--- a/app/[locale]/(public)/auth/signin/sign-in-form.tsx
+++ b/app/[locale]/(public)/auth/signin/sign-in-form.tsx
@@ -2,7 +2,7 @@
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { observer } from "mobx-react-lite";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -22,35 +22,51 @@ import { AppCardBody } from "@/components/card/app-card-body";
 import { AppCardFooter } from "@/components/card/app-card-footer";
 import { CardHeroHeader } from "@/components/card/card-hero-header";
 import { runUserAction } from "@/core/errors/report-application-error";
+import { Alert } from "@/components/shared/alert";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 type Props = {
-  isInvited: boolean;
+  callbackURL?: string;
+  inviterName?: string;
+  onboardingIntent?: string;
   socialProviders: { google: boolean; microsoft: boolean };
 };
 
-export const SignInForm = observer(({ isInvited, socialProviders }: Props) => {
+export const SignInForm = observer(({ callbackURL, inviterName, onboardingIntent, socialProviders }: Props) => {
   const searchParams = useSearchParams();
 
   const t = useTranslations();
 
   const { signInStore, appMode } = useRootStore();
-  const { isLoading } = signInStore;
-
-  useEffect(() => {
-    signInStore.setCallbackURL(searchParams.get("callbackURL") ?? undefined);
-  }, [searchParams]);
-
-  useEffect(() => {
+  const resolvedCallbackURL = callbackURL ?? searchParams.get("callbackURL") ?? undefined;
+  const errorCallbackURL = onboardingIntent ? pathWithOnboardingIntent("/auth/signin", onboardingIntent) : undefined;
+  useState(() => {
+    signInStore.setCallbackURLs(resolvedCallbackURL, errorCallbackURL);
     signInStore.setWithUnsavedChangesGuard(false);
-  }, []);
+  });
+  const { isLoading } = signInStore;
+  const isInvited = Boolean(onboardingIntent && inviterName);
+
+  useEffect(() => {
+    signInStore.setCallbackURLs(resolvedCallbackURL, errorCallbackURL);
+  }, [errorCallbackURL, resolvedCallbackURL, signInStore]);
 
   return (
     <AppForm store={signInStore}>
       <AppCard className="max-w-lg">
         <CardHeroHeader
+          alt=""
           subtitle={t.rich("SignInForm.switchToSignUp", {
             registerLink: (chunks) => (
-              <AppLink inheritSize appearance="inline" href="/auth/signup">
+              <AppLink
+                inheritSize
+                appearance="inline"
+                href={
+                  isInvited && onboardingIntent
+                    ? pathWithOnboardingIntent("/auth/signup", onboardingIntent)
+                    : "/auth/signup"
+                }
+              >
                 {chunks}
               </AppLink>
             ),
@@ -60,6 +76,12 @@ export const SignInForm = observer(({ isInvited, socialProviders }: Props) => {
 
         <AppCardBody>
           <SocialErrorToast />
+
+          {isInvited ? (
+            <Alert className="mb-4" role="note">
+              <p className="text-x-sm">{t("SignInForm.inviteSubtitle", { inviterName: inviterName ?? "" })}</p>
+            </Alert>
+          ) : null}
 
           {(socialProviders.google || socialProviders.microsoft) && (
             <>
@@ -109,7 +131,15 @@ export const SignInForm = observer(({ isInvited, socialProviders }: Props) => {
           <div className="flex w-full justify-between items-start gap-3">
             <FormCheckbox id="rememberMe" label={t("SignInForm.rememberMe")} />
 
-            <AppLink href="/auth/forgot-password">{t("SignInForm.forgotPassword")}</AppLink>
+            <AppLink
+              href={
+                onboardingIntent
+                  ? pathWithOnboardingIntent("/auth/forgot-password", onboardingIntent)
+                  : "/auth/forgot-password"
+              }
+            >
+              {t("SignInForm.forgotPassword")}
+            </AppLink>
           </div>
         </AppCardBody>
 

--- a/app/[locale]/(public)/auth/signin/sign-in.store.tsx
+++ b/app/[locale]/(public)/auth/signin/sign-in.store.tsx
@@ -8,31 +8,22 @@ import { continueWithGoogleAction, continueWithMicrosoftAction, signInWithEmailA
 
 import { BaseFormStore } from "@/core/base/base-form.store";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
+import { onboardingIntentFromPath, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 export class SignInStore extends BaseFormStore<EmailSignInData> {
-  callbackURL?: string;
-  errorCallbackURL?: string;
   showPassword = false;
 
   constructor(rootStore: RootStore) {
-    super(rootStore, { email: "", password: "", rememberMe: true });
+    super(rootStore, { email: "", password: "", rememberMe: true, callbackURL: undefined });
 
     makeObservable(this, {
       showPassword: observable,
-      callbackURL: observable,
-      errorCallbackURL: observable,
 
       onSubmit: action,
       continueWithProvider: action,
       toggleShowPassword: action,
-      setCallbackURLs: action,
     });
   }
-
-  setCallbackURLs = (callbackURL?: string, errorCallbackURL?: string) => {
-    this.callbackURL = callbackURL;
-    this.errorCallbackURL = errorCallbackURL;
-  };
 
   toggleShowPassword = () => {
     this.showPassword = !this.showPassword;
@@ -46,10 +37,7 @@ export class SignInStore extends BaseFormStore<EmailSignInData> {
     let isNavigating = false;
 
     try {
-      const res = await signInWithEmailAction({
-        ...toJS(this.form),
-        callbackURL: this.callbackURL,
-      });
+      const res = await signInWithEmailAction(toJS(this.form));
 
       if (res.ok) {
         window.location.assign(res.data.url);
@@ -68,7 +56,10 @@ export class SignInStore extends BaseFormStore<EmailSignInData> {
 
     try {
       const action = provider === "google" ? continueWithGoogleAction : continueWithMicrosoftAction;
-      const res = await action(this.callbackURL, this.errorCallbackURL ?? "/auth/signin");
+      const intent = onboardingIntentFromPath(this.form.callbackURL);
+      const errorCallbackURL =
+        intent.status === "valid" ? pathWithOnboardingIntent("/auth/signin", intent.intent) : "/auth/signin";
+      const res = await action(this.form.callbackURL, errorCallbackURL);
 
       if (!res.ok) toastZodErrorTree(res.error);
       else if (res.data.url) {

--- a/app/[locale]/(public)/auth/signin/sign-in.store.tsx
+++ b/app/[locale]/(public)/auth/signin/sign-in.store.tsx
@@ -11,6 +11,7 @@ import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 
 export class SignInStore extends BaseFormStore<EmailSignInData> {
   callbackURL?: string;
+  errorCallbackURL?: string;
   showPassword = false;
 
   constructor(rootStore: RootStore) {
@@ -19,16 +20,18 @@ export class SignInStore extends BaseFormStore<EmailSignInData> {
     makeObservable(this, {
       showPassword: observable,
       callbackURL: observable,
+      errorCallbackURL: observable,
 
       onSubmit: action,
       continueWithProvider: action,
       toggleShowPassword: action,
-      setCallbackURL: action,
+      setCallbackURLs: action,
     });
   }
 
-  setCallbackURL = (callbackURL?: string) => {
+  setCallbackURLs = (callbackURL?: string, errorCallbackURL?: string) => {
     this.callbackURL = callbackURL;
+    this.errorCallbackURL = errorCallbackURL;
   };
 
   toggleShowPassword = () => {
@@ -65,7 +68,7 @@ export class SignInStore extends BaseFormStore<EmailSignInData> {
 
     try {
       const action = provider === "google" ? continueWithGoogleAction : continueWithMicrosoftAction;
-      const res = await action(this.callbackURL, "/auth/signin");
+      const res = await action(this.callbackURL, this.errorCallbackURL ?? "/auth/signin");
 
       if (!res.ok) toastZodErrorTree(res.error);
       else if (res.data.url) {

--- a/app/[locale]/(public)/auth/signup/__tests__/sign-up.store.test.ts
+++ b/app/[locale]/(public)/auth/signup/__tests__/sign-up.store.test.ts
@@ -23,16 +23,54 @@ beforeEach(() => {
 });
 
 describe("SignUpStore social continuation", () => {
+  it("uses refreshed and cleared form intent for both provider callbacks", async () => {
+    authActions.continueWithMicrosoftAction.mockResolvedValue({ ok: true, data: { url: null } });
+    const store = new SignUpStore(rootStore);
+    store.onInitOrRefresh({ onboardingIntent: "invite-a" });
+    store.onInitOrRefresh({ onboardingIntent: "invite-b" });
+    await store.continueWithProvider("microsoft");
+    expect(authActions.continueWithMicrosoftAction).toHaveBeenLastCalledWith(
+      "/auth/invitation?intent=invite-b",
+      "/auth/signup?intent=invite-b",
+    );
+
+    store.onInitOrRefresh({ onboardingIntent: undefined });
+    await store.continueWithProvider("microsoft");
+    expect(authActions.continueWithMicrosoftAction).toHaveBeenLastCalledWith("/onboarding", "/auth/signup");
+  });
+
+  it("refreshes, resets and clears intent within the submitted form snapshot", async () => {
+    authActions.signUpWithEmailAction.mockResolvedValue({ ok: true, data: null });
+    const store = new SignUpStore(rootStore);
+    store.onInitOrRefresh({ onboardingIntent: "invite-a" });
+    store.onChange("email", "invited@example.com");
+    store.onInitOrRefresh({ onboardingIntent: "invite-b" });
+    store.onChange("onboardingIntent", "unsaved-intent");
+    store.resetForm();
+
+    await store.onSubmit();
+
+    expect(authActions.signUpWithEmailAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ email: "invited@example.com", onboardingIntent: "invite-b" }),
+    );
+    store.onInitOrRefresh({ onboardingIntent: undefined });
+    await store.onSubmit();
+
+    expect(authActions.signUpWithEmailAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({ email: "invited@example.com", onboardingIntent: undefined }),
+    );
+    expect(store.savedState.onboardingIntent).toBeUndefined();
+  });
+
   it("submits email signup with the active invitation intent", async () => {
     authActions.signUpWithEmailAction.mockResolvedValue({ ok: true, data: null });
     const store = new SignUpStore(rootStore);
-    store.setInvitationIntent("signed.intent");
+    store.onInitOrRefresh({ onboardingIntent: "signed.intent" });
 
     await store.onSubmit();
 
     expect(authActions.signUpWithEmailAction).toHaveBeenCalledWith(
-      expect.objectContaining({ email: "" }),
-      "signed.intent",
+      expect.objectContaining({ email: "", onboardingIntent: "signed.intent" }),
     );
   });
 
@@ -42,7 +80,7 @@ describe("SignUpStore social continuation", () => {
       data: { url: "https://accounts.google.test/authorize" },
     });
     const store = new SignUpStore(rootStore);
-    store.setInvitationIntent("signed.intent");
+    store.onInitOrRefresh({ onboardingIntent: "signed.intent" });
 
     await store.continueWithProvider("google");
 

--- a/app/[locale]/(public)/auth/signup/__tests__/sign-up.store.test.ts
+++ b/app/[locale]/(public)/auth/signup/__tests__/sign-up.store.test.ts
@@ -23,6 +23,35 @@ beforeEach(() => {
 });
 
 describe("SignUpStore social continuation", () => {
+  it("submits email signup with the active invitation intent", async () => {
+    authActions.signUpWithEmailAction.mockResolvedValue({ ok: true, data: null });
+    const store = new SignUpStore(rootStore);
+    store.setInvitationIntent("signed.intent");
+
+    await store.onSubmit();
+
+    expect(authActions.signUpWithEmailAction).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "" }),
+      "signed.intent",
+    );
+  });
+
+  it("keeps the invitation in provider success and error callbacks", async () => {
+    authActions.continueWithGoogleAction.mockResolvedValue({
+      ok: true,
+      data: { url: "https://accounts.google.test/authorize" },
+    });
+    const store = new SignUpStore(rootStore);
+    store.setInvitationIntent("signed.intent");
+
+    await store.continueWithProvider("google");
+
+    expect(authActions.continueWithGoogleAction).toHaveBeenCalledWith(
+      "/auth/invitation?intent=signed.intent",
+      "/auth/signup?intent=signed.intent",
+    );
+  });
+
   it("keeps both providers locked after hard navigation starts", async () => {
     authActions.continueWithGoogleAction.mockResolvedValue({
       ok: true,
@@ -33,7 +62,7 @@ describe("SignUpStore social continuation", () => {
     await store.continueWithProvider("google");
     await store.continueWithProvider("google");
 
-    expect(authActions.continueWithGoogleAction).toHaveBeenCalledExactlyOnceWith(undefined, "/auth/signup");
+    expect(authActions.continueWithGoogleAction).toHaveBeenCalledExactlyOnceWith("/onboarding", "/auth/signup");
     expect(assign).toHaveBeenCalledExactlyOnceWith("https://accounts.google.test/authorize");
     expect(store.isLoading).toBe(true);
   });

--- a/app/[locale]/(public)/auth/signup/page.tsx
+++ b/app/[locale]/(public)/auth/signup/page.tsx
@@ -1,30 +1,49 @@
 import type { Metadata } from "next";
 
-import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
 
 import { SignUpForm } from "./sign-up-form";
 
 import { generateMetadataFromMeta } from "@/core/fumadocs/metadata";
-import { getInviteTokenValidationInteractor } from "@/core/di";
 import { requireUnauthenticated } from "@/features/auth/next/require";
+import { resolveRequestAccountState } from "@/features/auth/next/resolve-account-state";
 import { enabledSocialProviders } from "@/core/auth/better-auth";
 import { CenteredCardPage } from "@/components/shared/centered-card-page";
+import { ONBOARDING_INTENT_QUERY_PARAM, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   return generateMetadataFromMeta({ locale, route: "/auth/signup" });
 }
 
-export default async function SignUpPage() {
-  await requireUnauthenticated();
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
 
-  const cookiesStore = await cookies();
-  const token = cookiesStore.get("inviteToken")?.value;
-  const result = await getInviteTokenValidationInteractor().invoke({ token });
+export default async function SignUpPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const onboardingIntent = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  if (onboardingIntent.status === "invalid" && onboardingIntent.source === "explicit")
+    redirect(buildLocalePath(await getLocale(), `/auth/error?type=${onboardingIntent.errorMessage}`));
+  if (onboardingIntent.status === "valid" && onboardingIntent.type !== "invitation")
+    redirect(buildLocalePath(await getLocale(), "/auth/error?type=invalidOnboardingIntent"));
+  const invitation =
+    onboardingIntent.status === "valid" && onboardingIntent.type === "invitation" ? onboardingIntent : null;
+  if (invitation && (await resolveRequestAccountState()).sessionUser)
+    redirect(buildLocalePath(await getLocale(), pathWithOnboardingIntent("/auth/invitation", invitation.intent)));
+
+  await requireUnauthenticated();
 
   return (
     <CenteredCardPage>
-      <SignUpForm isInvited={result.ok && result.data.valid} socialProviders={enabledSocialProviders} />
+      <SignUpForm
+        invitationIntent={invitation?.intent}
+        inviterName={invitation?.inviterName}
+        socialProviders={enabledSocialProviders}
+      />
     </CenteredCardPage>
   );
 }

--- a/app/[locale]/(public)/auth/signup/sign-up-form.tsx
+++ b/app/[locale]/(public)/auth/signup/sign-up-form.tsx
@@ -33,14 +33,15 @@ export const SignUpForm = observer(({ invitationIntent, inviterName, socialProvi
   const t = useTranslations();
   const { signUpStore, appMode } = useRootStore();
   useState(() => {
-    signUpStore.setInvitationIntent(invitationIntent);
+    signUpStore.onInitOrRefresh({ onboardingIntent: invitationIntent });
     signUpStore.setWithUnsavedChangesGuard(false);
   });
   const { isLoading, form } = signUpStore;
   const isInvited = Boolean(invitationIntent && inviterName);
 
   useEffect(() => {
-    signUpStore.setInvitationIntent(invitationIntent);
+    if (signUpStore.form.onboardingIntent !== invitationIntent)
+      signUpStore.onInitOrRefresh({ onboardingIntent: invitationIntent });
   }, [invitationIntent, signUpStore]);
 
   return (

--- a/app/[locale]/(public)/auth/signup/sign-up-form.tsx
+++ b/app/[locale]/(public)/auth/signup/sign-up-form.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { CLOUD_TRIAL } from "@/core/commercial/plan-catalog";
 import { observer } from "mobx-react-lite";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import SignInProviderButton from "../signin/sign-in-provider-button";
 import { SocialErrorToast } from "../social-error-toast";
@@ -22,28 +21,40 @@ import { AppCardFooter } from "@/components/card/app-card-footer";
 import { CardHeroHeader } from "@/components/card/card-hero-header";
 import { Reveal } from "@/components/shared/reveal";
 import { runUserAction } from "@/core/errors/report-application-error";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 type Props = {
-  isInvited: boolean;
+  invitationIntent?: string;
+  inviterName?: string;
   socialProviders: { google: boolean; microsoft: boolean };
 };
 
-export const SignUpForm = observer(({ isInvited, socialProviders }: Props) => {
+export const SignUpForm = observer(({ invitationIntent, inviterName, socialProviders }: Props) => {
   const t = useTranslations();
   const { signUpStore, appMode } = useRootStore();
+  useState(() => {
+    signUpStore.setInvitationIntent(invitationIntent);
+    signUpStore.setWithUnsavedChangesGuard(false);
+  });
   const { isLoading, form } = signUpStore;
+  const isInvited = Boolean(invitationIntent && inviterName);
 
   useEffect(() => {
-    signUpStore.setWithUnsavedChangesGuard(false);
-  }, []);
+    signUpStore.setInvitationIntent(invitationIntent);
+  }, [invitationIntent, signUpStore]);
 
   return (
     <AppForm store={signUpStore}>
       <AppCard className="max-w-lg">
         <CardHeroHeader
+          alt=""
           subtitle={t.rich("SignUpForm.switchToSignIn", {
             signInLink: (chunks) => (
-              <AppLink inheritSize appearance="inline" href="/auth/signin">
+              <AppLink
+                inheritSize
+                appearance="inline"
+                href={invitationIntent ? pathWithOnboardingIntent("/auth/signin", invitationIntent) : "/auth/signin"}
+              >
                 {chunks}
               </AppLink>
             ),
@@ -55,12 +66,12 @@ export const SignUpForm = observer(({ isInvited, socialProviders }: Props) => {
           <SocialErrorToast />
 
           {isInvited ? (
-            <Alert className="mb-4" color="success">
-              <p className="text-x-sm">{t("SignUpForm.inviteSubtitle")}</p>
+            <Alert className="mb-4" role="note">
+              <p className="text-x-sm">{t("SignUpForm.inviteSubtitle", { inviterName: inviterName ?? "" })}</p>
             </Alert>
           ) : appMode === "cloud" ? (
             <Alert className="mb-4" color="primary">
-              <p className="text-x-sm">{t("SignUpForm.newCompanySubtitle", { days: CLOUD_TRIAL.days })}</p>
+              <p className="text-x-sm">{t("SignUpForm.accountSubtitle")}</p>
             </Alert>
           ) : null}
 

--- a/app/[locale]/(public)/auth/signup/sign-up.store.tsx
+++ b/app/[locale]/(public)/auth/signup/sign-up.store.tsx
@@ -11,19 +11,16 @@ import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 export class SignUpStore extends BaseFormStore<EmailSignUpData> {
-  invitationIntent?: string;
   showPassword = false;
 
   constructor(rootStore: RootStore) {
-    super(rootStore, { email: "", confirmEmail: "", password: "", confirmPassword: "" });
+    super(rootStore, { email: "", confirmEmail: "", password: "", confirmPassword: "", onboardingIntent: undefined });
 
     makeObservable(this, {
       showPassword: observable,
-      invitationIntent: observable,
 
       onSubmit: action,
       continueWithProvider: action,
-      setInvitationIntent: action,
       toggleShowPassword: action,
     });
   }
@@ -32,16 +29,12 @@ export class SignUpStore extends BaseFormStore<EmailSignUpData> {
     this.showPassword = !this.showPassword;
   };
 
-  setInvitationIntent = (invitationIntent?: string) => {
-    this.invitationIntent = invitationIntent;
-  };
-
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await signUpWithEmailAction(toJS(this.form), this.invitationIntent);
+      const res = await signUpWithEmailAction(toJS(this.form));
 
       if (!res.ok) this.setError(res.error);
     } finally {
@@ -57,11 +50,11 @@ export class SignUpStore extends BaseFormStore<EmailSignUpData> {
 
     try {
       const action = provider === "google" ? continueWithGoogleAction : continueWithMicrosoftAction;
-      const callbackURL = this.invitationIntent
-        ? pathWithOnboardingIntent("/auth/invitation", this.invitationIntent)
+      const callbackURL = this.form.onboardingIntent
+        ? pathWithOnboardingIntent("/auth/invitation", this.form.onboardingIntent)
         : "/onboarding";
-      const errorCallbackURL = this.invitationIntent
-        ? pathWithOnboardingIntent("/auth/signup", this.invitationIntent)
+      const errorCallbackURL = this.form.onboardingIntent
+        ? pathWithOnboardingIntent("/auth/signup", this.form.onboardingIntent)
         : "/auth/signup";
       const res = await action(callbackURL, errorCallbackURL);
 

--- a/app/[locale]/(public)/auth/signup/sign-up.store.tsx
+++ b/app/[locale]/(public)/auth/signup/sign-up.store.tsx
@@ -8,8 +8,10 @@ import { continueWithGoogleAction, continueWithMicrosoftAction, signUpWithEmailA
 
 import { BaseFormStore } from "@/core/base/base-form.store";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 export class SignUpStore extends BaseFormStore<EmailSignUpData> {
+  invitationIntent?: string;
   showPassword = false;
 
   constructor(rootStore: RootStore) {
@@ -17,9 +19,11 @@ export class SignUpStore extends BaseFormStore<EmailSignUpData> {
 
     makeObservable(this, {
       showPassword: observable,
+      invitationIntent: observable,
 
       onSubmit: action,
       continueWithProvider: action,
+      setInvitationIntent: action,
       toggleShowPassword: action,
     });
   }
@@ -28,12 +32,16 @@ export class SignUpStore extends BaseFormStore<EmailSignUpData> {
     this.showPassword = !this.showPassword;
   };
 
+  setInvitationIntent = (invitationIntent?: string) => {
+    this.invitationIntent = invitationIntent;
+  };
+
   onSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     this.setIsLoading(true);
 
     try {
-      const res = await signUpWithEmailAction(toJS(this.form));
+      const res = await signUpWithEmailAction(toJS(this.form), this.invitationIntent);
 
       if (!res.ok) this.setError(res.error);
     } finally {
@@ -49,7 +57,13 @@ export class SignUpStore extends BaseFormStore<EmailSignUpData> {
 
     try {
       const action = provider === "google" ? continueWithGoogleAction : continueWithMicrosoftAction;
-      const res = await action(undefined, "/auth/signup");
+      const callbackURL = this.invitationIntent
+        ? pathWithOnboardingIntent("/auth/invitation", this.invitationIntent)
+        : "/onboarding";
+      const errorCallbackURL = this.invitationIntent
+        ? pathWithOnboardingIntent("/auth/signup", this.invitationIntent)
+        : "/auth/signup";
+      const res = await action(callbackURL, errorCallbackURL);
 
       if (!res.ok) toastZodErrorTree(res.error);
       else if (res.data.url) {

--- a/app/[locale]/(public)/auth/verify-email/__tests__/page.test.ts
+++ b/app/[locale]/(public)/auth/verify-email/__tests__/page.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAccountState: vi.fn(),
+  resolveOnboardingIntent: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => {
+    throw new Error(`REDIRECT:${path}`);
+  },
+}));
+vi.mock("next-intl/server", () => ({ getLocale: vi.fn().mockResolvedValue("en") }));
+vi.mock("@/features/auth/next/require", () => ({ requireAccountState: mocks.requireAccountState }));
+vi.mock("@/features/company/next/onboarding-intent", () => ({
+  resolveOnboardingIntent: mocks.resolveOnboardingIntent,
+}));
+vi.mock("@/components/shared/centered-card-page", () => ({ CenteredCardPage: "centered-card-page" }));
+vi.mock("../verify-email-card", () => ({ VerifyEmailCard: "verify-email-card" }));
+
+import VerifyEmailPage from "../page";
+
+describe("VerifyEmailPage onboarding intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves an invitation when the session expires before the page loads", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      companyId: "company-a",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      intent: "signed.intent",
+      inviterName: "Invite Admin",
+      source: "explicit",
+      status: "valid",
+      token: "invite-a",
+      type: "invitation",
+    });
+    mocks.requireAccountState.mockImplementation((_expected, _fallback, redirects) => {
+      throw new Error(`REDIRECT:${redirects.unauthenticated}`);
+    });
+
+    await expect(VerifyEmailPage({ searchParams: Promise.resolve({ intent: "signed.intent" }) })).rejects.toThrow(
+      "REDIRECT:/auth/signin?intent=signed.intent",
+    );
+    expect(mocks.resolveOnboardingIntent).toHaveBeenCalledWith("signed.intent");
+    expect(mocks.requireAccountState).toHaveBeenCalledWith(
+      ["overdueVerification", "unregistered"],
+      "/",
+      expect.objectContaining({ unauthenticated: "/auth/signin?intent=signed.intent" }),
+    );
+  });
+
+  it("lets an overdue account verify when an onboarding intent is invalid", async () => {
+    mocks.resolveOnboardingIntent.mockResolvedValue({
+      errorMessage: "onboardingSessionExpired",
+      source: "explicit",
+      status: "invalid",
+    });
+    mocks.requireAccountState.mockResolvedValue({
+      sessionUser: { email: "invited@example.com", id: "auth-user" },
+      state: "overdueVerification",
+    });
+
+    const result = await VerifyEmailPage({ searchParams: Promise.resolve({ intent: "expired.intent" }) });
+    const card = result.props.children;
+
+    expect(card.props).toMatchObject({ email: "invited@example.com" });
+    expect(card.props.inviterName).toBeUndefined();
+    expect(card.props.onboardingIntent).toBeUndefined();
+  });
+});

--- a/app/[locale]/(public)/auth/verify-email/__tests__/verify-email.store.test.ts
+++ b/app/[locale]/(public)/auth/verify-email/__tests__/verify-email.store.test.ts
@@ -60,4 +60,13 @@ describe("VerifyEmailStore", () => {
 
     expect(store.isSent).toBe(false);
   });
+
+  it("resends verification with the active onboarding intent", async () => {
+    const store = new VerifyEmailStore(rootStore);
+    store.activate("invited@example.test", "signed.intent");
+
+    await store.resend();
+
+    expect(authActions.resendVerificationEmailFromAuthAction).toHaveBeenCalledWith("signed.intent");
+  });
 });

--- a/app/[locale]/(public)/auth/verify-email/page.tsx
+++ b/app/[locale]/(public)/auth/verify-email/page.tsx
@@ -1,17 +1,57 @@
 import { VerifyEmailCard } from "./verify-email-card";
 
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
 import { CenteredCardPage } from "@/components/shared/centered-card-page";
 import { requireAccountState } from "@/features/auth/next/require";
 import { NOINDEX_METADATA } from "@/core/seo/noindex-metadata";
+import {
+  ONBOARDING_INTENT_QUERY_PARAM,
+  onboardingIntentAuthRedirects,
+  pathWithOnboardingIntent,
+} from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export const metadata = NOINDEX_METADATA;
 
-export default async function VerifyEmailPage() {
-  const resolution = await requireAccountState("overdueVerification");
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function VerifyEmailPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const onboardingIntent = await resolveOnboardingIntent(params[ONBOARDING_INTENT_QUERY_PARAM]);
+  const locale = await getLocale();
+
+  const activeIntent = onboardingIntent.status === "valid" ? onboardingIntent : null;
+  const resolution = await requireAccountState(
+    ["overdueVerification", "unregistered"],
+    "/",
+    activeIntent ? onboardingIntentAuthRedirects(activeIntent.intent) : undefined,
+  );
+  const invitation =
+    onboardingIntent.status === "valid" && onboardingIntent.type === "invitation" ? onboardingIntent : null;
+  if (activeIntent?.type === "createCompany" && activeIntent.authUserId !== resolution.sessionUser?.id)
+    redirect(buildLocalePath(locale, "/auth/error?type=invalidOnboardingIntent"));
+  if (resolution.state === "unregistered") {
+    const destination = activeIntent
+      ? pathWithOnboardingIntent(
+          activeIntent.type === "invitation" ? "/auth/invitation" : "/onboarding/wizard",
+          activeIntent.intent,
+        )
+      : "/onboarding";
+    redirect(buildLocalePath(locale, destination));
+  }
 
   return (
     <CenteredCardPage>
-      <VerifyEmailCard email={resolution.sessionUser?.email} />
+      <VerifyEmailCard
+        email={resolution.sessionUser?.email}
+        inviterName={invitation?.inviterName}
+        onboardingIntent={activeIntent?.intent}
+      />
     </CenteredCardPage>
   );
 }

--- a/app/[locale]/(public)/auth/verify-email/verify-email-card.tsx
+++ b/app/[locale]/(public)/auth/verify-email/verify-email-card.tsx
@@ -11,21 +11,34 @@ import { AppCardFooter } from "@/components/card/app-card-footer";
 import { CardHeroHeader } from "@/components/card/card-hero-header";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { runUserAction } from "@/core/errors/report-application-error";
+import { Alert } from "@/components/shared/alert";
 
-export const VerifyEmailCard = observer(({ email }: { email?: string }) => {
+type Props = {
+  email?: string;
+  inviterName?: string;
+  onboardingIntent?: string;
+};
+
+export const VerifyEmailCard = observer(({ email, inviterName, onboardingIntent }: Props) => {
   const t = useTranslations();
   const { verifyEmailStore } = useRootStore();
 
   useLayoutEffect(() => {
-    verifyEmailStore.activate(email);
+    verifyEmailStore.activate(email, onboardingIntent);
     return () => verifyEmailStore.deactivate(email);
-  }, [email, verifyEmailStore]);
+  }, [email, onboardingIntent, verifyEmailStore]);
 
   return (
     <AppCard className="max-w-md">
-      <CardHeroHeader subtitle={t("VerifyEmailCard.subtitle")} title={t("VerifyEmailCard.title")} />
+      <CardHeroHeader alt="" subtitle={t("VerifyEmailCard.subtitle")} title={t("VerifyEmailCard.title")} />
 
       <AppCardBody>
+        {inviterName ? (
+          <Alert role="note">
+            <p className="text-x-sm">{t("VerifyEmailCard.invitationFrom", { inviterName })}</p>
+          </Alert>
+        ) : null}
+
         <p className="text-x-sm text-center">{t("VerifyEmailCard.body")}</p>
       </AppCardBody>
 

--- a/app/[locale]/(public)/auth/verify-email/verify-email.store.ts
+++ b/app/[locale]/(public)/auth/verify-email/verify-email.store.ts
@@ -8,6 +8,7 @@ import { resendVerificationEmailFromAuthAction } from "@/app/[locale]/(public)/a
 export class VerifyEmailStore extends BaseStore {
   isSent = false;
   private activeEmail: string | undefined;
+  private onboardingIntent: string | undefined;
 
   constructor(rootStore: RootStore) {
     super(rootStore);
@@ -20,15 +21,17 @@ export class VerifyEmailStore extends BaseStore {
     });
   }
 
-  activate = (email: string | undefined): void => {
-    if (this.activeEmail === email && email !== undefined) return;
+  activate = (email: string | undefined, onboardingIntent?: string): void => {
+    if (this.activeEmail === email && this.onboardingIntent === onboardingIntent && email !== undefined) return;
     this.activeEmail = email;
+    this.onboardingIntent = onboardingIntent;
     this.isSent = false;
   };
 
   deactivate = (email: string | undefined): void => {
     if (this.activeEmail !== email) return;
     this.activeEmail = undefined;
+    this.onboardingIntent = undefined;
     this.isSent = false;
   };
 
@@ -37,7 +40,7 @@ export class VerifyEmailStore extends BaseStore {
     if (!email) return;
 
     await this.rootStore.loadingOverlayStore.withLoading(async () => {
-      const result = await resendVerificationEmailFromAuthAction();
+      const result = await resendVerificationEmailFromAuthAction(this.onboardingIntent);
       if (!result.ok || this.activeEmail !== email) return;
 
       runInAction(() => {

--- a/app/[locale]/(public)/invitation/[token]/__tests__/route.test.ts
+++ b/app/[locale]/(public)/invitation/[token]/__tests__/route.test.ts
@@ -1,13 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const auth = vi.hoisted(() => ({
-  getSession: vi.fn(),
-  validateInvite: vi.fn(),
-}));
+const auth = vi.hoisted(() => ({ getSession: vi.fn(), issueInvitation: vi.fn(), validateInvite: vi.fn() }));
 
 vi.mock("@/core/di", () => ({
   getAuthService: () => ({ getSession: auth.getSession }),
   getInviteTokenValidationInteractor: () => ({ invoke: auth.validateInvite }),
+  getOnboardingIntentService: () => ({ issueInvitation: auth.issueInvitation }),
 }));
 vi.mock("@/env", () => ({
   env: {
@@ -18,7 +16,11 @@ vi.mock("@/env", () => ({
 }));
 
 import { GET } from "../route";
-import { decodeOnboardingIntent, onboardingIntentSigningSecret } from "@/features/company/onboarding-intent-codec";
+import {
+  decodeOnboardingIntent,
+  encodeInvitationOnboardingIntent,
+  onboardingIntentSigningSecret,
+} from "@/features/company/onboarding-intent-codec";
 
 const expiresAt = new Date("2099-01-01T00:00:00.000Z");
 
@@ -39,14 +41,14 @@ describe("invitation route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     auth.getSession.mockResolvedValue(null);
+    auth.issueInvitation.mockImplementation((token: string, invitationExpiresAt: Date, now?: Date) => {
+      const secret = onboardingIntentSigningSecret("route-test-secret");
+      if (!secret) throw new Error("Missing test signing secret");
+      return encodeInvitationOnboardingIntent(token, invitationExpiresAt, secret, now);
+    });
     auth.validateInvite.mockResolvedValue({
       ok: true,
-      data: {
-        companyId: "invited-company",
-        expiresAt,
-        inviterName: "Invite Admin",
-        valid: true,
-      },
+      data: { companyId: "invited-company", expiresAt, inviterName: "Invite Admin", valid: true },
     });
   });
 
@@ -124,12 +126,7 @@ describe("invitation route", () => {
   it("fails closed if the invitation expires between validation and intent issuance", async () => {
     auth.validateInvite.mockResolvedValue({
       ok: true,
-      data: {
-        companyId: "invited-company",
-        expiresAt: new Date(0),
-        inviterName: "Invite Admin",
-        valid: true,
-      },
+      data: { companyId: "invited-company", expiresAt: new Date(0), inviterName: "Invite Admin", valid: true },
     });
 
     const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/invite-token"), {

--- a/app/[locale]/(public)/invitation/[token]/__tests__/route.test.ts
+++ b/app/[locale]/(public)/invitation/[token]/__tests__/route.test.ts
@@ -11,31 +11,61 @@ vi.mock("@/core/di", () => ({
 }));
 vi.mock("@/env", () => ({
   env: {
-    BASE_URL: "https://customermates-git-feat-inbox-customermates.vercel.app",
     AUTH_ALLOWED_HOSTS: ["customermates-git-feat-inbox-customermates.vercel.app", "*.customermates.com"],
+    BASE_URL: "https://customermates-git-feat-inbox-customermates.vercel.app",
+    BETTER_AUTH_SECRET: "route-test-secret",
   },
 }));
 
 import { GET } from "../route";
+import { decodeOnboardingIntent, onboardingIntentSigningSecret } from "@/features/company/onboarding-intent-codec";
+
+const expiresAt = new Date("2099-01-01T00:00:00.000Z");
+
+function invitationFrom(response: Response) {
+  const location = new URL(response.headers.get("location") ?? "");
+  const intent = location.searchParams.get("intent") ?? undefined;
+  const secret = onboardingIntentSigningSecret("route-test-secret");
+  if (!secret) throw new Error("Missing test signing secret");
+  return { decoded: decodeOnboardingIntent(intent, secret), intent, location };
+}
+
+function expectLegacyCookieCleared(response: Response) {
+  expect(response.headers.get("set-cookie")).toContain("inviteToken=");
+  expect(response.headers.get("set-cookie")).toContain("Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+}
 
 describe("invitation route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     auth.getSession.mockResolvedValue(null);
-    auth.validateInvite.mockResolvedValue({ ok: true, data: { valid: true } });
+    auth.validateInvite.mockResolvedValue({
+      ok: true,
+      data: {
+        companyId: "invited-company",
+        expiresAt,
+        inviterName: "Invite Admin",
+        valid: true,
+      },
+    });
   });
 
-  it("keeps signup and its invitation cookie on the validated vanity origin", async () => {
+  it("keeps signup and its signed invitation on the validated vanity origin", async () => {
     const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/invite-token"), {
       params: Promise.resolve({ locale: "en", token: "invite-token" }),
     });
+    const invitation = invitationFrom(response);
 
-    expect(response.headers.get("location")).toBe("https://feat-inbox.customermates.com/en/auth/signup");
-    expect(response.headers.get("set-cookie")).toContain("inviteToken=invite-token");
-    expect(response.headers.get("set-cookie")).toContain("Secure");
+    expect(invitation.location.origin).toBe("https://feat-inbox.customermates.com");
+    expect(invitation.location.pathname).toBe("/en/auth/signup");
+    expect(invitation.decoded).toMatchObject({
+      payload: { token: "invite-token", type: "invitation" },
+      status: "valid",
+    });
+    expectLegacyCookieCleared(response);
   });
 
-  it("sends a schema-rejected token to the invalid invite link page", async () => {
+  it("clears a stale legacy invitation when the token is schema-rejected", async () => {
     auth.validateInvite.mockResolvedValue({ ok: false, error: new Error("invalid") });
 
     const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/%7Btoken%7D"), {
@@ -45,7 +75,71 @@ describe("invitation route", () => {
     expect(response.headers.get("location")).toBe(
       "https://feat-inbox.customermates.com/en/auth/error?type=invalidInviteLink",
     );
-    expect(response.headers.get("set-cookie")).toBeNull();
+    expectLegacyCookieCleared(response);
+  });
+
+  it("sends a signed-in visitor to the invitation explanation with the signed intent", async () => {
+    auth.getSession.mockResolvedValue({ user: { email: "invited@example.com", emailVerified: true } });
+
+    const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/invite-token"), {
+      params: Promise.resolve({ locale: "en", token: "invite-token" }),
+    });
+    const invitation = invitationFrom(response);
+
+    expect(auth.validateInvite).toHaveBeenCalledWith({ token: "invite-token" });
+    expect(invitation.location.pathname).toBe("/en/auth/invitation");
+    expect(invitation.decoded).toMatchObject({
+      payload: { token: "invite-token", type: "invitation" },
+      status: "valid",
+    });
+    expectLegacyCookieCleared(response);
+  });
+
+  it("keeps the invitation for a signed-in visitor who has not verified their email", async () => {
+    auth.getSession.mockResolvedValue({ user: { email: "invited@example.com", emailVerified: false } });
+
+    const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/invite-token"), {
+      params: Promise.resolve({ locale: "en", token: "invite-token" }),
+    });
+
+    expect(invitationFrom(response).location.pathname).toBe("/en/auth/invitation");
+    expectLegacyCookieCleared(response);
+  });
+
+  it("sends an expired token to the error page and clears a stale legacy invitation", async () => {
+    auth.getSession.mockResolvedValue({ user: { email: "invited@example.com", emailVerified: true } });
+    auth.validateInvite.mockResolvedValue({ ok: true, data: { valid: false, errorMessage: "inviteLinkExpired" } });
+
+    const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/invite-token"), {
+      params: Promise.resolve({ locale: "en", token: "invite-token" }),
+    });
+
+    expect(response.headers.get("location")).toBe(
+      "https://feat-inbox.customermates.com/en/auth/error?type=inviteLinkExpired",
+    );
+    expect(auth.getSession).not.toHaveBeenCalled();
+    expectLegacyCookieCleared(response);
+  });
+
+  it("fails closed if the invitation expires between validation and intent issuance", async () => {
+    auth.validateInvite.mockResolvedValue({
+      ok: true,
+      data: {
+        companyId: "invited-company",
+        expiresAt: new Date(0),
+        inviterName: "Invite Admin",
+        valid: true,
+      },
+    });
+
+    const response = await GET(new Request("https://feat-inbox.customermates.com/en/invitation/invite-token"), {
+      params: Promise.resolve({ locale: "en", token: "invite-token" }),
+    });
+
+    expect(response.headers.get("location")).toBe(
+      "https://feat-inbox.customermates.com/en/auth/error?type=inviteLinkExpired",
+    );
+    expectLegacyCookieCleared(response);
   });
 
   it("falls back to the stable branch origin for an untrusted request host", async () => {
@@ -53,8 +147,9 @@ describe("invitation route", () => {
       params: Promise.resolve({ locale: "en", token: "invite-token" }),
     });
 
-    expect(response.headers.get("location")).toBe(
-      "https://customermates-git-feat-inbox-customermates.vercel.app/en/auth/signup",
-    );
+    const invitation = invitationFrom(response);
+    expect(invitation.location.origin).toBe("https://customermates-git-feat-inbox-customermates.vercel.app");
+    expect(invitation.location.pathname).toBe("/en/auth/signup");
+    expect(invitation.intent).toBeTruthy();
   });
 });

--- a/app/[locale]/(public)/invitation/[token]/__tests__/route.test.ts
+++ b/app/[locale]/(public)/invitation/[token]/__tests__/route.test.ts
@@ -2,11 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const auth = vi.hoisted(() => ({ getSession: vi.fn(), issueInvitation: vi.fn(), validateInvite: vi.fn() }));
 
-vi.mock("@/core/di", () => ({
-  getAuthService: () => ({ getSession: auth.getSession }),
-  getInviteTokenValidationInteractor: () => ({ invoke: auth.validateInvite }),
-  getOnboardingIntentService: () => ({ issueInvitation: auth.issueInvitation }),
-}));
+vi.mock("@/core/di", async () => {
+  const { OpenInvitationInteractor } = await import("@/features/company/open-invitation.interactor");
+  return {
+    getOpenInvitationInteractor: () =>
+      new OpenInvitationInteractor(
+        { invoke: auth.validateInvite } as never,
+        { getSession: auth.getSession } as never,
+        { issueInvitation: auth.issueInvitation } as never,
+      ),
+  };
+});
 vi.mock("@/env", () => ({
   env: {
     AUTH_ALLOWED_HOSTS: ["customermates-git-feat-inbox-customermates.vercel.app", "*.customermates.com"],

--- a/app/[locale]/(public)/invitation/[token]/route.ts
+++ b/app/[locale]/(public)/invitation/[token]/route.ts
@@ -1,41 +1,19 @@
 import { NextResponse } from "next/server";
 
-import { getAuthService, getInviteTokenValidationInteractor } from "@/core/di";
+import { getOpenInvitationInteractor } from "@/core/di";
 import { resolveRequestOrigin } from "@/core/config/environment";
 import { env } from "@/env";
-import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
-import { issueInvitationOnboardingIntent } from "@/features/company/next/onboarding-intent";
 import { INVITE_TOKEN_COOKIE_NAME } from "@/features/company/next/invite-token-cookie";
-
-function redirectWithoutLegacyInvitation(url: URL): NextResponse {
-  const response = NextResponse.redirect(url);
-  response.cookies.delete(INVITE_TOKEN_COOKIE_NAME);
-  return response;
-}
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function GET(request: Request, context: { params: Promise<{ locale: string; token: string }> }) {
   const { locale, token } = await context.params;
 
   const base = resolveRequestOrigin(request.url, env.AUTH_ALLOWED_HOSTS, env.BASE_URL);
 
-  const inviteTokenResult = await getInviteTokenValidationInteractor().invoke({ token });
-
-  if (!inviteTokenResult.ok)
-    return redirectWithoutLegacyInvitation(new URL(`/${locale}/auth/error?type=invalidInviteLink`, base));
-
-  const inviteToken = inviteTokenResult.data;
-
-  if (!inviteToken.valid)
-    return redirectWithoutLegacyInvitation(new URL(`/${locale}/auth/error?type=${inviteToken.errorMessage}`, base));
-
-  const session = await getAuthService().getSession();
-  const destination = session ? "auth/invitation" : "auth/signup";
-  const invitationIntent = issueInvitationOnboardingIntent(token, inviteToken.expiresAt);
-  if (!invitationIntent)
-    return redirectWithoutLegacyInvitation(new URL(`/${locale}/auth/error?type=inviteLinkExpired`, base));
-  const response = redirectWithoutLegacyInvitation(
-    new URL(pathWithOnboardingIntent(`/${locale}/${destination}`, invitationIntent), base),
-  );
+  const result = await getOpenInvitationInteractor().invoke({ token });
+  const response = NextResponse.redirect(new URL(buildLocalePath(locale, result.redirect), base));
+  response.cookies.delete(INVITE_TOKEN_COOKIE_NAME);
 
   return response;
 }

--- a/app/[locale]/(public)/invitation/[token]/route.ts
+++ b/app/[locale]/(public)/invitation/[token]/route.ts
@@ -3,35 +3,39 @@ import { NextResponse } from "next/server";
 import { getAuthService, getInviteTokenValidationInteractor } from "@/core/di";
 import { resolveRequestOrigin } from "@/core/config/environment";
 import { env } from "@/env";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { issueInvitationOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { INVITE_TOKEN_COOKIE_NAME } from "@/features/company/next/invite-token-cookie";
+
+function redirectWithoutLegacyInvitation(url: URL): NextResponse {
+  const response = NextResponse.redirect(url);
+  response.cookies.delete(INVITE_TOKEN_COOKIE_NAME);
+  return response;
+}
 
 export async function GET(request: Request, context: { params: Promise<{ locale: string; token: string }> }) {
   const { locale, token } = await context.params;
 
   const base = resolveRequestOrigin(request.url, env.AUTH_ALLOWED_HOSTS, env.BASE_URL);
 
-  const session = await getAuthService().getSession();
-  if (session) {
-    const redirectPath = session.user?.emailVerified ? "dashboard" : "auth/verify-email";
-    return NextResponse.redirect(new URL(`/${locale}/${redirectPath}`, base));
-  }
-
   const inviteTokenResult = await getInviteTokenValidationInteractor().invoke({ token });
 
   if (!inviteTokenResult.ok)
-    return NextResponse.redirect(new URL(`/${locale}/auth/error?type=invalidInviteLink`, base));
+    return redirectWithoutLegacyInvitation(new URL(`/${locale}/auth/error?type=invalidInviteLink`, base));
 
   const inviteToken = inviteTokenResult.data;
 
   if (!inviteToken.valid)
-    return NextResponse.redirect(new URL(`/${locale}/auth/error?type=${inviteToken.errorMessage}`, base));
+    return redirectWithoutLegacyInvitation(new URL(`/${locale}/auth/error?type=${inviteToken.errorMessage}`, base));
 
-  const response = NextResponse.redirect(new URL(`/${locale}/auth/signup`, base));
-
-  response.cookies.set("inviteToken", token, {
-    httpOnly: true,
-    secure: new URL(base).protocol === "https:",
-    path: "/",
-  });
+  const session = await getAuthService().getSession();
+  const destination = session ? "auth/invitation" : "auth/signup";
+  const invitationIntent = issueInvitationOnboardingIntent(token, inviteToken.expiresAt);
+  if (!invitationIntent)
+    return redirectWithoutLegacyInvitation(new URL(`/${locale}/auth/error?type=inviteLinkExpired`, base));
+  const response = redirectWithoutLegacyInvitation(
+    new URL(pathWithOnboardingIntent(`/${locale}/${destination}`, invitationIntent), base),
+  );
 
   return response;
 }

--- a/app/[locale]/__tests__/actions.test.ts
+++ b/app/[locale]/__tests__/actions.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/core/di", () => ({
 }));
 vi.mock("@/core/utils/action-result", () => ({ serializeResult: mocks.serializeResult }));
 vi.mock("@/core/validation/validation.utils", () => ({ unwrapValidated: mocks.unused }));
-import { signOutAction, signOutForInvitationAction } from "../actions";
+import { signOutAction, signOutWithOnboardingIntentAction } from "../actions";
 
 describe("shared account actions", () => {
   beforeEach(() => {
@@ -36,9 +36,9 @@ describe("shared account actions", () => {
   it("localizes the invitation sign-out destination returned by the interactor", async () => {
     mocks.signOut.mockResolvedValue({ redirect: "/auth/signup?intent=signed.intent" });
 
-    await signOutForInvitationAction("signed.intent");
+    await signOutWithOnboardingIntentAction("signed.intent");
 
-    expect(mocks.signOut).toHaveBeenCalledExactlyOnceWith({ invitationIntent: "signed.intent" });
+    expect(mocks.signOut).toHaveBeenCalledExactlyOnceWith({ onboardingIntent: "signed.intent" });
     expect(mocks.redirect).toHaveBeenCalledExactlyOnceWith("/en/auth/signup?intent=signed.intent");
   });
 });

--- a/app/[locale]/__tests__/actions.test.ts
+++ b/app/[locale]/__tests__/actions.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  clearInviteTokenCookie: vi.fn(),
+  redirect: vi.fn(),
   serializeResult: vi.fn(async (result: unknown) => await result),
   signOut: vi.fn(),
   unused: vi.fn(),
 }));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next-intl/server", () => ({ getLocale: () => Promise.resolve("en") }));
 
 vi.mock("@/core/di", () => ({
   getCaptureAdClickInteractor: () => ({ invoke: mocks.unused }),
@@ -16,26 +19,26 @@ vi.mock("@/core/di", () => ({
 }));
 vi.mock("@/core/utils/action-result", () => ({ serializeResult: mocks.serializeResult }));
 vi.mock("@/core/validation/validation.utils", () => ({ unwrapValidated: mocks.unused }));
-vi.mock("@/features/company/next/invite-token-cookie", () => ({
-  clearInviteTokenCookie: mocks.clearInviteTokenCookie,
-}));
-
-import { signOutAction } from "../actions";
+import { signOutAction, signOutForInvitationAction } from "../actions";
 
 describe("shared account actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.clearInviteTokenCookie.mockResolvedValue(undefined);
-    mocks.signOut.mockResolvedValue({ ok: true, data: null });
+    mocks.signOut.mockResolvedValue({ redirect: "/" });
   });
 
-  it("clears a legacy invitation before signing out", async () => {
+  it("delegates ordinary sign out to the interactor", async () => {
     await signOutAction();
 
-    expect(mocks.clearInviteTokenCookie).toHaveBeenCalledOnce();
-    expect(mocks.signOut).toHaveBeenCalledOnce();
-    expect(mocks.clearInviteTokenCookie.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.signOut.mock.invocationCallOrder[0],
-    );
+    expect(mocks.signOut).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("localizes the invitation sign-out destination returned by the interactor", async () => {
+    mocks.signOut.mockResolvedValue({ redirect: "/auth/signup?intent=signed.intent" });
+
+    await signOutForInvitationAction("signed.intent");
+
+    expect(mocks.signOut).toHaveBeenCalledExactlyOnceWith({ invitationIntent: "signed.intent" });
+    expect(mocks.redirect).toHaveBeenCalledExactlyOnceWith("/en/auth/signup?intent=signed.intent");
   });
 });

--- a/app/[locale]/__tests__/actions.test.ts
+++ b/app/[locale]/__tests__/actions.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearInviteTokenCookie: vi.fn(),
+  serializeResult: vi.fn(async (result: unknown) => await result),
+  signOut: vi.fn(),
+  unused: vi.fn(),
+}));
+
+vi.mock("@/core/di", () => ({
+  getCaptureAdClickInteractor: () => ({ invoke: mocks.unused }),
+  getDecideAdAttributionConsentInteractor: () => ({ invoke: mocks.unused }),
+  getReadAdAttributionConsentInteractor: () => ({ invoke: mocks.unused }),
+  getSignOutInteractor: () => ({ invoke: mocks.signOut }),
+  getWithdrawAdAttributionInteractor: () => ({ invoke: mocks.unused }),
+}));
+vi.mock("@/core/utils/action-result", () => ({ serializeResult: mocks.serializeResult }));
+vi.mock("@/core/validation/validation.utils", () => ({ unwrapValidated: mocks.unused }));
+vi.mock("@/features/company/next/invite-token-cookie", () => ({
+  clearInviteTokenCookie: mocks.clearInviteTokenCookie,
+}));
+
+import { signOutAction } from "../actions";
+
+describe("shared account actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clearInviteTokenCookie.mockResolvedValue(undefined);
+    mocks.signOut.mockResolvedValue({ ok: true, data: null });
+  });
+
+  it("clears a legacy invitation before signing out", async () => {
+    await signOutAction();
+
+    expect(mocks.clearInviteTokenCookie).toHaveBeenCalledOnce();
+    expect(mocks.signOut).toHaveBeenCalledOnce();
+    expect(mocks.clearInviteTokenCookie.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signOut.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/app/[locale]/actions.ts
+++ b/app/[locale]/actions.ts
@@ -17,28 +17,15 @@ import { getLocale } from "next-intl/server";
 
 import { serializeResult } from "@/core/utils/action-result";
 import { unwrapValidated } from "@/core/validation/validation.utils";
-import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
-import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
-import { clearInviteTokenCookie } from "@/features/company/next/invite-token-cookie";
 import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function signOutAction() {
-  await clearInviteTokenCookie();
   return serializeResult(getSignOutInteractor().invoke());
 }
 
 export async function signOutForInvitationAction(invitationIntent: string) {
-  const invitation = await resolveOnboardingIntent(invitationIntent);
-  await clearInviteTokenCookie();
-  await getSignOutInteractor().invoke();
-
-  const locale = await getLocale();
-  if (invitation.status !== "valid" || invitation.type !== "invitation") {
-    const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
-    return redirect(buildLocalePath(locale, `/auth/error?type=${errorMessage}`));
-  }
-
-  return redirect(buildLocalePath(locale, pathWithOnboardingIntent("/auth/signup", invitation.intent)));
+  const result = await getSignOutInteractor().invoke({ invitationIntent });
+  return redirect(buildLocalePath(await getLocale(), result.redirect));
 }
 
 export async function readAdAttributionConsentAction() {

--- a/app/[locale]/actions.ts
+++ b/app/[locale]/actions.ts
@@ -12,11 +12,33 @@ import {
   getSignOutInteractor,
   getWithdrawAdAttributionInteractor,
 } from "@/core/di";
+import { redirect } from "next/navigation";
+import { getLocale } from "next-intl/server";
+
 import { serializeResult } from "@/core/utils/action-result";
 import { unwrapValidated } from "@/core/validation/validation.utils";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import { resolveOnboardingIntent } from "@/features/company/next/onboarding-intent";
+import { clearInviteTokenCookie } from "@/features/company/next/invite-token-cookie";
+import { buildLocalePath } from "@/i18n/locale-registry";
 
 export async function signOutAction() {
+  await clearInviteTokenCookie();
   return serializeResult(getSignOutInteractor().invoke());
+}
+
+export async function signOutForInvitationAction(invitationIntent: string) {
+  const invitation = await resolveOnboardingIntent(invitationIntent);
+  await clearInviteTokenCookie();
+  await getSignOutInteractor().invoke();
+
+  const locale = await getLocale();
+  if (invitation.status !== "valid" || invitation.type !== "invitation") {
+    const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
+    return redirect(buildLocalePath(locale, `/auth/error?type=${errorMessage}`));
+  }
+
+  return redirect(buildLocalePath(locale, pathWithOnboardingIntent("/auth/signup", invitation.intent)));
 }
 
 export async function readAdAttributionConsentAction() {

--- a/app/[locale]/actions.ts
+++ b/app/[locale]/actions.ts
@@ -23,8 +23,8 @@ export async function signOutAction() {
   return serializeResult(getSignOutInteractor().invoke());
 }
 
-export async function signOutForInvitationAction(invitationIntent: string) {
-  const result = await getSignOutInteractor().invoke({ invitationIntent });
+export async function signOutWithOnboardingIntentAction(onboardingIntent: string) {
+  const result = await getSignOutInteractor().invoke({ onboardingIntent });
   return redirect(buildLocalePath(await getLocale(), result.redirect));
 }
 

--- a/app/components/navigation/__tests__/account-state-for-path.test.ts
+++ b/app/components/navigation/__tests__/account-state-for-path.test.ts
@@ -18,6 +18,7 @@ describe("accountStateForPath", () => {
   it.each([
     ["/auth/verify-email", "overdueVerification"],
     ["/auth/pending", "pending"],
+    ["/onboarding", "onboarding"],
     ["/onboarding/wizard", "onboarding"],
     ["/legal-update", "legal"],
     ["/subscription-expired", "subscription"],

--- a/app/components/navigation/__tests__/navigation-shell.test.ts
+++ b/app/components/navigation/__tests__/navigation-shell.test.ts
@@ -140,7 +140,7 @@ describe("resolveNavigationShell", () => {
     expect(
       resolveNavigationShell({
         accountState: "unregistered",
-        pathname: "/onboarding/wizard",
+        pathname: "/onboarding/join",
         isRegistered: false,
       }),
     ).toBe("public");
@@ -180,7 +180,7 @@ describe("resolveNavigationShell", () => {
     expect(
       resolveNavigationShell({
         accountState: "allowed",
-        pathname: "/onboarding/wizard/profile",
+        pathname: "/onboarding/join",
         isRegistered: true,
       }),
     ).toBe("public");

--- a/app/components/navigation/__tests__/navigation-switch.test.ts
+++ b/app/components/navigation/__tests__/navigation-switch.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
   appMode: "cloud" as "cloud" | "demo",
   pathname: "/dashboard",
+  searchParams: {} as Record<string, string[]>,
   refresh: vi.fn(),
   currentUser: null as { id: string } | null,
   navigationRenderActive: false,
@@ -23,7 +24,7 @@ state.setUser.mockImplementation((user: { id: string } | null) => {
 });
 
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => ({ getAll: () => [] }),
+  useSearchParams: () => ({ getAll: (key: string) => state.searchParams[key] ?? [] }),
 }));
 vi.mock("@/i18n/navigation", () => ({
   usePathname: () => state.pathname,
@@ -60,7 +61,8 @@ vi.mock("@/app/components/app-topbar", () => ({
     }),
 }));
 vi.mock("@/app/components/public-navbar", () => ({
-  PublicNavbar: () => jsx("div", { "data-public-navbar": true }),
+  PublicNavbar: ({ onboardingIntent }: { onboardingIntent?: string }) =>
+    jsx("div", { "data-onboarding-intent": onboardingIntent, "data-public-navbar": true }),
 }));
 vi.mock("@/app/components/shell-header", () => ({ ShellHeader: () => null }));
 vi.mock("@/app/[locale]/(static)/docs/components/docs-sidebar", () => ({
@@ -164,6 +166,7 @@ beforeEach(() => {
   state.renderPhaseUserWrites = [];
   state.appMode = "cloud";
   state.pathname = "/dashboard";
+  state.searchParams = {};
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -340,5 +343,23 @@ describe("NavigationSwitch account-state refresh", () => {
       );
     });
     expect(scrollport?.scrollTop).toBe(0);
+  });
+
+  it("passes one unambiguous onboarding intent to the public navbar", () => {
+    state.pathname = "/styleguide";
+    state.searchParams = { intent: ["signed.intent"] };
+
+    act(() => {
+      root.render(jsx(NavigationSwitch, { ...allowedProps(), children: "page" }));
+    });
+    expect(container.querySelector("[data-public-navbar]")?.getAttribute("data-onboarding-intent")).toBe(
+      "signed.intent",
+    );
+
+    state.searchParams = { intent: ["signed.intent", "second.intent"] };
+    act(() => {
+      root.render(jsx(NavigationSwitch, { ...allowedProps(), children: "page" }));
+    });
+    expect(container.querySelector("[data-public-navbar]")?.hasAttribute("data-onboarding-intent")).toBe(false);
   });
 });

--- a/app/components/navigation/__tests__/public-navbar-model.test.ts
+++ b/app/components/navigation/__tests__/public-navbar-model.test.ts
@@ -35,7 +35,7 @@ describe("resolvePublicNavbarActions", () => {
         pathname: "/pricing",
       }),
     ).toEqual({
-      cta: { href: "/onboarding/wizard", label: "continueSetup" },
+      cta: { href: "/onboarding", label: "continueSetup" },
       showContact: false,
       signOut: "hidden",
     });
@@ -46,7 +46,7 @@ describe("resolvePublicNavbarActions", () => {
       resolvePublicNavbarActions({
         accountState: "unregistered",
         hasValidSession: true,
-        pathname: "/onboarding/wizard",
+        pathname: "/onboarding",
       }),
     ).toEqual({
       cta: null,
@@ -60,7 +60,7 @@ describe("resolvePublicNavbarActions", () => {
       resolvePublicNavbarActions({
         accountState: "unregistered",
         hasValidSession: true,
-        pathname: "/onboarding/wizard/profile",
+        pathname: "/onboarding/join",
       }),
     ).toEqual({
       cta: null,

--- a/app/components/navigation/__tests__/public-navbar-model.test.ts
+++ b/app/components/navigation/__tests__/public-navbar-model.test.ts
@@ -3,6 +3,36 @@ import { describe, expect, it } from "vitest";
 import { resolvePublicNavbarActions } from "../public-navbar-model";
 
 describe("resolvePublicNavbarActions", () => {
+  it.each([
+    {
+      accountState: "unauthenticated" as const,
+      hasValidSession: false,
+      pathname: "/auth/signup",
+      target: "/auth/signin",
+    },
+    {
+      accountState: "unregistered" as const,
+      hasValidSession: true,
+      pathname: "/auth/invitation",
+      target: "/onboarding",
+    },
+  ])("preserves onboarding intent from $pathname", ({ target, ...context }) => {
+    expect(resolvePublicNavbarActions({ ...context, onboardingIntent: "signed+intent" }).cta?.href).toBe(
+      `${target}?intent=signed%2Bintent`,
+    );
+  });
+
+  it("does not attach onboarding intent to the dashboard", () => {
+    expect(
+      resolvePublicNavbarActions({
+        accountState: "allowed",
+        hasValidSession: true,
+        onboardingIntent: "signed.intent",
+        pathname: "/auth/invitation",
+      }).cta?.href,
+    ).toBe("/dashboard");
+  });
+
   it("offers sign-in and contact without a session", () => {
     expect(
       resolvePublicNavbarActions({

--- a/app/components/navigation/__tests__/public-navbar-sign-out.test.ts
+++ b/app/components/navigation/__tests__/public-navbar-sign-out.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  signOut: vi.fn(),
+  signOutWithOnboardingIntent: vi.fn(),
+}));
+
+vi.mock("@/app/[locale]/actions", () => ({
+  signOutAction: mocks.signOut,
+  signOutWithOnboardingIntentAction: mocks.signOutWithOnboardingIntent,
+}));
+
+import { signOutFromPublicNavbar } from "../public-navbar-sign-out";
+
+describe("signOutFromPublicNavbar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses ordinary sign out when no onboarding intent is active", async () => {
+    mocks.signOut.mockResolvedValue({ ok: true });
+
+    await expect(signOutFromPublicNavbar()).resolves.toEqual({ ok: true });
+    expect(mocks.signOut).toHaveBeenCalledOnce();
+    expect(mocks.signOutWithOnboardingIntent).not.toHaveBeenCalled();
+  });
+
+  it("preserves an active onboarding intent through sign out", async () => {
+    mocks.signOutWithOnboardingIntent.mockResolvedValue(undefined);
+
+    await expect(signOutFromPublicNavbar("signed.intent")).resolves.toBeNull();
+    expect(mocks.signOutWithOnboardingIntent).toHaveBeenCalledExactlyOnceWith("signed.intent");
+    expect(mocks.signOut).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/navigation/account-state-for-path.ts
+++ b/app/components/navigation/account-state-for-path.ts
@@ -24,7 +24,7 @@ export function accountStateForPath({
   if (!isRegistered) return accountState;
   if (pathname === "/auth/pending") return "pending";
   if (pathname === "/auth/error" && isInactiveError) return "inactive";
-  if (pathname === "/onboarding/wizard" || pathname.startsWith("/onboarding/wizard/")) return "onboarding";
+  if (pathname === "/onboarding" || pathname.startsWith("/onboarding/")) return "onboarding";
   if (pathname === "/legal-update") return "legal";
   if (pathname === "/subscription-expired") return "subscription";
 

--- a/app/components/navigation/navigation-shell.ts
+++ b/app/components/navigation/navigation-shell.ts
@@ -18,7 +18,7 @@ export function resolveNavigationShell({
   if (pathname === "/docs" || pathname.startsWith("/docs/")) return "docs";
   if (!isRegistered) return "public";
   if (accountState === "unauthenticated" || accountState === "unregistered") return "public";
-  if (pathname.startsWith("/auth/") || pathname === "/onboarding/wizard" || pathname.startsWith("/onboarding/wizard/"))
+  if (pathname.startsWith("/auth/") || pathname === "/onboarding" || pathname.startsWith("/onboarding/"))
     return "public";
 
   return "app";

--- a/app/components/navigation/navigation-switch.tsx
+++ b/app/components/navigation/navigation-switch.tsx
@@ -29,6 +29,7 @@ import { AppLocalePreferenceSync } from "@/components/shared/app-locale-preferen
 import { ProtectedEnhancementsProvider } from "./protected-enhancements-context";
 import { accountStateForPath } from "./account-state-for-path";
 import { resolveNavigationShell } from "./navigation-shell";
+import { ONBOARDING_INTENT_QUERY_PARAM } from "@/features/company/onboarding-intent-url";
 
 type NavigationSwitchProps = {
   accountState: AccountState;
@@ -71,6 +72,8 @@ export function NavigationSwitch({
   const router = useRouter();
   const searchParams = useSearchParams();
   const errorTypes = searchParams.getAll("type");
+  const onboardingIntents = searchParams.getAll(ONBOARDING_INTENT_QUERY_PARAM);
+  const onboardingIntent = onboardingIntents.length === 1 && onboardingIntents[0] ? onboardingIntents[0] : undefined;
   const hasValidSession = accountState !== "unauthenticated";
   const isRegistered = sidebarUser !== null;
   const currentAccountState = accountStateForPath({
@@ -142,7 +145,11 @@ export function NavigationSwitch({
         className="relative flex h-svh flex-col overflow-y-auto bg-background [--table-sticky-top:4rem] [--toc-sticky-top:4rem] [--toc-anchor-offset:5rem] xl:[--table-sticky-top:3.5rem] xl:[--toc-sticky-top:3.5rem] xl:[--toc-anchor-offset:4.5rem]"
       >
         <header className="sticky top-0 z-50 flex shrink-0 flex-col bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/75">
-          <PublicNavbar accountState={currentAccountState} hasValidSession={hasValidSession} />
+          <PublicNavbar
+            accountState={currentAccountState}
+            hasValidSession={hasValidSession}
+            onboardingIntent={onboardingIntent}
+          />
         </header>
 
         <main className="relative flex min-w-0 flex-1 flex-col">

--- a/app/components/navigation/public-navbar-model.ts
+++ b/app/components/navigation/public-navbar-model.ts
@@ -1,7 +1,9 @@
 import type { AccountState } from "@/features/auth/account-state";
 
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+
 type PublicNavbarCta = {
-  href: "/auth/signin" | "/dashboard" | "/onboarding";
+  href: string;
   label: "signIn" | "openApp" | "continueSetup";
 };
 
@@ -14,15 +16,23 @@ type PublicNavbarActions = {
 export function resolvePublicNavbarActions({
   accountState,
   hasValidSession,
+  onboardingIntent,
   pathname,
 }: {
   accountState: AccountState;
   hasValidSession: boolean;
+  onboardingIntent?: string;
   pathname: string;
 }): PublicNavbarActions {
   if (!hasValidSession) {
     return {
-      cta: pathname === "/auth/signin" ? null : { href: "/auth/signin", label: "signIn" },
+      cta:
+        pathname === "/auth/signin"
+          ? null
+          : {
+              href: onboardingIntent ? pathWithOnboardingIntent("/auth/signin", onboardingIntent) : "/auth/signin",
+              label: "signIn",
+            },
       showContact: true,
       signOut: "hidden",
     };
@@ -32,7 +42,12 @@ export function resolvePublicNavbarActions({
     const onboardingPath = pathname === "/onboarding" || pathname.startsWith("/onboarding/");
 
     return {
-      cta: onboardingPath ? null : { href: "/onboarding", label: "continueSetup" },
+      cta: onboardingPath
+        ? null
+        : {
+            href: onboardingIntent ? pathWithOnboardingIntent("/onboarding", onboardingIntent) : "/onboarding",
+            label: "continueSetup",
+          },
       showContact: false,
       signOut: onboardingPath ? "setupEscape" : "hidden",
     };

--- a/app/components/navigation/public-navbar-model.ts
+++ b/app/components/navigation/public-navbar-model.ts
@@ -1,7 +1,7 @@
 import type { AccountState } from "@/features/auth/account-state";
 
 type PublicNavbarCta = {
-  href: "/auth/signin" | "/dashboard" | "/onboarding/wizard";
+  href: "/auth/signin" | "/dashboard" | "/onboarding";
   label: "signIn" | "openApp" | "continueSetup";
 };
 
@@ -29,10 +29,10 @@ export function resolvePublicNavbarActions({
   }
 
   if (accountState === "unregistered") {
-    const onboardingPath = pathname === "/onboarding/wizard" || pathname.startsWith("/onboarding/wizard/");
+    const onboardingPath = pathname === "/onboarding" || pathname.startsWith("/onboarding/");
 
     return {
-      cta: onboardingPath ? null : { href: "/onboarding/wizard", label: "continueSetup" },
+      cta: onboardingPath ? null : { href: "/onboarding", label: "continueSetup" },
       showContact: false,
       signOut: onboardingPath ? "setupEscape" : "hidden",
     };

--- a/app/components/navigation/public-navbar-sign-out.ts
+++ b/app/components/navigation/public-navbar-sign-out.ts
@@ -1,0 +1,10 @@
+import { signOutAction, signOutWithOnboardingIntentAction } from "@/app/[locale]/actions";
+
+export async function signOutFromPublicNavbar(onboardingIntent?: string) {
+  if (onboardingIntent) {
+    await signOutWithOnboardingIntentAction(onboardingIntent);
+    return null;
+  }
+
+  return signOutAction();
+}

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -340,6 +340,7 @@ export const PublicNavbar = observer(({ accountState, hasValidSession, onboardin
   const actions = resolvePublicNavbarActions({
     accountState,
     hasValidSession,
+    onboardingIntent,
     pathname,
   });
   const { cta } = actions;

--- a/app/components/public-navbar.tsx
+++ b/app/components/public-navbar.tsx
@@ -53,10 +53,10 @@ import {
 } from "@/components/ui/sheet";
 import { ThemeSwitcher } from "@/components/shared/theme-switcher";
 import { cn } from "@/core/utils/cn";
-import { signOutAction } from "@/app/[locale]/actions";
 import { toastZodErrorTree } from "@/core/utils/toast-zod-error-tree";
 import { runUserAction } from "@/core/errors/report-application-error";
 import { resolvePublicNavbarActions } from "./navigation/public-navbar-model";
+import { signOutFromPublicNavbar } from "./navigation/public-navbar-sign-out";
 import {
   isPrimaryPublicNavLink,
   PublicNavLinkIcon,
@@ -70,12 +70,13 @@ import { MarketingContainer } from "@/components/marketing/marketing-container";
 type Props = {
   accountState: AccountState;
   hasValidSession: boolean;
+  onboardingIntent?: string;
 };
 
 const mobileOverviewRowClassName =
   "flex min-h-14 w-full items-center justify-between gap-4 rounded-md py-4 text-left text-base font-medium text-sidebar-foreground no-underline transition-all outline-none hover:no-underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50";
 
-export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) => {
+export const PublicNavbar = observer(({ accountState, hasValidSession, onboardingIntent }: Props) => {
   const t = useTranslations();
   const { layoutStore } = useRootStore();
   const pathname = usePathname();
@@ -366,8 +367,8 @@ export const PublicNavbar = observer(({ accountState, hasValidSession }: Props) 
     if (isSigningOut) return;
     setIsSigningOut(true);
     try {
-      const result = await signOutAction();
-      if (result.ok) return;
+      const result = await signOutFromPublicNavbar(onboardingIntent);
+      if (!result || result.ok) return;
 
       toastZodErrorTree(result.error);
       setIsSigningOut(false);

--- a/components/card/card-hero-header.tsx
+++ b/components/card/card-hero-header.tsx
@@ -31,7 +31,9 @@ export function CardHeroHeader({ alt, subtitle, title, isLoading }: Props) {
 
       <h1 className="text-x-2xl mt-4">{title}</h1>
 
-      {subtitle && <span className="text-x-sm text-subdued">{subtitle}</span>}
+      {subtitle && (
+        <span className="text-x-sm text-subdued min-w-0 max-w-full [overflow-wrap:anywhere]">{subtitle}</span>
+      )}
     </AppCardHeader>
   );
 }

--- a/components/shared/__tests__/alert.test.ts
+++ b/components/shared/__tests__/alert.test.ts
@@ -42,6 +42,8 @@ describe("Alert", () => {
     );
 
     expect(markup).toMatch(/data-slot="alert-description"[^>]*><p>Plain description<\/p><\/div>/);
-    expect(markup).toContain('<div class="col-start-2 min-w-0"><button type="button">Act</button></div>');
+    expect(markup).toContain(
+      '<div class="col-start-2 min-w-0 [overflow-wrap:anywhere]"><button type="button">Act</button></div>',
+    );
   });
 });

--- a/components/shared/alert.tsx
+++ b/components/shared/alert.tsx
@@ -55,7 +55,7 @@ export function Alert({ className, color = "default", title, description, icon, 
         </AlertDescription>
       )}
 
-      {children && <div className="col-start-2 min-w-0">{children}</div>}
+      {children && <div className="col-start-2 min-w-0 [overflow-wrap:anywhere]">{children}</div>}
     </UiAlert>
   );
 }

--- a/components/shared/centered-card-page-skeleton.tsx
+++ b/components/shared/centered-card-page-skeleton.tsx
@@ -2,7 +2,7 @@ import { SkeletonShape as Shape } from "@/components/page-state/skeleton-shape";
 import { cn } from "@/core/utils/cn";
 import type { ReactNode } from "react";
 
-type Props = { animated?: boolean; children?: ReactNode; maxWidth?: "2xl" | "3xl" };
+type Props = { animated?: boolean; children?: ReactNode; maxWidth?: "lg" | "2xl" | "3xl" };
 
 export function CenteredCardPageSkeleton({ animated = true, children, maxWidth = "2xl" }: Props) {
   return (
@@ -16,8 +16,8 @@ export function CenteredCardPageSkeleton({ animated = true, children, maxWidth =
       <div className="flex min-h-full w-full items-center justify-center p-4">
         <div
           className={cn(
-            "flex w-full flex-col gap-0 rounded-xl border border-border bg-card py-0 shadow-xs",
-            maxWidth === "3xl" ? "max-w-3xl" : "max-w-2xl",
+            "flex w-full flex-col gap-0 rounded-xl border border-border bg-background py-0 shadow-xs",
+            maxWidth === "3xl" ? "max-w-3xl" : maxWidth === "lg" ? "max-w-lg" : "max-w-2xl",
           )}
           data-skeleton-group="0"
         >

--- a/components/shared/icon-container.tsx
+++ b/components/shared/icon-container.tsx
@@ -43,7 +43,7 @@ export function IconContainer({
   const iconColorClass = color === "primary" ? "text-primary dark:text-primary" : "text-foreground";
 
   return (
-    <div className={cn(iconContainerVariants({ size, color }), className)}>
+    <div aria-hidden className={cn(iconContainerVariants({ size, color }), className)}>
       <Icon className={cn(iconColorClass, iconClassName)} icon={icon} size={iconSize} />
     </div>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/97",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
         secondary: "border border-border bg-secondary text-secondary-foreground shadow-xs hover:bg-accent",

--- a/core/auth/better-auth.ts
+++ b/core/auth/better-auth.ts
@@ -8,6 +8,7 @@ import * as Sentry from "@sentry/nextjs";
 import { prisma } from "@/prisma/db";
 import { runWithoutTenant } from "@/core/decorators/tenant-context";
 import { env } from "@/env";
+import { callbackUrlSchema } from "@/features/auth/callback-url.schema";
 import { API_KEY_MAX_EXPIRATION_DAYS, API_KEY_MIN_EXPIRATION_DAYS } from "@/features/api-key/api-key-expiration";
 
 const socialProviders = {
@@ -68,31 +69,6 @@ export const auth = betterAuth({
   }),
 
   databaseHooks: {
-    user: {
-      create: {
-        before: async (data, ctx) => {
-          const inviteToken = ctx?.getCookie("inviteToken");
-
-          if (!inviteToken) return { data };
-
-          const { getInviteTokenValidationInteractor } = await import("@/core/di");
-          const result = await getInviteTokenValidationInteractor().invoke({ token: inviteToken });
-
-          if (!result.ok) return { data };
-
-          const res = result.data;
-
-          if (!res.valid && res.errorMessage === "inviteLinkExpired") {
-            const { redirect } = await import("next/navigation");
-            redirect("/auth/error?type=inviteLinkExpired");
-          }
-
-          return {
-            data: res.valid ? { ...data, companyId: res.companyId } : { ...data },
-          };
-        },
-      },
-    },
     session: {
       create: {
         after: async (session) => {
@@ -156,7 +132,9 @@ export const auth = betterAuth({
     autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, url }) => {
       const verificationUrl = new URL(url);
-      verificationUrl.searchParams.set("callbackURL", "/onboarding/wizard");
+      const callbackURL = verificationUrl.searchParams.get("callbackURL");
+      if (!callbackURL || callbackURL === "/" || !callbackUrlSchema.safeParse(callbackURL).success)
+        verificationUrl.searchParams.set("callbackURL", "/onboarding");
 
       const { getAuthService } = await import("@/core/di");
       await getAuthService().sendVerificationEmail({ to: user.email, url: verificationUrl.toString() });

--- a/core/di.ts
+++ b/core/di.ts
@@ -81,6 +81,8 @@ import { ExportOrganizationsPageInteractor } from "@/features/data-transfer/expo
 import { ExportServicesPageInteractor } from "@/features/data-transfer/export/export-services-page.interactor";
 import { ExportTasksPageInteractor } from "@/features/data-transfer/export/export-tasks-page.interactor";
 import { GetImportRelationIndexInteractor } from "@/features/data-transfer/import/get-import-relation-index.interactor";
+import { DryRunImportChunkInteractor } from "@/features/data-transfer/import/dry-run-import-chunk.interactor";
+import { CommitImportChunkInteractor } from "@/features/data-transfer/import/commit-import-chunk.interactor";
 import { ImportRelationIndex } from "@/features/data-transfer/import/relation-index.service";
 import { GetContactsConfigurationInteractor } from "@/features/contacts/get/get-contacts-configuration.interactor";
 import { GetContactByIdInteractor } from "@/features/contacts/get/get-contact-by-id.interactor";
@@ -112,6 +114,8 @@ import { QueryParamsPrecheckInteractor } from "@/core/base/query-params-precheck
 import { CheckChannelConflictInteractor } from "@/features/contacts/upsert/check-channel-conflict.interactor";
 import { CreateManyContactsInteractor } from "@/features/contacts/upsert/create-many-contacts.interactor";
 import { UpdateContactInteractor } from "@/features/contacts/upsert/update-contact.interactor";
+import { LinkContactIdentifierInteractor } from "@/features/contacts/upsert/link-contact-identifier.interactor";
+import { UnlinkContactIdentifierInteractor } from "@/features/contacts/upsert/unlink-contact-identifier.interactor";
 import { UpdateManyContactsInteractor } from "@/features/contacts/upsert/update-many-contacts.interactor";
 import { DeleteContactInteractor } from "@/features/contacts/delete/delete-contact.interactor";
 import { DeleteManyContactsInteractor } from "@/features/contacts/delete/delete-many-contacts.interactor";
@@ -140,6 +144,7 @@ import { GetServicesInteractor } from "@/features/services/get/get-services.inte
 import { GetServicesConfigurationInteractor } from "@/features/services/get/get-services-configuration.interactor";
 import { GetServiceByIdInteractor } from "@/features/services/get/get-service-by-id.interactor";
 import { CreateServiceInteractor } from "@/features/services/upsert/create-service.interactor";
+import { CreateServiceByNameInteractor } from "@/features/services/upsert/create-service-by-name.interactor";
 import { CreateManyServicesInteractor } from "@/features/services/upsert/create-many-services.interactor";
 import { UpdateServiceInteractor } from "@/features/services/upsert/update-service.interactor";
 import { UpdateManyServicesInteractor } from "@/features/services/upsert/update-many-services.interactor";
@@ -181,6 +186,7 @@ import { UpdateCompanySettingsInteractor } from "@/features/company/update-compa
 import { GetOrCreateInviteTokenInteractor } from "@/features/company/get-or-create-invite-token.interactor";
 import { InviteUsersByEmailInteractor } from "@/features/company/invite-users-by-email.interactor";
 import { InviteTokenValidationInteractor } from "@/features/company/invite-token-validation.interactor";
+import { OpenInvitationInteractor } from "@/features/company/open-invitation.interactor";
 import { ChooseWorkspaceOnboardingInteractor } from "@/features/company/choose-workspace-onboarding.interactor";
 import { env } from "@/env";
 // Role interactors
@@ -366,13 +372,13 @@ import { ResetOperatorUserCreditsInteractor } from "@/ee/operator/reset-operator
 
 export const getContactRepo = () => new PrismaContactRepo();
 export const getOrganizationRepo = () => new PrismaOrganizationRepo();
-export const getDealRepo = () => new PrismaDealRepo();
+export const getDealRepo = () => new PrismaDealRepo(getCompanyRepo());
 export const getServiceRepo = () => new PrismaServiceRepo();
 export const getTaskRepo = () => new PrismaTaskRepo();
 export const getUserRepo = () => new PrismaUserRepo();
 export const getCompanyRepo = () => new PrismaCompanyRepo();
 export const getRoleRepo = () => new PrismaRoleRepo();
-export const getCustomColumnRepo = () => new PrismaCustomColumnRepo();
+export const getCustomColumnRepo = () => new PrismaCustomColumnRepo(getCompanyRepo());
 export const getP13nRepo = () => new PrismaP13nRepo();
 export const getWidgetRepo = () => new PrismaWidgetRepo();
 
@@ -570,6 +576,12 @@ export const getCreateManyContactsInteractor = () =>
     getEventService(),
     getContactWritePrecheck(),
   );
+
+export const getLinkContactIdentifierInteractor = () =>
+  new LinkContactIdentifierInteractor(getGetContactByIdInteractor(), getUpdateContactInteractor());
+
+export const getUnlinkContactIdentifierInteractor = () =>
+  new UnlinkContactIdentifierInteractor(getGetContactByIdInteractor(), getUpdateContactInteractor());
 
 export const getUpdateContactInteractor = () =>
   new UpdateContactInteractor(
@@ -783,6 +795,8 @@ export const getCreateServiceInteractor = () =>
     getEventService(),
     getServiceWritePrecheck(),
   );
+
+export const getCreateServiceByNameInteractor = () => new CreateServiceByNameInteractor(getCreateServiceInteractor());
 
 export const getCreateManyServicesInteractor = () =>
   new CreateManyServicesInteractor(
@@ -1006,6 +1020,9 @@ export const getInviteUsersByEmailInteractor = () =>
   new InviteUsersByEmailInteractor(getEmailService(), getGetOrCreateInviteTokenInteractor());
 
 export const getInviteTokenValidationInteractor = () => new InviteTokenValidationInteractor(getCompanyRepo());
+
+export const getOpenInvitationInteractor = () =>
+  new OpenInvitationInteractor(getInviteTokenValidationInteractor(), getAuthService(), getOnboardingIntentService());
 
 export const getChooseWorkspaceOnboardingInteractor = () =>
   new ChooseWorkspaceOnboardingInteractor(
@@ -1696,6 +1713,29 @@ export const getExportTasksPageInteractor = () => new ExportTasksPageInteractor(
 export const getDryRunImportContactsInteractor = () => new DryRunImportContactsInteractor(getContactWritePrecheck());
 
 export const getImportRelationIndex = () => new ImportRelationIndex();
+
+export const getDryRunImportChunkInteractor = () =>
+  new DryRunImportChunkInteractor(
+    getDryRunImportContactsInteractor(),
+    getDryRunImportOrganizationsInteractor(),
+    getDryRunImportDealsInteractor(),
+    getDryRunImportServicesInteractor(),
+    getDryRunImportTasksInteractor(),
+  );
+
+export const getCommitImportChunkInteractor = () =>
+  new CommitImportChunkInteractor(
+    getCreateManyContactsInteractor(),
+    getUpdateManyContactsInteractor(),
+    getCreateManyOrganizationsInteractor(),
+    getUpdateManyOrganizationsInteractor(),
+    getCreateManyDealsInteractor(),
+    getUpdateManyDealsInteractor(),
+    getCreateManyServicesInteractor(),
+    getUpdateManyServicesInteractor(),
+    getCreateManyTasksInteractor(),
+    getUpdateManyTasksInteractor(),
+  );
 
 export const getGetImportRelationIndexInteractor = () =>
   new GetImportRelationIndexInteractor(getImportRelationIndex(), getUserService());

--- a/core/di.ts
+++ b/core/di.ts
@@ -60,6 +60,8 @@ import { BackgroundTaskService } from "@/core/utils/background-task.service";
 import { CaptureAdClickInteractor } from "@/features/acquisition/capture-ad-click.interactor";
 import { DecideAdAttributionConsentInteractor } from "@/features/acquisition/decide-ad-attribution-consent.interactor";
 import { NextAdAttributionCookieRepo } from "@/features/acquisition/next/ad-attribution-cookie";
+import { NextInviteTokenCookieRepo } from "@/features/company/next/invite-token-cookie";
+import { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
 import { ReadAdAttributionConsentInteractor } from "@/features/acquisition/read-ad-attribution-consent.interactor";
 import { WithdrawAdAttributionInteractor } from "@/features/acquisition/withdraw-ad-attribution.interactor";
 // Task Listeners
@@ -157,6 +159,7 @@ import { DeleteTaskInteractor } from "@/features/tasks/delete/delete-task.intera
 import { DeleteManyTasksInteractor } from "@/features/tasks/delete/delete-many-tasks.interactor";
 // User interactors
 import { RegisterUserInteractor } from "@/features/user/register/register-user.interactor";
+import { RegisterOnboardingProfileInteractor } from "@/features/user/register/register-onboarding-profile.interactor";
 import { UpdateUserDetailsInteractor } from "@/features/user/upsert/update-user-details.interactor";
 import { CompleteOnboardingWizardInteractor } from "@/features/onboarding-wizard/complete-onboarding-wizard.interactor";
 import { GetUserDetailsInteractor } from "@/features/user/get/get-user-details.interactor";
@@ -178,6 +181,8 @@ import { UpdateCompanySettingsInteractor } from "@/features/company/update-compa
 import { GetOrCreateInviteTokenInteractor } from "@/features/company/get-or-create-invite-token.interactor";
 import { InviteUsersByEmailInteractor } from "@/features/company/invite-users-by-email.interactor";
 import { InviteTokenValidationInteractor } from "@/features/company/invite-token-validation.interactor";
+import { ChooseWorkspaceOnboardingInteractor } from "@/features/company/choose-workspace-onboarding.interactor";
+import { env } from "@/env";
 // Role interactors
 import { UpsertRoleInteractor } from "@/features/role/upsert-role.interactor";
 import { GetRolesInteractor } from "@/features/role/get-roles.interactor";
@@ -394,6 +399,9 @@ export const getUserService = () => new UserService(getAuthService(), getUserRep
 export const getRouteGuardService = () =>
   new RouteGuardService(getAuthService(), getUserRepo(), getCompanyRepo(), getGetLegalStatusInteractor());
 export const getBackgroundTaskService = () => new BackgroundTaskService();
+export const getInviteTokenCookieRepo = () => new NextInviteTokenCookieRepo();
+export const getOnboardingIntentService = () =>
+  new OnboardingIntentService(getInviteTokenValidationInteractor(), env.BETTER_AUTH_SECRET);
 export const getUserPendingAuthorizationTaskListener = () => new UserPendingAuthorizationTaskListener(getTaskRepo());
 
 const EXPECTED_EVENT_LISTENERS = [
@@ -906,7 +914,21 @@ export const getDeleteManyTasksInteractor = () =>
 // --- User ---
 
 export const getRegisterUserInteractor = () =>
-  new RegisterUserInteractor(getAuthService(), getUserRepo(), getEventService(), getRouteGuardService());
+  new RegisterUserInteractor(
+    getAuthService(),
+    getUserRepo(),
+    getEventService(),
+    getRouteGuardService(),
+    getCompanyRepo(),
+  );
+
+export const getRegisterOnboardingProfileInteractor = () =>
+  new RegisterOnboardingProfileInteractor(
+    getAuthService(),
+    getOnboardingIntentService(),
+    getInviteTokenCookieRepo(),
+    getRegisterUserInteractor(),
+  );
 
 export const getAdAttributionCookieRepo = () => new NextAdAttributionCookieRepo();
 
@@ -950,18 +972,23 @@ export const getGetUsersApiInteractor = () =>
 
 export const getSignInWithEmailInteractor = () => new SignInWithEmailInteractor(getAuthService());
 
-export const getSignUpWithEmailInteractor = () => new SignUpWithEmailInteractor(getAuthService());
+export const getSignUpWithEmailInteractor = () =>
+  new SignUpWithEmailInteractor(getAuthService(), getOnboardingIntentService());
 
-export const getRequestPasswordResetInteractor = () => new RequestPasswordResetInteractor(getAuthService());
+export const getRequestPasswordResetInteractor = () =>
+  new RequestPasswordResetInteractor(getAuthService(), getOnboardingIntentService());
 
-export const getResetPasswordInteractor = () => new ResetPasswordInteractor(getAuthService());
+export const getResetPasswordInteractor = () =>
+  new ResetPasswordInteractor(getAuthService(), getOnboardingIntentService());
 
 export const getContinueWithSocialsInteractor = () =>
   new ContinueWithSocialsInteractor(getAuthService(), getUserRepo());
 
-export const getResendVerificationEmailInteractor = () => new ResendVerificationEmailInteractor(getAuthService());
+export const getResendVerificationEmailInteractor = () =>
+  new ResendVerificationEmailInteractor(getAuthService(), getOnboardingIntentService());
 
-export const getSignOutInteractor = () => new SignOutInteractor(getAuthService());
+export const getSignOutInteractor = () =>
+  new SignOutInteractor(getAuthService(), getOnboardingIntentService(), getInviteTokenCookieRepo());
 
 export const getDecideMcpConsentInteractor = () =>
   new DecideMcpConsentInteractor(getAuthService(), getRouteGuardService());
@@ -979,6 +1006,13 @@ export const getInviteUsersByEmailInteractor = () =>
   new InviteUsersByEmailInteractor(getEmailService(), getGetOrCreateInviteTokenInteractor());
 
 export const getInviteTokenValidationInteractor = () => new InviteTokenValidationInteractor(getCompanyRepo());
+
+export const getChooseWorkspaceOnboardingInteractor = () =>
+  new ChooseWorkspaceOnboardingInteractor(
+    getRouteGuardService(),
+    getOnboardingIntentService(),
+    getInviteTokenCookieRepo(),
+  );
 
 // --- Role ---
 

--- a/core/fumadocs/__tests__/metadata.test.ts
+++ b/core/fumadocs/__tests__/metadata.test.ts
@@ -5,6 +5,7 @@ vi.mock("../route-source-map", () => {
     ["pricing|en", { data: { description: "Plans and pricing", title: "Pricing" } }],
     ["pricing|de", { data: { description: "Pläne und Preise", title: "Preise" } }],
     ["auth/signup|en", { data: { description: "Create an account", title: "Sign up" } }],
+    ["docs/openapi/contacts|en", { data: { description: "Contacts API", title: "Contacts" } }],
     ["best-crm|en", { data: { description: "", title: "Best CRM" } }],
     ["untitled|en", { data: { description: "Body without a title", title: "   " } }],
   ]);
@@ -17,6 +18,7 @@ vi.mock("../route-source-map", () => {
     ROUTE_SOURCE_MAP: {
       "/blog/:slug": { path: [":slug"], source },
       "/auth/signup": { path: ["auth", "signup"], source },
+      "/docs/openapi/:slug": { path: ["docs", "openapi", ":slug"], source },
       "/imprint": { path: ["imprint"], source },
       "/pricing": { path: ["pricing"], source },
     },
@@ -156,5 +158,15 @@ describe("generateMetadataFromMeta", () => {
         route: "/blog/:slug",
       }),
     ).toThrow(/has no title/);
+  });
+
+  it("does not fall back to English for noindex content in an application-only locale", () => {
+    expect(() =>
+      generateMetadataFromMeta({
+        locale: "fr",
+        params: { slug: "contacts" },
+        route: "/docs/openapi/:slug",
+      }),
+    ).toThrow(/NEXT_HTTP_ERROR_FALLBACK;404/);
   });
 });

--- a/core/fumadocs/__tests__/metadata.test.ts
+++ b/core/fumadocs/__tests__/metadata.test.ts
@@ -4,6 +4,7 @@ vi.mock("../route-source-map", () => {
   const pages = new Map([
     ["pricing|en", { data: { description: "Plans and pricing", title: "Pricing" } }],
     ["pricing|de", { data: { description: "Pläne und Preise", title: "Preise" } }],
+    ["auth/signup|en", { data: { description: "Create an account", title: "Sign up" } }],
     ["best-crm|en", { data: { description: "", title: "Best CRM" } }],
     ["untitled|en", { data: { description: "Body without a title", title: "   " } }],
   ]);
@@ -15,6 +16,7 @@ vi.mock("../route-source-map", () => {
   return {
     ROUTE_SOURCE_MAP: {
       "/blog/:slug": { path: [":slug"], source },
+      "/auth/signup": { path: ["auth", "signup"], source },
       "/imprint": { path: ["imprint"], source },
       "/pricing": { path: ["pricing"], source },
     },
@@ -135,6 +137,15 @@ describe("generateMetadataFromMeta", () => {
       () => generateMetadataFromMeta({ locale: "fr", route: "/pricing" }),
       "fr is a routing-only locale, so a request for it is a bad URL and not a build bug",
     ).toThrow(/NEXT_HTTP_ERROR_FALLBACK;404/);
+  });
+
+  it("uses default-locale metadata for a noindex app route in a routing-only locale", () => {
+    const metadata = generateMetadataFromMeta({ locale: "fr", route: "/auth/signup" });
+
+    expect(metadata.title).toBe("Sign up");
+    expect(metadata.description).toBe("Create an account");
+    expect(metadata.alternates).toEqual({ canonical: `${BASE_URL}/fr/auth/signup` });
+    expect(metadata.robots).toEqual({ follow: true, index: false });
   });
 
   it("refuses a page whose title is blank", () => {

--- a/core/fumadocs/metadata.ts
+++ b/core/fumadocs/metadata.ts
@@ -6,7 +6,7 @@ import { ROUTE_SOURCE_MAP } from "./route-source-map";
 
 import { env } from "@/env";
 import { buildAlternateLanguages } from "@/core/seo/alternates";
-import { CONTENT_LOCALES, buildLocalePath, isContentLocale } from "@/i18n/locale-registry";
+import { CONTENT_LOCALES, DEFAULT_LOCALE, buildLocalePath, isContentLocale } from "@/i18n/locale-registry";
 import { isNoindexPublicRoute } from "@/i18n/routing";
 
 type GenerateMetadataParams = {
@@ -29,7 +29,9 @@ export function generateMetadataFromMeta({
 }: GenerateMetadataParams): Metadata {
   const { source, path: mappedPath } = ROUTE_SOURCE_MAP[route];
   const path = mappedPath.map((part) => (part.startsWith(":") ? (params[part.slice(1)] ?? part) : part));
-  const page = source.getPage(path, locale);
+  const noindex = isNoindexPublicRoute(route);
+  const metadataLocale = noindex && !isContentLocale(locale) ? DEFAULT_LOCALE : locale;
+  const page = source.getPage(path, metadataLocale);
   const isSlugRoute = mappedPath.some((part) => part.startsWith(":"));
 
   if (!page) {
@@ -61,8 +63,6 @@ export function generateMetadataFromMeta({
     url: `/og/image.png?${ogImageParams.toString()}`,
     width: 1200,
   };
-
-  const noindex = isNoindexPublicRoute(route);
 
   const metadata: Metadata = {
     alternates: alternates && !noindex ? { canonical, languages: alternates } : { canonical },

--- a/core/fumadocs/metadata.ts
+++ b/core/fumadocs/metadata.ts
@@ -7,7 +7,7 @@ import { ROUTE_SOURCE_MAP } from "./route-source-map";
 import { env } from "@/env";
 import { buildAlternateLanguages } from "@/core/seo/alternates";
 import { CONTENT_LOCALES, DEFAULT_LOCALE, buildLocalePath, isContentLocale } from "@/i18n/locale-registry";
-import { isNoindexPublicRoute } from "@/i18n/routing";
+import { isContentPathname, isNoindexPublicRoute } from "@/i18n/routing";
 
 type GenerateMetadataParams = {
   canonicalPath?: string;
@@ -30,7 +30,7 @@ export function generateMetadataFromMeta({
   const { source, path: mappedPath } = ROUTE_SOURCE_MAP[route];
   const path = mappedPath.map((part) => (part.startsWith(":") ? (params[part.slice(1)] ?? part) : part));
   const noindex = isNoindexPublicRoute(route);
-  const metadataLocale = noindex && !isContentLocale(locale) ? DEFAULT_LOCALE : locale;
+  const metadataLocale = noindex && !isContentPathname(route) && !isContentLocale(locale) ? DEFAULT_LOCALE : locale;
   const page = source.getPage(path, metadataLocale);
   const isSlugRoute = mappedPath.some((part) => part.startsWith(":"));
 

--- a/ee/operator/__tests__/operator-workspace-delete.database.test.ts
+++ b/ee/operator/__tests__/operator-workspace-delete.database.test.ts
@@ -101,6 +101,43 @@ async function createWorkspace(args: { domain: string; members: number; platform
   return { companyId, members };
 }
 
+async function createRawBoundIdentity(companyId: string) {
+  const authUserId = randomUUID();
+  const accountId = randomUUID();
+  const sessionId = randomUUID();
+  authUserIds.push(authUserId);
+
+  await runWithoutTenant(async () => {
+    await prisma.authUser.create({
+      data: {
+        id: authUserId,
+        companyId,
+        email: `orphan-${randomUUID()}@example.invalid`,
+        emailVerified: true,
+        name: "Raw Bound Identity",
+      },
+    });
+    await prisma.authAccount.create({
+      data: {
+        id: accountId,
+        accountId: `account-${randomUUID()}`,
+        providerId: "credential",
+        userId: authUserId,
+      },
+    });
+    await prisma.authSession.create({
+      data: {
+        id: sessionId,
+        expiresAt: new Date("2027-01-01T00:00:00.000Z"),
+        token: `token-${randomUUID()}`,
+        userId: authUserId,
+      },
+    });
+  });
+
+  return { accountId, authUserId, sessionId };
+}
+
 afterAll(async () => {
   await runWithoutTenant(async () => {
     await prisma.operatorAuditEvent.deleteMany({ where: { actorUserId: { in: actorIds } } });
@@ -115,6 +152,7 @@ describeDatabase("operator workspace deletion against a real database", { timeou
     const repo = new PrismaOperatorRepo();
     const { companyId, members } = await createWorkspace({ domain: "doomed.invalid", members: 2 });
     const survivor = await createWorkspace({ domain: "safe.invalid", members: 1 });
+    const rawBoundIdentity = await createRawBoundIdentity(companyId);
     const actor = operatorActor();
 
     const result = await runWithOperator(actor, () =>
@@ -139,6 +177,15 @@ describeDatabase("operator workspace deletion against a real database", { timeou
       expect(await prisma.authUser.count({ where: { email: { in: emails } } })).toBe(0);
       expect(await prisma.authSession.count({ where: { userId: { in: members.map((m) => m.authUserId) } } })).toBe(0);
 
+      expect(
+        await prisma.authUser.findUnique({
+          where: { id: rawBoundIdentity.authUserId },
+          select: { companyId: true },
+        }),
+      ).toEqual({ companyId: null });
+      expect(await prisma.authAccount.count({ where: { id: rawBoundIdentity.accountId } })).toBe(1);
+      expect(await prisma.authSession.count({ where: { id: rawBoundIdentity.sessionId } })).toBe(1);
+
       expect(await prisma.company.count({ where: { id: survivor.companyId } })).toBe(1);
       expect(await prisma.user.count({ where: { companyId: survivor.companyId } })).toBe(1);
       expect(await prisma.authUser.count({ where: { email: { in: survivor.members.map((m) => m.email) } } })).toBe(1);
@@ -148,7 +195,15 @@ describeDatabase("operator workspace deletion against a real database", { timeou
       expect(audit[0]?.action).toBe(OPERATOR_AUDIT_ACTION.workspaceDelete);
       expect(audit[0]?.targetCompanyId).toBe(companyId);
       expect(audit[0]?.reason).toBe("Spam signup");
-      expect((audit[0]?.metadata as { workspaceLabel?: string })?.workspaceLabel).toBe("doomed.invalid");
+      expect(
+        audit[0]?.metadata as {
+          clearedAuthIdentityCompanyCount?: number;
+          workspaceLabel?: string;
+        },
+      ).toMatchObject({
+        clearedAuthIdentityCompanyCount: 1,
+        workspaceLabel: "doomed.invalid",
+      });
     });
   });
 
@@ -185,6 +240,7 @@ describeDatabase("operator workspace deletion against a real database", { timeou
   it("refuses a mismatched confirmation label and leaves the workspace intact", async () => {
     const repo = new PrismaOperatorRepo();
     const { companyId } = await createWorkspace({ domain: "typo.invalid", members: 1 });
+    const rawBoundIdentity = await createRawBoundIdentity(companyId);
 
     const result = await runWithOperator(operatorActor(), () =>
       repo.deleteWorkspaceUnscoped({
@@ -198,6 +254,12 @@ describeDatabase("operator workspace deletion against a real database", { timeou
     await runWithoutTenant(async () => {
       expect(await prisma.company.count({ where: { id: companyId } })).toBe(1);
       expect(await prisma.user.count({ where: { companyId } })).toBe(1);
+      expect(
+        await prisma.authUser.findUnique({
+          where: { id: rawBoundIdentity.authUserId },
+          select: { companyId: true },
+        }),
+      ).toEqual({ companyId });
     });
   });
 

--- a/ee/operator/prisma-operator.repository.ts
+++ b/ee/operator/prisma-operator.repository.ts
@@ -1072,7 +1072,6 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           where: { identifier: { in: memberEmails, mode: "insensitive" } },
         });
         await this.prisma.authUser.deleteMany({ where: { id: { in: identityIds } } });
-
         await this.prisma.messagingInboundEvent.deleteMany({ where: { companyId: data.companyId } });
 
         const [workflowSchema] = await this.prisma.$queryRaw<Array<{ installed: boolean }>>`
@@ -1102,6 +1101,10 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
         }
 
         await this.prisma.company.delete({ where: { id: data.companyId } });
+        const clearedAuthIdentityCompanies = await this.prisma.authUser.updateMany({
+          where: { companyId: data.companyId },
+          data: { companyId: null },
+        });
 
         await this.createAudit({
           action: OPERATOR_AUDIT_ACTION.workspaceDelete,
@@ -1111,6 +1114,7 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
             workspaceLabel,
             deletedMemberCount: memberIds.length,
             deletedAuthIdentityCount: identityIds.length,
+            clearedAuthIdentityCompanyCount: clearedAuthIdentityCompanies.count,
             deletedWorkflowRunCount: workflowRunIds.length,
             plan: company.subscription?.plan ?? null,
             subscriptionStatus: company.subscription?.status ?? null,

--- a/features/auth/__tests__/continue-with-socials.interactor.test.ts
+++ b/features/auth/__tests__/continue-with-socials.interactor.test.ts
@@ -141,4 +141,54 @@ describe("ContinueWithSocialsInteractor callback validation", () => {
 
     await expect(interactor.invoke({ provider: "google" })).resolves.toEqual({ redirect: "/auth/verify-email" });
   });
+
+  it("preserves onboarding intent across social email verification", async () => {
+    const interactor = new ContinueWithSocialsInteractor(
+      {
+        continueWithSocials: vi.fn().mockResolvedValue({
+          redirect: false,
+          user: {
+            createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+            email: "unverified@example.com",
+            emailVerified: false,
+            name: "Unverified User",
+          },
+        }),
+        sendNewUserNotificationEmail: vi.fn(),
+      } as unknown as AuthService,
+      { findCurrentUserUnscoped: vi.fn().mockResolvedValue({ id: "user-id" }) } as unknown as FindUserRepo,
+    );
+
+    await expect(
+      interactor.invoke({
+        callbackURL: "/auth/invitation?intent=signed.intent",
+        provider: "microsoft",
+      }),
+    ).resolves.toEqual({ redirect: "/auth/verify-email?intent=signed.intent" });
+  });
+
+  it("fails closed when a social verification callback contains duplicate intents", async () => {
+    const interactor = new ContinueWithSocialsInteractor(
+      {
+        continueWithSocials: vi.fn().mockResolvedValue({
+          redirect: false,
+          user: {
+            createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+            email: "unverified@example.com",
+            emailVerified: false,
+            name: "Unverified User",
+          },
+        }),
+        sendNewUserNotificationEmail: vi.fn(),
+      } as unknown as AuthService,
+      { findCurrentUserUnscoped: vi.fn().mockResolvedValue({ id: "user-id" }) } as unknown as FindUserRepo,
+    );
+
+    await expect(
+      interactor.invoke({
+        callbackURL: "/auth/invitation?intent=one&intent=two",
+        provider: "microsoft",
+      }),
+    ).resolves.toEqual({ redirect: "/auth/error?type=invalidOnboardingIntent" });
+  });
 });

--- a/features/auth/__tests__/onboarding-detour.interactors.test.ts
+++ b/features/auth/__tests__/onboarding-detour.interactors.test.ts
@@ -4,47 +4,163 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-intl/server", () => ({
   getLocale: vi.fn().mockResolvedValue("en"),
-  getTranslations: vi.fn().mockResolvedValue(
-    Object.assign((key: string) => key, {
-      raw: (key: string) => key,
-    }),
-  ),
+  getTranslations: vi.fn().mockResolvedValue(Object.assign((key: string) => key, { raw: (key: string) => key })),
 }));
 
 import { RequestPasswordResetInteractor } from "../request-password-reset.interactor";
 import { ResendVerificationEmailInteractor } from "../resend-verification-email.interactor";
+import { ResetPasswordInteractor } from "../reset-password.interactor";
+import { SignOutInteractor } from "../sign-out.interactor";
+import { SignUpWithEmailInteractor } from "../sign-up-with-email.interactor";
+
+const invitation = {
+  companyId: "company-a",
+  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  intent: "signed.intent",
+  inviterName: "Invite Admin",
+  source: "explicit",
+  status: "valid",
+  token: "invite-a",
+  type: "invitation",
+} as const;
 
 describe("onboarding authentication detours", () => {
+  const onboardingIntentService = { resolve: vi.fn() };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    onboardingIntentService.resolve.mockResolvedValue(invitation);
   });
 
-  it("passes the intent-preserving reset destination after validation", async () => {
+  it("derives the intent-preserving reset destination after validation", async () => {
     const requestPasswordReset = vi.fn().mockResolvedValue(undefined);
-    const interactor = new RequestPasswordResetInteractor({ requestPasswordReset } as unknown as AuthService);
+    const interactor = new RequestPasswordResetInteractor(
+      { requestPasswordReset } as unknown as AuthService,
+      onboardingIntentService as never,
+    );
     const data = { email: "invited@example.com", confirmEmail: "invited@example.com" };
 
-    await expect(interactor.invoke(data, "/auth/reset-password?intent=signed.intent")).resolves.toEqual({
-      ok: true,
-      data,
-    });
+    await expect(interactor.invoke(data, invitation.intent)).resolves.toEqual({ ok: true, data });
     expect(requestPasswordReset).toHaveBeenCalledWith(
       "invited@example.com",
       "/auth/reset-password?intent=signed.intent",
     );
   });
 
-  it("passes the intent-preserving verification callback while keeping the session", async () => {
-    const resendVerificationEmail = vi.fn().mockResolvedValue(undefined);
-    const interactor = new ResendVerificationEmailInteractor({
-      getSession: vi.fn().mockResolvedValue({ user: { email: "invited@example.com" } }),
-      resendVerificationEmail,
-    } as unknown as AuthService);
+  it("derives both reset-password continuations from the validated intent", async () => {
+    const resetPassword = vi.fn().mockRejectedValue(new Error("invalid token"));
+    const interactor = new ResetPasswordInteractor(
+      { resetPassword } as unknown as AuthService,
+      onboardingIntentService as never,
+    );
+    const data = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "reset-token" };
 
-    await expect(interactor.invoke("/auth/invitation?intent=signed.intent")).resolves.toEqual({ ok: true });
+    await expect(interactor.invoke(data, invitation.intent)).resolves.toEqual({
+      redirect: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
+    });
+  });
+
+  it("derives the exact verification callback while keeping the session", async () => {
+    const resendVerificationEmail = vi.fn().mockResolvedValue(undefined);
+    const interactor = new ResendVerificationEmailInteractor(
+      {
+        getSession: vi.fn().mockResolvedValue({ user: { email: "invited@example.com" } }),
+        resendVerificationEmail,
+      } as unknown as AuthService,
+      onboardingIntentService as never,
+    );
+
+    await expect(interactor.invoke(invitation.intent)).resolves.toEqual({ ok: true });
     expect(resendVerificationEmail).toHaveBeenCalledWith("invited@example.com", {
       callbackURL: "/auth/invitation?intent=signed.intent",
       keepSession: true,
     });
+  });
+
+  it("ignores an invalid intent for password recovery", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({
+      errorMessage: "onboardingSessionExpired",
+      source: "explicit",
+      status: "invalid",
+    });
+    const requestPasswordReset = vi.fn().mockResolvedValue(undefined);
+    const interactor = new RequestPasswordResetInteractor(
+      { requestPasswordReset } as unknown as AuthService,
+      onboardingIntentService as never,
+    );
+
+    await interactor.invoke({ confirmEmail: "invited@example.com", email: "invited@example.com" }, "expired.intent");
+
+    expect(requestPasswordReset).toHaveBeenCalledWith("invited@example.com", undefined);
+  });
+
+  it("accepts only invitation intent on account signup", async () => {
+    const registerWithEmail = vi.fn().mockResolvedValue({ ok: true });
+    const interactor = new SignUpWithEmailInteractor(
+      { registerWithEmail } as unknown as AuthService,
+      onboardingIntentService as never,
+    );
+    const data = {
+      confirmEmail: "invited@example.com",
+      confirmPassword: "ValidPass1!",
+      email: "invited@example.com",
+      password: "ValidPass1!",
+    };
+
+    await expect(interactor.invoke(data, invitation.intent)).resolves.toEqual({
+      redirect: "/auth/invitation?intent=signed.intent",
+    });
+    expect(registerWithEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ callbackURL: "/auth/invitation?intent=signed.intent" }),
+    );
+
+    onboardingIntentService.resolve.mockResolvedValue({
+      authUserId: "auth-user-one",
+      intent: "signed.create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+    await expect(interactor.invoke(data, "signed.create")).resolves.toEqual({
+      redirect: "/auth/error?type=invalidOnboardingIntent",
+    });
+    expect(registerWithEmail).toHaveBeenCalledOnce();
+  });
+
+  it("clears invitation state and signs out before returning the validated destination", async () => {
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    const clear = vi.fn().mockResolvedValue(undefined);
+    const interactor = new SignOutInteractor(
+      { signOut } as unknown as AuthService,
+      onboardingIntentService as never,
+      { clear } as never,
+    );
+
+    await expect(interactor.invoke({ invitationIntent: invitation.intent })).resolves.toEqual({
+      redirect: "/auth/signup?intent=signed.intent",
+    });
+    expect(clear).toHaveBeenCalledOnce();
+    expect(signOut).toHaveBeenCalledOnce();
+    expect(clear.mock.invocationCallOrder[0]).toBeLessThan(signOut.mock.invocationCallOrder[0]);
+  });
+
+  it("still signs out when the invitation intent is invalid", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({
+      errorMessage: "invalidOnboardingIntent",
+      source: "explicit",
+      status: "invalid",
+    });
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    const clear = vi.fn().mockResolvedValue(undefined);
+    const interactor = new SignOutInteractor(
+      { signOut } as unknown as AuthService,
+      onboardingIntentService as never,
+      { clear } as never,
+    );
+
+    await expect(interactor.invoke({ invitationIntent: "tampered" })).resolves.toEqual({
+      redirect: "/auth/error?type=invalidOnboardingIntent",
+    });
+    expect(signOut).toHaveBeenCalledOnce();
   });
 });

--- a/features/auth/__tests__/onboarding-detour.interactors.test.ts
+++ b/features/auth/__tests__/onboarding-detour.interactors.test.ts
@@ -136,12 +136,48 @@ describe("onboarding authentication detours", () => {
       { clear } as never,
     );
 
-    await expect(interactor.invoke({ invitationIntent: invitation.intent })).resolves.toEqual({
+    await expect(interactor.invoke({ onboardingIntent: invitation.intent })).resolves.toEqual({
       redirect: "/auth/signup?intent=signed.intent",
     });
     expect(clear).toHaveBeenCalledOnce();
     expect(signOut).toHaveBeenCalledOnce();
     expect(clear.mock.invocationCallOrder[0]).toBeLessThan(signOut.mock.invocationCallOrder[0]);
+  });
+
+  it("signs out without carrying a company-creation intent to another account", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({
+      authUserId: "auth-user-one",
+      intent: "signed.create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    const clear = vi.fn().mockResolvedValue(undefined);
+    const interactor = new SignOutInteractor(
+      { signOut } as unknown as AuthService,
+      onboardingIntentService as never,
+      { clear } as never,
+    );
+
+    await expect(interactor.invoke({ onboardingIntent: "signed.create" })).resolves.toEqual({ redirect: "/" });
+    expect(clear).toHaveBeenCalledOnce();
+    expect(signOut).toHaveBeenCalledOnce();
+  });
+
+  it("signs out normally when an explicit onboarding intent resolves as absent", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({ status: "absent" });
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    const clear = vi.fn().mockResolvedValue(undefined);
+    const interactor = new SignOutInteractor(
+      { signOut } as unknown as AuthService,
+      onboardingIntentService as never,
+      { clear } as never,
+    );
+
+    await expect(interactor.invoke({ onboardingIntent: "" })).resolves.toEqual({ redirect: "/" });
+    expect(clear).toHaveBeenCalledOnce();
+    expect(signOut).toHaveBeenCalledOnce();
   });
 
   it("still signs out when the invitation intent is invalid", async () => {
@@ -158,7 +194,7 @@ describe("onboarding authentication detours", () => {
       { clear } as never,
     );
 
-    await expect(interactor.invoke({ invitationIntent: "tampered" })).resolves.toEqual({
+    await expect(interactor.invoke({ onboardingIntent: "tampered" })).resolves.toEqual({
       redirect: "/auth/error?type=invalidOnboardingIntent",
     });
     expect(signOut).toHaveBeenCalledOnce();

--- a/features/auth/__tests__/onboarding-detour.interactors.test.ts
+++ b/features/auth/__tests__/onboarding-detour.interactors.test.ts
@@ -1,0 +1,50 @@
+import type { AuthService } from "../auth.service";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl/server", () => ({
+  getLocale: vi.fn().mockResolvedValue("en"),
+  getTranslations: vi.fn().mockResolvedValue(
+    Object.assign((key: string) => key, {
+      raw: (key: string) => key,
+    }),
+  ),
+}));
+
+import { RequestPasswordResetInteractor } from "../request-password-reset.interactor";
+import { ResendVerificationEmailInteractor } from "../resend-verification-email.interactor";
+
+describe("onboarding authentication detours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the intent-preserving reset destination after validation", async () => {
+    const requestPasswordReset = vi.fn().mockResolvedValue(undefined);
+    const interactor = new RequestPasswordResetInteractor({ requestPasswordReset } as unknown as AuthService);
+    const data = { email: "invited@example.com", confirmEmail: "invited@example.com" };
+
+    await expect(interactor.invoke(data, "/auth/reset-password?intent=signed.intent")).resolves.toEqual({
+      ok: true,
+      data,
+    });
+    expect(requestPasswordReset).toHaveBeenCalledWith(
+      "invited@example.com",
+      "/auth/reset-password?intent=signed.intent",
+    );
+  });
+
+  it("passes the intent-preserving verification callback while keeping the session", async () => {
+    const resendVerificationEmail = vi.fn().mockResolvedValue(undefined);
+    const interactor = new ResendVerificationEmailInteractor({
+      getSession: vi.fn().mockResolvedValue({ user: { email: "invited@example.com" } }),
+      resendVerificationEmail,
+    } as unknown as AuthService);
+
+    await expect(interactor.invoke("/auth/invitation?intent=signed.intent")).resolves.toEqual({ ok: true });
+    expect(resendVerificationEmail).toHaveBeenCalledWith("invited@example.com", {
+      callbackURL: "/auth/invitation?intent=signed.intent",
+      keepSession: true,
+    });
+  });
+});

--- a/features/auth/__tests__/onboarding-detour.interactors.test.ts
+++ b/features/auth/__tests__/onboarding-detour.interactors.test.ts
@@ -38,13 +38,34 @@ describe("onboarding authentication detours", () => {
       { requestPasswordReset } as unknown as AuthService,
       onboardingIntentService as never,
     );
-    const data = { email: "invited@example.com", confirmEmail: "invited@example.com" };
+    const data = {
+      email: "invited@example.com",
+      confirmEmail: "invited@example.com",
+      onboardingIntent: invitation.intent,
+    };
 
-    await expect(interactor.invoke(data, invitation.intent)).resolves.toEqual({ ok: true, data });
+    await expect(interactor.invoke(data)).resolves.toEqual({ ok: true, data });
     expect(requestPasswordReset).toHaveBeenCalledWith(
       "invited@example.com",
       "/auth/reset-password?intent=signed.intent",
     );
+  });
+
+  it.each([null, undefined])("returns validation failures for missing form data %j", async (data) => {
+    const auth = {
+      registerWithEmail: vi.fn(),
+      requestPasswordReset: vi.fn(),
+      resetPassword: vi.fn(),
+    };
+    const interactors = [
+      new SignUpWithEmailInteractor(auth as never, onboardingIntentService as never),
+      new RequestPasswordResetInteractor(auth as never, onboardingIntentService as never),
+      new ResetPasswordInteractor(auth as never, onboardingIntentService as never),
+    ];
+    for (const interactor of interactors)
+      await expect(interactor.invoke(data as never)).resolves.toMatchObject({ ok: false });
+    expect(onboardingIntentService.resolve).not.toHaveBeenCalled();
+    for (const method of Object.values(auth)) expect(method).not.toHaveBeenCalled();
   });
 
   it("derives both reset-password continuations from the validated intent", async () => {
@@ -55,7 +76,7 @@ describe("onboarding authentication detours", () => {
     );
     const data = { confirmPassword: "ValidPass1!", password: "ValidPass1!", token: "reset-token" };
 
-    await expect(interactor.invoke(data, invitation.intent)).resolves.toEqual({
+    await expect(interactor.invoke({ ...data, onboardingIntent: invitation.intent })).resolves.toEqual({
       redirect: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
     });
   });
@@ -89,7 +110,11 @@ describe("onboarding authentication detours", () => {
       onboardingIntentService as never,
     );
 
-    await interactor.invoke({ confirmEmail: "invited@example.com", email: "invited@example.com" }, "expired.intent");
+    await interactor.invoke({
+      confirmEmail: "invited@example.com",
+      email: "invited@example.com",
+      onboardingIntent: "expired.intent",
+    });
 
     expect(requestPasswordReset).toHaveBeenCalledWith("invited@example.com", undefined);
   });
@@ -107,7 +132,7 @@ describe("onboarding authentication detours", () => {
       password: "ValidPass1!",
     };
 
-    await expect(interactor.invoke(data, invitation.intent)).resolves.toEqual({
+    await expect(interactor.invoke({ ...data, onboardingIntent: invitation.intent })).resolves.toEqual({
       redirect: "/auth/invitation?intent=signed.intent",
     });
     expect(registerWithEmail).toHaveBeenCalledWith(
@@ -121,7 +146,7 @@ describe("onboarding authentication detours", () => {
       status: "valid",
       type: "createCompany",
     });
-    await expect(interactor.invoke(data, "signed.create")).resolves.toEqual({
+    await expect(interactor.invoke({ ...data, onboardingIntent: "signed.create" })).resolves.toEqual({
       redirect: "/auth/error?type=invalidOnboardingIntent",
     });
     expect(registerWithEmail).toHaveBeenCalledOnce();

--- a/features/auth/__tests__/reset-password.interactor.test.ts
+++ b/features/auth/__tests__/reset-password.interactor.test.ts
@@ -62,4 +62,28 @@ describe("ResetPasswordInteractor (validation flow)", () => {
 
     expect(result).toEqual({ redirect: "/auth/forgot-password?info=RESET_LINK_INVALID" });
   });
+
+  it("uses intent-preserving success and error destinations", async () => {
+    const interactor = new ResetPasswordInteractor(authService as never);
+    const data = {
+      password: "ValidPass1!",
+      confirmPassword: "ValidPass1!",
+      token: "tok-123",
+    };
+
+    await expect(
+      interactor.invoke(data, {
+        error: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
+        success: "/auth/signin?intent=signed.intent",
+      }),
+    ).resolves.toEqual({ redirect: "/auth/signin?intent=signed.intent" });
+
+    authService.resetPassword.mockRejectedValueOnce(new Error("invalid token"));
+    await expect(
+      interactor.invoke(data, {
+        error: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
+        success: "/auth/signin?intent=signed.intent",
+      }),
+    ).resolves.toEqual({ redirect: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent" });
+  });
 });

--- a/features/auth/__tests__/reset-password.interactor.test.ts
+++ b/features/auth/__tests__/reset-password.interactor.test.ts
@@ -78,12 +78,12 @@ describe("ResetPasswordInteractor (validation flow)", () => {
     });
     const data = { password: "ValidPass1!", confirmPassword: "ValidPass1!", token: "tok-123" };
 
-    await expect(interactor.invoke(data, "signed.intent")).resolves.toEqual({
+    await expect(interactor.invoke({ ...data, onboardingIntent: "signed.intent" })).resolves.toEqual({
       redirect: "/auth/signin?intent=signed.intent",
     });
 
     authService.resetPassword.mockRejectedValueOnce(new Error("invalid token"));
-    await expect(interactor.invoke(data, "signed.intent")).resolves.toEqual({
+    await expect(interactor.invoke({ ...data, onboardingIntent: "signed.intent" })).resolves.toEqual({
       redirect: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
     });
   });

--- a/features/auth/__tests__/reset-password.interactor.test.ts
+++ b/features/auth/__tests__/reset-password.interactor.test.ts
@@ -3,9 +3,7 @@ import { MOCK_ENV_MODULE, MOCK_ZOD_MODULE } from "@/tests/helpers/interactor-tes
 
 vi.mock("@/env", () => MOCK_ENV_MODULE);
 vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
-vi.mock("@/core/decorators/system-interactor.decorator", () => ({
-  SystemInteractor: (target: unknown) => target,
-}));
+vi.mock("@/core/decorators/system-interactor.decorator", () => ({ SystemInteractor: (target: unknown) => target }));
 vi.mock("next-intl/server", () => ({
   getTranslations: () => Promise.resolve((key: string) => key),
   getLocale: () => Promise.resolve("en"),
@@ -16,13 +14,16 @@ import { isRedirect } from "../auth-outcome";
 
 describe("ResetPasswordInteractor (validation flow)", () => {
   let authService: { resetPassword: ReturnType<typeof vi.fn> };
+  const onboardingIntentService = { resolve: vi.fn() };
 
   beforeEach(() => {
+    vi.clearAllMocks();
     authService = { resetPassword: vi.fn().mockResolvedValue(undefined) };
+    onboardingIntentService.resolve.mockResolvedValue({ status: "absent" });
   });
 
   it("returns ok:false zod error when passwords do not match — NOT a Redirect", async () => {
-    const interactor = new ResetPasswordInteractor(authService as never);
+    const interactor = new ResetPasswordInteractor(authService as never, onboardingIntentService as never);
 
     const result = await interactor.invoke({
       password: "ValidPass1!",
@@ -38,7 +39,7 @@ describe("ResetPasswordInteractor (validation flow)", () => {
   });
 
   it("returns Redirect to /auth/signin on successful reset", async () => {
-    const interactor = new ResetPasswordInteractor(authService as never);
+    const interactor = new ResetPasswordInteractor(authService as never, onboardingIntentService as never);
 
     const result = await interactor.invoke({
       password: "ValidPass1!",
@@ -52,7 +53,7 @@ describe("ResetPasswordInteractor (validation flow)", () => {
 
   it("returns Redirect to forgot-password when auth service throws (invalid token)", async () => {
     authService.resetPassword.mockRejectedValueOnce(new Error("invalid token"));
-    const interactor = new ResetPasswordInteractor(authService as never);
+    const interactor = new ResetPasswordInteractor(authService as never, onboardingIntentService as never);
 
     const result = await interactor.invoke({
       password: "ValidPass1!",
@@ -64,26 +65,26 @@ describe("ResetPasswordInteractor (validation flow)", () => {
   });
 
   it("uses intent-preserving success and error destinations", async () => {
-    const interactor = new ResetPasswordInteractor(authService as never);
-    const data = {
-      password: "ValidPass1!",
-      confirmPassword: "ValidPass1!",
-      token: "tok-123",
-    };
+    const interactor = new ResetPasswordInteractor(authService as never, onboardingIntentService as never);
+    onboardingIntentService.resolve.mockResolvedValue({
+      companyId: "company-a",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      intent: "signed.intent",
+      inviterName: "Invite Admin",
+      source: "explicit",
+      status: "valid",
+      token: "invite-a",
+      type: "invitation",
+    });
+    const data = { password: "ValidPass1!", confirmPassword: "ValidPass1!", token: "tok-123" };
 
-    await expect(
-      interactor.invoke(data, {
-        error: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
-        success: "/auth/signin?intent=signed.intent",
-      }),
-    ).resolves.toEqual({ redirect: "/auth/signin?intent=signed.intent" });
+    await expect(interactor.invoke(data, "signed.intent")).resolves.toEqual({
+      redirect: "/auth/signin?intent=signed.intent",
+    });
 
     authService.resetPassword.mockRejectedValueOnce(new Error("invalid token"));
-    await expect(
-      interactor.invoke(data, {
-        error: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
-        success: "/auth/signin?intent=signed.intent",
-      }),
-    ).resolves.toEqual({ redirect: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent" });
+    await expect(interactor.invoke(data, "signed.intent")).resolves.toEqual({
+      redirect: "/auth/forgot-password?info=RESET_LINK_INVALID&intent=signed.intent",
+    });
   });
 });

--- a/features/auth/__tests__/route-guard.service.test.ts
+++ b/features/auth/__tests__/route-guard.service.test.ts
@@ -25,6 +25,7 @@ const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
 const mocks = {
   getSession: vi.fn(),
+  findAuthUserCompanyIdUnscoped: vi.fn(),
   findCurrentUserUnscoped: vi.fn(),
   getSubscriptionOrThrowUnscoped: vi.fn(),
   getLegalStatus: vi.fn(),
@@ -33,7 +34,10 @@ const mocks = {
 function makeService() {
   return new RouteGuardService(
     { getSession: mocks.getSession } as unknown as AuthService,
-    { findCurrentUserUnscoped: mocks.findCurrentUserUnscoped } as unknown as FindUserRepo,
+    {
+      findAuthUserCompanyIdUnscoped: mocks.findAuthUserCompanyIdUnscoped,
+      findCurrentUserUnscoped: mocks.findCurrentUserUnscoped,
+    } as unknown as FindUserRepo,
     {
       getSubscriptionOrThrowUnscoped: mocks.getSubscriptionOrThrowUnscoped,
     } as unknown as RouteGuardSubscriptionRepo,
@@ -82,6 +86,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockEnv.APP_MODE = "cloud";
   mocks.getSession.mockResolvedValue(session());
+  mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue(null);
   mocks.findCurrentUserUnscoped.mockResolvedValue(user());
   mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.active));
   mocks.getLegalStatus.mockResolvedValue({ mustAccept: false });
@@ -130,6 +135,43 @@ describe("RouteGuardService.resolveAccountState", () => {
       state: "unregistered",
       user: null,
     });
+    expect(mocks.getLegalStatus).not.toHaveBeenCalled();
+    expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("uses only a live identity workspace binding for pre-tenant routing", async () => {
+    mocks.findCurrentUserUnscoped.mockResolvedValue(null);
+    mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue("invited-company-id");
+
+    expect(await makeService().resolveAccountState()).toMatchObject({
+      state: "unregistered",
+      sessionUser: { companyId: "invited-company-id" },
+    });
+  });
+
+  it("treats a cached session for a deleted identity as unauthenticated", async () => {
+    mocks.findCurrentUserUnscoped.mockResolvedValue(null);
+    mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue(undefined);
+
+    expect(await makeService().resolveAccountState()).toMatchObject({
+      state: "unauthenticated",
+      sessionUser: null,
+      user: null,
+    });
+    expect(mocks.getLegalStatus).not.toHaveBeenCalled();
+    expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("rejects a deleted identity even when the same email now has a tenant user", async () => {
+    mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue(undefined);
+    mocks.findCurrentUserUnscoped.mockResolvedValue(user());
+
+    expect(await makeService().resolveAccountState()).toMatchObject({
+      state: "unauthenticated",
+      sessionUser: null,
+      user: null,
+    });
+    expect(mocks.findCurrentUserUnscoped).not.toHaveBeenCalled();
     expect(mocks.getLegalStatus).not.toHaveBeenCalled();
     expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
   });
@@ -208,7 +250,7 @@ describe("accessRedirectForAccountState", () => {
   });
 
   it.each([
-    [null, null, "/onboarding/wizard"],
+    [null, null, "/onboarding"],
     [user({ status: Status.inactive }), null, "/auth/error?type=inactiveUser"],
     [user({ status: Status.pendingAuthorization }), null, "/auth/pending"],
     [user({ onboardingWizardCompletedAt: null }), null, "/onboarding/wizard"],

--- a/features/auth/__tests__/route-guard.service.test.ts
+++ b/features/auth/__tests__/route-guard.service.test.ts
@@ -1,7 +1,7 @@
 import type { TenantUser } from "@/features/user/user.schema";
 import type { AuthService } from "../auth.service";
 import type { FindUserRepo } from "../../user/user.service";
-import type { AccessOptions, RouteGuardSubscriptionRepo } from "../route-guard.service";
+import type { AccessOptions, RouteGuardCompanyRepo } from "../route-guard.service";
 import type { GetLegalStatusInteractor } from "@/features/legal/get-legal-status.interactor";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,6 +24,7 @@ const PAST = new Date(Date.now() - 48 * 60 * 60 * 1000);
 const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
 const mocks = {
+  existsUnscoped: vi.fn(),
   getSession: vi.fn(),
   findAuthUserCompanyIdUnscoped: vi.fn(),
   findCurrentUserUnscoped: vi.fn(),
@@ -39,8 +40,9 @@ function makeService() {
       findCurrentUserUnscoped: mocks.findCurrentUserUnscoped,
     } as unknown as FindUserRepo,
     {
+      existsUnscoped: mocks.existsUnscoped,
       getSubscriptionOrThrowUnscoped: mocks.getSubscriptionOrThrowUnscoped,
-    } as unknown as RouteGuardSubscriptionRepo,
+    } as unknown as RouteGuardCompanyRepo,
     { invoke: mocks.getLegalStatus } as unknown as GetLegalStatusInteractor,
   );
 }
@@ -87,6 +89,7 @@ beforeEach(() => {
   mockEnv.APP_MODE = "cloud";
   mocks.getSession.mockResolvedValue(session());
   mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue(null);
+  mocks.existsUnscoped.mockResolvedValue(true);
   mocks.findCurrentUserUnscoped.mockResolvedValue(user());
   mocks.getSubscriptionOrThrowUnscoped.mockResolvedValue(subscription(SubscriptionStatus.active));
   mocks.getLegalStatus.mockResolvedValue({ mustAccept: false });
@@ -160,6 +163,36 @@ describe("RouteGuardService.resolveAccountState", () => {
     });
     expect(mocks.getLegalStatus).not.toHaveBeenCalled();
     expect(mocks.getSubscriptionOrThrowUnscoped).not.toHaveBeenCalled();
+    expect(mocks.existsUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("discards an identity binding to a deleted workspace", async () => {
+    mocks.findCurrentUserUnscoped.mockResolvedValue(null);
+    mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue("deleted-company");
+    mocks.existsUnscoped.mockResolvedValue(false);
+
+    expect(await makeService().resolveAccountState()).toMatchObject({
+      state: "unregistered",
+      sessionUser: { companyId: null },
+    });
+    expect(mocks.existsUnscoped).toHaveBeenCalledExactlyOnceWith("deleted-company");
+  });
+
+  it("uses the tenant user's company without looking up the old identity binding", async () => {
+    mocks.findAuthUserCompanyIdUnscoped.mockResolvedValue("old-company");
+
+    expect(await makeService().resolveAccountState()).toMatchObject({ sessionUser: { companyId: "company-1" } });
+    expect(mocks.existsUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("does not look up a company for an unbound identity", async () => {
+    mocks.findCurrentUserUnscoped.mockResolvedValue(null);
+
+    expect(await makeService().resolveAccountState()).toMatchObject({
+      state: "unregistered",
+      sessionUser: { companyId: null },
+    });
+    expect(mocks.existsUnscoped).not.toHaveBeenCalled();
   });
 
   it("rejects a deleted identity even when the same email now has a tenant user", async () => {

--- a/features/auth/__tests__/sign-in-with-email.interactor.test.ts
+++ b/features/auth/__tests__/sign-in-with-email.interactor.test.ts
@@ -49,4 +49,32 @@ describe("SignInWithEmailInteractor", () => {
     if ("ok" in result && !result.ok) expect(result.error.issues[0].message).toBe("Common.errors.invalidCallbackUrl");
     expect(signInWithEmail).not.toHaveBeenCalled();
   });
+
+  it("preserves onboarding intent when an unverified account must verify first", async () => {
+    const signInWithEmail = vi.fn().mockResolvedValue({ ok: false, error: "emailNotVerified" });
+    const interactor = new SignInWithEmailInteractor({ signInWithEmail } as unknown as AuthService);
+
+    const result = await interactor.invoke({
+      callbackURL: "/auth/invitation?intent=signed.intent",
+      email: "synthetic@example.com",
+      password: "local-demo-password",
+      rememberMe: true,
+    });
+
+    expect(result).toEqual({ redirect: "/auth/verify-email?intent=signed.intent" });
+  });
+
+  it("fails closed when an unverified sign-in callback contains duplicate intents", async () => {
+    const signInWithEmail = vi.fn().mockResolvedValue({ ok: false, error: "emailNotVerified" });
+    const interactor = new SignInWithEmailInteractor({ signInWithEmail } as unknown as AuthService);
+
+    await expect(
+      interactor.invoke({
+        callbackURL: "/auth/invitation?intent=one&intent=two",
+        email: "synthetic@example.com",
+        password: "local-demo-password",
+        rememberMe: true,
+      }),
+    ).resolves.toEqual({ redirect: "/auth/error?type=invalidOnboardingIntent" });
+  });
 });

--- a/features/auth/account-state.ts
+++ b/features/auth/account-state.ts
@@ -15,7 +15,7 @@ export type AccountState = (typeof ACCOUNT_STATES)[number];
 const ACCOUNT_STATE_REDIRECTS: Record<AccountState, string | null> = {
   unauthenticated: "/auth/signin",
   overdueVerification: "/auth/verify-email",
-  unregistered: "/onboarding/wizard",
+  unregistered: "/onboarding",
   inactive: "/auth/error?type=inactiveUser",
   pending: "/auth/pending",
   onboarding: "/onboarding/wizard",

--- a/features/auth/auth.service.ts
+++ b/features/auth/auth.service.ts
@@ -139,10 +139,10 @@ export class AuthService {
     }
   }
 
-  async requestPasswordReset(email: string): Promise<void> {
+  async requestPasswordReset(email: string, redirectTo = "/auth/reset-password"): Promise<void> {
     await auth.api.requestPasswordReset({
       headers: await headers(),
-      body: { email, redirectTo: "/auth/reset-password" },
+      body: { email, redirectTo },
     });
   }
 
@@ -150,10 +150,13 @@ export class AuthService {
     await auth.api.resetPassword({ headers: await headers(), body: args });
   }
 
-  async resendVerificationEmail(email: string, options?: { keepSession?: boolean }): Promise<void> {
+  async resendVerificationEmail(
+    email: string,
+    options?: { callbackURL?: string; keepSession?: boolean },
+  ): Promise<void> {
     await auth.api.sendVerificationEmail({
       headers: await headers(),
-      body: { email, callbackURL: "/" },
+      body: { email, callbackURL: options?.callbackURL ?? "/" },
     });
 
     if (!options?.keepSession) await auth.api.signOut({ headers: await headers() });

--- a/features/auth/continue-with-socials.interactor.ts
+++ b/features/auth/continue-with-socials.interactor.ts
@@ -11,6 +11,7 @@ import { redirectTo } from "./auth-outcome";
 import { callbackUrlSchema } from "./callback-url.schema";
 
 import { mustVerifyEmail } from "./email-verification-grace";
+import { onboardingIntentFromPath, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 const Schema = z.object({
   provider: z.enum(["google", "microsoft"]),
@@ -41,7 +42,15 @@ export class ContinueWithSocialsInteractor {
         });
       }
 
-      if (mustVerifyEmail(res.user)) return redirectTo("/auth/verify-email");
+      if (mustVerifyEmail(res.user)) {
+        const onboardingIntent = onboardingIntentFromPath(data.callbackURL);
+        if (onboardingIntent.status === "invalid") return redirectTo("/auth/error?type=invalidOnboardingIntent");
+        return redirectTo(
+          onboardingIntent.status === "valid"
+            ? pathWithOnboardingIntent("/auth/verify-email", onboardingIntent.intent)
+            : "/auth/verify-email",
+        );
+      }
     }
 
     if (res.redirect) return redirectTo(res.url ?? data.callbackURL ?? "/");

--- a/features/auth/next/__tests__/require.test.ts
+++ b/features/auth/next/__tests__/require.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`REDIRECT:${path}`);
+  }),
+  resolveRequestAccountState: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({ setTag: vi.fn(), setUser: vi.fn() }));
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next-intl/server", () => ({ getLocale: vi.fn().mockResolvedValue("en") }));
+vi.mock("@/features/auth/next/resolve-account-state", () => ({
+  resolveRequestAccountState: mocks.resolveRequestAccountState,
+}));
+
+import { requireAccountState } from "../require";
+
+describe("requireAccountState redirect overrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves an onboarding intent when authentication has expired", async () => {
+    mocks.resolveRequestAccountState.mockResolvedValue({ state: "unauthenticated" });
+
+    await expect(
+      requireAccountState("unregistered", "/", {
+        unauthenticated: "/auth/signin?intent=signed.intent",
+      }),
+    ).rejects.toThrow("REDIRECT:/en/auth/signin?intent=signed.intent");
+  });
+
+  it("keeps the canonical redirect when no override is supplied", async () => {
+    mocks.resolveRequestAccountState.mockResolvedValue({ state: "overdueVerification" });
+
+    await expect(requireAccountState("unregistered")).rejects.toThrow("REDIRECT:/en/auth/verify-email");
+  });
+});

--- a/features/auth/next/require.ts
+++ b/features/auth/next/require.ts
@@ -34,10 +34,16 @@ export async function requireUnauthenticated(): Promise<void> {
 export async function requireAccountState(
   expected: AccountState | readonly AccountState[],
   fallback = "/",
+  redirectOverrides: Partial<Record<AccountState, string>> = {},
 ): Promise<AccountStateResolution> {
   const result = await resolveRequestAccountState();
   const expectedStates: readonly AccountState[] = Array.isArray(expected) ? expected : [expected];
   if (expectedStates.includes(result.state)) return result;
 
-  redirect(buildLocalePath(await getLocale(), accountStateRedirect(result.state) ?? fallback));
+  redirect(
+    buildLocalePath(
+      await getLocale(),
+      redirectOverrides[result.state] ?? accountStateRedirect(result.state) ?? fallback,
+    ),
+  );
 }

--- a/features/auth/request-password-reset.interactor.ts
+++ b/features/auth/request-password-reset.interactor.ts
@@ -1,5 +1,6 @@
 import type { Data, Validated } from "@/core/validation/validation.utils";
 import type { AuthService } from "./auth.service";
+import type { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
 
 import { z } from "zod";
 
@@ -8,6 +9,7 @@ import { ValidateOutput } from "@/core/decorators/validate-output.decorator";
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { callbackUrlSchema } from "./callback-url.schema";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 const Schema = z
   .object({
@@ -29,9 +31,19 @@ type RequestPasswordResetInvocation = Data<typeof InvocationSchema>;
 
 @SystemInteractor
 export class RequestPasswordResetInteractor {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+  ) {}
 
-  async invoke(data: RequestPasswordResetData, redirectTo?: string): Validated<RequestPasswordResetData> {
+  async invoke(data: RequestPasswordResetData, onboardingIntentValue?: string): Validated<RequestPasswordResetData> {
+    let redirectTo: string | undefined;
+    if (onboardingIntentValue !== undefined) {
+      const onboardingIntent = await this.onboardingIntentService.resolve(onboardingIntentValue);
+      if (onboardingIntent.status === "valid")
+        redirectTo = pathWithOnboardingIntent("/auth/reset-password", onboardingIntent.intent);
+    }
+
     return this.request({ ...data, redirectTo });
   }
 

--- a/features/auth/request-password-reset.interactor.ts
+++ b/features/auth/request-password-reset.interactor.ts
@@ -15,6 +15,7 @@ const Schema = z
   .object({
     email: z.email(),
     confirmEmail: z.email(),
+    onboardingIntent: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.email !== data.confirmEmail) {
@@ -36,10 +37,10 @@ export class RequestPasswordResetInteractor {
     private readonly onboardingIntentService: OnboardingIntentService,
   ) {}
 
-  async invoke(data: RequestPasswordResetData, onboardingIntentValue?: string): Validated<RequestPasswordResetData> {
+  async invoke(data: RequestPasswordResetData): Validated<RequestPasswordResetData> {
     let redirectTo: string | undefined;
-    if (onboardingIntentValue !== undefined) {
-      const onboardingIntent = await this.onboardingIntentService.resolve(onboardingIntentValue);
+    if (data?.onboardingIntent !== undefined) {
+      const onboardingIntent = await this.onboardingIntentService.resolve(data.onboardingIntent);
       if (onboardingIntent.status === "valid")
         redirectTo = pathWithOnboardingIntent("/auth/reset-password", onboardingIntent.intent);
     }

--- a/features/auth/request-password-reset.interactor.ts
+++ b/features/auth/request-password-reset.interactor.ts
@@ -7,6 +7,7 @@ import { Validate } from "@/core/decorators/validate.decorator";
 import { ValidateOutput } from "@/core/decorators/validate-output.decorator";
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 import { CustomErrorCode } from "@/core/validation/validation.types";
+import { callbackUrlSchema } from "./callback-url.schema";
 
 const Schema = z
   .object({
@@ -23,16 +24,23 @@ const Schema = z
     }
   });
 export type RequestPasswordResetData = Data<typeof Schema>;
+const InvocationSchema = Schema.and(z.object({ redirectTo: callbackUrlSchema.optional() }));
+type RequestPasswordResetInvocation = Data<typeof InvocationSchema>;
 
 @SystemInteractor
 export class RequestPasswordResetInteractor {
   constructor(private readonly authService: AuthService) {}
 
-  @Validate(Schema)
-  @ValidateOutput(Schema)
-  async invoke(data: RequestPasswordResetData): Validated<RequestPasswordResetData> {
-    await this.authService.requestPasswordReset(data.email);
+  async invoke(data: RequestPasswordResetData, redirectTo?: string): Validated<RequestPasswordResetData> {
+    return this.request({ ...data, redirectTo });
+  }
 
-    return { ok: true as const, data };
+  @Validate(InvocationSchema)
+  @ValidateOutput(Schema)
+  private async request(data: RequestPasswordResetInvocation): Validated<RequestPasswordResetData> {
+    const { redirectTo, ...requestData } = data;
+    await this.authService.requestPasswordReset(data.email, redirectTo);
+
+    return { ok: true as const, data: requestData };
   }
 }

--- a/features/auth/resend-verification-email.interactor.ts
+++ b/features/auth/resend-verification-email.interactor.ts
@@ -1,14 +1,28 @@
 import type { AuthService } from "./auth.service";
+import type { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
 
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 @SystemInteractor
 export class ResendVerificationEmailInteractor {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+  ) {}
 
-  async invoke(callbackURL?: string): Promise<{ ok: boolean }> {
+  async invoke(onboardingIntentValue?: string): Promise<{ ok: boolean }> {
     const session = await this.authService.getSession();
     if (!session?.user?.email) return { ok: false };
+
+    let callbackURL: string | undefined;
+    if (onboardingIntentValue !== undefined) {
+      const onboardingIntent = await this.onboardingIntentService.resolve(onboardingIntentValue);
+      if (onboardingIntent.status === "valid") {
+        const destination = onboardingIntent.type === "invitation" ? "/auth/invitation" : "/onboarding/wizard";
+        callbackURL = pathWithOnboardingIntent(destination, onboardingIntent.intent);
+      }
+    }
 
     await this.authService.resendVerificationEmail(session.user.email, { callbackURL, keepSession: true });
 

--- a/features/auth/resend-verification-email.interactor.ts
+++ b/features/auth/resend-verification-email.interactor.ts
@@ -6,11 +6,11 @@ import { SystemInteractor } from "@/core/decorators/system-interactor.decorator"
 export class ResendVerificationEmailInteractor {
   constructor(private readonly authService: AuthService) {}
 
-  async invoke(): Promise<{ ok: boolean }> {
+  async invoke(callbackURL?: string): Promise<{ ok: boolean }> {
     const session = await this.authService.getSession();
     if (!session?.user?.email) return { ok: false };
 
-    await this.authService.resendVerificationEmail(session.user.email, { keepSession: true });
+    await this.authService.resendVerificationEmail(session.user.email, { callbackURL, keepSession: true });
 
     return { ok: true };
   }

--- a/features/auth/reset-password.interactor.ts
+++ b/features/auth/reset-password.interactor.ts
@@ -16,6 +16,7 @@ const PasswordFieldsSchema = z.object({
   password: zx.password(),
   confirmPassword: z.string(),
   token: z.string(),
+  onboardingIntent: z.string().optional(),
 });
 
 function validatePasswordMatch(data: { password: string; confirmPassword: string }, ctx: z.RefinementCtx) {
@@ -48,16 +49,13 @@ export class ResetPasswordInteractor {
     private readonly onboardingIntentService: OnboardingIntentService,
   ) {}
 
-  async invoke(
-    data: ResetPasswordData,
-    onboardingIntentValue?: string,
-  ): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
+  async invoke(data: ResetPasswordData): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
     let redirects: ResetPasswordRedirects = {
       error: "/auth/forgot-password?info=RESET_LINK_INVALID",
       success: "/auth/signin",
     };
-    if (onboardingIntentValue !== undefined) {
-      const onboardingIntent = await this.onboardingIntentService.resolve(onboardingIntentValue);
+    if (data?.onboardingIntent !== undefined) {
+      const onboardingIntent = await this.onboardingIntentService.resolve(data.onboardingIntent);
       if (onboardingIntent.status === "valid") {
         redirects = {
           error: pathWithOnboardingIntent("/auth/forgot-password?info=RESET_LINK_INVALID", onboardingIntent.intent),

--- a/features/auth/reset-password.interactor.ts
+++ b/features/auth/reset-password.interactor.ts
@@ -8,36 +8,63 @@ import { Validate } from "@/core/decorators/validate.decorator";
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { redirectTo } from "./auth-outcome";
+import { callbackUrlSchema } from "./callback-url.schema";
 
-const Schema = z
-  .object({
-    password: zx.password(),
-    confirmPassword: z.string(),
-    token: z.string(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.password !== data.confirmPassword) {
-      ctx.addIssue({
-        code: "custom",
-        params: { error: CustomErrorCode.passwordMismatch },
-        path: ["confirmPassword"],
-      });
-    }
-  });
-export type ResetPasswordData = Data<typeof Schema>;
+const PasswordFieldsSchema = z.object({
+  password: zx.password(),
+  confirmPassword: z.string(),
+  token: z.string(),
+});
+
+function validatePasswordMatch(data: { password: string; confirmPassword: string }, ctx: z.RefinementCtx) {
+  if (data.password !== data.confirmPassword) {
+    ctx.addIssue({
+      code: "custom",
+      params: { error: CustomErrorCode.passwordMismatch },
+      path: ["confirmPassword"],
+    });
+  }
+}
+
+export type ResetPasswordData = Data<typeof PasswordFieldsSchema>;
+
+type ResetPasswordRedirects = {
+  error: string;
+  success: string;
+};
+
+const InvocationSchema = PasswordFieldsSchema.extend({
+  errorRedirect: callbackUrlSchema,
+  successRedirect: callbackUrlSchema,
+}).superRefine(validatePasswordMatch);
+type ResetPasswordInvocation = Data<typeof InvocationSchema>;
 
 @SystemInteractor
 export class ResetPasswordInteractor {
   constructor(private readonly authService: AuthService) {}
 
-  @Validate(Schema)
-  async invoke(data: ResetPasswordData): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
+  async invoke(
+    data: ResetPasswordData,
+    redirects: ResetPasswordRedirects = {
+      error: "/auth/forgot-password?info=RESET_LINK_INVALID",
+      success: "/auth/signin",
+    },
+  ): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
+    return this.reset({
+      ...data,
+      errorRedirect: redirects.error,
+      successRedirect: redirects.success,
+    });
+  }
+
+  @Validate(InvocationSchema)
+  private async reset(data: ResetPasswordInvocation): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
     try {
       await this.authService.resetPassword({ newPassword: data.password, token: data.token });
     } catch {
-      return redirectTo("/auth/forgot-password?info=RESET_LINK_INVALID");
+      return redirectTo(data.errorRedirect);
     }
 
-    return redirectTo("/auth/signin");
+    return redirectTo(data.successRedirect);
   }
 }

--- a/features/auth/reset-password.interactor.ts
+++ b/features/auth/reset-password.interactor.ts
@@ -1,5 +1,6 @@
 import type { AuthService } from "./auth.service";
 import type { Redirect } from "./auth-outcome";
+import type { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
 
 import { z } from "zod";
 
@@ -9,6 +10,7 @@ import { SystemInteractor } from "@/core/decorators/system-interactor.decorator"
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { redirectTo } from "./auth-outcome";
 import { callbackUrlSchema } from "./callback-url.schema";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 const PasswordFieldsSchema = z.object({
   password: zx.password(),
@@ -41,15 +43,29 @@ type ResetPasswordInvocation = Data<typeof InvocationSchema>;
 
 @SystemInteractor
 export class ResetPasswordInteractor {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+  ) {}
 
   async invoke(
     data: ResetPasswordData,
-    redirects: ResetPasswordRedirects = {
+    onboardingIntentValue?: string,
+  ): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
+    let redirects: ResetPasswordRedirects = {
       error: "/auth/forgot-password?info=RESET_LINK_INVALID",
       success: "/auth/signin",
-    },
-  ): Promise<Awaited<Validated<ResetPasswordData>> | Redirect> {
+    };
+    if (onboardingIntentValue !== undefined) {
+      const onboardingIntent = await this.onboardingIntentService.resolve(onboardingIntentValue);
+      if (onboardingIntent.status === "valid") {
+        redirects = {
+          error: pathWithOnboardingIntent("/auth/forgot-password?info=RESET_LINK_INVALID", onboardingIntent.intent),
+          success: pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent),
+        };
+      }
+    }
+
     return this.reset({
       ...data,
       errorRedirect: redirects.error,

--- a/features/auth/route-guard.service.ts
+++ b/features/auth/route-guard.service.ts
@@ -21,7 +21,8 @@ export type AccessOptions = {
   resource?: Resource;
 };
 
-export abstract class RouteGuardSubscriptionRepo {
+export abstract class RouteGuardCompanyRepo {
+  abstract existsUnscoped(companyId: string): Promise<boolean>;
   abstract getSubscriptionOrThrowUnscoped(companyId: string): Promise<Subscription>;
 }
 
@@ -81,7 +82,7 @@ export class RouteGuardService {
   constructor(
     private authService: AuthService,
     private userRepo: FindUserRepo,
-    private subscriptionRepo: RouteGuardSubscriptionRepo,
+    private companyRepo: RouteGuardCompanyRepo,
     private getLegalStatusInteractor: GetLegalStatusInteractor,
   ) {}
 
@@ -111,10 +112,13 @@ export class RouteGuardService {
     }
 
     const user = await this.userRepo.findCurrentUserUnscoped(session.user.email);
+    let companyId = user?.companyId ?? null;
+    if (!user && authUserCompanyId && (await this.companyRepo.existsUnscoped(authUserCompanyId)))
+      companyId = authUserCompanyId;
     const emailVerified = session.user.emailVerified ?? false;
     const sessionUser: AccountSessionUser = {
       ...session.user,
-      companyId: user?.companyId ?? authUserCompanyId,
+      companyId,
     };
     const base = {
       sessionUser,
@@ -146,7 +150,7 @@ export class RouteGuardService {
 
     let subscription: Subscription | null = null;
     if (env.APP_MODE !== "demo") {
-      subscription = await this.subscriptionRepo.getSubscriptionOrThrowUnscoped(user.companyId);
+      subscription = await this.companyRepo.getSubscriptionOrThrowUnscoped(user.companyId);
       if (isSubscriptionExpired(subscription)) return { state: "subscription", ...base, legalStatus, subscription };
     }
 

--- a/features/auth/route-guard.service.ts
+++ b/features/auth/route-guard.service.ts
@@ -98,9 +98,24 @@ export class RouteGuardService {
       };
     }
 
+    const authUserCompanyId = await this.userRepo.findAuthUserCompanyIdUnscoped(session.user.id);
+    if (authUserCompanyId === undefined) {
+      return {
+        state: "unauthenticated",
+        sessionUser: null,
+        user: null,
+        emailVerified: null,
+        legalStatus: null,
+        subscription: null,
+      };
+    }
+
     const user = await this.userRepo.findCurrentUserUnscoped(session.user.email);
     const emailVerified = session.user.emailVerified ?? false;
-    const sessionUser: AccountSessionUser = session.user;
+    const sessionUser: AccountSessionUser = {
+      ...session.user,
+      companyId: user?.companyId ?? authUserCompanyId,
+    };
     const base = {
       sessionUser,
       user,

--- a/features/auth/sign-in-with-email.interactor.ts
+++ b/features/auth/sign-in-with-email.interactor.ts
@@ -11,6 +11,7 @@ import { Validate } from "@/core/decorators/validate.decorator";
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { createZodError } from "@/core/validation/validation.utils";
+import { onboardingIntentFromPath, pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 const Schema = z.object({
   email: z.email(),
@@ -36,7 +37,15 @@ export class SignInWithEmailInteractor {
     if (isRedirect(res)) return res;
 
     if (!res.ok) {
-      if (res.error === CustomErrorCode.emailNotVerified) return redirectTo("/auth/verify-email");
+      if (res.error === CustomErrorCode.emailNotVerified) {
+        const onboardingIntent = onboardingIntentFromPath(data.callbackURL);
+        if (onboardingIntent.status === "invalid") return redirectTo("/auth/error?type=invalidOnboardingIntent");
+        return redirectTo(
+          onboardingIntent.status === "valid"
+            ? pathWithOnboardingIntent("/auth/verify-email", onboardingIntent.intent)
+            : "/auth/verify-email",
+        );
+      }
       const t = await getTranslations();
       const error = createZodError<EmailSignInData>(t(`Common.errors.${res.error}`));
 

--- a/features/auth/sign-out.interactor.ts
+++ b/features/auth/sign-out.interactor.ts
@@ -1,16 +1,32 @@
 import type { AuthService } from "./auth.service";
 import type { Redirect } from "./auth-outcome";
+import type { InviteTokenCookieRepo } from "@/features/company/invite-token-cookie.repo";
+import type { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
 
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 import { redirectTo } from "./auth-outcome";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 @SystemInteractor
 export class SignOutInteractor {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+    private readonly inviteTokenCookieRepo: InviteTokenCookieRepo,
+  ) {}
 
-  async invoke(): Promise<Redirect> {
+  async invoke(data: { invitationIntent?: string } = {}): Promise<Redirect> {
+    const invitation =
+      data.invitationIntent === undefined ? null : await this.onboardingIntentService.resolve(data.invitationIntent);
+    await this.inviteTokenCookieRepo.clear();
     await this.authService.signOut();
 
-    return redirectTo("/");
+    if (!invitation) return redirectTo("/");
+    if (invitation.status !== "valid" || invitation.type !== "invitation") {
+      const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
+      return redirectTo(`/auth/error?type=${errorMessage}`);
+    }
+
+    return redirectTo(pathWithOnboardingIntent("/auth/signup", invitation.intent));
   }
 }

--- a/features/auth/sign-out.interactor.ts
+++ b/features/auth/sign-out.interactor.ts
@@ -15,18 +15,17 @@ export class SignOutInteractor {
     private readonly inviteTokenCookieRepo: InviteTokenCookieRepo,
   ) {}
 
-  async invoke(data: { invitationIntent?: string } = {}): Promise<Redirect> {
-    const invitation =
-      data.invitationIntent === undefined ? null : await this.onboardingIntentService.resolve(data.invitationIntent);
+  async invoke(data: { onboardingIntent?: string } = {}): Promise<Redirect> {
+    const onboardingIntent =
+      data.onboardingIntent === undefined ? null : await this.onboardingIntentService.resolve(data.onboardingIntent);
     await this.inviteTokenCookieRepo.clear();
     await this.authService.signOut();
 
-    if (!invitation) return redirectTo("/");
-    if (invitation.status !== "valid" || invitation.type !== "invitation") {
-      const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
-      return redirectTo(`/auth/error?type=${errorMessage}`);
-    }
+    if (!onboardingIntent) return redirectTo("/");
+    if (onboardingIntent.status === "invalid") return redirectTo(`/auth/error?type=${onboardingIntent.errorMessage}`);
+    if (onboardingIntent.status === "absent") return redirectTo("/");
+    if (onboardingIntent.type !== "invitation") return redirectTo("/");
 
-    return redirectTo(pathWithOnboardingIntent("/auth/signup", invitation.intent));
+    return redirectTo(pathWithOnboardingIntent("/auth/signup", onboardingIntent.intent));
   }
 }

--- a/features/auth/sign-up-with-email.interactor.ts
+++ b/features/auth/sign-up-with-email.interactor.ts
@@ -1,5 +1,6 @@
 import type { AuthService } from "./auth.service";
 import type { Redirect } from "./auth-outcome";
+import type { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
 
 import { z } from "zod";
 import { getTranslations } from "next-intl/server";
@@ -10,6 +11,7 @@ import { CustomErrorCode } from "@/core/validation/validation.types";
 import { Validate } from "@/core/decorators/validate.decorator";
 import { redirectTo } from "./auth-outcome";
 import { callbackUrlSchema } from "./callback-url.schema";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
 
 const Schema = z
   .object({
@@ -40,10 +42,30 @@ export type EmailSignUpData = Data<typeof Schema>;
 
 @SystemInteractor
 export class SignUpWithEmailInteractor {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private onboardingIntentService: OnboardingIntentService,
+  ) {}
+
+  async invoke(
+    data: EmailSignUpData,
+    onboardingIntentValue?: string,
+  ): Promise<Awaited<Validated<EmailSignUpData>> | Redirect> {
+    if (onboardingIntentValue !== undefined) {
+      const invitation = await this.onboardingIntentService.resolve(onboardingIntentValue);
+      if (invitation.status !== "valid" || invitation.type !== "invitation") {
+        const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
+        return redirectTo(`/auth/error?type=${errorMessage}`);
+      }
+
+      return this.signUp({ ...data, callbackURL: pathWithOnboardingIntent("/auth/invitation", invitation.intent) });
+    }
+
+    return this.signUp(data);
+  }
 
   @Validate(Schema)
-  async invoke(data: EmailSignUpData): Promise<Awaited<Validated<EmailSignUpData>> | Redirect> {
+  private async signUp(data: EmailSignUpData): Promise<Awaited<Validated<EmailSignUpData>> | Redirect> {
     const res = await this.authService.registerWithEmail({
       email: data.email,
       name: data.email,

--- a/features/auth/sign-up-with-email.interactor.ts
+++ b/features/auth/sign-up-with-email.interactor.ts
@@ -20,6 +20,7 @@ const Schema = z
     password: zx.password(),
     confirmPassword: z.string(),
     callbackURL: callbackUrlSchema.optional(),
+    onboardingIntent: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.email !== data.confirmEmail) {
@@ -47,12 +48,9 @@ export class SignUpWithEmailInteractor {
     private onboardingIntentService: OnboardingIntentService,
   ) {}
 
-  async invoke(
-    data: EmailSignUpData,
-    onboardingIntentValue?: string,
-  ): Promise<Awaited<Validated<EmailSignUpData>> | Redirect> {
-    if (onboardingIntentValue !== undefined) {
-      const invitation = await this.onboardingIntentService.resolve(onboardingIntentValue);
+  async invoke(data: EmailSignUpData): Promise<Awaited<Validated<EmailSignUpData>> | Redirect> {
+    if (data?.onboardingIntent !== undefined) {
+      const invitation = await this.onboardingIntentService.resolve(data.onboardingIntent);
       if (invitation.status !== "valid" || invitation.type !== "invitation") {
         const errorMessage = invitation.status === "invalid" ? invitation.errorMessage : "invalidOnboardingIntent";
         return redirectTo(`/auth/error?type=${errorMessage}`);

--- a/features/auth/sign-up-with-email.interactor.ts
+++ b/features/auth/sign-up-with-email.interactor.ts
@@ -9,6 +9,7 @@ import { SystemInteractor } from "@/core/decorators/system-interactor.decorator"
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { Validate } from "@/core/decorators/validate.decorator";
 import { redirectTo } from "./auth-outcome";
+import { callbackUrlSchema } from "./callback-url.schema";
 
 const Schema = z
   .object({
@@ -16,6 +17,7 @@ const Schema = z
     confirmEmail: z.email(),
     password: zx.password(),
     confirmPassword: z.string(),
+    callbackURL: callbackUrlSchema.optional(),
   })
   .superRefine((data, ctx) => {
     if (data.email !== data.confirmEmail) {
@@ -46,6 +48,7 @@ export class SignUpWithEmailInteractor {
       email: data.email,
       name: data.email,
       password: data.password,
+      callbackURL: data.callbackURL,
     });
 
     if (!res.ok) {
@@ -56,6 +59,6 @@ export class SignUpWithEmailInteractor {
         error,
       };
     }
-    return redirectTo("/onboarding/wizard");
+    return redirectTo(data.callbackURL ?? "/onboarding");
   }
 }

--- a/features/company/__tests__/choose-workspace-onboarding.interactor.test.ts
+++ b/features/company/__tests__/choose-workspace-onboarding.interactor.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChooseWorkspaceOnboardingInteractor } from "../choose-workspace-onboarding.interactor";
+
+describe("ChooseWorkspaceOnboardingInteractor", () => {
+  const routeGuardService = { resolveAccountState: vi.fn() };
+  const onboardingIntentService = { issueCreateCompany: vi.fn() };
+  const inviteTokenCookieRepo = { clear: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeGuardService.resolveAccountState.mockResolvedValue({
+      state: "unregistered",
+      sessionUser: { id: "auth-user-one" },
+    });
+    onboardingIntentService.issueCreateCompany.mockReturnValue("signed-create-intent");
+    inviteTokenCookieRepo.clear.mockResolvedValue(undefined);
+  });
+
+  function createInteractor() {
+    return new ChooseWorkspaceOnboardingInteractor(
+      routeGuardService as never,
+      onboardingIntentService as never,
+      inviteTokenCookieRepo as never,
+    );
+  }
+
+  it("binds company creation to the signed-in identity", async () => {
+    await expect(createInteractor().invoke({ choice: "create" })).resolves.toEqual({
+      redirect: "/onboarding/wizard?intent=signed-create-intent",
+    });
+    expect(onboardingIntentService.issueCreateCompany).toHaveBeenCalledExactlyOnceWith("auth-user-one");
+    expect(inviteTokenCookieRepo.clear).toHaveBeenCalledOnce();
+  });
+
+  it("routes join intent to instructions without issuing a creation intent", async () => {
+    await expect(createInteractor().invoke({ choice: "join" })).resolves.toEqual({ redirect: "/onboarding/join" });
+    expect(onboardingIntentService.issueCreateCompany).not.toHaveBeenCalled();
+    expect(inviteTokenCookieRepo.clear).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an unknown choice without reading account state", async () => {
+    await expect(createInteractor().invoke({ choice: "unknown" })).resolves.toBeNull();
+    expect(routeGuardService.resolveAccountState).not.toHaveBeenCalled();
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+  });
+
+  it("redirects account states that are not eligible for workspace choice", async () => {
+    routeGuardService.resolveAccountState.mockResolvedValue({ state: "pending", sessionUser: { id: "auth-user-one" } });
+
+    await expect(createInteractor().invoke({ choice: "create" })).resolves.toEqual({ redirect: "/auth/pending" });
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+  });
+});

--- a/features/company/__tests__/deal-weighting.database.test.ts
+++ b/features/company/__tests__/deal-weighting.database.test.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from "node:crypto";
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { createMockUser } from "@/tests/helpers/mock-user";
+
+vi.mock("@/env", () => ({
+  env: { APP_MODE: "cloud", DATABASE_URL: process.env.DATABASE_URL, NODE_ENV: "test" },
+}));
+vi.mock("@/core/di", () => ({
+  getDealRepo: () => new PrismaDealRepo(new PrismaCompanyRepo()),
+  getCustomColumnRepo: () => new PrismaCustomColumnRepo(new PrismaCompanyRepo()),
+}));
+
+const { PrismaCompanyRepo } = await import("@/features/company/prisma-company.repository");
+const { PrismaDealRepo } = await import("@/features/deals/prisma-deal.repository");
+const { PrismaCustomColumnRepo } = await import("@/features/custom-column/prisma-custom-column.repository");
+const { prisma } = await import("@/prisma/db");
+const { runWithTenant, runWithoutTenant } = await import("@/core/decorators/tenant-context");
+const { runInTransaction } = await import("@/core/decorators/transaction-runner");
+
+const describeDatabase = getLocalDatabaseTestUrl() ? describe : describe.skip;
+const companyIds: string[] = [];
+
+async function makeWorkspace() {
+  return runWithoutTenant(async () => {
+    const company = await prisma.company.create({ data: {} });
+    companyIds.push(company.id);
+    const optionValue = randomUUID();
+    const column = await prisma.customColumn.create({
+      data: {
+        companyId: company.id,
+        label: "Stage",
+        type: "singleSelect",
+        entityType: "deal",
+        options: {
+          options: [{ value: optionValue, label: "Qualified", color: "info", isDefault: true, index: 0, weight: 25 }],
+        },
+      },
+    });
+    await prisma.company.update({ where: { id: company.id }, data: { dealWeightingColumnId: column.id } });
+    const deal = await prisma.deal.create({ data: { companyId: company.id, name: "Weighted deal" } });
+    const service = await prisma.service.create({ data: { companyId: company.id, name: "Service", amount: 100 } });
+    await prisma.serviceDeal.create({
+      data: { companyId: company.id, serviceId: service.id, dealId: deal.id, quantity: 2 },
+    });
+    await prisma.customFieldValue.create({
+      data: {
+        companyId: company.id,
+        entityType: "deal",
+        type: "singleSelect",
+        columnId: column.id,
+        dealId: deal.id,
+        value: optionValue,
+      },
+    });
+    return { company, column, deal, optionValue, user: createMockUser({ id: randomUUID(), companyId: company.id }) };
+  });
+}
+
+function readDeal(id: string) {
+  return runWithoutTenant(() =>
+    prisma.deal.findUniqueOrThrow({
+      where: { id },
+      select: { totalValue: true, totalQuantity: true, weightedValue: true },
+    }),
+  );
+}
+
+describeDatabase("company-owned deal weighting configuration", () => {
+  afterAll(async () => {
+    await runWithoutTenant(() => prisma.company.deleteMany({ where: { id: { in: companyIds } } }));
+    await prisma.$disconnect();
+  });
+
+  it("uses the active tenant's configuration without recalculating another tenant's deal", async () => {
+    const first = await makeWorkspace();
+    const second = await makeWorkspace();
+    const repo = new PrismaDealRepo(new PrismaCompanyRepo());
+    await runWithTenant(first.user, () =>
+      runInTransaction(() => repo.recalculateTotals([first.deal.id, second.deal.id])),
+    );
+    expect(await readDeal(first.deal.id)).toEqual({ totalValue: 200, totalQuantity: 2, weightedValue: 50 });
+    expect(await readDeal(second.deal.id)).toEqual({ totalValue: 0, totalQuantity: 0, weightedValue: null });
+  });
+
+  it("recalculates using selected stage weights written in the same transaction", async () => {
+    const fixture = await makeWorkspace();
+    await runWithTenant(fixture.user, () =>
+      new PrismaCompanyRepo().setDealStageWeights([{ optionValue: fixture.optionValue, weight: 60 }]),
+    );
+    expect(await readDeal(fixture.deal.id)).toEqual({ totalValue: 200, totalQuantity: 2, weightedValue: 120 });
+  });
+
+  it("rolls back stage weights and weighted totals when the outer transaction fails", async () => {
+    const fixture = await makeWorkspace();
+    const companyRepo = new PrismaCompanyRepo();
+    const dealRepo = new PrismaDealRepo(companyRepo);
+    await runWithTenant(fixture.user, () => runInTransaction(() => dealRepo.recalculateTotals([fixture.deal.id])));
+    await expect(
+      runWithTenant(fixture.user, () =>
+        runInTransaction(async () => {
+          await companyRepo.setDealStageWeights([{ optionValue: fixture.optionValue, weight: 60 }]);
+          throw new Error("Forced rollback");
+        }),
+      ),
+    ).rejects.toThrow("Forced rollback");
+    expect((await readDeal(fixture.deal.id)).weightedValue).toBe(50);
+    const column = await runWithoutTenant(() =>
+      prisma.customColumn.findUniqueOrThrow({
+        where: { id: fixture.column.id },
+        select: { options: true },
+      }),
+    );
+    expect(column.options).toEqual(fixture.column.options);
+  });
+
+  it("clears weighted totals after deleting the selected column", async () => {
+    const fixture = await makeWorkspace();
+    const companyRepo = new PrismaCompanyRepo();
+    const dealRepo = new PrismaDealRepo(companyRepo);
+    const columnRepo = new PrismaCustomColumnRepo(companyRepo);
+    await runWithTenant(fixture.user, () => runInTransaction(() => dealRepo.recalculateTotals([fixture.deal.id])));
+    await runWithTenant(fixture.user, () => columnRepo.delete(fixture.column.id));
+    expect(await runWithTenant(fixture.user, () => companyRepo.getDealWeightingColumnId())).toBeNull();
+    expect(await readDeal(fixture.deal.id)).toEqual({ totalValue: 200, totalQuantity: 2, weightedValue: null });
+  });
+
+  it("preserves weighting for an unrelated column's update or deletion", async () => {
+    const fixture = await makeWorkspace();
+    const companyRepo = new PrismaCompanyRepo();
+    const columnRepo = new PrismaCustomColumnRepo(companyRepo);
+    const unrelated = await runWithoutTenant(() =>
+      prisma.customColumn.create({
+        data: {
+          companyId: fixture.company.id,
+          label: "Unrelated stage",
+          type: "singleSelect",
+          entityType: "deal",
+          options: fixture.column.options ?? [],
+        },
+      }),
+    );
+    await runWithTenant(fixture.user, async () => {
+      await runInTransaction(() => new PrismaDealRepo(companyRepo).recalculateTotals([fixture.deal.id]));
+      await columnRepo.setOptionWeights(unrelated.id, [{ optionValue: fixture.optionValue, weight: 95 }]);
+      await columnRepo.delete(unrelated.id);
+    });
+    expect(await readDeal(fixture.deal.id)).toEqual({ totalValue: 200, totalQuantity: 2, weightedValue: 50 });
+    expect(await runWithTenant(fixture.user, () => companyRepo.getDealWeightingColumnId())).toBe(fixture.column.id);
+  });
+
+  it("preserves ordinary totals when weighting is disabled", async () => {
+    const fixture = await makeWorkspace();
+    const companyRepo = new PrismaCompanyRepo();
+    await runWithTenant(fixture.user, () => companyRepo.updateDetails({ dealWeightingColumnId: null }));
+    expect(await runWithTenant(fixture.user, () => companyRepo.getDealWeightingColumnId())).toBeNull();
+    expect(await readDeal(fixture.deal.id)).toEqual({ totalValue: 200, totalQuantity: 2, weightedValue: null });
+  });
+});

--- a/features/company/__tests__/invite-token-validation.interactor.test.ts
+++ b/features/company/__tests__/invite-token-validation.interactor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MOCK_ENV_MODULE, MOCK_ZOD_MODULE } from "@/tests/helpers/interactor-test-setup";
 
@@ -16,6 +16,10 @@ function interactor() {
 describe("InviteTokenValidationInteractor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it.each(["{token}", "has spaces", "slash/token", "%7Btoken%7D"])(
@@ -45,9 +49,11 @@ describe("InviteTokenValidationInteractor", () => {
   });
 
   it("looks up a well-formed token", async () => {
+    const expiresAt = new Date(Date.now() + 60_000);
     repo.findTokenUnscoped.mockResolvedValue({
       companyId: "00000000-0000-4000-8000-000000000001",
-      expiresAt: new Date(Date.now() + 60_000),
+      createdBy: { email: "admin@example.com", firstName: "Invite", lastName: "Admin" },
+      expiresAt,
     });
 
     const result = await interactor().invoke({ token: "well-formed_TOKEN123" });
@@ -55,7 +61,12 @@ describe("InviteTokenValidationInteractor", () => {
     expect(repo.findTokenUnscoped).toHaveBeenCalledWith("well-formed_TOKEN123");
     expect(result).toEqual({
       ok: true,
-      data: { valid: true, companyId: "00000000-0000-4000-8000-000000000001" },
+      data: {
+        companyId: "00000000-0000-4000-8000-000000000001",
+        expiresAt,
+        inviterName: "Invite Admin",
+        valid: true,
+      },
     });
   });
 
@@ -68,5 +79,40 @@ describe("InviteTokenValidationInteractor", () => {
     const result = await interactor().invoke({ token: "expired-token" });
 
     expect(result).toEqual({ ok: true, data: { valid: false, errorMessage: "inviteLinkExpired" } });
+  });
+
+  it("treats the exact expiry instant as expired", async () => {
+    const now = new Date("2026-09-04T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    repo.findTokenUnscoped.mockResolvedValue({
+      companyId: "00000000-0000-4000-8000-000000000001",
+      createdBy: { email: "admin@example.com", firstName: "Invite", lastName: "Admin" },
+      expiresAt: now,
+    });
+
+    await expect(interactor().invoke({ token: "exact-expiry" })).resolves.toEqual({
+      ok: true,
+      data: { valid: false, errorMessage: "inviteLinkExpired" },
+    });
+  });
+
+  it("falls back to the inviter email when no name is available", async () => {
+    const expiresAt = new Date(Date.now() + 60_000);
+    repo.findTokenUnscoped.mockResolvedValue({
+      companyId: "00000000-0000-4000-8000-000000000001",
+      createdBy: { email: "admin@example.com", firstName: "", lastName: "" },
+      expiresAt,
+    });
+
+    await expect(interactor().invoke({ token: "email-fallback" })).resolves.toEqual({
+      ok: true,
+      data: {
+        companyId: "00000000-0000-4000-8000-000000000001",
+        expiresAt,
+        inviterName: "admin@example.com",
+        valid: true,
+      },
+    });
   });
 });

--- a/features/company/__tests__/onboarding-intent-codec.test.ts
+++ b/features/company/__tests__/onboarding-intent-codec.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { hmacSha256Hex } from "@/core/utils/hmac";
+import {
+  decodeOnboardingIntent,
+  encodeCreateCompanyOnboardingIntent,
+  encodeInvitationOnboardingIntent,
+  ONBOARDING_INTENT_MAX_AGE_MS,
+  ONBOARDING_INTENT_VALUE_MAX_BYTES,
+  onboardingIntentSigningSecret,
+} from "../onboarding-intent-codec";
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+const secret = "codec-test-secret";
+
+function signedPayload(payload: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${encoded}.${hmacSha256Hex(secret, encoded)}`;
+}
+
+describe("onboarding intent codec", () => {
+  it("round-trips an invitation and caps it at the invitation expiry", () => {
+    const inviteExpiresAt = new Date(now.getTime() + 15 * 60_000);
+    const encoded = encodeInvitationOnboardingIntent("invite-token", inviteExpiresAt, secret, now);
+
+    expect(decodeOnboardingIntent(encoded ?? undefined, secret, now)).toEqual({
+      payload: {
+        expiresAt: inviteExpiresAt.getTime(),
+        token: "invite-token",
+        type: "invitation",
+      },
+      status: "valid",
+    });
+  });
+
+  it("caps a long-lived invitation at the two-hour onboarding lifetime", () => {
+    const encoded = encodeInvitationOnboardingIntent(
+      "invite-token",
+      new Date(now.getTime() + 7 * 24 * 60 * 60_000),
+      secret,
+      now,
+    );
+
+    expect(decodeOnboardingIntent(encoded ?? undefined, secret, now)).toMatchObject({
+      payload: { expiresAt: now.getTime() + ONBOARDING_INTENT_MAX_AGE_MS },
+      status: "valid",
+    });
+  });
+
+  it("round-trips a company-creation decision bound to one identity", () => {
+    const encoded = encodeCreateCompanyOnboardingIntent("auth-user-one", secret, now);
+
+    expect(decodeOnboardingIntent(encoded ?? undefined, secret, now)).toEqual({
+      payload: {
+        authUserId: "auth-user-one",
+        expiresAt: now.getTime() + ONBOARDING_INTENT_MAX_AGE_MS,
+        type: "createCompany",
+      },
+      status: "valid",
+    });
+  });
+
+  it("rejects tampering, malformed values, and oversized input", () => {
+    const encoded = encodeCreateCompanyOnboardingIntent("auth-user-one", secret, now);
+    if (!encoded) throw new Error("Expected an encoded test intent");
+
+    expect(decodeOnboardingIntent(`${encoded}x`, secret, now)).toEqual({ status: "invalid" });
+    expect(decodeOnboardingIntent("not-an-intent", secret, now)).toEqual({ status: "invalid" });
+    expect(decodeOnboardingIntent("x".repeat(ONBOARDING_INTENT_VALUE_MAX_BYTES + 1), secret, now)).toEqual({
+      status: "invalid",
+    });
+  });
+
+  it("expires exactly at the signed expiry instant", () => {
+    const expiresAt = new Date(now.getTime() + 60_000);
+    const encoded = encodeInvitationOnboardingIntent("invite-token", expiresAt, secret, now);
+
+    expect(decodeOnboardingIntent(encoded ?? undefined, secret, expiresAt)).toEqual({ status: "expired" });
+  });
+
+  it("rejects a validly signed payload beyond the maximum lifetime", () => {
+    const encoded = signedPayload({
+      authUserId: "auth-user-one",
+      expiresAt: now.getTime() + ONBOARDING_INTENT_MAX_AGE_MS + 1,
+      type: "createCompany",
+    });
+
+    expect(decodeOnboardingIntent(encoded, secret, now)).toEqual({ status: "invalid" });
+  });
+
+  it("refuses to issue an invitation that is already expired", () => {
+    expect(encodeInvitationOnboardingIntent("invite-token", now, secret, now)).toBeNull();
+  });
+
+  it("derives a non-empty domain-separated secret", () => {
+    expect(onboardingIntentSigningSecret("  base-secret  ")).toBe("onboarding-intent:v1:base-secret");
+    expect(onboardingIntentSigningSecret(" ")).toBeNull();
+  });
+});

--- a/features/company/__tests__/onboarding-intent-url.test.ts
+++ b/features/company/__tests__/onboarding-intent-url.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  onboardingIntentAuthRedirects,
+  onboardingIntentFromPath,
+  pathWithOnboardingIntent,
+} from "../onboarding-intent-url";
+
+describe("onboarding intent URLs", () => {
+  it("appends an encoded intent without replacing existing query parameters", () => {
+    expect(pathWithOnboardingIntent("/auth/forgot-password?info=invalid", "signed/value")).toBe(
+      "/auth/forgot-password?info=invalid&intent=signed%2Fvalue",
+    );
+  });
+
+  it("extracts one intent from an internal callback path", () => {
+    expect(onboardingIntentFromPath("/onboarding/wizard?intent=signed.intent")).toEqual({
+      intent: "signed.intent",
+      status: "valid",
+    });
+  });
+
+  it("preserves intent across authentication and verification detours", () => {
+    expect(onboardingIntentAuthRedirects("signed.intent")).toEqual({
+      overdueVerification: "/auth/verify-email?intent=signed.intent",
+      unauthenticated: "/auth/signin?intent=signed.intent",
+    });
+  });
+
+  it("rejects duplicate intent parameters", () => {
+    expect(onboardingIntentFromPath("/onboarding/wizard?intent=one&intent=two")).toEqual({ status: "invalid" });
+  });
+
+  it("ignores malformed callback paths", () => {
+    expect(onboardingIntentFromPath("http://[")).toEqual({ status: "invalid" });
+  });
+});

--- a/features/company/__tests__/onboarding-intent.service.test.ts
+++ b/features/company/__tests__/onboarding-intent.service.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { decodeOnboardingIntent, onboardingIntentSigningSecret } from "../../onboarding-intent-codec";
-import { OnboardingIntentService } from "../../onboarding-intent.service";
+import { decodeOnboardingIntent, onboardingIntentSigningSecret } from "../onboarding-intent-codec";
+import { OnboardingIntentService } from "../onboarding-intent.service";
 
 const now = new Date("2026-09-04T12:00:00.000Z");
 const inviteExpiresAt = new Date(now.getTime() + 60 * 60_000);

--- a/features/company/__tests__/open-invitation.interactor.test.ts
+++ b/features/company/__tests__/open-invitation.interactor.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenInvitationInteractor } from "../open-invitation.interactor";
+
+describe("OpenInvitationInteractor", () => {
+  const validation = { invoke: vi.fn() };
+  const auth = { getSession: vi.fn() };
+  const intents = { issueInvitation: vi.fn() };
+  const expiresAt = new Date("2099-01-01T00:00:00Z");
+  const interactor = new OpenInvitationInteractor(validation as never, auth as never, intents as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validation.invoke.mockResolvedValue({ ok: true, data: { valid: true, expiresAt } });
+    auth.getSession.mockResolvedValue(null);
+    intents.issueInvitation.mockReturnValue("signed-invitation");
+  });
+
+  it.each([
+    [null, "/auth/signup"],
+    [{ user: { emailVerified: true } }, "/auth/invitation"],
+    [{ user: { emailVerified: false } }, "/auth/invitation"],
+  ])("retains the invitation for session %j", async (session, destination) => {
+    auth.getSession.mockResolvedValue(session);
+
+    await expect(interactor.invoke({ token: "invite-token" })).resolves.toEqual({
+      redirect: `${destination}?intent=signed-invitation`,
+    });
+    expect(validation.invoke).toHaveBeenCalledExactlyOnceWith({ token: "invite-token" });
+    expect(validation.invoke.mock.invocationCallOrder[0]).toBeLessThan(auth.getSession.mock.invocationCallOrder[0]);
+    expect(intents.issueInvitation).toHaveBeenCalledExactlyOnceWith("invite-token", expiresAt);
+  });
+
+  it.each([
+    [{ ok: false }, "invalidInviteLink"],
+    [{ ok: true, data: { valid: false, errorMessage: "invalidInviteLink" } }, "invalidInviteLink"],
+    [{ ok: true, data: { valid: false, errorMessage: "inviteLinkExpired" } }, "inviteLinkExpired"],
+  ])("rejects invalid invitations before reading the session", async (result, error) => {
+    validation.invoke.mockResolvedValue(result);
+    await expect(interactor.invoke({ token: "invalid-token" })).resolves.toEqual({
+      redirect: `/auth/error?type=${error}`,
+    });
+    expect(auth.getSession).not.toHaveBeenCalled();
+    expect(intents.issueInvitation).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the invitation expires before issuance", async () => {
+    intents.issueInvitation.mockReturnValue(null);
+    await expect(interactor.invoke({ token: "invite-token" })).resolves.toEqual({
+      redirect: "/auth/error?type=inviteLinkExpired",
+    });
+  });
+});

--- a/features/company/choose-workspace-onboarding.interactor.ts
+++ b/features/company/choose-workspace-onboarding.interactor.ts
@@ -1,0 +1,32 @@
+import type { RouteGuardService } from "@/features/auth/route-guard.service";
+import type { Redirect } from "@/features/auth/auth-outcome";
+import type { InviteTokenCookieRepo } from "./invite-token-cookie.repo";
+import type { OnboardingIntentService } from "./onboarding-intent.service";
+
+import { accountStateRedirect } from "@/features/auth/account-state";
+import { redirectTo } from "@/features/auth/auth-outcome";
+import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
+import { pathWithOnboardingIntent } from "./onboarding-intent-url";
+
+@SystemInteractor
+export class ChooseWorkspaceOnboardingInteractor {
+  constructor(
+    private readonly routeGuardService: RouteGuardService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+    private readonly inviteTokenCookieRepo: InviteTokenCookieRepo,
+  ) {}
+
+  async invoke(data: { choice: unknown }): Promise<Redirect | null> {
+    if (data.choice !== "create" && data.choice !== "join") return null;
+
+    const resolution = await this.routeGuardService.resolveAccountState();
+    if (resolution.state !== "unregistered") return redirectTo(accountStateRedirect(resolution.state) ?? "/");
+    if (!resolution.sessionUser) return redirectTo("/auth/signin");
+
+    await this.inviteTokenCookieRepo.clear();
+    if (data.choice === "join") return redirectTo("/onboarding/join");
+
+    const intent = this.onboardingIntentService.issueCreateCompany(resolution.sessionUser.id);
+    return redirectTo(pathWithOnboardingIntent("/onboarding/wizard", intent));
+  }
+}

--- a/features/company/get-deal-weighting-column.repo.ts
+++ b/features/company/get-deal-weighting-column.repo.ts
@@ -1,0 +1,3 @@
+export abstract class GetDealWeightingColumnRepo {
+  abstract getDealWeightingColumnId(): Promise<string | null>;
+}

--- a/features/company/invite-token-cookie.repo.ts
+++ b/features/company/invite-token-cookie.repo.ts
@@ -1,0 +1,4 @@
+export abstract class InviteTokenCookieRepo {
+  abstract read(): Promise<string | undefined>;
+  abstract clear(): Promise<void>;
+}

--- a/features/company/invite-token-validation.interactor.ts
+++ b/features/company/invite-token-validation.interactor.ts
@@ -2,15 +2,21 @@ import type { Data, Validated } from "@/core/validation/validation.utils";
 
 import { z } from "zod";
 
-import type { InviteToken } from "@/generated/prisma";
-
 import { Validate } from "@/core/decorators/validate.decorator";
 import { ValidateOutput } from "@/core/decorators/validate-output.decorator";
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 
 const OutputSchema = z.discriminatedUnion("valid", [
-  z.object({ valid: z.literal(true), companyId: z.string() }),
-  z.object({ valid: z.literal(false), errorMessage: z.string() }),
+  z.object({
+    valid: z.literal(true),
+    companyId: z.string(),
+    expiresAt: z.date(),
+    inviterName: z.string().min(1),
+  }),
+  z.object({
+    valid: z.literal(false),
+    errorMessage: z.enum(["invalidInviteLink", "inviteLinkExpired"]),
+  }),
 ]);
 
 const Schema = z.object({
@@ -24,7 +30,11 @@ type InviteTokenData = Data<typeof Schema>;
 type ValidatedInviteToken = z.infer<typeof OutputSchema>;
 
 export abstract class InviteTokenRepo {
-  abstract findTokenUnscoped(token: string): Promise<InviteToken | null>;
+  abstract findTokenUnscoped(token: string): Promise<{
+    companyId: string;
+    createdBy: { email: string; firstName: string; lastName: string };
+    expiresAt: Date;
+  } | null>;
 }
 
 @SystemInteractor
@@ -56,7 +66,7 @@ export class InviteTokenValidationInteractor {
       };
     }
 
-    if (new Date() > inviteToken.expiresAt) {
+    if (Date.now() >= inviteToken.expiresAt.getTime()) {
       return {
         ok: true,
         data: {
@@ -71,6 +81,9 @@ export class InviteTokenValidationInteractor {
       data: {
         valid: true,
         companyId: inviteToken.companyId,
+        expiresAt: inviteToken.expiresAt,
+        inviterName:
+          `${inviteToken.createdBy.firstName} ${inviteToken.createdBy.lastName}`.trim() || inviteToken.createdBy.email,
       },
     };
   }

--- a/features/company/next/__tests__/onboarding-intent.adapter.test.ts
+++ b/features/company/next/__tests__/onboarding-intent.adapter.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ readCookie: vi.fn(), resolve: vi.fn() }));
+
+vi.mock("@/core/di", () => ({ getOnboardingIntentService: () => ({ resolve: mocks.resolve }) }));
+vi.mock("../invite-token-cookie", () => ({ readInviteTokenCookie: mocks.readCookie }));
+
+import { resolveOnboardingIntent } from "../onboarding-intent";
+
+describe("onboarding intent Next adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readCookie.mockResolvedValue("legacy-token");
+    mocks.resolve.mockResolvedValue({ status: "absent" });
+  });
+
+  it("does not read ambient invitation state when an explicit intent is present", async () => {
+    await resolveOnboardingIntent("signed.intent");
+
+    expect(mocks.readCookie).not.toHaveBeenCalled();
+    expect(mocks.resolve).toHaveBeenCalledExactlyOnceWith("signed.intent", undefined);
+  });
+
+  it("passes the rollout cookie only when no explicit intent is present", async () => {
+    await resolveOnboardingIntent();
+
+    expect(mocks.readCookie).toHaveBeenCalledOnce();
+    expect(mocks.resolve).toHaveBeenCalledExactlyOnceWith(undefined, "legacy-token");
+  });
+});

--- a/features/company/next/__tests__/onboarding-intent.test.ts
+++ b/features/company/next/__tests__/onboarding-intent.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readInviteTokenCookie: vi.fn(),
+  validateInvite: vi.fn(),
+}));
+
+vi.mock("@/core/di", () => ({
+  getInviteTokenValidationInteractor: () => ({ invoke: mocks.validateInvite }),
+}));
+vi.mock("@/env", () => ({ env: { BETTER_AUTH_SECRET: "resolver-test-secret" } }));
+vi.mock("../invite-token-cookie", () => ({
+  readInviteTokenCookie: mocks.readInviteTokenCookie,
+}));
+
+import {
+  issueCreateCompanyOnboardingIntent,
+  issueInvitationOnboardingIntent,
+  resolveOnboardingIntent,
+} from "../onboarding-intent";
+import { decodeOnboardingIntent, onboardingIntentSigningSecret } from "../../onboarding-intent-codec";
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+const inviteExpiresAt = new Date(now.getTime() + 60 * 60_000);
+
+function validInvitation(companyId = "company-a") {
+  return {
+    ok: true,
+    data: {
+      companyId,
+      expiresAt: inviteExpiresAt,
+      inviterName: `${companyId} Admin`,
+      valid: true,
+    },
+  };
+}
+
+describe("resolveOnboardingIntent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mocks.readInviteTokenCookie.mockResolvedValue(undefined);
+    mocks.validateInvite.mockResolvedValue(validInvitation());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("makes the explicit tab invitation authoritative over a legacy cookie", async () => {
+    mocks.readInviteTokenCookie.mockResolvedValue("invite-b");
+    const intent = issueInvitationOnboardingIntent("invite-a", inviteExpiresAt);
+    if (!intent) throw new Error("Expected invitation intent");
+
+    await expect(resolveOnboardingIntent(intent)).resolves.toMatchObject({
+      companyId: "company-a",
+      intent,
+      source: "explicit",
+      status: "valid",
+      token: "invite-a",
+      type: "invitation",
+    });
+    expect(mocks.validateInvite).toHaveBeenCalledWith({ token: "invite-a" });
+    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+  });
+
+  it.each(["", ["one", "two"]] as const)(
+    "fails closed for an empty or duplicate explicit query value",
+    async (value) => {
+      const queryValue: string | string[] = typeof value === "string" ? value : Array.from(value);
+      await expect(resolveOnboardingIntent(queryValue)).resolves.toEqual({
+        errorMessage: "invalidOnboardingIntent",
+        source: "explicit",
+        status: "invalid",
+      });
+      expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+      expect(mocks.validateInvite).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails closed for a tampered explicit value without reading the cookie", async () => {
+    const intent = issueCreateCompanyOnboardingIntent("auth-user-one");
+
+    await expect(resolveOnboardingIntent(`${intent}tampered`)).resolves.toEqual({
+      errorMessage: "invalidOnboardingIntent",
+      source: "explicit",
+      status: "invalid",
+    });
+    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for an expired explicit value without reading the cookie", async () => {
+    const intent = issueCreateCompanyOnboardingIntent("auth-user-one");
+    vi.setSystemTime(new Date(now.getTime() + 2 * 60 * 60_000 + 1));
+
+    await expect(resolveOnboardingIntent(intent)).resolves.toEqual({
+      errorMessage: "onboardingSessionExpired",
+      source: "explicit",
+      status: "invalid",
+    });
+    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+  });
+
+  it("revalidates an explicit invitation and rejects a revoked token", async () => {
+    const intent = issueInvitationOnboardingIntent("invite-a", inviteExpiresAt);
+    if (!intent) throw new Error("Expected invitation intent");
+    mocks.validateInvite.mockResolvedValue({
+      ok: true,
+      data: { errorMessage: "invalidInviteLink", valid: false },
+    });
+
+    await expect(resolveOnboardingIntent(intent)).resolves.toEqual({
+      errorMessage: "invalidInviteLink",
+      source: "explicit",
+      status: "invalid",
+    });
+  });
+
+  it("converts the rollout cookie into a signed invitation", async () => {
+    mocks.readInviteTokenCookie.mockResolvedValue("legacy-invite");
+    mocks.validateInvite.mockResolvedValue(validInvitation("legacy-company"));
+
+    const resolved = await resolveOnboardingIntent();
+
+    expect(resolved).toMatchObject({
+      companyId: "legacy-company",
+      source: "legacy",
+      status: "valid",
+      token: "legacy-invite",
+      type: "invitation",
+    });
+    if (resolved.status !== "valid") throw new Error("Expected a valid legacy invitation");
+    const secret = onboardingIntentSigningSecret("resolver-test-secret");
+    if (!secret) throw new Error("Missing test signing secret");
+    expect(decodeOnboardingIntent(resolved.intent, secret, now)).toMatchObject({
+      payload: { token: "legacy-invite", type: "invitation" },
+      status: "valid",
+    });
+  });
+
+  it("fails closed if a rollout invitation expires during reissuance", async () => {
+    mocks.readInviteTokenCookie.mockResolvedValue("legacy-invite");
+    mocks.validateInvite.mockResolvedValue({
+      ok: true,
+      data: {
+        companyId: "legacy-company",
+        expiresAt: now,
+        inviterName: "Legacy Admin",
+        valid: true,
+      },
+    });
+
+    await expect(resolveOnboardingIntent()).resolves.toEqual({
+      errorMessage: "inviteLinkExpired",
+      source: "legacy",
+      status: "invalid",
+    });
+  });
+
+  it("decodes a create decision without consulting invitation state", async () => {
+    const intent = issueCreateCompanyOnboardingIntent("auth-user-one");
+
+    await expect(resolveOnboardingIntent(intent)).resolves.toEqual({
+      authUserId: "auth-user-one",
+      intent,
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+    expect(mocks.validateInvite).not.toHaveBeenCalled();
+  });
+
+  it("reports absence only when neither URL nor rollout cookie contains an intent", async () => {
+    await expect(resolveOnboardingIntent()).resolves.toEqual({ status: "absent" });
+  });
+});

--- a/features/company/next/__tests__/onboarding-intent.test.ts
+++ b/features/company/next/__tests__/onboarding-intent.test.ts
@@ -1,47 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  readInviteTokenCookie: vi.fn(),
-  validateInvite: vi.fn(),
-}));
-
-vi.mock("@/core/di", () => ({
-  getInviteTokenValidationInteractor: () => ({ invoke: mocks.validateInvite }),
-}));
-vi.mock("@/env", () => ({ env: { BETTER_AUTH_SECRET: "resolver-test-secret" } }));
-vi.mock("../invite-token-cookie", () => ({
-  readInviteTokenCookie: mocks.readInviteTokenCookie,
-}));
-
-import {
-  issueCreateCompanyOnboardingIntent,
-  issueInvitationOnboardingIntent,
-  resolveOnboardingIntent,
-} from "../onboarding-intent";
 import { decodeOnboardingIntent, onboardingIntentSigningSecret } from "../../onboarding-intent-codec";
+import { OnboardingIntentService } from "../../onboarding-intent.service";
 
 const now = new Date("2026-09-04T12:00:00.000Z");
 const inviteExpiresAt = new Date(now.getTime() + 60 * 60_000);
+const validateInvite = vi.fn();
 
 function validInvitation(companyId = "company-a") {
-  return {
-    ok: true,
-    data: {
-      companyId,
-      expiresAt: inviteExpiresAt,
-      inviterName: `${companyId} Admin`,
-      valid: true,
-    },
-  };
+  return { ok: true, data: { companyId, expiresAt: inviteExpiresAt, inviterName: `${companyId} Admin`, valid: true } };
 }
 
-describe("resolveOnboardingIntent", () => {
+describe("OnboardingIntentService", () => {
+  let service: OnboardingIntentService;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(now);
-    mocks.readInviteTokenCookie.mockResolvedValue(undefined);
-    mocks.validateInvite.mockResolvedValue(validInvitation());
+    validateInvite.mockResolvedValue(validInvitation());
+    service = new OnboardingIntentService({ invoke: validateInvite } as never, "resolver-test-secret");
   });
 
   afterEach(() => {
@@ -49,11 +27,10 @@ describe("resolveOnboardingIntent", () => {
   });
 
   it("makes the explicit tab invitation authoritative over a legacy cookie", async () => {
-    mocks.readInviteTokenCookie.mockResolvedValue("invite-b");
-    const intent = issueInvitationOnboardingIntent("invite-a", inviteExpiresAt);
+    const intent = service.issueInvitation("invite-a", inviteExpiresAt);
     if (!intent) throw new Error("Expected invitation intent");
 
-    await expect(resolveOnboardingIntent(intent)).resolves.toMatchObject({
+    await expect(service.resolve(intent, "invite-b")).resolves.toMatchObject({
       companyId: "company-a",
       intent,
       source: "explicit",
@@ -61,56 +38,45 @@ describe("resolveOnboardingIntent", () => {
       token: "invite-a",
       type: "invitation",
     });
-    expect(mocks.validateInvite).toHaveBeenCalledWith({ token: "invite-a" });
-    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+    expect(validateInvite).toHaveBeenCalledExactlyOnceWith({ token: "invite-a" });
   });
 
-  it.each(["", ["one", "two"]] as const)(
-    "fails closed for an empty or duplicate explicit query value",
-    async (value) => {
-      const queryValue: string | string[] = typeof value === "string" ? value : Array.from(value);
-      await expect(resolveOnboardingIntent(queryValue)).resolves.toEqual({
-        errorMessage: "invalidOnboardingIntent",
-        source: "explicit",
-        status: "invalid",
-      });
-      expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
-      expect(mocks.validateInvite).not.toHaveBeenCalled();
-    },
-  );
-
-  it("fails closed for a tampered explicit value without reading the cookie", async () => {
-    const intent = issueCreateCompanyOnboardingIntent("auth-user-one");
-
-    await expect(resolveOnboardingIntent(`${intent}tampered`)).resolves.toEqual({
+  it.each(["", ["one", "two"]] as const)("fails closed for an invalid explicit value", async (value) => {
+    await expect(service.resolve(value, "legacy-invite")).resolves.toEqual({
       errorMessage: "invalidOnboardingIntent",
       source: "explicit",
       status: "invalid",
     });
-    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
+    expect(validateInvite).not.toHaveBeenCalled();
   });
 
-  it("fails closed for an expired explicit value without reading the cookie", async () => {
-    const intent = issueCreateCompanyOnboardingIntent("auth-user-one");
+  it("fails closed for a tampered explicit value", async () => {
+    const intent = service.issueCreateCompany("auth-user-one");
+
+    await expect(service.resolve(`${intent}tampered`, "legacy-invite")).resolves.toEqual({
+      errorMessage: "invalidOnboardingIntent",
+      source: "explicit",
+      status: "invalid",
+    });
+  });
+
+  it("fails closed for an expired explicit value", async () => {
+    const intent = service.issueCreateCompany("auth-user-one");
     vi.setSystemTime(new Date(now.getTime() + 2 * 60 * 60_000 + 1));
 
-    await expect(resolveOnboardingIntent(intent)).resolves.toEqual({
+    await expect(service.resolve(intent)).resolves.toEqual({
       errorMessage: "onboardingSessionExpired",
       source: "explicit",
       status: "invalid",
     });
-    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
   });
 
   it("revalidates an explicit invitation and rejects a revoked token", async () => {
-    const intent = issueInvitationOnboardingIntent("invite-a", inviteExpiresAt);
+    const intent = service.issueInvitation("invite-a", inviteExpiresAt);
     if (!intent) throw new Error("Expected invitation intent");
-    mocks.validateInvite.mockResolvedValue({
-      ok: true,
-      data: { errorMessage: "invalidInviteLink", valid: false },
-    });
+    validateInvite.mockResolvedValue({ ok: true, data: { errorMessage: "invalidInviteLink", valid: false } });
 
-    await expect(resolveOnboardingIntent(intent)).resolves.toEqual({
+    await expect(service.resolve(intent)).resolves.toEqual({
       errorMessage: "invalidInviteLink",
       source: "explicit",
       status: "invalid",
@@ -118,10 +84,9 @@ describe("resolveOnboardingIntent", () => {
   });
 
   it("converts the rollout cookie into a signed invitation", async () => {
-    mocks.readInviteTokenCookie.mockResolvedValue("legacy-invite");
-    mocks.validateInvite.mockResolvedValue(validInvitation("legacy-company"));
+    validateInvite.mockResolvedValue(validInvitation("legacy-company"));
 
-    const resolved = await resolveOnboardingIntent();
+    const resolved = await service.resolve(undefined, "legacy-invite");
 
     expect(resolved).toMatchObject({
       companyId: "legacy-company",
@@ -140,18 +105,12 @@ describe("resolveOnboardingIntent", () => {
   });
 
   it("fails closed if a rollout invitation expires during reissuance", async () => {
-    mocks.readInviteTokenCookie.mockResolvedValue("legacy-invite");
-    mocks.validateInvite.mockResolvedValue({
+    validateInvite.mockResolvedValue({
       ok: true,
-      data: {
-        companyId: "legacy-company",
-        expiresAt: now,
-        inviterName: "Legacy Admin",
-        valid: true,
-      },
+      data: { companyId: "legacy-company", expiresAt: now, inviterName: "Legacy Admin", valid: true },
     });
 
-    await expect(resolveOnboardingIntent()).resolves.toEqual({
+    await expect(service.resolve(undefined, "legacy-invite")).resolves.toEqual({
       errorMessage: "inviteLinkExpired",
       source: "legacy",
       status: "invalid",
@@ -159,20 +118,19 @@ describe("resolveOnboardingIntent", () => {
   });
 
   it("decodes a create decision without consulting invitation state", async () => {
-    const intent = issueCreateCompanyOnboardingIntent("auth-user-one");
+    const intent = service.issueCreateCompany("auth-user-one");
 
-    await expect(resolveOnboardingIntent(intent)).resolves.toEqual({
+    await expect(service.resolve(intent)).resolves.toEqual({
       authUserId: "auth-user-one",
       intent,
       source: "explicit",
       status: "valid",
       type: "createCompany",
     });
-    expect(mocks.readInviteTokenCookie).not.toHaveBeenCalled();
-    expect(mocks.validateInvite).not.toHaveBeenCalled();
+    expect(validateInvite).not.toHaveBeenCalled();
   });
 
-  it("reports absence only when neither URL nor rollout cookie contains an intent", async () => {
-    await expect(resolveOnboardingIntent()).resolves.toEqual({ status: "absent" });
+  it("reports absence only when neither source contains an intent", async () => {
+    await expect(service.resolve()).resolves.toEqual({ status: "absent" });
   });
 });

--- a/features/company/next/invite-token-cookie.ts
+++ b/features/company/next/invite-token-cookie.ts
@@ -23,7 +23,3 @@ const inviteTokenCookieRepo = new NextInviteTokenCookieRepo();
 export async function readInviteTokenCookie(): Promise<string | undefined> {
   return inviteTokenCookieRepo.read();
 }
-
-export async function clearInviteTokenCookie(): Promise<void> {
-  return inviteTokenCookieRepo.clear();
-}

--- a/features/company/next/invite-token-cookie.ts
+++ b/features/company/next/invite-token-cookie.ts
@@ -1,0 +1,15 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+export const INVITE_TOKEN_COOKIE_NAME = "inviteToken";
+
+export async function readInviteTokenCookie(): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  return cookieStore.get(INVITE_TOKEN_COOKIE_NAME)?.value;
+}
+
+export async function clearInviteTokenCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(INVITE_TOKEN_COOKIE_NAME);
+}

--- a/features/company/next/invite-token-cookie.ts
+++ b/features/company/next/invite-token-cookie.ts
@@ -2,14 +2,28 @@ import "server-only";
 
 import { cookies } from "next/headers";
 
+import { InviteTokenCookieRepo } from "../invite-token-cookie.repo";
+
 export const INVITE_TOKEN_COOKIE_NAME = "inviteToken";
 
+export class NextInviteTokenCookieRepo extends InviteTokenCookieRepo {
+  async read(): Promise<string | undefined> {
+    const cookieStore = await cookies();
+    return cookieStore.get(INVITE_TOKEN_COOKIE_NAME)?.value;
+  }
+
+  async clear(): Promise<void> {
+    const cookieStore = await cookies();
+    cookieStore.delete(INVITE_TOKEN_COOKIE_NAME);
+  }
+}
+
+const inviteTokenCookieRepo = new NextInviteTokenCookieRepo();
+
 export async function readInviteTokenCookie(): Promise<string | undefined> {
-  const cookieStore = await cookies();
-  return cookieStore.get(INVITE_TOKEN_COOKIE_NAME)?.value;
+  return inviteTokenCookieRepo.read();
 }
 
 export async function clearInviteTokenCookie(): Promise<void> {
-  const cookieStore = await cookies();
-  cookieStore.delete(INVITE_TOKEN_COOKIE_NAME);
+  return inviteTokenCookieRepo.clear();
 }

--- a/features/company/next/onboarding-intent.ts
+++ b/features/company/next/onboarding-intent.ts
@@ -1,127 +1,20 @@
 import "server-only";
 
-import { getInviteTokenValidationInteractor } from "@/core/di";
-import { env } from "@/env";
-import {
-  decodeOnboardingIntent,
-  encodeCreateCompanyOnboardingIntent,
-  encodeInvitationOnboardingIntent,
-  onboardingIntentSigningSecret,
-} from "@/features/company/onboarding-intent-codec";
+import { getOnboardingIntentService } from "@/core/di";
 
 import { readInviteTokenCookie } from "./invite-token-cookie";
 
-export type OnboardingIntentError =
-  | "invalidInviteLink"
-  | "invalidOnboardingIntent"
-  | "inviteLinkExpired"
-  | "onboardingSessionExpired";
-
-type IntentSource = "explicit" | "legacy";
-
-export type OnboardingIntentState =
-  | { status: "absent" }
-  | { errorMessage: OnboardingIntentError; source: IntentSource; status: "invalid" }
-  | {
-      authUserId: string;
-      intent: string;
-      source: IntentSource;
-      status: "valid";
-      type: "createCompany";
-    }
-  | {
-      companyId: string;
-      expiresAt: Date;
-      intent: string;
-      inviterName: string;
-      source: IntentSource;
-      status: "valid";
-      token: string;
-      type: "invitation";
-    };
-
-function signingSecret(): string {
-  const secret = onboardingIntentSigningSecret(env.BETTER_AUTH_SECRET);
-  if (!secret) throw new Error("BETTER_AUTH_SECRET is required to issue onboarding intents.");
-  return secret;
-}
+export type { OnboardingIntentError, OnboardingIntentState } from "../onboarding-intent.service";
 
 export function issueInvitationOnboardingIntent(token: string, inviteExpiresAt: Date, now = new Date()): string | null {
-  return encodeInvitationOnboardingIntent(token, inviteExpiresAt, signingSecret(), now);
+  return getOnboardingIntentService().issueInvitation(token, inviteExpiresAt, now);
 }
 
 export function issueCreateCompanyOnboardingIntent(authUserId: string, now = new Date()): string {
-  const intent = encodeCreateCompanyOnboardingIntent(authUserId, signingSecret(), now);
-  if (!intent) throw new Error("Could not issue company creation onboarding intent.");
-  return intent;
+  return getOnboardingIntentService().issueCreateCompany(authUserId, now);
 }
 
-async function validateInvitation(
-  token: string,
-  source: IntentSource,
-  existingIntent?: string,
-): Promise<OnboardingIntentState> {
-  const result = await getInviteTokenValidationInteractor().invoke({ token });
-  if (!result.ok) {
-    return {
-      errorMessage: "invalidInviteLink",
-      source,
-      status: "invalid",
-    };
-  }
-
-  if (!result.data.valid) {
-    return {
-      errorMessage: result.data.errorMessage,
-      source,
-      status: "invalid",
-    };
-  }
-
-  const intent = existingIntent ?? issueInvitationOnboardingIntent(token, result.data.expiresAt);
-  if (!intent) {
-    return {
-      errorMessage: "inviteLinkExpired",
-      source,
-      status: "invalid",
-    };
-  }
-
-  return {
-    companyId: result.data.companyId,
-    expiresAt: result.data.expiresAt,
-    intent,
-    inviterName: result.data.inviterName,
-    source,
-    status: "valid",
-    token,
-    type: "invitation",
-  };
-}
-
-export async function resolveOnboardingIntent(value?: string | string[]): Promise<OnboardingIntentState> {
-  if (value !== undefined) {
-    if (typeof value !== "string" || value.length === 0)
-      return { errorMessage: "invalidOnboardingIntent", source: "explicit", status: "invalid" };
-
-    const decoded = decodeOnboardingIntent(value, signingSecret());
-    if (decoded.status === "expired")
-      return { errorMessage: "onboardingSessionExpired", source: "explicit", status: "invalid" };
-    if (decoded.status === "invalid")
-      return { errorMessage: "invalidOnboardingIntent", source: "explicit", status: "invalid" };
-
-    if (decoded.payload.type === "invitation") return validateInvitation(decoded.payload.token, "explicit", value);
-
-    return {
-      authUserId: decoded.payload.authUserId,
-      intent: value,
-      source: "explicit",
-      status: "valid",
-      type: "createCompany",
-    };
-  }
-
-  const legacyToken = await readInviteTokenCookie();
-  if (legacyToken) return validateInvitation(legacyToken, "legacy");
-  return { status: "absent" };
+export async function resolveOnboardingIntent(value?: string | string[]) {
+  const legacyToken = value === undefined ? await readInviteTokenCookie() : undefined;
+  return getOnboardingIntentService().resolve(value, legacyToken);
 }

--- a/features/company/next/onboarding-intent.ts
+++ b/features/company/next/onboarding-intent.ts
@@ -4,14 +4,8 @@ import { getOnboardingIntentService } from "@/core/di";
 
 import { readInviteTokenCookie } from "./invite-token-cookie";
 
-export type { OnboardingIntentError, OnboardingIntentState } from "../onboarding-intent.service";
-
 export function issueInvitationOnboardingIntent(token: string, inviteExpiresAt: Date, now = new Date()): string | null {
   return getOnboardingIntentService().issueInvitation(token, inviteExpiresAt, now);
-}
-
-export function issueCreateCompanyOnboardingIntent(authUserId: string, now = new Date()): string {
-  return getOnboardingIntentService().issueCreateCompany(authUserId, now);
 }
 
 export async function resolveOnboardingIntent(value?: string | string[]) {

--- a/features/company/next/onboarding-intent.ts
+++ b/features/company/next/onboarding-intent.ts
@@ -4,10 +4,6 @@ import { getOnboardingIntentService } from "@/core/di";
 
 import { readInviteTokenCookie } from "./invite-token-cookie";
 
-export function issueInvitationOnboardingIntent(token: string, inviteExpiresAt: Date, now = new Date()): string | null {
-  return getOnboardingIntentService().issueInvitation(token, inviteExpiresAt, now);
-}
-
 export async function resolveOnboardingIntent(value?: string | string[]) {
   const legacyToken = value === undefined ? await readInviteTokenCookie() : undefined;
   return getOnboardingIntentService().resolve(value, legacyToken);

--- a/features/company/next/onboarding-intent.ts
+++ b/features/company/next/onboarding-intent.ts
@@ -1,0 +1,127 @@
+import "server-only";
+
+import { getInviteTokenValidationInteractor } from "@/core/di";
+import { env } from "@/env";
+import {
+  decodeOnboardingIntent,
+  encodeCreateCompanyOnboardingIntent,
+  encodeInvitationOnboardingIntent,
+  onboardingIntentSigningSecret,
+} from "@/features/company/onboarding-intent-codec";
+
+import { readInviteTokenCookie } from "./invite-token-cookie";
+
+export type OnboardingIntentError =
+  | "invalidInviteLink"
+  | "invalidOnboardingIntent"
+  | "inviteLinkExpired"
+  | "onboardingSessionExpired";
+
+type IntentSource = "explicit" | "legacy";
+
+export type OnboardingIntentState =
+  | { status: "absent" }
+  | { errorMessage: OnboardingIntentError; source: IntentSource; status: "invalid" }
+  | {
+      authUserId: string;
+      intent: string;
+      source: IntentSource;
+      status: "valid";
+      type: "createCompany";
+    }
+  | {
+      companyId: string;
+      expiresAt: Date;
+      intent: string;
+      inviterName: string;
+      source: IntentSource;
+      status: "valid";
+      token: string;
+      type: "invitation";
+    };
+
+function signingSecret(): string {
+  const secret = onboardingIntentSigningSecret(env.BETTER_AUTH_SECRET);
+  if (!secret) throw new Error("BETTER_AUTH_SECRET is required to issue onboarding intents.");
+  return secret;
+}
+
+export function issueInvitationOnboardingIntent(token: string, inviteExpiresAt: Date, now = new Date()): string | null {
+  return encodeInvitationOnboardingIntent(token, inviteExpiresAt, signingSecret(), now);
+}
+
+export function issueCreateCompanyOnboardingIntent(authUserId: string, now = new Date()): string {
+  const intent = encodeCreateCompanyOnboardingIntent(authUserId, signingSecret(), now);
+  if (!intent) throw new Error("Could not issue company creation onboarding intent.");
+  return intent;
+}
+
+async function validateInvitation(
+  token: string,
+  source: IntentSource,
+  existingIntent?: string,
+): Promise<OnboardingIntentState> {
+  const result = await getInviteTokenValidationInteractor().invoke({ token });
+  if (!result.ok) {
+    return {
+      errorMessage: "invalidInviteLink",
+      source,
+      status: "invalid",
+    };
+  }
+
+  if (!result.data.valid) {
+    return {
+      errorMessage: result.data.errorMessage,
+      source,
+      status: "invalid",
+    };
+  }
+
+  const intent = existingIntent ?? issueInvitationOnboardingIntent(token, result.data.expiresAt);
+  if (!intent) {
+    return {
+      errorMessage: "inviteLinkExpired",
+      source,
+      status: "invalid",
+    };
+  }
+
+  return {
+    companyId: result.data.companyId,
+    expiresAt: result.data.expiresAt,
+    intent,
+    inviterName: result.data.inviterName,
+    source,
+    status: "valid",
+    token,
+    type: "invitation",
+  };
+}
+
+export async function resolveOnboardingIntent(value?: string | string[]): Promise<OnboardingIntentState> {
+  if (value !== undefined) {
+    if (typeof value !== "string" || value.length === 0)
+      return { errorMessage: "invalidOnboardingIntent", source: "explicit", status: "invalid" };
+
+    const decoded = decodeOnboardingIntent(value, signingSecret());
+    if (decoded.status === "expired")
+      return { errorMessage: "onboardingSessionExpired", source: "explicit", status: "invalid" };
+    if (decoded.status === "invalid")
+      return { errorMessage: "invalidOnboardingIntent", source: "explicit", status: "invalid" };
+
+    if (decoded.payload.type === "invitation") return validateInvitation(decoded.payload.token, "explicit", value);
+
+    return {
+      authUserId: decoded.payload.authUserId,
+      intent: value,
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    };
+  }
+
+  const legacyToken = await readInviteTokenCookie();
+  if (legacyToken) return validateInvitation(legacyToken, "legacy");
+  return { status: "absent" };
+}

--- a/features/company/onboarding-intent-codec.ts
+++ b/features/company/onboarding-intent-codec.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+import { hmacSha256Hex, verifyHmacSha256Hex } from "@/core/utils/hmac";
+
+export const ONBOARDING_INTENT_MAX_AGE_MS = 2 * 60 * 60 * 1_000;
+export const ONBOARDING_INTENT_VALUE_MAX_BYTES = 2_048;
+
+const InvitationPayloadSchema = z.object({
+  expiresAt: z.number().int().positive(),
+  token: z
+    .string()
+    .min(1)
+    .max(512)
+    .regex(/^[a-zA-Z0-9_-]+$/),
+  type: z.literal("invitation"),
+});
+
+const CreateCompanyPayloadSchema = z.object({
+  authUserId: z.string().min(1).max(512),
+  expiresAt: z.number().int().positive(),
+  type: z.literal("createCompany"),
+});
+
+const OnboardingIntentPayloadSchema = z.discriminatedUnion("type", [
+  InvitationPayloadSchema,
+  CreateCompanyPayloadSchema,
+]);
+
+export type OnboardingIntentPayload = z.infer<typeof OnboardingIntentPayloadSchema>;
+
+export type DecodedOnboardingIntent =
+  | { status: "expired" }
+  | { status: "invalid" }
+  | { payload: OnboardingIntentPayload; status: "valid" };
+
+export function onboardingIntentSigningSecret(secret: string | undefined): string | null {
+  const trimmed = secret?.trim();
+  return trimmed ? `onboarding-intent:v1:${trimmed}` : null;
+}
+
+function encodePayload(payload: OnboardingIntentPayload, secret: string): string | null {
+  const parsed = OnboardingIntentPayloadSchema.safeParse(payload);
+  if (!parsed.success) return null;
+
+  const encodedPayload = Buffer.from(JSON.stringify(parsed.data)).toString("base64url");
+  const encoded = `${encodedPayload}.${hmacSha256Hex(secret, encodedPayload)}`;
+
+  return Buffer.byteLength(encoded, "utf8") <= ONBOARDING_INTENT_VALUE_MAX_BYTES ? encoded : null;
+}
+
+export function encodeInvitationOnboardingIntent(
+  token: string,
+  inviteExpiresAt: Date,
+  secret: string,
+  now = new Date(),
+): string | null {
+  const expiresAt = Math.min(inviteExpiresAt.getTime(), now.getTime() + ONBOARDING_INTENT_MAX_AGE_MS);
+  if (!Number.isFinite(expiresAt) || expiresAt <= now.getTime()) return null;
+
+  return encodePayload({ expiresAt, token, type: "invitation" }, secret);
+}
+
+export function encodeCreateCompanyOnboardingIntent(
+  authUserId: string,
+  secret: string,
+  now = new Date(),
+): string | null {
+  return encodePayload(
+    { authUserId, expiresAt: now.getTime() + ONBOARDING_INTENT_MAX_AGE_MS, type: "createCompany" },
+    secret,
+  );
+}
+
+export function decodeOnboardingIntent(
+  value: string | undefined,
+  secret: string,
+  now = new Date(),
+): DecodedOnboardingIntent {
+  if (!value || Buffer.byteLength(value, "utf8") > ONBOARDING_INTENT_VALUE_MAX_BYTES) return { status: "invalid" };
+
+  const parts = value.split(".");
+  if (parts.length !== 2) return { status: "invalid" };
+
+  const [payload, signature] = parts;
+  if (!payload || !signature || !/^[0-9a-f]{64}$/u.test(signature)) return { status: "invalid" };
+
+  try {
+    if (!verifyHmacSha256Hex(secret, payload, signature)) return { status: "invalid" };
+
+    const parsed = OnboardingIntentPayloadSchema.safeParse(
+      JSON.parse(Buffer.from(payload, "base64url").toString("utf8")),
+    );
+    if (!parsed.success) return { status: "invalid" };
+    if (parsed.data.expiresAt <= now.getTime()) return { status: "expired" };
+    if (parsed.data.expiresAt > now.getTime() + ONBOARDING_INTENT_MAX_AGE_MS) return { status: "invalid" };
+
+    return { payload: parsed.data, status: "valid" };
+  } catch {
+    return { status: "invalid" };
+  }
+}

--- a/features/company/onboarding-intent-url.ts
+++ b/features/company/onboarding-intent-url.ts
@@ -1,0 +1,31 @@
+export const ONBOARDING_INTENT_QUERY_PARAM = "intent";
+
+export function pathWithOnboardingIntent(path: string, onboardingIntent: string): string {
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}${ONBOARDING_INTENT_QUERY_PARAM}=${encodeURIComponent(onboardingIntent)}`;
+}
+
+export function onboardingIntentAuthRedirects(onboardingIntent: string) {
+  return {
+    overdueVerification: pathWithOnboardingIntent("/auth/verify-email", onboardingIntent),
+    unauthenticated: pathWithOnboardingIntent("/auth/signin", onboardingIntent),
+  } as const;
+}
+
+export type OnboardingIntentFromPath =
+  | { status: "absent" }
+  | { status: "invalid" }
+  | { intent: string; status: "valid" };
+
+export function onboardingIntentFromPath(path: string | undefined): OnboardingIntentFromPath {
+  if (!path) return { status: "absent" };
+
+  try {
+    const values = new URL(path, "https://customermates.local").searchParams.getAll(ONBOARDING_INTENT_QUERY_PARAM);
+    if (values.length === 0) return { status: "absent" };
+    if (values.length !== 1 || !values[0]) return { status: "invalid" };
+    return { intent: values[0], status: "valid" };
+  } catch {
+    return { status: "invalid" };
+  }
+}

--- a/features/company/onboarding-intent.service.ts
+++ b/features/company/onboarding-intent.service.ts
@@ -1,0 +1,106 @@
+import type { InviteTokenValidationInteractor } from "./invite-token-validation.interactor";
+
+import {
+  decodeOnboardingIntent,
+  encodeCreateCompanyOnboardingIntent,
+  encodeInvitationOnboardingIntent,
+  onboardingIntentSigningSecret,
+} from "./onboarding-intent-codec";
+
+export type OnboardingIntentError =
+  | "invalidInviteLink"
+  | "invalidOnboardingIntent"
+  | "inviteLinkExpired"
+  | "onboardingSessionExpired";
+
+type IntentSource = "explicit" | "legacy";
+
+export type OnboardingIntentState =
+  | { status: "absent" }
+  | { errorMessage: OnboardingIntentError; source: IntentSource; status: "invalid" }
+  | { authUserId: string; intent: string; source: IntentSource; status: "valid"; type: "createCompany" }
+  | {
+      companyId: string;
+      expiresAt: Date;
+      intent: string;
+      inviterName: string;
+      source: IntentSource;
+      status: "valid";
+      token: string;
+      type: "invitation";
+    };
+
+export class OnboardingIntentService {
+  private readonly signingSecret: string;
+
+  constructor(
+    private readonly inviteTokenValidationInteractor: InviteTokenValidationInteractor,
+    betterAuthSecret: string,
+  ) {
+    const signingSecret = onboardingIntentSigningSecret(betterAuthSecret);
+    if (!signingSecret) throw new Error("BETTER_AUTH_SECRET is required to issue onboarding intents.");
+    this.signingSecret = signingSecret;
+  }
+
+  issueInvitation(token: string, inviteExpiresAt: Date, now = new Date()): string | null {
+    return encodeInvitationOnboardingIntent(token, inviteExpiresAt, this.signingSecret, now);
+  }
+
+  issueCreateCompany(authUserId: string, now = new Date()): string {
+    const intent = encodeCreateCompanyOnboardingIntent(authUserId, this.signingSecret, now);
+    if (!intent) throw new Error("Could not issue company creation onboarding intent.");
+    return intent;
+  }
+
+  async resolve(value?: unknown, legacyToken?: string): Promise<OnboardingIntentState> {
+    if (value !== undefined) {
+      if (typeof value !== "string" || value.length === 0)
+        return { errorMessage: "invalidOnboardingIntent", source: "explicit", status: "invalid" };
+
+      const decoded = decodeOnboardingIntent(value, this.signingSecret);
+      if (decoded.status === "expired")
+        return { errorMessage: "onboardingSessionExpired", source: "explicit", status: "invalid" };
+
+      if (decoded.status === "invalid")
+        return { errorMessage: "invalidOnboardingIntent", source: "explicit", status: "invalid" };
+
+      if (decoded.payload.type === "invitation")
+        return this.validateInvitation(decoded.payload.token, "explicit", value);
+
+      return {
+        authUserId: decoded.payload.authUserId,
+        intent: value,
+        source: "explicit",
+        status: "valid",
+        type: "createCompany",
+      };
+    }
+
+    if (legacyToken) return this.validateInvitation(legacyToken, "legacy");
+    return { status: "absent" };
+  }
+
+  private async validateInvitation(
+    token: string,
+    source: IntentSource,
+    existingIntent?: string,
+  ): Promise<OnboardingIntentState> {
+    const result = await this.inviteTokenValidationInteractor.invoke({ token });
+    if (!result.ok) return { errorMessage: "invalidInviteLink", source, status: "invalid" };
+    if (!result.data.valid) return { errorMessage: result.data.errorMessage, source, status: "invalid" };
+
+    const intent = existingIntent ?? this.issueInvitation(token, result.data.expiresAt);
+    if (!intent) return { errorMessage: "inviteLinkExpired", source, status: "invalid" };
+
+    return {
+      companyId: result.data.companyId,
+      expiresAt: result.data.expiresAt,
+      intent,
+      inviterName: result.data.inviterName,
+      source,
+      status: "valid",
+      token,
+      type: "invitation",
+    };
+  }
+}

--- a/features/company/open-invitation.interactor.ts
+++ b/features/company/open-invitation.interactor.ts
@@ -1,0 +1,29 @@
+import type { AuthService } from "@/features/auth/auth.service";
+import type { Redirect } from "@/features/auth/auth-outcome";
+import type { InviteTokenValidationInteractor } from "./invite-token-validation.interactor";
+import type { OnboardingIntentService } from "./onboarding-intent.service";
+
+import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
+import { redirectTo } from "@/features/auth/auth-outcome";
+import { pathWithOnboardingIntent } from "./onboarding-intent-url";
+
+@SystemInteractor
+export class OpenInvitationInteractor {
+  constructor(
+    private readonly inviteTokenValidationInteractor: InviteTokenValidationInteractor,
+    private readonly authService: AuthService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+  ) {}
+
+  async invoke(data: { token: string }): Promise<Redirect> {
+    const result = await this.inviteTokenValidationInteractor.invoke(data);
+    if (!result.ok) return redirectTo("/auth/error?type=invalidInviteLink");
+    if (!result.data.valid) return redirectTo(`/auth/error?type=${result.data.errorMessage}`);
+
+    const session = await this.authService.getSession();
+    const intent = this.onboardingIntentService.issueInvitation(data.token, result.data.expiresAt);
+    if (!intent) return redirectTo("/auth/error?type=inviteLinkExpired");
+
+    return redirectTo(pathWithOnboardingIntent(session ? "/auth/invitation" : "/auth/signup", intent));
+  }
+}

--- a/features/company/prisma-company.repository.ts
+++ b/features/company/prisma-company.repository.ts
@@ -12,6 +12,7 @@ import type { RouteGuardSubscriptionRepo } from "@/features/auth/route-guard.ser
 import type { AdminUpdateUserSubscriptionRepo } from "@/features/user/upsert/admin-update-user-details.interactor";
 import type { EntitlementSubscriptionRepo } from "@/ee/subscription/entitlement.service";
 import type { CreateAuthLinkSubscriptionRepo } from "@/ee/messaging/connect/create-auth-link.interactor";
+import type { RegisterUserCompanyRepo } from "@/features/user/register/register-user.interactor";
 
 import { ConversionEventType, SubscriptionStatus } from "@/generated/prisma";
 
@@ -34,7 +35,8 @@ export class PrismaCompanyRepo
     AdminUpdateUserSubscriptionRepo,
     RouteGuardSubscriptionRepo,
     EntitlementSubscriptionRepo,
-    CreateAuthLinkSubscriptionRepo
+    CreateAuthLinkSubscriptionRepo,
+    RegisterUserCompanyRepo
 {
   @Transaction
   async updateDetails(args: RepoArgs<UpdateCompanySettingsRepo, "updateDetails">) {
@@ -193,5 +195,14 @@ export class PrismaCompanyRepo
     });
 
     return subscription;
+  }
+
+  @BypassTenantGuard
+  async existsUnscoped(companyId: string) {
+    const company = await this.prisma.company.findUnique({
+      where: { id: companyId },
+      select: { id: true },
+    });
+    return Boolean(company);
   }
 }

--- a/features/company/prisma-company.repository.ts
+++ b/features/company/prisma-company.repository.ts
@@ -122,7 +122,14 @@ export class PrismaCompanyRepo
 
   @BypassTenantGuard
   async findTokenUnscoped(token: string) {
-    return this.prisma.inviteToken.findUnique({ where: { token } });
+    return this.prisma.inviteToken.findUnique({
+      where: { token },
+      select: {
+        companyId: true,
+        expiresAt: true,
+        createdBy: { select: { email: true, firstName: true, lastName: true } },
+      },
+    });
   }
 
   @BypassTenantGuard

--- a/features/company/prisma-company.repository.ts
+++ b/features/company/prisma-company.repository.ts
@@ -13,6 +13,7 @@ import type { AdminUpdateUserSubscriptionRepo } from "@/features/user/upsert/adm
 import type { EntitlementSubscriptionRepo } from "@/ee/subscription/entitlement.service";
 import type { CreateAuthLinkSubscriptionRepo } from "@/ee/messaging/connect/create-auth-link.interactor";
 import type { RegisterUserCompanyRepo } from "@/features/user/register/register-user.interactor";
+import type { GetDealWeightingColumnRepo } from "./get-deal-weighting-column.repo";
 
 import { ConversionEventType, SubscriptionStatus } from "@/generated/prisma";
 
@@ -36,7 +37,8 @@ export class PrismaCompanyRepo
     RouteGuardCompanyRepo,
     EntitlementSubscriptionRepo,
     CreateAuthLinkSubscriptionRepo,
-    RegisterUserCompanyRepo
+    RegisterUserCompanyRepo,
+    GetDealWeightingColumnRepo
 {
   @Transaction
   async updateDetails(args: RepoArgs<UpdateCompanySettingsRepo, "updateDetails">) {
@@ -55,6 +57,14 @@ export class PrismaCompanyRepo
     return await this.prisma.company.findUniqueOrThrow({ where: { id: companyId } });
   }
 
+  async getDealWeightingColumnId(): Promise<string | null> {
+    const company = await this.prisma.company.findUnique({
+      where: { id: this.companyId },
+      select: { dealWeightingColumnId: true },
+    });
+    return company?.dealWeightingColumnId ?? null;
+  }
+
   async getTerminology(): Promise<EntityTerminologyOverride[]> {
     const { companyId } = this.user;
 
@@ -67,16 +77,10 @@ export class PrismaCompanyRepo
 
   @Transaction
   async setDealStageWeights(entries: RepoArgs<UpdateCompanySettingsRepo, "setDealStageWeights">) {
-    const { companyId } = this.user;
+    const columnId = await this.getDealWeightingColumnId();
+    if (!columnId) return;
 
-    const company = await this.prisma.company.findUnique({
-      where: { id: companyId },
-      select: { dealWeightingColumnId: true },
-    });
-
-    if (!company?.dealWeightingColumnId) return;
-
-    await getCustomColumnRepo().setOptionWeights(company.dealWeightingColumnId, entries);
+    await getCustomColumnRepo().setOptionWeights(columnId, entries);
   }
 
   @Transaction

--- a/features/company/prisma-company.repository.ts
+++ b/features/company/prisma-company.repository.ts
@@ -8,7 +8,7 @@ import type { SubscriptionRepo } from "@/ee/subscription/subscription.service";
 import type { GetSubscriptionRepo } from "@/ee/subscription/get-subscription.interactor";
 import type { RefreshSubscriptionRepo } from "@/ee/subscription/refresh-subscription.interactor";
 import type { CreateCheckoutCompanyRepo } from "@/ee/subscription/create-checkout-session.interactor";
-import type { RouteGuardSubscriptionRepo } from "@/features/auth/route-guard.service";
+import type { RouteGuardCompanyRepo } from "@/features/auth/route-guard.service";
 import type { AdminUpdateUserSubscriptionRepo } from "@/features/user/upsert/admin-update-user-details.interactor";
 import type { EntitlementSubscriptionRepo } from "@/ee/subscription/entitlement.service";
 import type { CreateAuthLinkSubscriptionRepo } from "@/ee/messaging/connect/create-auth-link.interactor";
@@ -33,7 +33,7 @@ export class PrismaCompanyRepo
     RefreshSubscriptionRepo,
     CreateCheckoutCompanyRepo,
     AdminUpdateUserSubscriptionRepo,
-    RouteGuardSubscriptionRepo,
+    RouteGuardCompanyRepo,
     EntitlementSubscriptionRepo,
     CreateAuthLinkSubscriptionRepo,
     RegisterUserCompanyRepo

--- a/features/contacts/__tests__/contact-identifier.database.test.ts
+++ b/features/contacts/__tests__/contact-identifier.database.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTranslator } from "next-intl";
+import { Action, Resource } from "@/generated/prisma";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { createMockUser, createMockUserWithPermissions } from "@/tests/helpers/mock-user";
+import messages from "@/i18n/locales/en.json";
+
+vi.mock("next-intl/server", () => ({
+  getLocale: () => Promise.resolve("en"),
+  getTranslations: (namespace?: "Common.errors") =>
+    Promise.resolve(createTranslator({ locale: "en", messages, namespace })),
+}));
+vi.mock("@/env", () => ({
+  env: {
+    APP_MODE: "cloud",
+    DATABASE_URL: process.env.DATABASE_URL,
+    BASE_URL: "http://localhost:4000",
+    NODE_ENV: "test",
+  },
+}));
+
+const { getLinkContactIdentifierInteractor, getUnlinkContactIdentifierInteractor } = await import("@/core/di");
+const { prisma } = await import("@/prisma/db");
+const { runWithTenant, runWithoutTenant } = await import("@/core/decorators/tenant-context");
+const { ForbiddenError } = await import("@/core/errors/app-errors");
+const describeDatabase = getLocalDatabaseTestUrl() ? describe : describe.skip;
+const companyId = randomUUID();
+const otherCompanyId = randomUUID();
+const userId = randomUUID();
+const user = createMockUser({ id: userId, companyId });
+
+async function makeContact(tenant = companyId) {
+  return runWithoutTenant(() =>
+    prisma.contact.create({
+      data: { companyId: tenant, firstName: "Link", lastName: "Fixture" },
+    }),
+  );
+}
+async function identifiers(contactId: string) {
+  return runWithoutTenant(() =>
+    prisma.contactIdentifier.findMany({
+      where: { contactId },
+      select: { provider: true, value: true },
+      orderBy: { value: "asc" },
+    }),
+  );
+}
+
+describeDatabase("contact identifier linking with real tenant transactions", { timeout: 60000 }, () => {
+  beforeAll(async () => {
+    await runWithoutTenant(async () => {
+      await prisma.company.createMany({ data: [{ id: companyId }, { id: otherCompanyId }] });
+      await prisma.user.create({
+        data: {
+          id: userId,
+          companyId,
+          email: `link-${userId}@example.com`,
+          firstName: "Link",
+          lastName: "Tester",
+          status: "active",
+        },
+      });
+    });
+  });
+  afterAll(async () => {
+    await runWithoutTenant(() => prisma.company.deleteMany({ where: { id: { in: [companyId, otherCompanyId] } } }));
+  });
+
+  it("retains both identifiers when concurrent links target the same contact", async () => {
+    const contact = await makeContact();
+    const link = getLinkContactIdentifierInteractor();
+    const results = await Promise.all([
+      runWithTenant(user, () =>
+        link.invoke({ contactId: contact.id, provider: "mail", identifier: "first@example.com" }),
+      ),
+      runWithTenant(user, () =>
+        link.invoke({ contactId: contact.id, provider: "mail", identifier: "second@example.com" }),
+      ),
+    ]);
+    expect(results.map((result) => result.ok)).toEqual([true, true]);
+    expect(await identifiers(contact.id)).toEqual([
+      { provider: "mail", value: "first@example.com" },
+      { provider: "mail", value: "second@example.com" },
+    ]);
+    const auditCount = await runWithoutTenant(() =>
+      prisma.auditLog.count({ where: { companyId, entityId: contact.id } }),
+    );
+    expect(auditCount).toBe(2);
+  });
+
+  it("unlinks across equivalent email providers while preserving other identifiers", async () => {
+    const contact = await makeContact();
+    await runWithTenant(user, async () => {
+      const link = getLinkContactIdentifierInteractor();
+      expect(
+        (await link.invoke({ contactId: contact.id, provider: "google", identifier: "unlink@example.com" })).ok,
+      ).toBe(true);
+      expect(
+        (await link.invoke({ contactId: contact.id, provider: "whatsapp", identifier: "+4915112345678" })).ok,
+      ).toBe(true);
+      expect(
+        (
+          await getUnlinkContactIdentifierInteractor().invoke({
+            contactId: contact.id,
+            provider: "outlook",
+            identifier: "unlink@example.com",
+          })
+        ).ok,
+      ).toBe(true);
+    });
+    expect(await identifiers(contact.id)).toEqual([{ provider: "whatsapp", value: "+4915112345678" }]);
+  });
+
+  it("rejects another tenant's contact without changing it", async () => {
+    const contact = await makeContact(otherCompanyId);
+    const result = await runWithTenant(user, () =>
+      getLinkContactIdentifierInteractor().invoke({
+        contactId: contact.id,
+        provider: "mail",
+        identifier: "cross-tenant@example.com",
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, error: { issues: [{ params: { error: "contactNotFound" } }] } });
+    expect(await identifiers(contact.id)).toEqual([]);
+  });
+
+  it("preserves read-own visibility when update permission is present", async () => {
+    const contact = await makeContact();
+    const reader = {
+      ...createMockUserWithPermissions([
+        { resource: Resource.contacts, action: Action.readOwn },
+        { resource: Resource.contacts, action: Action.update },
+      ]),
+      id: userId,
+      companyId,
+    };
+    const result = await runWithTenant(reader, () =>
+      getLinkContactIdentifierInteractor().invoke({
+        contactId: contact.id,
+        provider: "mail",
+        identifier: "hidden@example.com",
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, error: { issues: [{ params: { error: "contactNotFound" } }] } });
+    expect(await identifiers(contact.id)).toEqual([]);
+  });
+
+  it("rejects a read-only user's unlink without deleting the identifier", async () => {
+    const contact = await makeContact();
+    await runWithTenant(user, () =>
+      getLinkContactIdentifierInteractor().invoke({
+        contactId: contact.id,
+        provider: "mail",
+        identifier: "protected@example.com",
+      }),
+    );
+    const reader = {
+      ...createMockUserWithPermissions([{ resource: Resource.contacts, action: Action.readAll }]),
+      id: userId,
+      companyId,
+    };
+    await expect(
+      runWithTenant(reader, () =>
+        getUnlinkContactIdentifierInteractor().invoke({
+          contactId: contact.id,
+          provider: "mail",
+          identifier: "protected@example.com",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(await identifiers(contact.id)).toEqual([{ provider: "mail", value: "protected@example.com" }]);
+  });
+});

--- a/features/contacts/__tests__/contact-identifier.interactors.test.ts
+++ b/features/contacts/__tests__/contact-identifier.interactors.test.ts
@@ -1,0 +1,203 @@
+import type { ContactDto, ContactIdentifierDto } from "../contact.schema";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ForbiddenError } from "@/core/errors/app-errors";
+import { createZodError } from "@/core/validation/validation.utils";
+import { createMockUser, createMockUserWithPermissions } from "@/tests/helpers/mock-user";
+import {
+  MOCK_ENV_MODULE,
+  createMockDiModule,
+  MOCK_ZOD_MODULE,
+  MOCK_PRISMA_DB_MODULE,
+} from "@/tests/helpers/interactor-test-setup";
+
+let mockUser = createMockUser();
+vi.mock("@/env", () => MOCK_ENV_MODULE);
+vi.mock("@/core/di", () => createMockDiModule(() => mockUser));
+vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
+vi.mock("@/prisma/db", () => MOCK_PRISMA_DB_MODULE);
+vi.mock("next-intl/server", () => ({ getTranslations: () => Promise.resolve({ raw: (key: string) => key }) }));
+
+import { LinkContactIdentifierInteractor } from "../upsert/link-contact-identifier.interactor";
+import { UnlinkContactIdentifierInteractor } from "../upsert/unlink-contact-identifier.interactor";
+
+const contactId = "10000000-0000-4000-8000-000000000001";
+function identifier(overrides: Partial<ContactIdentifierDto> = {}): ContactIdentifierDto {
+  return {
+    id: "10000000-0000-4000-8000-000000000002",
+    provider: "google",
+    value: "ada@example.com",
+    messagingId: null,
+    displayName: null,
+    profileUrl: null,
+    ...overrides,
+  };
+}
+function contact(identifiers: ContactIdentifierDto[] = []): ContactDto {
+  return {
+    id: contactId,
+    firstName: "Ada",
+    lastName: "Example",
+    avatarUrl: null,
+    notes: null,
+    identifiers,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    organizations: [],
+    users: [],
+    deals: [],
+    tasks: [],
+    customFieldValues: [],
+  };
+}
+
+const getContact = { invoke: vi.fn() };
+const updateContact = { invoke: vi.fn() };
+function operation(kind: "link" | "unlink") {
+  return kind === "link"
+    ? new LinkContactIdentifierInteractor(getContact as never, updateContact as never)
+    : new UnlinkContactIdentifierInteractor(getContact as never, updateContact as never);
+}
+
+describe("contact identifier interactors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = createMockUser();
+    getContact.invoke.mockResolvedValue({ ok: true, data: { contact: contact(), customColumns: [] } });
+    updateContact.invoke.mockResolvedValue({ ok: true, data: contact() });
+  });
+
+  it("replaces an equivalent email channel and preserves unrelated identifier metadata", async () => {
+    getContact.invoke.mockResolvedValue({
+      ok: true,
+      data: {
+        contact: contact([
+          identifier(),
+          identifier({
+            provider: "instagram",
+            value: "ada",
+            messagingId: "opaque-id",
+            displayName: "Ada Example",
+            profileUrl: "https://www.instagram.com/ada",
+          }),
+        ]),
+        customColumns: [],
+      },
+    });
+    const result = await operation("link").invoke({
+      contactId,
+      provider: "outlook",
+      identifier: "ada@example.com",
+      displayName: "Ada",
+    });
+    expect(result.ok).toBe(true);
+    expect(updateContact.invoke).toHaveBeenCalledWith({
+      id: contactId,
+      identifiers: [
+        {
+          provider: "instagram",
+          value: "ada",
+          messagingId: "opaque-id",
+          displayName: "Ada Example",
+          profileUrl: "https://www.instagram.com/ada",
+        },
+        {
+          provider: "outlook",
+          value: "ada@example.com",
+          messagingId: undefined,
+          displayName: "Ada",
+          profileUrl: undefined,
+        },
+      ],
+    });
+  });
+
+  it("replaces an existing handle matched by messagingId", async () => {
+    getContact.invoke.mockResolvedValue({
+      ok: true,
+      data: {
+        contact: contact([identifier({ provider: "instagram", value: "ada", messagingId: "opaque-id" })]),
+        customColumns: [],
+      },
+    });
+    await operation("link").invoke({ contactId, provider: "instagram", identifier: "opaque-id" });
+    expect(updateContact.invoke).toHaveBeenCalledWith({
+      id: contactId,
+      identifiers: [
+        {
+          provider: "instagram",
+          value: "opaque-id",
+          messagingId: "opaque-id",
+          displayName: undefined,
+          profileUrl: undefined,
+        },
+      ],
+    });
+  });
+
+  it("unlinks the equivalent email channel without removing another provider", async () => {
+    getContact.invoke.mockResolvedValue({
+      ok: true,
+      data: {
+        contact: contact([identifier(), identifier({ provider: "instagram", value: "ada", messagingId: "opaque-id" })]),
+        customColumns: [],
+      },
+    });
+    await operation("unlink").invoke({ contactId, provider: "mail", identifier: "ada@example.com" });
+    expect(updateContact.invoke).toHaveBeenCalledWith({
+      id: contactId,
+      identifiers: [
+        {
+          provider: "instagram",
+          value: "ada",
+          messagingId: "opaque-id",
+          displayName: undefined,
+          profileUrl: undefined,
+        },
+      ],
+    });
+  });
+
+  it.each(["link", "unlink"] as const)("returns a localized not-found failure for %s", async (kind) => {
+    getContact.invoke.mockResolvedValue({ ok: true, data: { contact: null, customColumns: [] } });
+    const result = await operation(kind).invoke({ contactId, provider: "mail", identifier: "ada@example.com" });
+    expect(result).toMatchObject({
+      ok: false,
+      error: { issues: [{ path: ["contactId"], params: { error: "contactNotFound", kind: "not_found" } }] },
+    });
+    expect(updateContact.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each(["link", "unlink"] as const)("preserves a scoped read failure for %s", async (kind) => {
+    const failure = { ok: false, error: createZodError("Unavailable") };
+    getContact.invoke.mockResolvedValue(failure);
+    await expect(
+      operation(kind).invoke({ contactId, provider: "mail", identifier: "ada@example.com" }),
+    ).resolves.toEqual(failure);
+    expect(updateContact.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each(["link", "unlink"] as const)("rejects malformed input before reading for %s", async (kind) => {
+    const result = await operation(kind).invoke({ contactId, provider: "mail", identifier: "" });
+    expect(result.ok).toBe(false);
+    expect(getContact.invoke).not.toHaveBeenCalled();
+    expect(updateContact.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each(["link", "unlink"] as const)("requires update permission for %s", async (kind) => {
+    mockUser = createMockUserWithPermissions([]);
+    await expect(
+      operation(kind).invoke({ contactId, provider: "mail", identifier: "ada@example.com" }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(getContact.invoke).not.toHaveBeenCalled();
+    expect(updateContact.invoke).not.toHaveBeenCalled();
+  });
+
+  it("preserves update failures", async () => {
+    const failure = { ok: false, error: createZodError("Already linked", ["identifiers"]) };
+    updateContact.invoke.mockResolvedValue(failure);
+    await expect(
+      operation("link").invoke({ contactId, provider: "mail", identifier: "ada@example.com" }),
+    ).resolves.toEqual(failure);
+  });
+});

--- a/features/contacts/upsert/contact-identifier.ts
+++ b/features/contacts/upsert/contact-identifier.ts
@@ -1,0 +1,35 @@
+import type { MessagingProvider } from "@/generated/prisma";
+import type { ContactDto, IdentifierInput } from "../contact.schema";
+import type { Data } from "@/core/validation/validation.utils";
+
+import { channelClass } from "@/ee/messaging/provider";
+import { IdentifierInputSchema } from "../contact.schema";
+import { ContactKeySchema } from "../contact-key";
+
+export const LinkContactIdentifierSchema = IdentifierInputSchema.pick({
+  provider: true,
+  displayName: true,
+  profileUrl: true,
+}).extend({ contactId: ContactKeySchema, identifier: IdentifierInputSchema.shape.value });
+export type LinkContactIdentifierData = Data<typeof LinkContactIdentifierSchema>;
+export const UnlinkContactIdentifierSchema = LinkContactIdentifierSchema.pick({
+  contactId: true,
+  provider: true,
+  identifier: true,
+});
+export type UnlinkContactIdentifierData = Data<typeof UnlinkContactIdentifierSchema>;
+
+export function identifiersExcept(contact: ContactDto, provider: MessagingProvider, value: string): IdentifierInput[] {
+  const targetClass = channelClass(provider);
+  return contact.identifiers
+    .filter(
+      (dto) => !(channelClass(dto.provider) === targetClass && (dto.value === value || dto.messagingId === value)),
+    )
+    .map((dto) => ({
+      provider: dto.provider,
+      value: dto.value,
+      messagingId: dto.messagingId ?? undefined,
+      displayName: dto.displayName ?? undefined,
+      profileUrl: dto.profileUrl ?? undefined,
+    }));
+}

--- a/features/contacts/upsert/link-contact-identifier.interactor.ts
+++ b/features/contacts/upsert/link-contact-identifier.interactor.ts
@@ -1,0 +1,48 @@
+import type { GetContactByIdInteractor } from "../get/get-contact-by-id.interactor";
+import type { UpdateContactInteractor } from "./update-contact.interactor";
+import type { LinkContactIdentifierData } from "./contact-identifier";
+import type { ContactDto } from "../contact.schema";
+import type { Validated } from "@/core/validation/validation.utils";
+
+import { Action, Resource } from "@/generated/prisma";
+
+import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
+import { TenantInteractor } from "@/core/decorators/tenant-interactor.decorator";
+import { Write } from "@/core/decorators/write.decorator";
+import { failNotFound } from "@/core/validation/interactor-failure-server";
+import { CustomErrorCode } from "@/core/validation/validation.types";
+import { isHandleProvider } from "@/ee/messaging/provider";
+import { ContactDtoSchema } from "../contact.schema";
+import { identifiersExcept, LinkContactIdentifierSchema } from "./contact-identifier";
+
+@TenantInteractor({ resource: Resource.contacts, action: Action.update })
+export class LinkContactIdentifierInteractor extends AuthenticatedInteractor<LinkContactIdentifierData, ContactDto> {
+  constructor(
+    private readonly getContact: GetContactByIdInteractor,
+    private readonly updateContact: UpdateContactInteractor,
+  ) {
+    super();
+  }
+
+  @Write({ input: LinkContactIdentifierSchema, output: ContactDtoSchema })
+  async invoke(data: LinkContactIdentifierData): Validated<ContactDto> {
+    const result = await this.getContact.invoke({ id: data.contactId });
+    if (!result.ok) return result;
+    const contact = result.data.contact;
+    if (!contact) return failNotFound(CustomErrorCode.contactNotFound, ["contactId"]);
+
+    return await this.updateContact.invoke({
+      id: data.contactId,
+      identifiers: [
+        ...identifiersExcept(contact, data.provider, data.identifier),
+        {
+          provider: data.provider,
+          value: data.identifier,
+          messagingId: isHandleProvider(data.provider) ? data.identifier : undefined,
+          displayName: data.displayName,
+          profileUrl: data.profileUrl,
+        },
+      ],
+    });
+  }
+}

--- a/features/contacts/upsert/unlink-contact-identifier.interactor.ts
+++ b/features/contacts/upsert/unlink-contact-identifier.interactor.ts
@@ -1,0 +1,41 @@
+import type { GetContactByIdInteractor } from "../get/get-contact-by-id.interactor";
+import type { UpdateContactInteractor } from "./update-contact.interactor";
+import type { UnlinkContactIdentifierData } from "./contact-identifier";
+import type { ContactDto } from "../contact.schema";
+import type { Validated } from "@/core/validation/validation.utils";
+
+import { Action, Resource } from "@/generated/prisma";
+
+import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
+import { TenantInteractor } from "@/core/decorators/tenant-interactor.decorator";
+import { Write } from "@/core/decorators/write.decorator";
+import { failNotFound } from "@/core/validation/interactor-failure-server";
+import { CustomErrorCode } from "@/core/validation/validation.types";
+import { ContactDtoSchema } from "../contact.schema";
+import { identifiersExcept, UnlinkContactIdentifierSchema } from "./contact-identifier";
+
+@TenantInteractor({ resource: Resource.contacts, action: Action.update })
+export class UnlinkContactIdentifierInteractor extends AuthenticatedInteractor<
+  UnlinkContactIdentifierData,
+  ContactDto
+> {
+  constructor(
+    private readonly getContact: GetContactByIdInteractor,
+    private readonly updateContact: UpdateContactInteractor,
+  ) {
+    super();
+  }
+
+  @Write({ input: UnlinkContactIdentifierSchema, output: ContactDtoSchema })
+  async invoke(data: UnlinkContactIdentifierData): Validated<ContactDto> {
+    const result = await this.getContact.invoke({ id: data.contactId });
+    if (!result.ok) return result;
+    const contact = result.data.contact;
+    if (!contact) return failNotFound(CustomErrorCode.contactNotFound, ["contactId"]);
+
+    return await this.updateContact.invoke({
+      id: data.contactId,
+      identifiers: identifiersExcept(contact, data.provider, data.identifier),
+    });
+  }
+}

--- a/features/custom-column/prisma-custom-column.repository.ts
+++ b/features/custom-column/prisma-custom-column.repository.ts
@@ -1,4 +1,5 @@
 import type { RepoArgs } from "@/core/utils/types";
+import type { GetDealWeightingColumnRepo } from "@/features/company/get-deal-weighting-column.repo";
 import type { UpsertCustomColumnRepo } from "./upsert-custom-column.interactor";
 import type { GetCustomColumnsRepo } from "./get-custom-columns.interactor";
 import type { GetCustomColumnsByEntityTypeRepo } from "./get-custom-columns-by-entity-type.interactor";
@@ -37,6 +38,10 @@ export class PrismaCustomColumnRepo
     ServiceCustomColumnRepo,
     TaskCustomColumnRepo
 {
+  constructor(private readonly companyRepo: GetDealWeightingColumnRepo) {
+    super();
+  }
+
   private get baseSelect() {
     return {
       id: true,
@@ -196,12 +201,7 @@ export class PrismaCustomColumnRepo
   async delete(id: string) {
     const { companyId } = this.user;
 
-    const company = await this.prisma.company.findUnique({
-      where: { id: companyId },
-      select: { dealWeightingColumnId: true },
-    });
-
-    const wasWeightingColumn = company?.dealWeightingColumnId === id;
+    const wasWeightingColumn = (await this.companyRepo.getDealWeightingColumnId()) === id;
 
     await Promise.all([
       this.prisma.widget.deleteMany({
@@ -290,14 +290,7 @@ export class PrismaCustomColumnRepo
   }
 
   private async recalculateDealsWhenWeightingColumn(columnId: string) {
-    const { companyId } = this.user;
-
-    const company = await this.prisma.company.findUnique({
-      where: { id: companyId },
-      select: { dealWeightingColumnId: true },
-    });
-
-    if (company?.dealWeightingColumnId !== columnId) return;
+    if ((await this.companyRepo.getDealWeightingColumnId()) !== columnId) return;
 
     await getDealRepo().recalculateWeightedValuesForCompany();
   }

--- a/features/data-transfer/__tests__/import-roundtrip.database.test.ts
+++ b/features/data-transfer/__tests__/import-roundtrip.database.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/features/user/user.service", () => ({
   },
 }));
 
-const { getCreateManyContactsInteractor } = await import("@/core/di");
+const { getCommitImportChunkInteractor, getDryRunImportChunkInteractor } = await import("@/core/di");
 const { prisma } = await import("@/prisma/db");
 const { runWithoutTenant } = await import("@/core/decorators/tenant-context");
 const { buildExportColumns, buildSchemaSheetRows } = await import("../workbook-columns");
@@ -167,9 +167,13 @@ describeDatabase("spreadsheet round trip against a real database", { timeout: 12
     expect(plan.create).toHaveLength(2);
     expect(plan.update).toHaveLength(0);
 
-    const result = await getCreateManyContactsInteractor().invoke({
-      contacts: plan.create.map((row) => row.payload),
-    } as never);
+    const chunk = {
+      entityType: EntityType.contact,
+      mode: "create" as const,
+      rows: plan.create.map((row) => row.payload),
+    };
+    expect((await getDryRunImportChunkInteractor().invoke(chunk)).ok).toBe(true);
+    const result = await getCommitImportChunkInteractor().invoke(chunk);
 
     expect(result.ok).toBe(true);
 
@@ -215,5 +219,14 @@ describeDatabase("spreadsheet round trip against a real database", { timeout: 12
     expect(plan.create).toHaveLength(0);
     expect(plan.update).toHaveLength(1);
     expect(plan.update[0].payload.id).toBe(existing?.id);
+    const chunk = {
+      entityType: EntityType.contact,
+      mode: "update" as const,
+      rows: plan.update.map((row) => row.payload),
+    };
+    expect((await getDryRunImportChunkInteractor().invoke(chunk)).ok).toBe(true);
+    expect((await getCommitImportChunkInteractor().invoke(chunk)).ok).toBe(true);
+    const count = await runWithoutTenant(() => prisma.contact.count({ where: { companyId: company } }));
+    expect(count).toBe(2);
   });
 });

--- a/features/data-transfer/data-transfer.schema.ts
+++ b/features/data-transfer/data-transfer.schema.ts
@@ -49,6 +49,9 @@ export const DryRunImportSchema = z.object({
 });
 export type DryRunImportData = Data<typeof DryRunImportSchema>;
 
+export const ImportChunkSchema = DryRunImportSchema.extend({ entityType: z.enum(EntityType) });
+export type ImportChunkData = Data<typeof ImportChunkSchema>;
+
 export const RELATION_INDEX_LIMIT = 5000;
 
 export const RELATION_INDEX_PAGE_SIZE = 500;

--- a/features/data-transfer/import/__tests__/import-chunk.interactors.test.ts
+++ b/features/data-transfer/import/__tests__/import-chunk.interactors.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EntityType } from "@/generated/prisma";
+
+import { createZodError } from "@/core/validation/validation.utils";
+import { createMockUser } from "@/tests/helpers/mock-user";
+import { MOCK_ENV_MODULE, createMockDiModule, MOCK_ZOD_MODULE } from "@/tests/helpers/interactor-test-setup";
+
+const mockUser = createMockUser();
+vi.mock("@/env", () => MOCK_ENV_MODULE);
+vi.mock("@/core/di", () => createMockDiModule(() => mockUser));
+vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
+
+import { CommitImportChunkInteractor } from "../commit-import-chunk.interactor";
+import { DryRunImportChunkInteractor } from "../dry-run-import-chunk.interactor";
+
+function dependencies() {
+  return {
+    contacts: { invoke: vi.fn() },
+    organizations: { invoke: vi.fn() },
+    deals: { invoke: vi.fn() },
+    services: { invoke: vi.fn() },
+    tasks: { invoke: vi.fn() },
+  };
+}
+
+const create = dependencies();
+const update = dependencies();
+const dry = dependencies();
+const cases = [
+  [EntityType.contact, "contacts"],
+  [EntityType.organization, "organizations"],
+  [EntityType.deal, "deals"],
+  [EntityType.service, "services"],
+  [EntityType.task, "tasks"],
+] as const;
+
+function commit() {
+  return new CommitImportChunkInteractor(
+    create.contacts as never,
+    update.contacts as never,
+    create.organizations as never,
+    update.organizations as never,
+    create.deals as never,
+    update.deals as never,
+    create.services as never,
+    update.services as never,
+    create.tasks as never,
+    update.tasks as never,
+  );
+}
+
+function dryRun() {
+  return new DryRunImportChunkInteractor(
+    dry.contacts as never,
+    dry.organizations as never,
+    dry.deals as never,
+    dry.services as never,
+    dry.tasks as never,
+  );
+}
+
+describe("import chunk interactors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const dependency of [...Object.values(create), ...Object.values(update)])
+      dependency.invoke.mockResolvedValue({ ok: true, data: [{ id: "record-1" }] });
+    for (const dependency of Object.values(dry)) dependency.invoke.mockResolvedValue({ ok: true, data: null });
+  });
+
+  it.each(cases)("routes create %s using its existing collection key", async (entityType, key) => {
+    const rows = [{ name: "Synthetic record" }];
+    await expect(commit().invoke({ entityType, mode: "create", rows })).resolves.toEqual({
+      ok: true,
+      data: [{ id: "record-1" }],
+    });
+    expect(create[key].invoke).toHaveBeenCalledExactlyOnceWith({ [key]: rows });
+    for (const dependency of Object.values(update)) expect(dependency.invoke).not.toHaveBeenCalled();
+    for (const [other, dependency] of Object.entries(create))
+      if (other !== key) expect(dependency.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)("routes update %s using its existing collection key", async (entityType, key) => {
+    const rows = [{ id: "record-1", name: "Changed record" }];
+    await commit().invoke({ entityType, mode: "update", rows });
+    expect(update[key].invoke).toHaveBeenCalledExactlyOnceWith({ [key]: rows });
+    for (const dependency of Object.values(create)) expect(dependency.invoke).not.toHaveBeenCalled();
+    for (const [other, dependency] of Object.entries(update))
+      if (other !== key) expect(dependency.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)("routes dry-run %s without committing", async (entityType, key) => {
+    const rows = [{ name: "Synthetic record" }];
+    await expect(dryRun().invoke({ entityType, mode: "update", rows })).resolves.toEqual({ ok: true, data: null });
+    expect(dry[key].invoke).toHaveBeenCalledExactlyOnceWith({ mode: "update", rows });
+    for (const dependency of [...Object.values(create), ...Object.values(update)])
+      expect(dependency.invoke).not.toHaveBeenCalled();
+    for (const [other, dependency] of Object.entries(dry))
+      if (other !== key) expect(dependency.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { entityType: "companies", mode: "create", rows: [{}] },
+    { entityType: EntityType.contact, mode: "replace", rows: [{}] },
+    { entityType: EntityType.contact, mode: "create", rows: [] },
+    { entityType: EntityType.contact, mode: "create", rows: Array.from({ length: 101 }, () => ({})) },
+  ])("returns structured validation for invalid input %#", async (input) => {
+    const committed = await commit().invoke(input as never);
+    const checked = await dryRun().invoke(input as never);
+    expect(committed.ok).toBe(false);
+    expect(checked.ok).toBe(false);
+    for (const dependency of [...Object.values(create), ...Object.values(update), ...Object.values(dry)])
+      expect(dependency.invoke).not.toHaveBeenCalled();
+  });
+
+  it("preserves row-specific commit failures", async () => {
+    const failure = { ok: false, error: createZodError("Invalid row", ["contacts", 0, "firstName"]) };
+    create.contacts.invoke.mockResolvedValue(failure);
+    await expect(commit().invoke({ entityType: EntityType.contact, mode: "create", rows: [{}] })).resolves.toEqual(
+      failure,
+    );
+  });
+
+  it("preserves row-specific dry-run failures", async () => {
+    const failure = { ok: false, error: createZodError("Invalid row", ["tasks", 0, "name"]) };
+    dry.tasks.invoke.mockResolvedValue(failure);
+    await expect(dryRun().invoke({ entityType: EntityType.task, mode: "create", rows: [{}] })).resolves.toEqual(
+      failure,
+    );
+  });
+});

--- a/features/data-transfer/import/commit-import-chunk.interactor.ts
+++ b/features/data-transfer/import/commit-import-chunk.interactor.ts
@@ -1,0 +1,67 @@
+import type { CreateManyContactsInteractor } from "@/features/contacts/upsert/create-many-contacts.interactor";
+import type { UpdateManyContactsInteractor } from "@/features/contacts/upsert/update-many-contacts.interactor";
+import type { CreateManyOrganizationsInteractor } from "@/features/organizations/upsert/create-many-organizations.interactor";
+import type { UpdateManyOrganizationsInteractor } from "@/features/organizations/upsert/update-many-organizations.interactor";
+import type { CreateManyDealsInteractor } from "@/features/deals/upsert/create-many-deals.interactor";
+import type { UpdateManyDealsInteractor } from "@/features/deals/upsert/update-many-deals.interactor";
+import type { CreateManyServicesInteractor } from "@/features/services/upsert/create-many-services.interactor";
+import type { UpdateManyServicesInteractor } from "@/features/services/upsert/update-many-services.interactor";
+import type { CreateManyTasksInteractor } from "@/features/tasks/upsert/create-many-tasks.interactor";
+import type { UpdateManyTasksInteractor } from "@/features/tasks/upsert/update-many-tasks.interactor";
+import type { ImportChunkData } from "../data-transfer.schema";
+import type { Validated } from "@/core/validation/validation.utils";
+
+import { EntityType } from "@/generated/prisma";
+import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
+import { TenantInteractor } from "@/core/decorators/tenant-interactor.decorator";
+import { Validate } from "@/core/decorators/validate.decorator";
+import { ImportChunkSchema } from "../data-transfer.schema";
+import { IMPORT_ENTITIES } from "./import-entity.registry";
+
+@TenantInteractor()
+export class CommitImportChunkInteractor extends AuthenticatedInteractor<ImportChunkData, Array<{ id: string }>> {
+  constructor(
+    private readonly createContacts: CreateManyContactsInteractor,
+    private readonly updateContacts: UpdateManyContactsInteractor,
+    private readonly createOrganizations: CreateManyOrganizationsInteractor,
+    private readonly updateOrganizations: UpdateManyOrganizationsInteractor,
+    private readonly createDeals: CreateManyDealsInteractor,
+    private readonly updateDeals: UpdateManyDealsInteractor,
+    private readonly createServices: CreateManyServicesInteractor,
+    private readonly updateServices: UpdateManyServicesInteractor,
+    private readonly createTasks: CreateManyTasksInteractor,
+    private readonly updateTasks: UpdateManyTasksInteractor,
+  ) {
+    super();
+  }
+
+  @Validate(ImportChunkSchema)
+  async invoke(data: ImportChunkData): Validated<Array<{ id: string }>> {
+    switch (data.entityType) {
+      case EntityType.contact:
+        return data.mode === "create"
+          ? await this.createContacts.invoke(collectionPayload(data.entityType, data.rows))
+          : await this.updateContacts.invoke(collectionPayload(data.entityType, data.rows));
+      case EntityType.organization:
+        return data.mode === "create"
+          ? await this.createOrganizations.invoke(collectionPayload(data.entityType, data.rows))
+          : await this.updateOrganizations.invoke(collectionPayload(data.entityType, data.rows));
+      case EntityType.deal:
+        return data.mode === "create"
+          ? await this.createDeals.invoke(collectionPayload(data.entityType, data.rows))
+          : await this.updateDeals.invoke(collectionPayload(data.entityType, data.rows));
+      case EntityType.service:
+        return data.mode === "create"
+          ? await this.createServices.invoke(collectionPayload(data.entityType, data.rows))
+          : await this.updateServices.invoke(collectionPayload(data.entityType, data.rows));
+      case EntityType.task:
+        return data.mode === "create"
+          ? await this.createTasks.invoke(collectionPayload(data.entityType, data.rows))
+          : await this.updateTasks.invoke(collectionPayload(data.entityType, data.rows));
+    }
+  }
+}
+
+function collectionPayload<T>(entityType: EntityType, rows: unknown[]): T {
+  return { [IMPORT_ENTITIES[entityType].collectionKey]: rows } as T;
+}

--- a/features/data-transfer/import/dry-run-import-chunk.interactor.ts
+++ b/features/data-transfer/import/dry-run-import-chunk.interactor.ts
@@ -1,0 +1,43 @@
+import type { DryRunImportContactsInteractor } from "./dry-run-import-contacts.interactor";
+import type { DryRunImportOrganizationsInteractor } from "./dry-run-import-organizations.interactor";
+import type { DryRunImportDealsInteractor } from "./dry-run-import-deals.interactor";
+import type { DryRunImportServicesInteractor } from "./dry-run-import-services.interactor";
+import type { DryRunImportTasksInteractor } from "./dry-run-import-tasks.interactor";
+import type { ImportChunkData } from "../data-transfer.schema";
+import type { Validated } from "@/core/validation/validation.utils";
+
+import { EntityType } from "@/generated/prisma";
+import { AuthenticatedInteractor } from "@/core/base/authenticated-interactor";
+import { TenantInteractor } from "@/core/decorators/tenant-interactor.decorator";
+import { Validate } from "@/core/decorators/validate.decorator";
+import { ImportChunkSchema } from "../data-transfer.schema";
+
+@TenantInteractor()
+export class DryRunImportChunkInteractor extends AuthenticatedInteractor<ImportChunkData, null> {
+  constructor(
+    private readonly contacts: DryRunImportContactsInteractor,
+    private readonly organizations: DryRunImportOrganizationsInteractor,
+    private readonly deals: DryRunImportDealsInteractor,
+    private readonly services: DryRunImportServicesInteractor,
+    private readonly tasks: DryRunImportTasksInteractor,
+  ) {
+    super();
+  }
+
+  @Validate(ImportChunkSchema)
+  async invoke(data: ImportChunkData): Validated<null> {
+    const input = { mode: data.mode, rows: data.rows };
+    switch (data.entityType) {
+      case EntityType.contact:
+        return await this.contacts.invoke(input);
+      case EntityType.organization:
+        return await this.organizations.invoke(input);
+      case EntityType.deal:
+        return await this.deals.invoke(input);
+      case EntityType.service:
+        return await this.services.invoke(input);
+      case EntityType.task:
+        return await this.tasks.invoke(input);
+    }
+  }
+}

--- a/features/deals/prisma-deal.repository.ts
+++ b/features/deals/prisma-deal.repository.ts
@@ -1,4 +1,5 @@
 import type { RepoArgs } from "@/core/utils/types";
+import type { GetDealWeightingColumnRepo } from "@/features/company/get-deal-weighting-column.repo";
 import type { GetWidgetFilterableFieldsDealRepo } from "../widget/get-widget-filterable-fields.interactor";
 import type { GetCompanyWideDealRepo } from "./get-company-wide-deal.repo";
 import type { CreateDealRepo } from "./upsert/create-deal.repo";
@@ -40,6 +41,10 @@ export class PrismaDealRepo
     ModifyRelationDealRepo,
     ExportRecordsRepo<DealDto>
 {
+  constructor(private readonly companyRepo: GetDealWeightingColumnRepo) {
+    super();
+  }
+
   private get userScopedSelect() {
     return {
       id: true,
@@ -595,15 +600,11 @@ export class PrismaDealRepo
   }
 
   private async resolveDealWeighting(companyId: string) {
-    const company = await this.prisma.company.findUnique({
-      where: { id: companyId },
-      select: { dealWeightingColumnId: true },
-    });
-
-    if (!company?.dealWeightingColumnId) return null;
+    const columnId = await this.companyRepo.getDealWeightingColumnId();
+    if (!columnId) return null;
 
     const column = await this.prisma.customColumn.findFirst({
-      where: { id: company.dealWeightingColumnId, companyId, entityType: EntityType.deal },
+      where: { id: columnId, companyId, entityType: EntityType.deal },
       select: { id: true, options: true },
     });
 

--- a/features/services/__tests__/service-interactors.test.ts
+++ b/features/services/__tests__/service-interactors.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createMockUser } from "@/tests/helpers/mock-user";
+import { createMockUser, createMockUserWithPermissions } from "@/tests/helpers/mock-user";
+import { runWithTenant } from "@/core/decorators/tenant-context";
 import {
   MOCK_ENV_MODULE,
   createMockDiModule,
@@ -15,6 +16,7 @@ vi.mock("@/core/validation/zod-error-map-server", () => MOCK_ZOD_MODULE);
 vi.mock("@/prisma/db", () => MOCK_PRISMA_DB_MODULE);
 
 import { CreateServiceInteractor } from "../upsert/create-service.interactor";
+import { CreateServiceByNameInteractor } from "../upsert/create-service-by-name.interactor";
 import { UpdateServiceInteractor } from "../upsert/update-service.interactor";
 import { DeleteServiceInteractor } from "../delete/delete-service.interactor";
 import { CreateManyServicesInteractor } from "../upsert/create-many-services.interactor";
@@ -113,6 +115,58 @@ describe("CreateServiceInteractor", () => {
       makeServiceWritePrecheck(),
     );
   }
+
+  describe("quick-create by name", () => {
+    it.each(["00000000-0000-4000-8000-000000000099", null, undefined])(
+      "applies defaults for user %s",
+      async (userId) => {
+        const service = makeServiceDto({ name: "Quick service", amount: 100 });
+        mockCreateRepo.createServiceOrThrow.mockResolvedValue(service);
+        const result = await new CreateServiceByNameInteractor(createInteractor()).invoke({
+          name: "Quick service",
+          userId,
+        });
+        expect(result).toEqual({ ok: true, data: service });
+        expect(mockCreateRepo.createServiceOrThrow).toHaveBeenCalledWith({
+          name: "Quick service",
+          amount: 100,
+          notes: null,
+          userIds: userId ? [userId] : [],
+          dealIds: [],
+          taskIds: [],
+          customFieldValues: [],
+        });
+        expect(mockEventService.publish).toHaveBeenCalledWith(DomainEvent.SERVICE_CREATED, {
+          entityId: SERVICE_ID,
+          payload: service,
+        });
+      },
+    );
+
+    it.each([{ name: "   " }, { name: "Quick service", userId: "invalid-user-id" }])(
+      "preserves creation validation for %j",
+      async (data) => {
+        const result = await new CreateServiceByNameInteractor(createInteractor()).invoke(data);
+        expect(result.ok).toBe(false);
+        expect(mockCreateRepo.createServiceOrThrow).not.toHaveBeenCalled();
+        expect(mockEventService.publish).not.toHaveBeenCalled();
+      },
+    );
+
+    it("enforces create permission before delegating", async () => {
+      const interactor = new CreateServiceByNameInteractor(createInteractor());
+      await expect(
+        runWithTenant(createMockUserWithPermissions([]), () => interactor.invoke({ name: "Quick service" })),
+      ).rejects.toThrow("Access denied");
+      expect(mockCreateRepo.createServiceOrThrow).not.toHaveBeenCalled();
+    });
+
+    it.each([null, undefined])("returns validation failures for missing quick-create data %j", async (data) => {
+      const result = await new CreateServiceByNameInteractor(createInteractor()).invoke(data as never);
+      expect(result.ok).toBe(false);
+      expect(mockCreateRepo.createServiceOrThrow).not.toHaveBeenCalled();
+    });
+  });
 
   it("publishes SERVICE_CREATED event with correct entityId and payload", async () => {
     const interactor = createInteractor();

--- a/features/services/upsert/create-service-by-name.interactor.ts
+++ b/features/services/upsert/create-service-by-name.interactor.ts
@@ -1,0 +1,25 @@
+import type { CreateServiceInteractor } from "./create-service.interactor";
+import type { ServiceDto } from "../service.schema";
+import type { Validated } from "@/core/validation/validation.utils";
+
+import { Resource, Action } from "@/generated/prisma";
+import { TenantInteractor } from "@/core/decorators/tenant-interactor.decorator";
+
+export type CreateServiceByNameData = { name: string; userId?: string | null };
+
+@TenantInteractor({ resource: Resource.services, action: Action.create })
+export class CreateServiceByNameInteractor {
+  constructor(private readonly createServiceInteractor: CreateServiceInteractor) {}
+
+  async invoke(data: CreateServiceByNameData): Validated<ServiceDto> {
+    return this.createServiceInteractor.invoke({
+      name: data?.name,
+      amount: 100,
+      notes: null,
+      userIds: data?.userId ? [data.userId] : [],
+      dealIds: [],
+      taskIds: [],
+      customFieldValues: [],
+    });
+  }
+}

--- a/features/user/__tests__/register-onboarding-profile.interactor.test.ts
+++ b/features/user/__tests__/register-onboarding-profile.interactor.test.ts
@@ -158,6 +158,19 @@ describe("RegisterOnboardingProfileInteractor", () => {
     expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
   });
 
+  it.each([
+    invitation,
+    { authUserId: "user-one", intent: "signed-create", source: "explicit", status: "valid", type: "createCompany" },
+  ])("preserves $type intent when verification becomes overdue during profile entry", async (intent) => {
+    onboardingIntentService.resolve.mockResolvedValue(intent);
+    registerUserInteractor.invoke.mockResolvedValue({ redirect: "/auth/verify-email" });
+
+    await expect(createInteractor().invoke({ ...registration, onboardingIntent: intent.intent })).resolves.toEqual({
+      redirect: `/auth/verify-email?intent=${intent.intent}`,
+    });
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+  });
+
   it("preserves a create decision when its session needs to be restored", async () => {
     onboardingIntentService.resolve.mockResolvedValue({
       authUserId: "user-one",

--- a/features/user/__tests__/register-onboarding-profile.interactor.test.ts
+++ b/features/user/__tests__/register-onboarding-profile.interactor.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RegisterOnboardingProfileInteractor } from "../register/register-onboarding-profile.interactor";
+
+const registration = {
+  agreeToTerms: true,
+  avatarUrl: null,
+  country: "de" as const,
+  email: "owner@example.com",
+  firstName: "Owner",
+  lastName: "Example",
+};
+
+const invitation = {
+  companyId: "company-invited",
+  expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  intent: "signed-invitation-a",
+  inviterName: "Invite Admin",
+  source: "explicit",
+  status: "valid",
+  token: "invite-a",
+  type: "invitation",
+} as const;
+
+describe("RegisterOnboardingProfileInteractor", () => {
+  const authService = { getSession: vi.fn() };
+  const onboardingIntentService = { resolve: vi.fn() };
+  const inviteTokenCookieRepo = { clear: vi.fn(), read: vi.fn() };
+  const registerUserInteractor = { invoke: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authService.getSession.mockResolvedValue({ user: { id: "user-one" } });
+    onboardingIntentService.resolve.mockResolvedValue(invitation);
+    inviteTokenCookieRepo.clear.mockResolvedValue(undefined);
+    inviteTokenCookieRepo.read.mockResolvedValue(undefined);
+    registerUserInteractor.invoke.mockResolvedValue({ data: { redirectTo: "/auth/pending" }, ok: true });
+  });
+
+  function createInteractor() {
+    return new RegisterOnboardingProfileInteractor(
+      authService as never,
+      onboardingIntentService as never,
+      inviteTokenCookieRepo as never,
+      registerUserInteractor as never,
+    );
+  }
+
+  it("gives an explicit invitation precedence over ambient state", async () => {
+    await expect(createInteractor().invoke({ ...registration, onboardingIntent: invitation.intent })).resolves.toEqual({
+      data: { redirectTo: "/auth/pending" },
+      ok: true,
+    });
+
+    expect(inviteTokenCookieRepo.read).not.toHaveBeenCalled();
+    expect(registerUserInteractor.invoke).toHaveBeenCalledWith(registration, {
+      adAttribution: undefined,
+      target: { companyId: "company-invited", type: "invitation" },
+    });
+    expect(inviteTokenCookieRepo.clear).toHaveBeenCalledOnce();
+  });
+
+  it("uses a create decision only for the identity that made it", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({
+      authUserId: "user-one",
+      intent: "signed-create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+
+    await createInteractor().invoke({ ...registration, onboardingIntent: "signed-create" });
+
+    expect(registerUserInteractor.invoke).toHaveBeenCalledWith(registration, {
+      adAttribution: undefined,
+      target: { type: "createCompany" },
+    });
+  });
+
+  it("rejects a create decision made by another identity", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({
+      authUserId: "user-two",
+      intent: "signed-create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+
+    await expect(createInteractor().invoke({ ...registration, onboardingIntent: "signed-create" })).resolves.toEqual({
+      redirect: "/auth/error?type=invalidOnboardingIntent",
+    });
+    expect(registerUserInteractor.invoke).not.toHaveBeenCalled();
+    expect(inviteTokenCookieRepo.clear).toHaveBeenCalledOnce();
+  });
+
+  it.each(["invalidOnboardingIntent", "onboardingSessionExpired"] as const)(
+    "fails closed for an explicit %s intent",
+    async (errorMessage) => {
+      onboardingIntentService.resolve.mockResolvedValue({ errorMessage, source: "explicit", status: "invalid" });
+
+      await expect(createInteractor().invoke({ ...registration, onboardingIntent: "bad-intent" })).resolves.toEqual({
+        redirect: `/auth/error?type=${errorMessage}`,
+      });
+      expect(registerUserInteractor.invoke).not.toHaveBeenCalled();
+      expect(inviteTokenCookieRepo.clear).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("resumes a preexisting invitation binding only without explicit intent", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({ status: "absent" });
+    inviteTokenCookieRepo.read.mockResolvedValue(undefined);
+
+    await createInteractor().invoke(registration);
+
+    expect(onboardingIntentService.resolve).toHaveBeenCalledWith(undefined, undefined);
+    expect(registerUserInteractor.invoke).toHaveBeenCalledWith(registration, {
+      adAttribution: undefined,
+      target: { type: "existingAuthUserCompanyBinding" },
+    });
+  });
+
+  it("clears an invalid rollout cookie and continues with a live identity binding", async () => {
+    inviteTokenCookieRepo.read.mockResolvedValue("rollout-invite");
+    onboardingIntentService.resolve.mockResolvedValue({
+      errorMessage: "inviteLinkExpired",
+      source: "legacy",
+      status: "invalid",
+    });
+
+    await createInteractor().invoke(registration);
+
+    expect(inviteTokenCookieRepo.clear).toHaveBeenCalledTimes(2);
+    expect(registerUserInteractor.invoke).toHaveBeenCalledWith(registration, {
+      adAttribution: undefined,
+      target: { type: "existingAuthUserCompanyBinding" },
+    });
+  });
+
+  it("preserves the intent across authentication redirects and recoverable validation", async () => {
+    registerUserInteractor.invoke.mockResolvedValueOnce({ redirect: "/auth/signin" });
+    await expect(createInteractor().invoke({ ...registration, onboardingIntent: invitation.intent })).resolves.toEqual({
+      redirect: `/auth/signin?intent=${invitation.intent}`,
+    });
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+
+    registerUserInteractor.invoke.mockResolvedValueOnce({ ok: false, error: new Error("validation") });
+    const result = await createInteractor().invoke({ ...registration, onboardingIntent: invitation.intent });
+    expect(result).toMatchObject({ ok: false });
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+  });
+
+  it("preserves an invitation when registration needs the account signup screen", async () => {
+    registerUserInteractor.invoke.mockResolvedValue({ redirect: "/auth/signup" });
+
+    await expect(createInteractor().invoke({ ...registration, onboardingIntent: invitation.intent })).resolves.toEqual({
+      redirect: `/auth/signup?intent=${invitation.intent}`,
+    });
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+  });
+
+  it("preserves a create decision when its session needs to be restored", async () => {
+    onboardingIntentService.resolve.mockResolvedValue({
+      authUserId: "user-one",
+      intent: "signed-create",
+      source: "explicit",
+      status: "valid",
+      type: "createCompany",
+    });
+    authService.getSession.mockResolvedValue(null);
+
+    await expect(createInteractor().invoke({ ...registration, onboardingIntent: "signed-create" })).resolves.toEqual({
+      redirect: "/auth/signin?intent=signed-create",
+    });
+    expect(registerUserInteractor.invoke).not.toHaveBeenCalled();
+    expect(inviteTokenCookieRepo.clear).not.toHaveBeenCalled();
+  });
+});

--- a/features/user/__tests__/registration.database.test.ts
+++ b/features/user/__tests__/registration.database.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/core/di", () => ({
 }));
 
 const { PrismaUserRepo } = await import("@/features/user/prisma-user.repository");
+const { PrismaCompanyRepo } = await import("@/features/company/prisma-company.repository");
 const { RegisterUserInteractor } = await import("@/features/user/register/register-user.interactor");
 const { EventService } = await import("@/features/event/event.service");
 const { DomainEventListener } = await import("@/features/event/domain-event.listener");
@@ -309,6 +310,7 @@ describeDatabase("registration against a real database", () => {
       new PrismaUserRepo(),
       eventService,
       unregisteredRouteGuardService(authUserId, registrationEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -465,6 +467,7 @@ describeDatabase("registration against a real database", () => {
       repo,
       eventService,
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -476,7 +479,7 @@ describeDatabase("registration against a real database", () => {
         agreeToTerms: true,
         avatarUrl: null,
       },
-      { target: { type: "legacyAuthBinding" } },
+      { target: { type: "existingAuthUserCompanyBinding" } },
     );
     expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
 
@@ -532,6 +535,7 @@ describeDatabase("registration against a real database", () => {
       repo,
       newEventService(),
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -601,6 +605,7 @@ describeDatabase("registration against a real database", () => {
       repo,
       newEventService(),
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -645,6 +650,7 @@ describeDatabase("registration against a real database", () => {
       new PrismaUserRepo(),
       newEventService(),
       unregisteredRouteGuardService(authUserId, registrationEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     await expect(
@@ -684,6 +690,7 @@ describeDatabase("registration against a real database", () => {
       new PrismaUserRepo(),
       newEventService(),
       unregisteredRouteGuardService(authUserId, registrationEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -695,7 +702,7 @@ describeDatabase("registration against a real database", () => {
         agreeToTerms: true,
         avatarUrl: null,
       },
-      { target: { type: "legacyAuthBinding" } },
+      { target: { type: "existingAuthUserCompanyBinding" } },
     );
 
     expect(result).toEqual({ redirect: "/onboarding" });
@@ -724,6 +731,7 @@ describeDatabase("registration against a real database", () => {
       repo,
       newEventService(),
       unregisteredRouteGuardService(missingAuthUserId, registrationEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -786,6 +794,7 @@ describeDatabase("registration against a real database", () => {
       repo,
       newEventService(),
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     const result = await interactor.invoke(
@@ -813,23 +822,10 @@ describeDatabase("registration against a real database", () => {
     ).toEqual({ companyId: currentWorkspaceAdmin.companyId });
   });
 
-  it("makes simultaneous invitation registrations for one identity idempotent", async () => {
+  it("makes simultaneous company-creation registrations for one identity idempotent", async () => {
     const suffix = randomUUID();
-    const setupRepo = new PrismaUserRepo();
-    const invitedWorkspaceAdmin = await runWithoutTenant(() =>
-      setupRepo.createCompanyAndUser({
-        email: `duplicate-target-${suffix}@duplicate-target.invalid`,
-        firstName: "Duplicate",
-        lastName: "Target",
-        country: "de",
-        agreeToTerms: true,
-        avatarUrl: null,
-      }),
-    );
-    companyIds.push(invitedWorkspaceAdmin.companyId);
-
     const authUserId = `auth-duplicate-${suffix}`;
-    const invitedEmail = `duplicate-member-${suffix}@example.invalid`;
+    const invitedEmail = `duplicate-owner-${suffix}@example.invalid`;
     await runWithoutTenant(() =>
       prisma.authUser.create({
         data: {
@@ -852,8 +848,8 @@ describeDatabase("registration against a real database", () => {
     });
 
     class FirstRegistrationPausingUserRepo extends PrismaUserRepo {
-      override async lockAuthUserCompanyIdForRegistrationUnscoped(userId: string) {
-        const companyId = await super.lockAuthUserCompanyIdForRegistrationUnscoped(userId);
+      override async findAuthUserCompanyIdForUpdateUnscoped(userId: string) {
+        const companyId = await super.findAuthUserCompanyIdForUpdateUnscoped(userId);
         const [connection] = await this.prisma.$queryRaw<Array<{ pid: number }>>`
           SELECT pg_backend_pid() AS pid
         `;
@@ -872,15 +868,14 @@ describeDatabase("registration against a real database", () => {
       agreeToTerms: true,
       avatarUrl: null,
     };
-    const registrationTarget = {
-      target: { type: "invitation" as const, companyId: invitedWorkspaceAdmin.companyId },
-    };
+    const registrationTarget = { target: { type: "createCompany" as const } };
     const authService = { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never;
     const firstRegistration = new RegisterUserInteractor(
       authService,
       new FirstRegistrationPausingUserRepo(),
       newEventService(),
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     ).invoke(registrationData, registrationTarget);
 
     const blockerPid = await authUserLocked;
@@ -889,6 +884,7 @@ describeDatabase("registration against a real database", () => {
       new PrismaUserRepo(),
       newEventService(),
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     ).invoke(registrationData, registrationTarget);
 
     const secondRegistrationBlocked = await waitForBlockedDatabaseSession(blockerPid);
@@ -896,24 +892,21 @@ describeDatabase("registration against a real database", () => {
 
     const [firstResult, secondResult] = await Promise.all([firstRegistration, secondRegistration]);
     expect(secondRegistrationBlocked).toBe(true);
-    expect(firstResult).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
-    expect(secondResult).toEqual({ redirect: "/auth/pending" });
+    expect(firstResult).toEqual({ ok: true, data: { redirectTo: "/onboarding/wizard" } });
+    expect(secondResult).toEqual({ redirect: "/onboarding/wizard" });
 
     await runWithoutTenant(async () => {
       expect(await prisma.user.count({ where: { email: invitedEmail } })).toBe(1);
-      expect(
-        await prisma.user.count({
-          where: { email: invitedEmail, companyId: invitedWorkspaceAdmin.companyId },
-        }),
-      ).toBe(1);
       expect(
         await prisma.company.count({
           where: { users: { some: { email: invitedEmail } } },
         }),
       ).toBe(1);
+      const user = await prisma.user.findUniqueOrThrow({ where: { email: invitedEmail }, select: { companyId: true } });
+      companyIds.push(user.companyId);
       expect(
         await prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
-      ).toEqual({ companyId: invitedWorkspaceAdmin.companyId });
+      ).toEqual({ companyId: user.companyId });
     });
   });
 
@@ -966,8 +959,8 @@ describeDatabase("registration against a real database", () => {
     });
 
     class LockPausingUserRepo extends PrismaUserRepo {
-      override async lockAuthUserCompanyIdForRegistrationUnscoped(userId: string) {
-        const companyId = await super.lockAuthUserCompanyIdForRegistrationUnscoped(userId);
+      override async findAuthUserCompanyIdForUpdateUnscoped(userId: string) {
+        const companyId = await super.findAuthUserCompanyIdForUpdateUnscoped(userId);
         const [connection] = await this.prisma.$queryRaw<Array<{ pid: number }>>`
           SELECT pg_backend_pid() AS pid
         `;
@@ -983,6 +976,7 @@ describeDatabase("registration against a real database", () => {
       new LockPausingUserRepo(),
       newEventService(),
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+      new PrismaCompanyRepo(),
     ).invoke(
       {
         email: invitedEmail,
@@ -1186,6 +1180,7 @@ describeDatabase("registration against a real database", () => {
       new PrismaUserRepo(),
       eventService,
       unregisteredRouteGuardService(authUserId, rollbackEmail) as never,
+      new PrismaCompanyRepo(),
     );
 
     await expect(

--- a/features/user/__tests__/registration.database.test.ts
+++ b/features/user/__tests__/registration.database.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { describe, it, expect, afterAll, vi } from "vitest";
 
 import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
@@ -44,10 +46,34 @@ const { currentLegalDocumentVersions } = await import("@/constants/legal-documen
 const { prisma } = await import("@/prisma/db");
 const { runWithTenant, runWithoutTenant } = await import("@/core/decorators/tenant-context");
 const { runInTransaction } = await import("@/core/decorators/transaction-runner");
+const { runWithOperator } = await import("@/core/decorators/operator-context");
+const { PrismaOperatorRepo } = await import("@/ee/operator/prisma-operator.repository");
 
 const email = `real-db-check-${Date.now()}@example.com`;
 const companyIds: string[] = [];
 const authUserIds: string[] = [];
+const operatorActorIds: string[] = [];
+
+async function hasBlockedDatabaseSession(blockerPid: number): Promise<boolean> {
+  const [row] = await prisma.$queryRaw<Array<{ blocked: boolean }>>`
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_stat_activity activity
+      WHERE ${blockerPid} = ANY(pg_blocking_pids(activity.pid))
+    ) AS blocked
+  `;
+
+  return Boolean(row?.blocked);
+}
+
+async function waitForBlockedDatabaseSession(blockerPid: number): Promise<boolean> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (await hasBlockedDatabaseSession(blockerPid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  return false;
+}
 
 function unregisteredRouteGuardService(id: string, sessionEmail: string) {
   return {
@@ -67,10 +93,30 @@ function unregisteredRouteGuardService(id: string, sessionEmail: string) {
   };
 }
 
+function newEventService() {
+  return new EventService(
+    [],
+    {
+      getWebhooksForEvent: vi.fn().mockResolvedValue([]),
+      getWebhooksForEventUnscoped: vi.fn().mockResolvedValue([]),
+    },
+    {
+      create: vi.fn().mockResolvedValue([]),
+      createUnscoped: vi.fn().mockResolvedValue([]),
+    },
+    new PrismaAuditLogRepo(),
+    { dispatch: vi.fn().mockResolvedValue(undefined) } as never,
+  );
+}
+
 afterAll(async () => {
+  await runWithoutTenant(() =>
+    prisma.operatorAuditEvent.deleteMany({ where: { actorUserId: { in: operatorActorIds } } }),
+  );
   for (const authUserId of authUserIds)
-    await runWithoutTenant(() => prisma.authUser.delete({ where: { id: authUserId } }));
-  for (const companyId of companyIds) await runWithoutTenant(() => prisma.company.delete({ where: { id: companyId } }));
+    await runWithoutTenant(() => prisma.authUser.deleteMany({ where: { id: authUserId } }));
+  for (const companyId of companyIds)
+    await runWithoutTenant(() => prisma.company.deleteMany({ where: { id: companyId } }));
   await prisma.$disconnect();
 });
 
@@ -239,6 +285,12 @@ describeDatabase("registration against a real database", () => {
     const authService = {
       sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined),
     };
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: { id: authUserId, name: "Legal Evidence", email: registrationEmail, companyId: null },
+      }),
+    );
+    authUserIds.push(authUserId);
     const eventService = new EventService(
       [],
       {
@@ -259,14 +311,17 @@ describeDatabase("registration against a real database", () => {
       unregisteredRouteGuardService(authUserId, registrationEmail) as never,
     );
 
-    const result = await interactor.invoke({
-      email: registrationEmail,
-      firstName: "Legal",
-      lastName: "Evidence",
-      country: "de",
-      agreeToTerms: true,
-      avatarUrl: null,
-    });
+    const result = await interactor.invoke(
+      {
+        email: registrationEmail,
+        firstName: "Legal",
+        lastName: "Evidence",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "createCompany" } },
+    );
     expect(result).toEqual({
       ok: true,
       data: { redirectTo: "/onboarding/wizard" },
@@ -274,6 +329,11 @@ describeDatabase("registration against a real database", () => {
 
     const user = await runWithoutTenant(() => prisma.user.findUniqueOrThrow({ where: { email: registrationEmail } }));
     companyIds.push(user.companyId);
+    expect(
+      await runWithoutTenant(() =>
+        prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ),
+    ).toEqual({ companyId: user.companyId });
     const acceptance = await runWithoutTenant(() =>
       prisma.auditLog.findFirstOrThrow({
         where: {
@@ -407,14 +467,17 @@ describeDatabase("registration against a real database", () => {
       unregisteredRouteGuardService(authUserId, invitedEmail) as never,
     );
 
-    const result = await interactor.invoke({
-      email: "forged-invited-email@example.com",
-      firstName: "Invited",
-      lastName: "Member",
-      country: "de",
-      agreeToTerms: true,
-      avatarUrl: null,
-    });
+    const result = await interactor.invoke(
+      {
+        email: "forged-invited-email@example.com",
+        firstName: "Invited",
+        lastName: "Member",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "legacyAuthBinding" } },
+    );
     expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
 
     const invitedUser = await runWithoutTenant(() =>
@@ -438,6 +501,539 @@ describeDatabase("registration against a real database", () => {
         }),
       ),
     ).toBe(0);
+  });
+
+  it("joins the invited workspace when the identity carries no company of its own", async () => {
+    const suffix = `${Date.now()}-cookie`;
+    const repo = new PrismaUserRepo();
+    const inviter = await runWithoutTenant(() =>
+      repo.createCompanyAndUser({
+        email: `cookie-admin-${suffix}@example.com`,
+        firstName: "Cookie",
+        lastName: "Admin",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    companyIds.push(inviter.companyId);
+
+    const authUserId = `auth-cookie-${suffix}`;
+    const invitedEmail = `cookie-member-${suffix}@example.com`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: { id: authUserId, name: "Cookie Member", email: invitedEmail, companyId: null },
+      }),
+    );
+    authUserIds.push(authUserId);
+
+    const interactor = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      repo,
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+    );
+
+    const result = await interactor.invoke(
+      {
+        email: invitedEmail,
+        firstName: "Cookie",
+        lastName: "Member",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "invitation", companyId: inviter.companyId } },
+    );
+    expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
+
+    const joined = await runWithoutTenant(() =>
+      prisma.user.findUniqueOrThrow({
+        where: { email: invitedEmail },
+        select: { companyId: true, status: true },
+      }),
+    );
+    expect(joined).toEqual({ companyId: inviter.companyId, status: "pendingAuthorization" });
+    expect(
+      await runWithoutTenant(() =>
+        prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ),
+    ).toEqual({ companyId: inviter.companyId });
+    expect(
+      await runWithoutTenant(() =>
+        prisma.company.count({
+          where: { id: { not: inviter.companyId }, users: { some: { email: invitedEmail } } },
+        }),
+      ),
+    ).toBe(0);
+  });
+
+  it("ignores an identity company that no longer exists and joins the invited workspace instead", async () => {
+    const suffix = `${Date.now()}-stale`;
+    const repo = new PrismaUserRepo();
+    const inviter = await runWithoutTenant(() =>
+      repo.createCompanyAndUser({
+        email: `stale-admin-${suffix}@example.com`,
+        firstName: "Stale",
+        lastName: "Admin",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    companyIds.push(inviter.companyId);
+
+    const deletedCompany = await runWithoutTenant(() => prisma.company.create({ data: {} }));
+    const authUserId = `auth-stale-${suffix}`;
+    const invitedEmail = `stale-member-${suffix}@example.com`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: { id: authUserId, name: "Stale Member", email: invitedEmail, companyId: deletedCompany.id },
+      }),
+    );
+    authUserIds.push(authUserId);
+    await runWithoutTenant(() => prisma.company.delete({ where: { id: deletedCompany.id } }));
+
+    expect(await runWithoutTenant(() => repo.findAuthUserCompanyIdUnscoped(authUserId))).toBeNull();
+
+    const interactor = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      repo,
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+    );
+
+    const result = await interactor.invoke(
+      {
+        email: invitedEmail,
+        firstName: "Stale",
+        lastName: "Member",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "invitation", companyId: inviter.companyId } },
+    );
+    expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
+
+    const joined = await runWithoutTenant(() =>
+      prisma.user.findUniqueOrThrow({ where: { email: invitedEmail }, select: { companyId: true } }),
+    );
+    expect(joined.companyId).toBe(inviter.companyId);
+    expect(
+      await runWithoutTenant(() =>
+        prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ),
+    ).toEqual({ companyId: inviter.companyId });
+  });
+
+  it("fails cleanly when the invited workspace was deleted before registration", async () => {
+    const suffix = `${Date.now()}-deleted-invite`;
+    const deletedCompany = await runWithoutTenant(() => prisma.company.create({ data: {} }));
+    await runWithoutTenant(() => prisma.company.delete({ where: { id: deletedCompany.id } }));
+
+    const authUserId = `auth-${suffix}`;
+    const registrationEmail = `deleted-invite-${suffix}@example.com`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: { id: authUserId, name: "Deleted Invite", email: registrationEmail, companyId: null },
+      }),
+    );
+    authUserIds.push(authUserId);
+    const interactor = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      new PrismaUserRepo(),
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, registrationEmail) as never,
+    );
+
+    await expect(
+      interactor.invoke(
+        {
+          email: registrationEmail,
+          firstName: "Deleted",
+          lastName: "Invite",
+          country: "de",
+          agreeToTerms: true,
+          avatarUrl: null,
+        },
+        { target: { type: "invitation", companyId: deletedCompany.id } },
+      ),
+    ).resolves.toEqual({ redirect: "/auth/error?type=invalidInviteLink" });
+    expect(await runWithoutTenant(() => prisma.user.findUnique({ where: { email: registrationEmail } }))).toBeNull();
+    expect(
+      await runWithoutTenant(() =>
+        prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ),
+    ).toEqual({ companyId: null });
+  });
+
+  it("creates nothing without an invitation or explicit create decision", async () => {
+    const suffix = `${Date.now()}-no-decision`;
+    const authUserId = `auth-${suffix}`;
+    const registrationEmail = `no-decision-${suffix}@example.com`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: { id: authUserId, name: "No Decision", email: registrationEmail, companyId: null },
+      }),
+    );
+    authUserIds.push(authUserId);
+
+    const interactor = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      new PrismaUserRepo(),
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, registrationEmail) as never,
+    );
+
+    const result = await interactor.invoke(
+      {
+        email: registrationEmail,
+        firstName: "No",
+        lastName: "Decision",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "legacyAuthBinding" } },
+    );
+
+    expect(result).toEqual({ redirect: "/onboarding" });
+    expect(await runWithoutTenant(() => prisma.user.findUnique({ where: { email: registrationEmail } }))).toBeNull();
+  });
+
+  it("creates nothing when a cached session references a deleted AuthUser", async () => {
+    const suffix = `${Date.now()}-deleted-identity`;
+    const repo = new PrismaUserRepo();
+    const inviter = await runWithoutTenant(() =>
+      repo.createCompanyAndUser({
+        email: `deleted-identity-admin-${suffix}@example.com`,
+        firstName: "Deleted Identity",
+        lastName: "Admin",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    companyIds.push(inviter.companyId);
+
+    const missingAuthUserId = `auth-${suffix}`;
+    const registrationEmail = `deleted-identity-member-${suffix}@example.com`;
+    const interactor = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      repo,
+      newEventService(),
+      unregisteredRouteGuardService(missingAuthUserId, registrationEmail) as never,
+    );
+
+    const result = await interactor.invoke(
+      {
+        email: registrationEmail,
+        firstName: "Deleted",
+        lastName: "Identity",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "invitation", companyId: inviter.companyId } },
+    );
+
+    expect(result).toEqual({ redirect: "/auth/signup" });
+    expect(await runWithoutTenant(() => prisma.user.findUnique({ where: { email: registrationEmail } }))).toBeNull();
+  });
+
+  it("prefers the current invitation over an older live identity binding", async () => {
+    const suffix = `${Date.now()}-invite-precedence`;
+    const repo = new PrismaUserRepo();
+    const olderWorkspaceAdmin = await runWithoutTenant(() =>
+      repo.createCompanyAndUser({
+        email: `older-admin-${suffix}@example.com`,
+        firstName: "Older",
+        lastName: "Admin",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    const currentWorkspaceAdmin = await runWithoutTenant(() =>
+      repo.createCompanyAndUser({
+        email: `current-admin-${suffix}@example.com`,
+        firstName: "Current",
+        lastName: "Admin",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    companyIds.push(olderWorkspaceAdmin.companyId, currentWorkspaceAdmin.companyId);
+
+    const authUserId = `auth-${suffix}`;
+    const invitedEmail = `precedence-member-${suffix}@example.com`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: {
+          id: authUserId,
+          name: "Precedence Member",
+          email: invitedEmail,
+          companyId: olderWorkspaceAdmin.companyId,
+        },
+      }),
+    );
+    authUserIds.push(authUserId);
+
+    const interactor = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      repo,
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+    );
+
+    const result = await interactor.invoke(
+      {
+        email: invitedEmail,
+        firstName: "Precedence",
+        lastName: "Member",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "invitation", companyId: currentWorkspaceAdmin.companyId } },
+    );
+
+    expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
+    expect(
+      await runWithoutTenant(() =>
+        prisma.user.findUniqueOrThrow({ where: { email: invitedEmail }, select: { companyId: true, status: true } }),
+      ),
+    ).toEqual({ companyId: currentWorkspaceAdmin.companyId, status: "pendingAuthorization" });
+    expect(
+      await runWithoutTenant(() =>
+        prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ),
+    ).toEqual({ companyId: currentWorkspaceAdmin.companyId });
+  });
+
+  it("makes simultaneous invitation registrations for one identity idempotent", async () => {
+    const suffix = randomUUID();
+    const setupRepo = new PrismaUserRepo();
+    const invitedWorkspaceAdmin = await runWithoutTenant(() =>
+      setupRepo.createCompanyAndUser({
+        email: `duplicate-target-${suffix}@duplicate-target.invalid`,
+        firstName: "Duplicate",
+        lastName: "Target",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    companyIds.push(invitedWorkspaceAdmin.companyId);
+
+    const authUserId = `auth-duplicate-${suffix}`;
+    const invitedEmail = `duplicate-member-${suffix}@example.invalid`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: {
+          id: authUserId,
+          name: "Duplicate Member",
+          email: invitedEmail,
+          companyId: null,
+        },
+      }),
+    );
+    authUserIds.push(authUserId);
+
+    let reportLocked!: (pid: number) => void;
+    const authUserLocked = new Promise<number>((resolve) => {
+      reportLocked = resolve;
+    });
+    let releaseFirstRegistration!: () => void;
+    const firstRegistrationReleased = new Promise<void>((resolve) => {
+      releaseFirstRegistration = resolve;
+    });
+
+    class FirstRegistrationPausingUserRepo extends PrismaUserRepo {
+      override async lockAuthUserCompanyIdForRegistrationUnscoped(userId: string) {
+        const companyId = await super.lockAuthUserCompanyIdForRegistrationUnscoped(userId);
+        const [connection] = await this.prisma.$queryRaw<Array<{ pid: number }>>`
+          SELECT pg_backend_pid() AS pid
+        `;
+        if (!connection) throw new Error("Registration transaction has no database connection");
+        reportLocked(connection.pid);
+        await firstRegistrationReleased;
+        return companyId;
+      }
+    }
+
+    const registrationData = {
+      email: invitedEmail,
+      firstName: "Duplicate",
+      lastName: "Member",
+      country: "de" as const,
+      agreeToTerms: true,
+      avatarUrl: null,
+    };
+    const registrationTarget = {
+      target: { type: "invitation" as const, companyId: invitedWorkspaceAdmin.companyId },
+    };
+    const authService = { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never;
+    const firstRegistration = new RegisterUserInteractor(
+      authService,
+      new FirstRegistrationPausingUserRepo(),
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+    ).invoke(registrationData, registrationTarget);
+
+    const blockerPid = await authUserLocked;
+    const secondRegistration = new RegisterUserInteractor(
+      authService,
+      new PrismaUserRepo(),
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+    ).invoke(registrationData, registrationTarget);
+
+    const secondRegistrationBlocked = await waitForBlockedDatabaseSession(blockerPid);
+    releaseFirstRegistration();
+
+    const [firstResult, secondResult] = await Promise.all([firstRegistration, secondRegistration]);
+    expect(secondRegistrationBlocked).toBe(true);
+    expect(firstResult).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
+    expect(secondResult).toEqual({ redirect: "/auth/pending" });
+
+    await runWithoutTenant(async () => {
+      expect(await prisma.user.count({ where: { email: invitedEmail } })).toBe(1);
+      expect(
+        await prisma.user.count({
+          where: { email: invitedEmail, companyId: invitedWorkspaceAdmin.companyId },
+        }),
+      ).toBe(1);
+      expect(
+        await prisma.company.count({
+          where: { users: { some: { email: invitedEmail } } },
+        }),
+      ).toBe(1);
+      expect(
+        await prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ).toEqual({ companyId: invitedWorkspaceAdmin.companyId });
+    });
+  });
+
+  it("keeps the invited workspace binding when operator deletion races with registration", async () => {
+    const suffix = randomUUID();
+    const setupRepo = new PrismaUserRepo();
+    const deletedWorkspaceAdmin = await runWithoutTenant(() =>
+      setupRepo.createCompanyAndUser({
+        email: `race-source-${suffix}@race-source.invalid`,
+        firstName: "Race",
+        lastName: "Source",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    const invitedWorkspaceAdmin = await runWithoutTenant(() =>
+      setupRepo.createCompanyAndUser({
+        email: `race-target-${suffix}@race-target.invalid`,
+        firstName: "Race",
+        lastName: "Target",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      }),
+    );
+    companyIds.push(deletedWorkspaceAdmin.companyId, invitedWorkspaceAdmin.companyId);
+
+    const authUserId = `auth-race-${suffix}`;
+    const invitedEmail = `race-member-${suffix}@example.invalid`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: {
+          id: authUserId,
+          name: "Race Member",
+          email: invitedEmail,
+          companyId: deletedWorkspaceAdmin.companyId,
+        },
+      }),
+    );
+    authUserIds.push(authUserId);
+
+    let reportLocked!: (pid: number) => void;
+    const authUserLocked = new Promise<number>((resolve) => {
+      reportLocked = resolve;
+    });
+    let releaseRegistration!: () => void;
+    const registrationReleased = new Promise<void>((resolve) => {
+      releaseRegistration = resolve;
+    });
+
+    class LockPausingUserRepo extends PrismaUserRepo {
+      override async lockAuthUserCompanyIdForRegistrationUnscoped(userId: string) {
+        const companyId = await super.lockAuthUserCompanyIdForRegistrationUnscoped(userId);
+        const [connection] = await this.prisma.$queryRaw<Array<{ pid: number }>>`
+          SELECT pg_backend_pid() AS pid
+        `;
+        if (!connection) throw new Error("Registration transaction has no database connection");
+        reportLocked(connection.pid);
+        await registrationReleased;
+        return companyId;
+      }
+    }
+
+    const registration = new RegisterUserInteractor(
+      { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,
+      new LockPausingUserRepo(),
+      newEventService(),
+      unregisteredRouteGuardService(authUserId, invitedEmail) as never,
+    ).invoke(
+      {
+        email: invitedEmail,
+        firstName: "Race",
+        lastName: "Member",
+        country: "de",
+        agreeToTerms: true,
+        avatarUrl: null,
+      },
+      { target: { type: "invitation", companyId: invitedWorkspaceAdmin.companyId } },
+    );
+
+    const blockerPid = await authUserLocked;
+    const actor = {
+      authUserId: `auth-operator-${suffix}`,
+      companyId: `operator-company-${suffix}`,
+      email: `operator-${suffix}@example.invalid`,
+      userId: `operator-${suffix}`,
+    };
+    operatorActorIds.push(actor.userId);
+    const deletion = runWithOperator(actor, () =>
+      new PrismaOperatorRepo().deleteWorkspaceUnscoped({
+        companyId: deletedWorkspaceAdmin.companyId,
+        confirmWorkspaceLabel: "race-source.invalid",
+        reason: "Concurrency regression",
+      }),
+    );
+
+    const operatorDeletionBlocked = await waitForBlockedDatabaseSession(blockerPid);
+    releaseRegistration();
+
+    const [registrationResult, deletionResult] = await Promise.all([registration, deletion]);
+    expect(operatorDeletionBlocked).toBe(true);
+    expect(registrationResult).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
+    expect(deletionResult).toMatchObject({
+      companyId: deletedWorkspaceAdmin.companyId,
+      deletedMemberCount: 1,
+    });
+
+    await runWithoutTenant(async () => {
+      expect(await prisma.company.findUnique({ where: { id: deletedWorkspaceAdmin.companyId } })).toBeNull();
+      expect(
+        await prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ).toEqual({ companyId: invitedWorkspaceAdmin.companyId });
+      expect(
+        await prisma.user.findUniqueOrThrow({
+          where: { email: invitedEmail },
+          select: { companyId: true, status: true },
+        }),
+      ).toEqual({ companyId: invitedWorkspaceAdmin.companyId, status: "pendingAuthorization" });
+    });
   });
 
   it("enforces and clears one company-wide deadline across an administrator and member", async () => {
@@ -559,6 +1155,12 @@ describeDatabase("registration against a real database", () => {
   it("rolls back the company, user, and queued acceptance evidence together", async () => {
     const rollbackEmail = `legal-rollback-${Date.now()}@example.com`;
     const authUserId = `auth-rollback-${Date.now()}`;
+    await runWithoutTenant(() =>
+      prisma.authUser.create({
+        data: { id: authUserId, name: "Rollback Check", email: rollbackEmail, companyId: null },
+      }),
+    );
+    authUserIds.push(authUserId);
     class FailingRegistrationListener extends DomainEventListener {
       readonly handlers = {
         [DomainEvent.USER_REGISTERED]: () => Promise.reject(new Error("forced registration rollback")),
@@ -587,17 +1189,25 @@ describeDatabase("registration against a real database", () => {
     );
 
     await expect(
-      interactor.invoke({
-        email: rollbackEmail,
-        firstName: "Rollback",
-        lastName: "Check",
-        country: "de",
-        agreeToTerms: true,
-        avatarUrl: null,
-      }),
+      interactor.invoke(
+        {
+          email: rollbackEmail,
+          firstName: "Rollback",
+          lastName: "Check",
+          country: "de",
+          agreeToTerms: true,
+          avatarUrl: null,
+        },
+        { target: { type: "createCompany" } },
+      ),
     ).rejects.toThrow("forced registration rollback");
 
     expect(await runWithoutTenant(() => prisma.user.findUnique({ where: { email: rollbackEmail } }))).toBeNull();
+    expect(
+      await runWithoutTenant(() =>
+        prisma.authUser.findUniqueOrThrow({ where: { id: authUserId }, select: { companyId: true } }),
+      ),
+    ).toEqual({ companyId: null });
     expect(
       await runWithoutTenant(() =>
         prisma.auditLog.count({

--- a/features/user/__tests__/registration.database.test.ts
+++ b/features/user/__tests__/registration.database.test.ts
@@ -598,7 +598,8 @@ describeDatabase("registration against a real database", () => {
     authUserIds.push(authUserId);
     await runWithoutTenant(() => prisma.company.delete({ where: { id: deletedCompany.id } }));
 
-    expect(await runWithoutTenant(() => repo.findAuthUserCompanyIdUnscoped(authUserId))).toBeNull();
+    expect(await runWithoutTenant(() => repo.findAuthUserCompanyIdUnscoped(authUserId))).toBe(deletedCompany.id);
+    expect(await runWithoutTenant(() => new PrismaCompanyRepo().existsUnscoped(deletedCompany.id))).toBe(false);
 
     const interactor = new RegisterUserInteractor(
       { sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined) } as never,

--- a/features/user/__tests__/user-interactors.test.ts
+++ b/features/user/__tests__/user-interactors.test.ts
@@ -40,6 +40,7 @@ describe("RegisterUserInteractor", () => {
   let mockRepo: any;
   let mockEventService: any;
   let mockRouteGuardService: any;
+  let mockCompanyRepo: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -51,8 +52,7 @@ describe("RegisterUserInteractor", () => {
     mockRepo = {
       bindAuthUserToCompanyOrThrowUnscoped: vi.fn().mockResolvedValue(undefined),
       findCurrentUserUnscoped: vi.fn().mockResolvedValue(null),
-      lockAuthUserCompanyIdForRegistrationUnscoped: vi.fn().mockResolvedValue(null),
-      lockCompanyForRegistrationUnscoped: vi.fn().mockResolvedValue(true),
+      findAuthUserCompanyIdForUpdateUnscoped: vi.fn().mockResolvedValue(null),
       peekAuthUserCompanyIdUnscoped: vi.fn().mockResolvedValue(null),
       createCompanyAndUser: vi.fn().mockResolvedValue(mockTenantUser),
       registerExistingCompany: vi.fn().mockResolvedValue(mockTenantUser),
@@ -75,10 +75,17 @@ describe("RegisterUserInteractor", () => {
         subscription: null,
       }),
     };
+    mockCompanyRepo = { existsUnscoped: vi.fn().mockResolvedValue(true) };
   });
 
   function createInteractor() {
-    return new RegisterUserInteractor(mockAuthService, mockRepo, mockEventService, mockRouteGuardService);
+    return new RegisterUserInteractor(
+      mockAuthService,
+      mockRepo,
+      mockEventService,
+      mockRouteGuardService,
+      mockCompanyRepo,
+    );
   }
 
   it("publishes USER_REGISTERED event for new company", async () => {
@@ -179,12 +186,12 @@ describe("RegisterUserInteractor", () => {
     expect(mockRepo.createCompanyAndUser).toHaveBeenCalledWith(expect.objectContaining({ adAttribution }));
 
     vi.clearAllMocks();
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue(mockTenantUser);
     mockEventService.publish.mockResolvedValue(undefined);
     mockAuthService.sendNewUserNotificationEmail.mockResolvedValue(undefined);
-    await createInteractor().invoke(data, { adAttribution, target: { type: "legacyAuthBinding" } });
+    await createInteractor().invoke(data, { adAttribution, target: { type: "existingAuthUserCompanyBinding" } });
 
     const existingCompanyArgs = mockRepo.registerExistingCompany.mock.calls[0]?.[0];
     expect(existingCompanyArgs).toEqual({ ...data, companyId: "existing-company-id" });
@@ -243,7 +250,7 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("publishes USER_REGISTERED with isNewCompany false for existing company", async () => {
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const interactor = createInteractor();
@@ -256,7 +263,7 @@ describe("RegisterUserInteractor", () => {
         avatarUrl: null,
         agreeToTerms: false,
       },
-      { target: { type: "legacyAuthBinding" } },
+      { target: { type: "existingAuthUserCompanyBinding" } },
     );
 
     expect(mockEventService.publish).toHaveBeenCalledWith(
@@ -276,7 +283,7 @@ describe("RegisterUserInteractor", () => {
 
   it("rejects an unchecked invited cloud user before updating records", async () => {
     mutableEnv.APP_MODE = "cloud";
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const result = await createInteractor().invoke(
@@ -288,7 +295,7 @@ describe("RegisterUserInteractor", () => {
         avatarUrl: null,
         agreeToTerms: false,
       },
-      { target: { type: "legacyAuthBinding" } },
+      { target: { type: "existingAuthUserCompanyBinding" } },
     );
 
     expect("ok" in result && result.ok).toBe(false);
@@ -298,7 +305,7 @@ describe("RegisterUserInteractor", () => {
 
   it("does not record managed-service acceptance for an invited cloud user", async () => {
     (MOCK_ENV_MODULE.env as { APP_MODE: "cloud" | "demo" | "self-hosted" }).APP_MODE = "cloud";
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const interactor = createInteractor();
@@ -311,7 +318,7 @@ describe("RegisterUserInteractor", () => {
         avatarUrl: null,
         agreeToTerms: true,
       },
-      { target: { type: "legacyAuthBinding" } },
+      { target: { type: "existingAuthUserCompanyBinding" } },
     );
 
     expect(mockRepo.registerExistingCompany).toHaveBeenCalledWith(
@@ -436,7 +443,7 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("returns the pending destination for an invited user", async () => {
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue({
       ...mockTenantUser,
@@ -452,7 +459,7 @@ describe("RegisterUserInteractor", () => {
         avatarUrl: null,
         agreeToTerms: true,
       },
-      { target: { type: "legacyAuthBinding" } },
+      { target: { type: "existingAuthUserCompanyBinding" } },
     );
 
     expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
@@ -469,7 +476,7 @@ describe("RegisterUserInteractor", () => {
           avatarUrl: null,
           agreeToTerms: true,
         },
-        { target: { type: "legacyAuthBinding" } },
+        { target: { type: "existingAuthUserCompanyBinding" } },
       ),
     ).resolves.toEqual({ redirect: "/onboarding" });
     expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
@@ -479,7 +486,7 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("fails closed when the cached session identity no longer exists", async () => {
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue(undefined);
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue(undefined);
 
     await expect(
       createInteractor().invoke(
@@ -527,7 +534,7 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("gives the current invitation precedence over an older live identity binding", async () => {
-    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("older-company-id");
+    mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("older-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue({
       ...mockTenantUser,
       status: "pendingAuthorization",
@@ -556,7 +563,7 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("fails cleanly when the invited workspace disappears before registration", async () => {
-    mockRepo.lockCompanyForRegistrationUnscoped.mockResolvedValue(false);
+    mockCompanyRepo.existsUnscoped.mockResolvedValue(false);
 
     await expect(
       createInteractor().invoke(
@@ -571,7 +578,7 @@ describe("RegisterUserInteractor", () => {
         { target: { type: "invitation", companyId: "deleted-company-id" } },
       ),
     ).resolves.toEqual({ redirect: "/auth/error?type=invalidInviteLink" });
-    expect(mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped).not.toHaveBeenCalled();
+    expect(mockRepo.findAuthUserCompanyIdForUpdateUnscoped).not.toHaveBeenCalled();
     expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
     expect(mockRepo.bindAuthUserToCompanyOrThrowUnscoped).not.toHaveBeenCalled();
   });
@@ -596,10 +603,10 @@ describe("RegisterUserInteractor", () => {
           avatarUrl: null,
           agreeToTerms: true,
         },
-        { target: { type: "legacyAuthBinding" } },
+        { target: { type: "existingAuthUserCompanyBinding" } },
       ),
     ).resolves.toEqual({ redirect: "/auth/signin" });
-    expect(mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped).not.toHaveBeenCalled();
+    expect(mockRepo.findAuthUserCompanyIdForUpdateUnscoped).not.toHaveBeenCalled();
     expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
     expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
     expect(mockEventService.publish).not.toHaveBeenCalled();
@@ -633,10 +640,10 @@ describe("RegisterUserInteractor", () => {
             avatarUrl: null,
             agreeToTerms: true,
           },
-          { target: { type: "legacyAuthBinding" } },
+          { target: { type: "existingAuthUserCompanyBinding" } },
         ),
       ).resolves.toEqual({ redirect: accountStateRedirect(state) ?? "/" });
-      expect(mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped).not.toHaveBeenCalled();
+      expect(mockRepo.findAuthUserCompanyIdForUpdateUnscoped).not.toHaveBeenCalled();
       expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
       expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
       expect(mockEventService.publish).not.toHaveBeenCalled();

--- a/features/user/__tests__/user-interactors.test.ts
+++ b/features/user/__tests__/user-interactors.test.ts
@@ -53,7 +53,7 @@ describe("RegisterUserInteractor", () => {
       bindAuthUserToCompanyOrThrowUnscoped: vi.fn().mockResolvedValue(undefined),
       findCurrentUserUnscoped: vi.fn().mockResolvedValue(null),
       findAuthUserCompanyIdForUpdateUnscoped: vi.fn().mockResolvedValue(null),
-      peekAuthUserCompanyIdUnscoped: vi.fn().mockResolvedValue(null),
+      findAuthUserCompanyIdUnscoped: vi.fn().mockResolvedValue(null),
       createCompanyAndUser: vi.fn().mockResolvedValue(mockTenantUser),
       registerExistingCompany: vi.fn().mockResolvedValue(mockTenantUser),
     };
@@ -187,7 +187,7 @@ describe("RegisterUserInteractor", () => {
 
     vi.clearAllMocks();
     mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
-    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue(mockTenantUser);
     mockEventService.publish.mockResolvedValue(undefined);
     mockAuthService.sendNewUserNotificationEmail.mockResolvedValue(undefined);
@@ -251,7 +251,7 @@ describe("RegisterUserInteractor", () => {
 
   it("publishes USER_REGISTERED with isNewCompany false for existing company", async () => {
     mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
-    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const interactor = createInteractor();
     await interactor.invoke(
@@ -284,7 +284,7 @@ describe("RegisterUserInteractor", () => {
   it("rejects an unchecked invited cloud user before updating records", async () => {
     mutableEnv.APP_MODE = "cloud";
     mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
-    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const result = await createInteractor().invoke(
       {
@@ -306,7 +306,7 @@ describe("RegisterUserInteractor", () => {
   it("does not record managed-service acceptance for an invited cloud user", async () => {
     (MOCK_ENV_MODULE.env as { APP_MODE: "cloud" | "demo" | "self-hosted" }).APP_MODE = "cloud";
     mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
-    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const interactor = createInteractor();
     await interactor.invoke(
@@ -444,7 +444,7 @@ describe("RegisterUserInteractor", () => {
 
   it("returns the pending destination for an invited user", async () => {
     mockRepo.findAuthUserCompanyIdForUpdateUnscoped.mockResolvedValue("existing-company-id");
-    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.findAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue({
       ...mockTenantUser,
       status: "pendingAuthorization",

--- a/features/user/__tests__/user-interactors.test.ts
+++ b/features/user/__tests__/user-interactors.test.ts
@@ -49,7 +49,11 @@ describe("RegisterUserInteractor", () => {
       sendNewUserNotificationEmail: vi.fn().mockResolvedValue(undefined),
     };
     mockRepo = {
-      findCompanyIdUnscoped: vi.fn().mockResolvedValue(null),
+      bindAuthUserToCompanyOrThrowUnscoped: vi.fn().mockResolvedValue(undefined),
+      findCurrentUserUnscoped: vi.fn().mockResolvedValue(null),
+      lockAuthUserCompanyIdForRegistrationUnscoped: vi.fn().mockResolvedValue(null),
+      lockCompanyForRegistrationUnscoped: vi.fn().mockResolvedValue(true),
+      peekAuthUserCompanyIdUnscoped: vi.fn().mockResolvedValue(null),
       createCompanyAndUser: vi.fn().mockResolvedValue(mockTenantUser),
       registerExistingCompany: vi.fn().mockResolvedValue(mockTenantUser),
     };
@@ -79,14 +83,17 @@ describe("RegisterUserInteractor", () => {
 
   it("publishes USER_REGISTERED event for new company", async () => {
     const interactor = createInteractor();
-    await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(mockEventService.publish).toHaveBeenCalledWith(
       DomainEvent.USER_REGISTERED,
@@ -99,19 +106,26 @@ describe("RegisterUserInteractor", () => {
         }),
       }),
     );
+    expect(mockRepo.bindAuthUserToCompanyOrThrowUnscoped).toHaveBeenCalledWith({
+      authUserId: USER_ID,
+      companyId: mockTenantUser.companyId,
+    });
   });
 
   it("records current company-wide legal acceptance for a new cloud company", async () => {
     (MOCK_ENV_MODULE.env as { APP_MODE: "cloud" | "demo" | "self-hosted" }).APP_MODE = "cloud";
     const interactor = createInteractor();
-    await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(mockRepo.createCompanyAndUser).toHaveBeenCalledWith(expect.objectContaining({ agreeToTerms: true }));
     expect(mockEventService.publish).toHaveBeenNthCalledWith(
@@ -161,15 +175,16 @@ describe("RegisterUserInteractor", () => {
       agreeToTerms: true,
     };
 
-    await createInteractor().invoke(data, { adAttribution });
+    await createInteractor().invoke(data, { adAttribution, target: { type: "createCompany" } });
     expect(mockRepo.createCompanyAndUser).toHaveBeenCalledWith(expect.objectContaining({ adAttribution }));
 
     vi.clearAllMocks();
-    mockRepo.findCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue(mockTenantUser);
     mockEventService.publish.mockResolvedValue(undefined);
     mockAuthService.sendNewUserNotificationEmail.mockResolvedValue(undefined);
-    await createInteractor().invoke(data, { adAttribution });
+    await createInteractor().invoke(data, { adAttribution, target: { type: "legacyAuthBinding" } });
 
     const existingCompanyArgs = mockRepo.registerExistingCompany.mock.calls[0]?.[0];
     expect(existingCompanyArgs).toEqual({ ...data, companyId: "existing-company-id" });
@@ -200,6 +215,7 @@ describe("RegisterUserInteractor", () => {
             expiresAt: new Date("2026-01-02T00:00:00.000Z"),
           },
         ],
+        target: { type: "createCompany" },
       },
     );
 
@@ -209,14 +225,17 @@ describe("RegisterUserInteractor", () => {
   it("rejects an unchecked new cloud company before creating records", async () => {
     (MOCK_ENV_MODULE.env as { APP_MODE: "cloud" | "demo" | "self-hosted" }).APP_MODE = "cloud";
 
-    const result = await createInteractor().invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: false,
-    });
+    const result = await createInteractor().invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: false,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect("ok" in result && result.ok).toBe(false);
     expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
@@ -224,17 +243,21 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("publishes USER_REGISTERED with isNewCompany false for existing company", async () => {
-    mockRepo.findCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const interactor = createInteractor();
-    await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: false,
-    });
+    await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: false,
+      },
+      { target: { type: "legacyAuthBinding" } },
+    );
 
     expect(mockEventService.publish).toHaveBeenCalledWith(
       DomainEvent.USER_REGISTERED,
@@ -253,16 +276,20 @@ describe("RegisterUserInteractor", () => {
 
   it("rejects an unchecked invited cloud user before updating records", async () => {
     mutableEnv.APP_MODE = "cloud";
-    mockRepo.findCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
-    const result = await createInteractor().invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: false,
-    });
+    const result = await createInteractor().invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: false,
+      },
+      { target: { type: "legacyAuthBinding" } },
+    );
 
     expect("ok" in result && result.ok).toBe(false);
     expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
@@ -271,17 +298,21 @@ describe("RegisterUserInteractor", () => {
 
   it("does not record managed-service acceptance for an invited cloud user", async () => {
     (MOCK_ENV_MODULE.env as { APP_MODE: "cloud" | "demo" | "self-hosted" }).APP_MODE = "cloud";
-    mockRepo.findCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
 
     const interactor = createInteractor();
-    await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "legacyAuthBinding" } },
+    );
 
     expect(mockRepo.registerExistingCompany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -294,28 +325,34 @@ describe("RegisterUserInteractor", () => {
 
   it("does not represent self-hosted onboarding as acceptance of the managed-service documents", async () => {
     const interactor = createInteractor();
-    await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: false,
-    });
+    await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: false,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(mockRepo.createCompanyAndUser).toHaveBeenCalledWith(expect.objectContaining({ agreeToTerms: false }));
     expect(mockEventService.publish).not.toHaveBeenCalledWith(DomainEvent.LEGAL_DOCUMENTS_ACCEPTED, expect.anything());
   });
 
   it("preserves a submitted self-hosted acknowledgement without creating managed-service acceptance", async () => {
-    await createInteractor().invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    await createInteractor().invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(mockRepo.createCompanyAndUser).toHaveBeenCalledWith(expect.objectContaining({ agreeToTerms: true }));
     expect(mockEventService.publish).not.toHaveBeenCalledWith(DomainEvent.LEGAL_DOCUMENTS_ACCEPTED, expect.anything());
@@ -325,14 +362,17 @@ describe("RegisterUserInteractor", () => {
     (MOCK_ENV_MODULE.env as { APP_MODE: "cloud" | "demo" | "self-hosted" }).APP_MODE = "demo";
 
     expect(() =>
-      createInteractor().invoke({
-        email: "jane@example.com",
-        firstName: "Jane",
-        lastName: "Doe",
-        country: "de",
-        avatarUrl: null,
-        agreeToTerms: true,
-      }),
+      createInteractor().invoke(
+        {
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          country: "de",
+          avatarUrl: null,
+          agreeToTerms: true,
+        },
+        { target: { type: "createCompany" } },
+      ),
     ).toThrow(DemoModeError);
 
     expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
@@ -341,14 +381,17 @@ describe("RegisterUserInteractor", () => {
 
   it("calls authService.sendNewUserNotificationEmail", async () => {
     const interactor = createInteractor();
-    await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(mockAuthService.sendNewUserNotificationEmail).toHaveBeenCalledWith({
       email: "jane@example.com",
@@ -358,28 +401,34 @@ describe("RegisterUserInteractor", () => {
 
   it("returns the onboarding destination for a new active administrator", async () => {
     const interactor = createInteractor();
-    const result: any = await interactor.invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    const result: any = await interactor.invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(result.ok).toBe(true);
     expect(result.data).toEqual({ redirectTo: "/onboarding/wizard" });
   });
 
   it("uses the authenticated email instead of a forged submitted email", async () => {
-    const result: any = await createInteractor().invoke({
-      email: "not-an-email",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    const result: any = await createInteractor().invoke(
+      {
+        email: "not-an-email",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "createCompany" } },
+    );
 
     expect(result).toMatchObject({ ok: true });
     expect(mockRepo.createCompanyAndUser).toHaveBeenCalledWith(expect.objectContaining({ email: "jane@example.com" }));
@@ -387,22 +436,144 @@ describe("RegisterUserInteractor", () => {
   });
 
   it("returns the pending destination for an invited user", async () => {
-    mockRepo.findCompanyIdUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("existing-company-id");
+    mockRepo.peekAuthUserCompanyIdUnscoped.mockResolvedValue("existing-company-id");
     mockRepo.registerExistingCompany.mockResolvedValue({
       ...mockTenantUser,
       status: "pendingAuthorization",
     });
 
-    const result: any = await createInteractor().invoke({
-      email: "jane@example.com",
-      firstName: "Jane",
-      lastName: "Doe",
-      country: "de",
-      avatarUrl: null,
-      agreeToTerms: true,
-    });
+    const result: any = await createInteractor().invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "legacyAuthBinding" } },
+    );
 
     expect(result).toEqual({ ok: true, data: { redirectTo: "/auth/pending" } });
+  });
+
+  it("requires an explicit create decision when no workspace invitation exists", async () => {
+    await expect(
+      createInteractor().invoke(
+        {
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          country: "de",
+          avatarUrl: null,
+          agreeToTerms: true,
+        },
+        { target: { type: "legacyAuthBinding" } },
+      ),
+    ).resolves.toEqual({ redirect: "/onboarding" });
+    expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
+    expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
+    expect(mockEventService.publish).not.toHaveBeenCalled();
+    expect(mockAuthService.sendNewUserNotificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the cached session identity no longer exists", async () => {
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue(undefined);
+
+    await expect(
+      createInteractor().invoke(
+        {
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          country: "de",
+          avatarUrl: null,
+          agreeToTerms: true,
+        },
+        { target: { type: "invitation", companyId: "invited-company-id" } },
+      ),
+    ).resolves.toEqual({ redirect: "/auth/signup" });
+    expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
+    expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
+    expect(mockEventService.publish).not.toHaveBeenCalled();
+    expect(mockAuthService.sendNewUserNotificationEmail).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["pendingAuthorization", "/auth/pending"],
+    ["active", "/onboarding/wizard"],
+    ["inactive", "/auth/error?type=inactiveUser"],
+  ] as const)("makes a repeated registration for an existing %s user idempotent", async (status, redirect) => {
+    mockRepo.findCurrentUserUnscoped.mockResolvedValue({ ...mockTenantUser, status });
+
+    await expect(
+      createInteractor().invoke(
+        {
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          country: "de",
+          avatarUrl: null,
+          agreeToTerms: true,
+        },
+        { target: { type: "invitation", companyId: "invited-company-id" } },
+      ),
+    ).resolves.toEqual({ redirect });
+    expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
+    expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
+    expect(mockRepo.bindAuthUserToCompanyOrThrowUnscoped).not.toHaveBeenCalled();
+    expect(mockEventService.publish).not.toHaveBeenCalled();
+  });
+
+  it("gives the current invitation precedence over an older live identity binding", async () => {
+    mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped.mockResolvedValue("older-company-id");
+    mockRepo.registerExistingCompany.mockResolvedValue({
+      ...mockTenantUser,
+      status: "pendingAuthorization",
+    });
+
+    await createInteractor().invoke(
+      {
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        country: "de",
+        avatarUrl: null,
+        agreeToTerms: true,
+      },
+      { target: { type: "invitation", companyId: "current-invited-company-id" } },
+    );
+
+    expect(mockRepo.registerExistingCompany).toHaveBeenCalledWith(
+      expect.objectContaining({ companyId: "current-invited-company-id" }),
+    );
+    expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
+    expect(mockRepo.bindAuthUserToCompanyOrThrowUnscoped).toHaveBeenCalledWith({
+      authUserId: USER_ID,
+      companyId: mockTenantUser.companyId,
+    });
+  });
+
+  it("fails cleanly when the invited workspace disappears before registration", async () => {
+    mockRepo.lockCompanyForRegistrationUnscoped.mockResolvedValue(false);
+
+    await expect(
+      createInteractor().invoke(
+        {
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          country: "de",
+          avatarUrl: null,
+          agreeToTerms: true,
+        },
+        { target: { type: "invitation", companyId: "deleted-company-id" } },
+      ),
+    ).resolves.toEqual({ redirect: "/auth/error?type=invalidInviteLink" });
+    expect(mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped).not.toHaveBeenCalled();
+    expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
+    expect(mockRepo.bindAuthUserToCompanyOrThrowUnscoped).not.toHaveBeenCalled();
   });
 
   it("rejects a missing authenticated session before any write", async () => {
@@ -416,16 +587,19 @@ describe("RegisterUserInteractor", () => {
     });
 
     await expect(
-      createInteractor().invoke({
-        email: "jane@example.com",
-        firstName: "Jane",
-        lastName: "Doe",
-        country: "de",
-        avatarUrl: null,
-        agreeToTerms: true,
-      }),
+      createInteractor().invoke(
+        {
+          email: "jane@example.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          country: "de",
+          avatarUrl: null,
+          agreeToTerms: true,
+        },
+        { target: { type: "legacyAuthBinding" } },
+      ),
     ).resolves.toEqual({ redirect: "/auth/signin" });
-    expect(mockRepo.findCompanyIdUnscoped).not.toHaveBeenCalled();
+    expect(mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped).not.toHaveBeenCalled();
     expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
     expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
     expect(mockEventService.publish).not.toHaveBeenCalled();
@@ -450,16 +624,19 @@ describe("RegisterUserInteractor", () => {
       });
 
       await expect(
-        createInteractor().invoke({
-          email: "jane@example.com",
-          firstName: "Jane",
-          lastName: "Doe",
-          country: "de",
-          avatarUrl: null,
-          agreeToTerms: true,
-        }),
+        createInteractor().invoke(
+          {
+            email: "jane@example.com",
+            firstName: "Jane",
+            lastName: "Doe",
+            country: "de",
+            avatarUrl: null,
+            agreeToTerms: true,
+          },
+          { target: { type: "legacyAuthBinding" } },
+        ),
       ).resolves.toEqual({ redirect: accountStateRedirect(state) ?? "/" });
-      expect(mockRepo.findCompanyIdUnscoped).not.toHaveBeenCalled();
+      expect(mockRepo.lockAuthUserCompanyIdForRegistrationUnscoped).not.toHaveBeenCalled();
       expect(mockRepo.createCompanyAndUser).not.toHaveBeenCalled();
       expect(mockRepo.registerExistingCompany).not.toHaveBeenCalled();
       expect(mockEventService.publish).not.toHaveBeenCalled();

--- a/features/user/prisma-user.repository.ts
+++ b/features/user/prisma-user.repository.ts
@@ -512,13 +512,47 @@ export class PrismaUserRepo
   }
 
   @BypassTenantGuard
-  async findCompanyIdUnscoped(userId: string) {
+  async peekAuthUserCompanyIdUnscoped(userId: string) {
     const authUser = await this.prisma.authUser.findUnique({
       where: { id: userId },
       select: { companyId: true },
     });
+    return authUser?.companyId;
+  }
 
-    return authUser?.companyId ?? null;
+  @BypassTenantGuard
+  async lockCompanyForRegistrationUnscoped(companyId: string) {
+    await this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${companyId}, 0))`;
+    const company = await this.prisma.company.findUnique({ where: { id: companyId }, select: { id: true } });
+    return Boolean(company);
+  }
+
+  @BypassTenantGuard
+  async findAuthUserCompanyIdUnscoped(userId: string) {
+    const authUser = await this.prisma.authUser.findUnique({
+      where: { id: userId },
+      select: { companyId: true },
+    });
+    if (!authUser) return undefined;
+    if (!authUser.companyId) return null;
+
+    const company = await this.prisma.company.findUnique({
+      where: { id: authUser.companyId },
+      select: { id: true },
+    });
+
+    return company?.id ?? null;
+  }
+
+  @BypassTenantGuard
+  async lockAuthUserCompanyIdForRegistrationUnscoped(userId: string) {
+    const [authUser] = await this.prisma.$queryRaw<Array<{ companyId: string | null }>>`
+      SELECT "companyId"
+      FROM "AuthUser"
+      WHERE id = ${userId}
+      FOR UPDATE
+    `;
+    return authUser?.companyId;
   }
 
   @BypassTenantGuard
@@ -712,6 +746,14 @@ export class PrismaUserRepo
         where: { id: userId, companyId },
         data: { status: Status.inactive, agentCreditActivatedAt: null },
       });
+    });
+  }
+
+  @BypassTenantGuard
+  async bindAuthUserToCompanyOrThrowUnscoped(args: { authUserId: string; companyId: string }) {
+    await this.prisma.authUser.update({
+      where: { id: args.authUserId },
+      data: { companyId: args.companyId },
     });
   }
 }

--- a/features/user/prisma-user.repository.ts
+++ b/features/user/prisma-user.repository.ts
@@ -521,13 +521,6 @@ export class PrismaUserRepo
   }
 
   @BypassTenantGuard
-  async lockCompanyForRegistrationUnscoped(companyId: string) {
-    await this.prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${companyId}, 0))`;
-    const company = await this.prisma.company.findUnique({ where: { id: companyId }, select: { id: true } });
-    return Boolean(company);
-  }
-
-  @BypassTenantGuard
   async findAuthUserCompanyIdUnscoped(userId: string) {
     const authUser = await this.prisma.authUser.findUnique({
       where: { id: userId },
@@ -545,7 +538,7 @@ export class PrismaUserRepo
   }
 
   @BypassTenantGuard
-  async lockAuthUserCompanyIdForRegistrationUnscoped(userId: string) {
+  async findAuthUserCompanyIdForUpdateUnscoped(userId: string) {
     const [authUser] = await this.prisma.$queryRaw<Array<{ companyId: string | null }>>`
       SELECT "companyId"
       FROM "AuthUser"

--- a/features/user/prisma-user.repository.ts
+++ b/features/user/prisma-user.repository.ts
@@ -512,29 +512,12 @@ export class PrismaUserRepo
   }
 
   @BypassTenantGuard
-  async peekAuthUserCompanyIdUnscoped(userId: string) {
-    const authUser = await this.prisma.authUser.findUnique({
-      where: { id: userId },
-      select: { companyId: true },
-    });
-    return authUser?.companyId;
-  }
-
-  @BypassTenantGuard
   async findAuthUserCompanyIdUnscoped(userId: string) {
     const authUser = await this.prisma.authUser.findUnique({
       where: { id: userId },
       select: { companyId: true },
     });
-    if (!authUser) return undefined;
-    if (!authUser.companyId) return null;
-
-    const company = await this.prisma.company.findUnique({
-      where: { id: authUser.companyId },
-      select: { id: true },
-    });
-
-    return company?.id ?? null;
+    return authUser?.companyId;
   }
 
   @BypassTenantGuard

--- a/features/user/register/register-onboarding-profile.interactor.ts
+++ b/features/user/register/register-onboarding-profile.interactor.ts
@@ -1,0 +1,75 @@
+import type { AuthService } from "@/features/auth/auth.service";
+import type { Redirect } from "@/features/auth/auth-outcome";
+import type { RegistrationAdAttribution } from "@/features/acquisition/ad-attribution.schema";
+import type { InviteTokenCookieRepo } from "@/features/company/invite-token-cookie.repo";
+import type { OnboardingIntentService } from "@/features/company/onboarding-intent.service";
+import type { Validated } from "@/core/validation/validation.utils";
+
+import { isRedirect, redirectTo } from "@/features/auth/auth-outcome";
+import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
+import { pathWithOnboardingIntent } from "@/features/company/onboarding-intent-url";
+import {
+  type RegisterUserInteractor,
+  type RegisterUserData,
+  type RegisterUserResult,
+  type RegistrationTarget,
+} from "./register-user.interactor";
+
+export type RegisterOnboardingProfileData = RegisterUserData & { onboardingIntent?: string };
+
+type RegistrationContext = { adAttribution?: RegistrationAdAttribution[] };
+
+@SystemInteractor
+export class RegisterOnboardingProfileInteractor {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly onboardingIntentService: OnboardingIntentService,
+    private readonly inviteTokenCookieRepo: InviteTokenCookieRepo,
+    private readonly registerUserInteractor: RegisterUserInteractor,
+  ) {}
+
+  async invoke(
+    data: RegisterOnboardingProfileData,
+    context: RegistrationContext = {},
+  ): Promise<Awaited<Validated<RegisterUserResult>> | Redirect> {
+    const legacyToken = data.onboardingIntent === undefined ? await this.inviteTokenCookieRepo.read() : undefined;
+    const onboardingIntent = await this.onboardingIntentService.resolve(data.onboardingIntent, legacyToken);
+    if (onboardingIntent.status === "invalid") {
+      await this.inviteTokenCookieRepo.clear();
+      if (onboardingIntent.source === "explicit")
+        return redirectTo(`/auth/error?type=${onboardingIntent.errorMessage}`);
+    }
+
+    let target: RegistrationTarget = { type: "existingAuthUserCompanyBinding" };
+    if (onboardingIntent.status === "valid" && onboardingIntent.type === "invitation")
+      target = { type: "invitation", companyId: onboardingIntent.companyId };
+    if (onboardingIntent.status === "valid" && onboardingIntent.type === "createCompany") {
+      const session = await this.authService.getSession();
+      if (!session) return redirectTo(pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent));
+
+      if (onboardingIntent.authUserId !== session.user.id) {
+        await this.inviteTokenCookieRepo.clear();
+        return redirectTo("/auth/error?type=invalidOnboardingIntent");
+      }
+      target = { type: "createCompany" };
+    }
+
+    const registrationData = { ...data };
+    delete registrationData.onboardingIntent;
+    const result = await this.registerUserInteractor.invoke(registrationData, {
+      adAttribution: context.adAttribution,
+      target,
+    });
+
+    if (isRedirect(result) && onboardingIntent.status === "valid") {
+      if (result.redirect === "/auth/signin")
+        return redirectTo(pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent));
+
+      if (result.redirect === "/auth/signup" && onboardingIntent.type === "invitation")
+        return redirectTo(pathWithOnboardingIntent("/auth/signup", onboardingIntent.intent));
+    }
+
+    if (!isRedirect(result) && result.ok) await this.inviteTokenCookieRepo.clear();
+    return result;
+  }
+}

--- a/features/user/register/register-onboarding-profile.interactor.ts
+++ b/features/user/register/register-onboarding-profile.interactor.ts
@@ -62,8 +62,8 @@ export class RegisterOnboardingProfileInteractor {
     });
 
     if (isRedirect(result) && onboardingIntent.status === "valid") {
-      if (result.redirect === "/auth/signin")
-        return redirectTo(pathWithOnboardingIntent("/auth/signin", onboardingIntent.intent));
+      if (result.redirect === "/auth/signin" || result.redirect === "/auth/verify-email")
+        return redirectTo(pathWithOnboardingIntent(result.redirect, onboardingIntent.intent));
 
       if (result.redirect === "/auth/signup" && onboardingIntent.type === "invitation")
         return redirectTo(pathWithOnboardingIntent("/auth/signup", onboardingIntent.intent));

--- a/features/user/register/register-user.interactor.ts
+++ b/features/user/register/register-user.interactor.ts
@@ -14,10 +14,10 @@ import { env } from "@/env";
 import { DomainEvent } from "@/features/event/domain-events";
 
 import { runWithTenant } from "@/core/decorators/tenant-context";
+import { runInTransaction } from "@/core/decorators/transaction-runner";
 import { Validate } from "@/core/decorators/validate.decorator";
 import { ValidateOutput } from "@/core/decorators/validate-output.decorator";
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
-import { Transaction } from "@/core/decorators/transaction.decorator";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 import { zx } from "@/core/validation/validation.utils";
 import { accountStateRedirect } from "@/features/auth/account-state";
@@ -27,7 +27,7 @@ import {
   type RegistrationAdAttribution,
 } from "@/features/acquisition/ad-attribution.schema";
 
-const Schema = z
+export const RegisterUserSchema = z
   .object({
     email: z.email(),
     firstName: z.string().min(1),
@@ -45,7 +45,7 @@ const Schema = z
       });
     }
   });
-export type RegisterUserData = Data<typeof Schema>;
+export type RegisterUserData = Data<typeof RegisterUserSchema>;
 
 const OutputSchema = z.object({
   redirectTo: z.enum(["/auth/pending", "/onboarding/wizard"]),
@@ -55,11 +55,11 @@ export type RegisterUserResult = Data<typeof OutputSchema>;
 const RegistrationTargetSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("createCompany") }),
   z.object({ type: z.literal("invitation"), companyId: z.string().min(1) }),
-  z.object({ type: z.literal("legacyAuthBinding") }),
+  z.object({ type: z.literal("existingAuthUserCompanyBinding") }),
 ]);
 export type RegistrationTarget = Data<typeof RegistrationTargetSchema>;
 
-const RegistrationSchema = Schema.extend({
+const RegistrationSchema = RegisterUserSchema.extend({
   sessionUserId: z.string().min(1),
   adAttribution: z.array(RegistrationAdAttributionSchema),
   target: RegistrationTargetSchema,
@@ -73,8 +73,7 @@ type RegistrationContext = {
 
 export abstract class RegisterUserRepo {
   abstract peekAuthUserCompanyIdUnscoped(userId: string): Promise<string | null | undefined>;
-  abstract lockCompanyForRegistrationUnscoped(companyId: string): Promise<boolean>;
-  abstract lockAuthUserCompanyIdForRegistrationUnscoped(userId: string): Promise<string | null | undefined>;
+  abstract findAuthUserCompanyIdForUpdateUnscoped(userId: string): Promise<string | null | undefined>;
   abstract findCurrentUserUnscoped(email: string): Promise<TenantUser | null>;
   abstract bindAuthUserToCompanyOrThrowUnscoped(args: { authUserId: string; companyId: string }): Promise<void>;
   abstract createCompanyAndUser(
@@ -85,6 +84,10 @@ export abstract class RegisterUserRepo {
   abstract registerExistingCompany(args: RegisterUserData & { companyId: string }): Promise<TenantUser>;
 }
 
+export abstract class RegisterUserCompanyRepo {
+  abstract existsUnscoped(companyId: string): Promise<boolean>;
+}
+
 @SystemInteractor
 export class RegisterUserInteractor {
   constructor(
@@ -92,6 +95,7 @@ export class RegisterUserInteractor {
     private repo: RegisterUserRepo,
     private eventService: EventService,
     private routeGuardService: RouteGuardService,
+    private companyRepo: RegisterUserCompanyRepo,
   ) {}
 
   async invoke(
@@ -112,23 +116,30 @@ export class RegisterUserInteractor {
   }
 
   @Validate(RegistrationSchema)
-  @Transaction
-  @ValidateOutput(OutputSchema)
   private async register(data: RegistrationData): Promise<Awaited<Validated<RegisterUserResult>> | Redirect> {
-    const { sessionUserId, adAttribution, target, ...registrationData } = data;
     const plannedCompanyId =
-      target.type === "invitation"
-        ? target.companyId
-        : target.type === "legacyAuthBinding"
-          ? await this.repo.peekAuthUserCompanyIdUnscoped(sessionUserId)
+      data.target.type === "invitation"
+        ? data.target.companyId
+        : data.target.type === "existingAuthUserCompanyBinding"
+          ? await this.repo.peekAuthUserCompanyIdUnscoped(data.sessionUserId)
           : null;
-    if (plannedCompanyId) {
-      const companyExists = await this.repo.lockCompanyForRegistrationUnscoped(plannedCompanyId);
-      if (!companyExists)
-        return redirectTo(target.type === "invitation" ? "/auth/error?type=invalidInviteLink" : "/onboarding");
-    }
 
-    const authUserCompanyId = await this.repo.lockAuthUserCompanyIdForRegistrationUnscoped(sessionUserId);
+    return runInTransaction(
+      () => this.registerLocked(data, plannedCompanyId),
+      plannedCompanyId ? { companyId: plannedCompanyId } : undefined,
+    );
+  }
+
+  @ValidateOutput(OutputSchema)
+  private async registerLocked(
+    data: RegistrationData,
+    plannedCompanyId: string | null | undefined,
+  ): Promise<Awaited<Validated<RegisterUserResult>> | Redirect> {
+    const { sessionUserId, adAttribution, target, ...registrationData } = data;
+    if (plannedCompanyId && !(await this.companyRepo.existsUnscoped(plannedCompanyId)))
+      return redirectTo(target.type === "invitation" ? "/auth/error?type=invalidInviteLink" : "/onboarding");
+
+    const authUserCompanyId = await this.repo.findAuthUserCompanyIdForUpdateUnscoped(sessionUserId);
     if (authUserCompanyId === undefined) return redirectTo("/auth/signup");
     const existingUser = await this.repo.findCurrentUserUnscoped(registrationData.email);
     if (existingUser) {
@@ -140,10 +151,15 @@ export class RegisterUserInteractor {
             : "/onboarding/wizard",
       );
     }
-    if (target.type === "legacyAuthBinding" && authUserCompanyId !== plannedCompanyId) return redirectTo("/onboarding");
+    if (target.type === "existingAuthUserCompanyBinding" && authUserCompanyId !== plannedCompanyId)
+      return redirectTo("/onboarding");
 
     const companyId =
-      target.type === "invitation" ? target.companyId : target.type === "legacyAuthBinding" ? authUserCompanyId : null;
+      target.type === "invitation"
+        ? target.companyId
+        : target.type === "existingAuthUserCompanyBinding"
+          ? authUserCompanyId
+          : null;
     if (!companyId && target.type !== "createCompany") return redirectTo("/onboarding");
 
     const isNewCloudCompany = env.APP_MODE === "cloud" && target.type === "createCompany";

--- a/features/user/register/register-user.interactor.ts
+++ b/features/user/register/register-user.interactor.ts
@@ -52,18 +52,31 @@ const OutputSchema = z.object({
 });
 export type RegisterUserResult = Data<typeof OutputSchema>;
 
+const RegistrationTargetSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("createCompany") }),
+  z.object({ type: z.literal("invitation"), companyId: z.string().min(1) }),
+  z.object({ type: z.literal("legacyAuthBinding") }),
+]);
+export type RegistrationTarget = Data<typeof RegistrationTargetSchema>;
+
 const RegistrationSchema = Schema.extend({
   sessionUserId: z.string().min(1),
   adAttribution: z.array(RegistrationAdAttributionSchema),
+  target: RegistrationTargetSchema,
 });
 type RegistrationData = Data<typeof RegistrationSchema>;
 
 type RegistrationContext = {
   adAttribution?: RegistrationAdAttribution[];
+  target: RegistrationTarget;
 };
 
 export abstract class RegisterUserRepo {
-  abstract findCompanyIdUnscoped(userId: string): Promise<string | null>;
+  abstract peekAuthUserCompanyIdUnscoped(userId: string): Promise<string | null | undefined>;
+  abstract lockCompanyForRegistrationUnscoped(companyId: string): Promise<boolean>;
+  abstract lockAuthUserCompanyIdForRegistrationUnscoped(userId: string): Promise<string | null | undefined>;
+  abstract findCurrentUserUnscoped(email: string): Promise<TenantUser | null>;
+  abstract bindAuthUserToCompanyOrThrowUnscoped(args: { authUserId: string; companyId: string }): Promise<void>;
   abstract createCompanyAndUser(
     args: RegisterUserData & {
       adAttribution?: RegistrationAdAttribution[];
@@ -83,7 +96,7 @@ export class RegisterUserInteractor {
 
   async invoke(
     data: RegisterUserData,
-    context: RegistrationContext = {},
+    context: RegistrationContext,
   ): Promise<Awaited<Validated<RegisterUserResult>> | Redirect> {
     const resolution = await this.routeGuardService.resolveAccountState();
     if (!resolution.sessionUser) return redirectTo("/auth/signin");
@@ -94,17 +107,46 @@ export class RegisterUserInteractor {
       email: resolution.sessionUser.email,
       sessionUserId: resolution.sessionUser.id,
       adAttribution: context.adAttribution ?? [],
+      target: context.target,
     });
   }
 
   @Validate(RegistrationSchema)
   @Transaction
   @ValidateOutput(OutputSchema)
-  private async register(data: RegistrationData): Promise<Awaited<Validated<RegisterUserResult>>> {
-    const { sessionUserId, adAttribution, ...registrationData } = data;
+  private async register(data: RegistrationData): Promise<Awaited<Validated<RegisterUserResult>> | Redirect> {
+    const { sessionUserId, adAttribution, target, ...registrationData } = data;
+    const plannedCompanyId =
+      target.type === "invitation"
+        ? target.companyId
+        : target.type === "legacyAuthBinding"
+          ? await this.repo.peekAuthUserCompanyIdUnscoped(sessionUserId)
+          : null;
+    if (plannedCompanyId) {
+      const companyExists = await this.repo.lockCompanyForRegistrationUnscoped(plannedCompanyId);
+      if (!companyExists)
+        return redirectTo(target.type === "invitation" ? "/auth/error?type=invalidInviteLink" : "/onboarding");
+    }
 
-    const companyId = await this.repo.findCompanyIdUnscoped(sessionUserId);
-    const isNewCloudCompany = env.APP_MODE === "cloud" && !companyId;
+    const authUserCompanyId = await this.repo.lockAuthUserCompanyIdForRegistrationUnscoped(sessionUserId);
+    if (authUserCompanyId === undefined) return redirectTo("/auth/signup");
+    const existingUser = await this.repo.findCurrentUserUnscoped(registrationData.email);
+    if (existingUser) {
+      return redirectTo(
+        existingUser.status === Status.pendingAuthorization
+          ? "/auth/pending"
+          : existingUser.status === Status.inactive
+            ? "/auth/error?type=inactiveUser"
+            : "/onboarding/wizard",
+      );
+    }
+    if (target.type === "legacyAuthBinding" && authUserCompanyId !== plannedCompanyId) return redirectTo("/onboarding");
+
+    const companyId =
+      target.type === "invitation" ? target.companyId : target.type === "legacyAuthBinding" ? authUserCompanyId : null;
+    if (!companyId && target.type !== "createCompany") return redirectTo("/onboarding");
+
+    const isNewCloudCompany = env.APP_MODE === "cloud" && target.type === "createCompany";
     const eligibleAdAttribution =
       env.APP_MODE === "cloud"
         ? adAttribution.filter((attribution) => attribution.expiresAt.getTime() > Date.now())
@@ -119,6 +161,11 @@ export class RegisterUserInteractor {
           ...registrationData,
           adAttribution: eligibleAdAttribution,
         });
+
+    await this.repo.bindAuthUserToCompanyOrThrowUnscoped({
+      authUserId: sessionUserId,
+      companyId: tenantUser.companyId,
+    });
 
     await runWithTenant(tenantUser, async () => {
       if (isNewCloudCompany) {
@@ -142,7 +189,7 @@ export class RegisterUserInteractor {
           status: tenantUser.status,
           avatarUrl: tenantUser.avatarUrl,
           roleId: tenantUser.roleId,
-          isNewCompany: !companyId,
+          isNewCompany: target.type === "createCompany",
         },
       });
 

--- a/features/user/register/register-user.interactor.ts
+++ b/features/user/register/register-user.interactor.ts
@@ -27,7 +27,7 @@ import {
   type RegistrationAdAttribution,
 } from "@/features/acquisition/ad-attribution.schema";
 
-export const RegisterUserSchema = z
+const RegisterUserSchema = z
   .object({
     email: z.email(),
     firstName: z.string().min(1),
@@ -72,7 +72,7 @@ type RegistrationContext = {
 };
 
 export abstract class RegisterUserRepo {
-  abstract peekAuthUserCompanyIdUnscoped(userId: string): Promise<string | null | undefined>;
+  abstract findAuthUserCompanyIdUnscoped(userId: string): Promise<string | null | undefined>;
   abstract findAuthUserCompanyIdForUpdateUnscoped(userId: string): Promise<string | null | undefined>;
   abstract findCurrentUserUnscoped(email: string): Promise<TenantUser | null>;
   abstract bindAuthUserToCompanyOrThrowUnscoped(args: { authUserId: string; companyId: string }): Promise<void>;
@@ -121,7 +121,7 @@ export class RegisterUserInteractor {
       data.target.type === "invitation"
         ? data.target.companyId
         : data.target.type === "existingAuthUserCompanyBinding"
-          ? await this.repo.peekAuthUserCompanyIdUnscoped(data.sessionUserId)
+          ? await this.repo.findAuthUserCompanyIdUnscoped(data.sessionUserId)
           : null;
 
     return runInTransaction(

--- a/features/user/user.service.ts
+++ b/features/user/user.service.ts
@@ -11,6 +11,7 @@ import { tenantStorage } from "@/core/decorators/tenant-context";
 export type { TenantUser } from "./user.schema";
 
 export abstract class FindUserRepo {
+  abstract findAuthUserCompanyIdUnscoped(userId: string): Promise<string | null | undefined>;
   abstract findCurrentUserUnscoped(email: string): Promise<TenantUser | null>;
   abstract findCurrentUserOrThrowUnscoped(email: string): Promise<TenantUser>;
   abstract findUserByIdOrThrowUnscoped(userId: string): Promise<TenantUser>;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -2027,7 +2027,9 @@
     "demoModeError": "Speichern, Löschen und Ändern von Daten ist im Demo-Modus nicht verfügbar. <link>Jetzt kostenlos starten</link>, um auf alle Funktionen zuzugreifen.",
     "inactiveUser": "Dein Konto ist derzeit inaktiv. Kontaktiere deinen Administrator, um dein Konto zu reaktivieren.",
     "invalidInviteLink": "Der Einladungslink, den du verwendet hast, ist ungültig oder wurde möglicherweise manipuliert. Kontaktiere deinen Administrator, um einen neuen, gültigen Einladungslink zu erhalten und deine Registrierung fortzusetzen.",
+    "invalidOnboardingIntent": "Dieser Onboarding-Link ist ungültig. Kehre zum Onboarding zurück oder öffne den ursprünglichen Einladungslink erneut.",
     "inviteLinkExpired": "Der Einladungslink, den du verwendet hast, ist abgelaufen und kann nicht mehr verwendet werden. Kontaktiere deinen Administrator und bitte ihn, einen neuen Einladungslink für dich zu erstellen, damit du deine Kontoeinrichtung abschließen kannst.",
+    "onboardingSessionExpired": "Diese Onboarding-Sitzung ist abgelaufen. Öffne den ursprünglichen Einladungslink erneut oder wähle noch einmal aus, wie du starten möchtest.",
     "retry": "Erneut versuchen",
     "subtitle": "Ups! Etwas ist schiefgelaufen",
     "title": "Das ist jetzt peinlich",
@@ -2267,6 +2269,39 @@
     },
     "youPrefix": "Du:"
   },
+  "InvitationCard": {
+    "inviter": "Einladung von {inviterName}",
+    "joinAction": "Weiter",
+    "joinBody": "Richte dein Profil ein und beantrage den Zugang. Ein Workspace-Administrator muss dich freigeben, bevor du beitreten kannst.",
+    "joinSubtitle": "Du bist als {email} angemeldet",
+    "joinTitle": "Einladung annehmen",
+    "switchBody": "Dieses Konto gehört bereits zu einem Workspace. Melde dich ab, um mit einem anderen Konto fortzufahren.",
+    "switchSubtitle": "Du bist als {email} angemeldet",
+    "switchTitle": "Du bist bereits angemeldet"
+  },
+  "JoinWorkspace": {
+    "backAction": "Zurück zur Auswahl",
+    "emailLabel": "E-Mail-Adresse für die Einladung",
+    "safeBody": "Du kannst diese Seite schließen und zurückkehren, sobald du eine Einladung erhalten hast.",
+    "safeTitle": "Es wurde kein Workspace erstellt",
+    "steps": {
+      "complete": {
+        "body": "Warte anschließend auf die Freigabe durch einen Workspace-Administrator.",
+        "title": "Profil vervollständigen"
+      },
+      "open": {
+        "body": "Nutze dazu den Link aus der Einladungs-E-Mail oder einen direkt geteilten Einladungslink in diesem Browser.",
+        "title": "Einladungslink öffnen"
+      },
+      "request": {
+        "body": "Sende diese E-Mail-Adresse an einen Administrator des Workspaces.",
+        "title": "Einladung anfordern"
+      }
+    },
+    "stepsTitle": "So trittst du bei",
+    "subtitle": "Ein Workspace-Administrator muss {email} einladen.",
+    "title": "Bestehendem Workspace beitreten"
+  },
   "LegalDocumentNotice": {
     "contractBody": "Wir haben die unten aufgeführten Rechtsdokumente aktualisiert. Bitte prüfen Sie diese für den Geschäftskunden und veranlassen Sie die elektronische Annahme durch einen berechtigten Systemadministrator.",
     "contractDeadlineLabel": "Widerspruchs- und Annahmefrist",
@@ -2417,8 +2452,26 @@
     "subtitle": "Diese Seite ist ohne uns zu informieren in den Urlaub gefahren",
     "title": "Huch! Sie haben die Leere betreten"
   },
+  "OnboardingChoice": {
+    "create": {
+      "description": "Richte einen eigenen Workspace für ein Unternehmen ein, das du führst oder verwaltest.",
+      "note": "{days} Tage kostenlos testen",
+      "title": "Neuen Workspace erstellen"
+    },
+    "footnote": "Ein Workspace wird erst erstellt, wenn du Erstellen wählst und dein Profil abschließt.",
+    "join": {
+      "description": "Tritt einem Team bei, das Customermates bereits nutzt. Dafür brauchst du eine Einladung von einem Workspace-Administrator.",
+      "note": "Es wird kein Workspace erstellt",
+      "title": "Bestehendem Workspace beitreten"
+    },
+    "optionsLabel": "Auswahl für die Workspace-Einrichtung",
+    "signedInAs": "Angemeldet als {email}",
+    "subtitle": "Erstelle einen Workspace für dein Unternehmen oder tritt einem Team bei, das Customermates bereits nutzt.",
+    "title": "Wie möchtest du starten?"
+  },
   "OnboardingForm": {
     "agreeToTerms": "Ich bin berechtigt, für den Geschäftskunden zu handeln, und stimme den <termsOfServiceLink>AGB</termsOfServiceLink> sowie dem <dpaLink>AVV</dpaLink> zu. Die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> habe ich gelesen.",
+    "invitationFrom": "Einladung von {inviterName}",
     "invitedAgreeToTerms": "Ich verpflichte mich, die <termsOfServiceLink>AGB</termsOfServiceLink> einzuhalten, und habe den <dpaLink>AVV</dpaLink> sowie die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> gelesen."
   },
   "OnboardingWizard": {
@@ -2550,6 +2603,7 @@
         "title": "Team einladen"
       },
       "profile": {
+        "invitedSubtitle": "Vervollständige dein Profil, um Zugang zum eingeladenen Workspace anzufordern.",
         "subtitle": "Erzähle uns, wer du bist, damit wir deinen Workspace einrichten können.",
         "title": "Dein Profil"
       }
@@ -2830,6 +2884,7 @@
     "agreeToTerms": "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
     "buttonLabel": "Anmelden mit {provider}",
     "forgotPassword": "Passwort vergessen?",
+    "inviteSubtitle": "{inviterName} hat dich in einen Workspace eingeladen. Melde dich an, um die Einladung zu prüfen.",
     "or": "ODER",
     "rememberMe": "Angemeldet bleiben",
     "signInCta": "Anmelden",
@@ -2837,12 +2892,12 @@
     "switchToSignUp": "Noch kein Konto? <registerLink>Registrieren</registerLink>"
   },
   "SignUpForm": {
-    "acceptInviteCta": "Einladung annehmen",
+    "acceptInviteCta": "Weiter",
+    "accountSubtitle": "Erstelle zuerst dein Konto. Anschließend entscheidest du, ob du einen neuen Workspace erstellst oder einem bestehenden beitrittst.",
     "agreeToTerms": "Mit dem Fortfahren stimmst du unseren <termsOfServiceLink>AGB</termsOfServiceLink> zu und nimmst unsere <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> zur Kenntnis. Siehe unseren <dpaLink>AVV</dpaLink>.",
     "buttonLabel": "Registrieren mit {provider}",
-    "inviteSubtitle": "Du wurdest eingeladen, einem Team auf Customermates beizutreten. Wähle deine Anmeldemethode, um die Einladung anzunehmen.",
+    "inviteSubtitle": "{inviterName} hat dich in einen Workspace auf Customermates eingeladen. Wähle aus, wie du dein Konto erstellen möchtest.",
     "inviteTitle": "Firmeneinladung annehmen",
-    "newCompanySubtitle": "Registriere ein neues Unternehmen und teste Customermates kostenlos für {days} Tage. Keine Kreditkarte erforderlich.",
     "or": "ODER",
     "signUpCta": "Konto erstellen",
     "switchToSignIn": "Bereits ein Konto? <signInLink>Anmelden</signInLink>",
@@ -3004,6 +3059,7 @@
   "VerifyEmailCard": {
     "body": "Wir haben dir eine Verifizierungs-E-Mail gesendet. Bitte überprüfe dein Postfach und klicke auf den Link, um deine E-Mail-Adresse zu verifizieren.",
     "ctaLabel": "Verifizierungs-E-Mail erneut senden",
+    "invitationFrom": "Einladung von {inviterName}",
     "resendSuccess": "Verifizierungs-E-Mail wurde erfolgreich gesendet.",
     "subtitle": "Verifiziere deine E-Mail-Adresse, um fortzufahren.",
     "title": "E-Mail-Verifizierung"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2027,7 +2027,9 @@
     "demoModeError": "Saving, deleting and changing data is not available in demo mode. <link>Start for free now</link> to access all features.",
     "inactiveUser": "Your account is currently inactive. Please contact your administrator to reactivate your account.",
     "invalidInviteLink": "The invitation link you used is not valid or may have been altered. Please reach out to your administrator to request a new, valid invitation link so you can proceed with your registration.",
+    "invalidOnboardingIntent": "This onboarding link is not valid. Return to onboarding or reopen the original invitation link.",
     "inviteLinkExpired": "The invitation link you tried to use has expired and can no longer be used. Please contact your administrator and ask them to generate a fresh invitation link for you to complete your account setup.",
+    "onboardingSessionExpired": "This onboarding session has expired. Reopen the original invitation link or choose how to get started again.",
     "retry": "Try again",
     "subtitle": "Oops! Something went wrong",
     "title": "Well, that's awkward",
@@ -2267,6 +2269,39 @@
     },
     "youPrefix": "You:"
   },
+  "InvitationCard": {
+    "inviter": "Invitation from {inviterName}",
+    "joinAction": "Continue",
+    "joinBody": "Continue to set up your profile and request access. A workspace administrator must approve you before you can join.",
+    "joinSubtitle": "You are signed in as {email}",
+    "joinTitle": "Accept your invitation",
+    "switchBody": "This account already belongs to a workspace. Sign out to continue with a different account.",
+    "switchSubtitle": "You are signed in as {email}",
+    "switchTitle": "You are already signed in"
+  },
+  "JoinWorkspace": {
+    "backAction": "Back to choices",
+    "emailLabel": "Email address to invite",
+    "safeBody": "You can safely leave this page and return when you receive an invitation.",
+    "safeTitle": "No workspace has been created",
+    "steps": {
+      "complete": {
+        "body": "Then wait for a workspace administrator to approve your access.",
+        "title": "Complete your profile"
+      },
+      "open": {
+        "body": "Use the link from the invitation email, or a directly shared invitation link, in this browser.",
+        "title": "Open the invitation link"
+      },
+      "request": {
+        "body": "Send this email address to a workspace administrator.",
+        "title": "Request an invitation"
+      }
+    },
+    "stepsTitle": "How to join",
+    "subtitle": "A workspace administrator needs to invite {email}.",
+    "title": "Join an existing workspace"
+  },
   "LegalDocumentNotice": {
     "contractBody": "We updated the legal documents listed below. Please review them for the business customer and arrange electronic acceptance by an authorised system administrator.",
     "contractDeadlineLabel": "Objection and acceptance deadline",
@@ -2417,8 +2452,26 @@
     "subtitle": "This page went on vacation without telling us",
     "title": "Oops! You've entered the void"
   },
+  "OnboardingChoice": {
+    "create": {
+      "description": "Set up a separate workspace for a company you own or manage.",
+      "note": "Free for {days} days",
+      "title": "Create a new workspace"
+    },
+    "footnote": "No workspace is created until you choose Create and complete your profile.",
+    "join": {
+      "description": "Join a team that already uses Customermates. You will need an invitation from a workspace administrator.",
+      "note": "No workspace will be created",
+      "title": "Join an existing workspace"
+    },
+    "optionsLabel": "Workspace setup choices",
+    "signedInAs": "Signed in as {email}",
+    "subtitle": "Create a workspace for your company or join a team that already uses Customermates.",
+    "title": "Choose how to get started"
+  },
   "OnboardingForm": {
     "agreeToTerms": "I am authorised to act for the business customer and accept the <termsOfServiceLink>Terms</termsOfServiceLink> and <dpaLink>DPA</dpaLink>. I have read the <dataPrivacyLink>Privacy Policy</dataPrivacyLink>.",
+    "invitationFrom": "Invitation from {inviterName}",
     "invitedAgreeToTerms": "I agree to comply with the <termsOfServiceLink>Terms</termsOfServiceLink> and have read the <dpaLink>DPA</dpaLink> and <dataPrivacyLink>Privacy Policy</dataPrivacyLink>."
   },
   "OnboardingWizard": {
@@ -2550,6 +2603,7 @@
         "title": "Invite your team"
       },
       "profile": {
+        "invitedSubtitle": "Complete your profile to request access to the invited workspace.",
         "subtitle": "Tell us who you are so we can set up your workspace.",
         "title": "Your profile"
       }
@@ -2830,6 +2884,7 @@
     "agreeToTerms": "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continue with {provider}",
     "forgotPassword": "Forgot password?",
+    "inviteSubtitle": "{inviterName} invited you to join their workspace. Sign in to review the invitation.",
     "or": "OR",
     "rememberMe": "Remember me",
     "signInCta": "Sign In",
@@ -2837,12 +2892,12 @@
     "switchToSignUp": "Don't have an account? <registerLink>Register</registerLink>"
   },
   "SignUpForm": {
-    "acceptInviteCta": "Accept invitation",
+    "acceptInviteCta": "Continue",
+    "accountSubtitle": "Create your account first. Next, choose whether to create a new workspace or join an existing one.",
     "agreeToTerms": "By continuing, you agree to our <termsOfServiceLink>Terms</termsOfServiceLink> and acknowledge our <dataPrivacyLink>Privacy Policy</dataPrivacyLink>. See our <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Register with {provider}",
-    "inviteSubtitle": "You have been invited to join a team on Customermates. Choose your sign-in method to accept the invitation.",
+    "inviteSubtitle": "{inviterName} invited you to join their workspace on Customermates. Choose how you want to create your account.",
     "inviteTitle": "Accept Company Invitation",
-    "newCompanySubtitle": "Register a new company and test Customermates for free for {days} days. No credit card required.",
     "or": "OR",
     "signUpCta": "Create account",
     "switchToSignIn": "Already have an account? <signInLink>Sign in</signInLink>",
@@ -3004,6 +3059,7 @@
   "VerifyEmailCard": {
     "body": "We've sent you a verification email. Please check your inbox and click the link to verify your email address.",
     "ctaLabel": "Resend verification email",
+    "invitationFrom": "Invitation from {inviterName}",
     "resendSuccess": "Verification email sent successfully.",
     "subtitle": "Verify your email address to continue.",
     "title": "Email Verification"

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -2027,7 +2027,9 @@
     "demoModeError": "En el modo demo no se puede guardar, eliminar ni modificar datos. <link>Empieza gratis ahora</link> para acceder a todas las funciones.",
     "inactiveUser": "Tu cuenta está inactiva actualmente. Contacta con tu administrador para reactivarla.",
     "invalidInviteLink": "El enlace de invitación que has usado no es válido o puede haber sido alterado. Contacta con tu administrador para solicitar un enlace nuevo y válido y continuar con tu registro.",
+    "invalidOnboardingIntent": "Este enlace de incorporación no es válido. Vuelve a la incorporación o abre de nuevo el enlace de invitación original.",
     "inviteLinkExpired": "El enlace de invitación que has intentado usar ha caducado y ya no se puede utilizar. Contacta con tu administrador y pídele que genere uno nuevo para completar la configuración de tu cuenta.",
+    "onboardingSessionExpired": "Esta sesión de incorporación ha caducado. Abre de nuevo el enlace de invitación original o vuelve a elegir cómo quieres empezar.",
     "retry": "Inténtalo de nuevo",
     "subtitle": "¡Vaya! Algo ha fallado",
     "title": "Qué incómodo",
@@ -2267,6 +2269,39 @@
     },
     "youPrefix": "Tú:"
   },
+  "InvitationCard": {
+    "inviter": "Invitación de {inviterName}",
+    "joinAction": "Continuar",
+    "joinBody": "Configura tu perfil y solicita acceso. Un administrador del espacio de trabajo debe aprobarte antes de que puedas unirte.",
+    "joinSubtitle": "Has iniciado sesión como {email}",
+    "joinTitle": "Acepta tu invitación",
+    "switchBody": "Esta cuenta ya pertenece a un espacio de trabajo. Cierra sesión para continuar con otra cuenta.",
+    "switchSubtitle": "Has iniciado sesión como {email}",
+    "switchTitle": "Ya has iniciado sesión"
+  },
+  "JoinWorkspace": {
+    "backAction": "Volver a las opciones",
+    "emailLabel": "Dirección de correo que deben invitar",
+    "safeBody": "Puedes salir de esta página y volver cuando recibas una invitación.",
+    "safeTitle": "No se ha creado ningún espacio de trabajo",
+    "steps": {
+      "complete": {
+        "body": "Después, espera a que un administrador del espacio de trabajo apruebe tu acceso.",
+        "title": "Completa tu perfil"
+      },
+      "open": {
+        "body": "Usa en este navegador el enlace del correo de invitación o un enlace de invitación compartido directamente.",
+        "title": "Abre el enlace de invitación"
+      },
+      "request": {
+        "body": "Envía esta dirección de correo a un administrador del espacio de trabajo.",
+        "title": "Solicita una invitación"
+      }
+    },
+    "stepsTitle": "Cómo unirte",
+    "subtitle": "Un administrador del espacio de trabajo debe invitar a {email}.",
+    "title": "Unirte a un espacio de trabajo existente"
+  },
   "LegalDocumentNotice": {
     "contractBody": "Hemos actualizado los documentos legales que se indican a continuación. Revísalos en nombre del cliente empresarial y organiza su aceptación electrónica por parte de un administrador del sistema autorizado.",
     "contractDeadlineLabel": "Fecha límite de objeción y aceptación",
@@ -2417,8 +2452,26 @@
     "subtitle": "Esta página se fue de vacaciones sin avisarnos",
     "title": "¡Vaya! Has entrado en el vacío"
   },
+  "OnboardingChoice": {
+    "create": {
+      "description": "Configura un espacio de trabajo independiente para una empresa que poseas o gestiones.",
+      "note": "Gratis durante {days} días",
+      "title": "Crear un espacio de trabajo nuevo"
+    },
+    "footnote": "No se crea ningún espacio de trabajo hasta que eliges Crear y completas tu perfil.",
+    "join": {
+      "description": "Únete a un equipo que ya usa Customermates. Necesitarás una invitación de un administrador.",
+      "note": "No se creará ningún espacio de trabajo",
+      "title": "Unirte a un espacio de trabajo existente"
+    },
+    "optionsLabel": "Opciones de configuración del espacio de trabajo",
+    "signedInAs": "Sesión iniciada como {email}",
+    "subtitle": "Crea un espacio de trabajo para tu empresa o únete a un equipo que ya usa Customermates.",
+    "title": "¿Cómo quieres empezar?"
+  },
   "OnboardingForm": {
     "agreeToTerms": "Estoy autorizado para actuar en nombre del cliente empresarial y acepto los <termsOfServiceLink>Términos</termsOfServiceLink> y el <dpaLink>DPA</dpaLink>. He leído la <dataPrivacyLink>Política de privacidad</dataPrivacyLink>.",
+    "invitationFrom": "Invitación de {inviterName}",
     "invitedAgreeToTerms": "Acepto cumplir los <termsOfServiceLink>Términos</termsOfServiceLink> y he leído el <dpaLink>DPA</dpaLink> y la <dataPrivacyLink>Política de privacidad</dataPrivacyLink>."
   },
   "OnboardingWizard": {
@@ -2550,6 +2603,7 @@
         "title": "Invita a tu equipo"
       },
       "profile": {
+        "invitedSubtitle": "Completa tu perfil para solicitar acceso al espacio de trabajo de la invitación.",
         "subtitle": "Cuéntanos quién eres para que podamos configurar tu espacio de trabajo.",
         "title": "Tu perfil"
       }
@@ -2830,6 +2884,7 @@
     "agreeToTerms": "Al continuar, aceptas nuestros <termsOfServiceLink>Términos</termsOfServiceLink> y reconoces haber leído nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>. Consulta nuestro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continuar con {provider}",
     "forgotPassword": "¿Has olvidado tu contraseña?",
+    "inviteSubtitle": "{inviterName} te ha invitado a unirte a su espacio de trabajo. Inicia sesión para revisar la invitación.",
     "or": "O",
     "rememberMe": "Recordarme",
     "signInCta": "Iniciar sesión",
@@ -2837,12 +2892,12 @@
     "switchToSignUp": "¿No tienes cuenta? <registerLink>Regístrate</registerLink>"
   },
   "SignUpForm": {
-    "acceptInviteCta": "Aceptar la invitación",
+    "acceptInviteCta": "Continuar",
+    "accountSubtitle": "Crea primero tu cuenta. Después elige si quieres crear un espacio de trabajo nuevo o unirte a uno existente.",
     "agreeToTerms": "Al continuar, aceptas nuestros <termsOfServiceLink>Términos</termsOfServiceLink> y reconoces haber leído nuestra <dataPrivacyLink>Política de privacidad</dataPrivacyLink>. Consulta nuestro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Regístrate con {provider}",
-    "inviteSubtitle": "Te han invitado a unirte a un equipo en Customermates. Elige tu método de inicio de sesión para aceptar la invitación.",
+    "inviteSubtitle": "{inviterName} te ha invitado a unirte a su espacio de trabajo en Customermates. Elige cómo quieres crear tu cuenta.",
     "inviteTitle": "Aceptar la invitación de la empresa",
-    "newCompanySubtitle": "Registra una empresa nueva y prueba Customermates gratis durante {days} días. Sin tarjeta de crédito.",
     "or": "O",
     "signUpCta": "Crear una cuenta",
     "switchToSignIn": "¿Ya tienes una cuenta? <signInLink>Inicia sesión</signInLink>",
@@ -3004,6 +3059,7 @@
   "VerifyEmailCard": {
     "body": "Te hemos enviado un correo de verificación. Revisa tu bandeja de entrada y haz clic en el enlace para verificar tu dirección de correo.",
     "ctaLabel": "Reenviar el correo de verificación",
+    "invitationFrom": "Invitación de {inviterName}",
     "resendSuccess": "Correo de verificación enviado correctamente.",
     "subtitle": "Verifica tu dirección de correo para continuar.",
     "title": "Verificación del correo"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -2027,7 +2027,9 @@
     "demoModeError": "L'enregistrement, la suppression et la modification de données ne sont pas disponibles en mode démo. <link>Commencez gratuitement</link> pour accéder à toutes les fonctionnalités.",
     "inactiveUser": "Votre compte est actuellement inactif. Contactez votre administrateur pour le réactiver.",
     "invalidInviteLink": "Le lien d'invitation utilisé n'est pas valide ou a peut-être été modifié. Contactez votre administrateur pour obtenir un nouveau lien valide et poursuivre votre inscription.",
+    "invalidOnboardingIntent": "Ce lien d'intégration n'est pas valide. Revenez à l'intégration ou rouvrez le lien d'invitation d'origine.",
     "inviteLinkExpired": "Le lien d'invitation que vous avez utilisé a expiré et ne peut plus servir. Contactez votre administrateur pour qu'il vous génère un nouveau lien et terminez la configuration de votre compte.",
+    "onboardingSessionExpired": "Cette session d'intégration a expiré. Rouvrez le lien d'invitation d'origine ou choisissez à nouveau comment commencer.",
     "retry": "Réessayer",
     "subtitle": "Oups ! Une erreur est survenue",
     "title": "Voilà qui est gênant",
@@ -2267,6 +2269,39 @@
     },
     "youPrefix": "Vous :"
   },
+  "InvitationCard": {
+    "inviter": "Invitation de {inviterName}",
+    "joinAction": "Continuer",
+    "joinBody": "Configurez votre profil et demandez l'accès. Un administrateur doit vous approuver avant que vous puissiez rejoindre l'espace de travail.",
+    "joinSubtitle": "Vous êtes connecté en tant que {email}",
+    "joinTitle": "Accepter votre invitation",
+    "switchBody": "Ce compte appartient déjà à un espace de travail. Déconnectez-vous pour continuer avec un autre compte.",
+    "switchSubtitle": "Vous êtes connecté en tant que {email}",
+    "switchTitle": "Vous êtes déjà connecté"
+  },
+  "JoinWorkspace": {
+    "backAction": "Retour aux choix",
+    "emailLabel": "Adresse e-mail à inviter",
+    "safeBody": "Vous pouvez quitter cette page et revenir lorsque vous aurez reçu une invitation.",
+    "safeTitle": "Aucun espace de travail n'a été créé",
+    "steps": {
+      "complete": {
+        "body": "Attendez ensuite qu'un administrateur de l'espace de travail approuve votre accès.",
+        "title": "Complétez votre profil"
+      },
+      "open": {
+        "body": "Utilisez dans ce navigateur le lien reçu par e-mail ou un lien d'invitation partagé directement.",
+        "title": "Ouvrez le lien d'invitation"
+      },
+      "request": {
+        "body": "Envoyez cette adresse e-mail à un administrateur de l'espace de travail.",
+        "title": "Demandez une invitation"
+      }
+    },
+    "stepsTitle": "Comment rejoindre l'espace de travail",
+    "subtitle": "Un administrateur de l'espace de travail doit inviter {email}.",
+    "title": "Rejoindre un espace de travail existant"
+  },
   "LegalDocumentNotice": {
     "contractBody": "Nous avons mis à jour les documents juridiques indiqués ci-dessous. Veuillez les examiner pour le client professionnel et faire procéder à leur acceptation électronique par un administrateur système habilité.",
     "contractDeadlineLabel": "Date limite d’opposition et d’acceptation",
@@ -2417,8 +2452,26 @@
     "subtitle": "Cette page est partie en vacances sans nous prévenir",
     "title": "Oups ! Vous êtes entré dans le vide"
   },
+  "OnboardingChoice": {
+    "create": {
+      "description": "Configurez un espace de travail distinct pour une entreprise que vous dirigez ou gérez.",
+      "note": "Gratuit pendant {days} jours",
+      "title": "Créer un nouvel espace de travail"
+    },
+    "footnote": "Aucun espace de travail n'est créé tant que vous n'avez pas choisi Créer et complété votre profil.",
+    "join": {
+      "description": "Rejoignez une équipe qui utilise déjà Customermates. Vous aurez besoin d'une invitation d'un administrateur.",
+      "note": "Aucun espace de travail ne sera créé",
+      "title": "Rejoindre un espace de travail existant"
+    },
+    "optionsLabel": "Choix de configuration de l'espace de travail",
+    "signedInAs": "Connecté en tant que {email}",
+    "subtitle": "Créez un espace de travail pour votre entreprise ou rejoignez une équipe qui utilise déjà Customermates.",
+    "title": "Comment souhaitez-vous commencer ?"
+  },
   "OnboardingForm": {
     "agreeToTerms": "Je suis habilité à agir pour le client professionnel et j’accepte les <termsOfServiceLink>conditions générales</termsOfServiceLink> et le <dpaLink>DPA</dpaLink>. J’ai lu la <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>.",
+    "invitationFrom": "Invitation de {inviterName}",
     "invitedAgreeToTerms": "J’accepte de respecter les <termsOfServiceLink>conditions générales</termsOfServiceLink> et j’ai lu le <dpaLink>DPA</dpaLink> ainsi que la <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>."
   },
   "OnboardingWizard": {
@@ -2550,6 +2603,7 @@
         "title": "Invitez votre équipe"
       },
       "profile": {
+        "invitedSubtitle": "Complétez votre profil pour demander l'accès à l'espace de travail indiqué dans l'invitation.",
         "subtitle": "Dites-nous qui vous êtes pour que nous configurions votre espace de travail.",
         "title": "Votre profil"
       }
@@ -2830,6 +2884,7 @@
     "agreeToTerms": "En continuant, vous acceptez nos <termsOfServiceLink>conditions générales</termsOfServiceLink> et reconnaissez avoir lu notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>. Consultez notre <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continuer avec {provider}",
     "forgotPassword": "Mot de passe oublié ?",
+    "inviteSubtitle": "{inviterName} vous invite à rejoindre son espace de travail. Connectez-vous pour consulter l'invitation.",
     "or": "OU",
     "rememberMe": "Se souvenir de moi",
     "signInCta": "Se connecter",
@@ -2837,12 +2892,12 @@
     "switchToSignUp": "Vous n'avez pas de compte ? <registerLink>Inscrivez-vous</registerLink>"
   },
   "SignUpForm": {
-    "acceptInviteCta": "Accepter l'invitation",
+    "acceptInviteCta": "Continuer",
+    "accountSubtitle": "Créez d'abord votre compte. Vous choisirez ensuite de créer un nouvel espace de travail ou d'en rejoindre un existant.",
     "agreeToTerms": "En continuant, vous acceptez nos <termsOfServiceLink>conditions générales</termsOfServiceLink> et reconnaissez avoir lu notre <dataPrivacyLink>politique de confidentialité</dataPrivacyLink>. Consultez notre <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "S'inscrire avec {provider}",
-    "inviteSubtitle": "Vous avez été invité à rejoindre une équipe sur Customermates. Choisissez votre méthode de connexion pour accepter l'invitation.",
+    "inviteSubtitle": "{inviterName} vous invite à rejoindre son espace de travail sur Customermates. Choisissez comment créer votre compte.",
     "inviteTitle": "Accepter l'invitation de l'entreprise",
-    "newCompanySubtitle": "Enregistrez une nouvelle entreprise et testez Customermates gratuitement pendant {days} jours. Sans carte bancaire.",
     "or": "OU",
     "signUpCta": "Créer un compte",
     "switchToSignIn": "Vous avez déjà un compte ? <signInLink>Connectez-vous</signInLink>",
@@ -3004,6 +3059,7 @@
   "VerifyEmailCard": {
     "body": "Nous vous avons envoyé un e-mail de vérification. Consultez votre boîte de réception et cliquez sur le lien pour vérifier votre adresse.",
     "ctaLabel": "Renvoyer l'e-mail de vérification",
+    "invitationFrom": "Invitation de {inviterName}",
     "resendSuccess": "E-mail de vérification envoyé.",
     "subtitle": "Vérifiez votre adresse e-mail pour continuer.",
     "title": "Vérification de l'adresse e-mail"

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -2027,7 +2027,9 @@
     "demoModeError": "Il salvataggio, l'eliminazione e la modifica dei dati non sono disponibili in modalità demo. <link>Inizia gratuitamente</link> per accedere a tutte le funzionalità.",
     "inactiveUser": "Il tuo account è attualmente inattivo. Contatta il tuo amministratore per riattivarlo.",
     "invalidInviteLink": "Il link di invito che hai usato non è valido o potrebbe essere stato alterato. Contatta il tuo amministratore per richiedere un nuovo link valido e proseguire con la registrazione.",
+    "invalidOnboardingIntent": "Questo link di configurazione non è valido. Torna alla configurazione o riapri il link di invito originale.",
     "inviteLinkExpired": "Il link di invito che hai provato a usare è scaduto e non può più essere utilizzato. Contatta il tuo amministratore e chiedigli di generarne uno nuovo per completare la configurazione del tuo account.",
+    "onboardingSessionExpired": "Questa sessione di configurazione è scaduta. Riapri il link di invito originale o scegli di nuovo come iniziare.",
     "retry": "Riprova",
     "subtitle": "Ops! Si è verificato un errore",
     "title": "Che imbarazzo",
@@ -2267,6 +2269,39 @@
     },
     "youPrefix": "Tu:"
   },
+  "InvitationCard": {
+    "inviter": "Invito da {inviterName}",
+    "joinAction": "Continua",
+    "joinBody": "Completa il tuo profilo e richiedi l'accesso. Un amministratore deve approvarti prima che tu possa entrare nello spazio di lavoro.",
+    "joinSubtitle": "Hai effettuato l'accesso come {email}",
+    "joinTitle": "Accetta l'invito",
+    "switchBody": "Questo account appartiene già a uno spazio di lavoro. Esci per continuare con un altro account.",
+    "switchSubtitle": "Hai effettuato l'accesso come {email}",
+    "switchTitle": "Hai già effettuato l'accesso"
+  },
+  "JoinWorkspace": {
+    "backAction": "Torna alle opzioni",
+    "emailLabel": "Indirizzo e-mail da invitare",
+    "safeBody": "Puoi lasciare questa pagina e tornare quando avrai ricevuto un invito.",
+    "safeTitle": "Non è stato creato alcuno spazio di lavoro",
+    "steps": {
+      "complete": {
+        "body": "Poi attendi che un amministratore dello spazio di lavoro approvi il tuo accesso.",
+        "title": "Completa il tuo profilo"
+      },
+      "open": {
+        "body": "Usa in questo browser il link ricevuto nell'e-mail di invito o un link di invito condiviso direttamente.",
+        "title": "Apri il link di invito"
+      },
+      "request": {
+        "body": "Invia questo indirizzo e-mail a un amministratore dello spazio di lavoro.",
+        "title": "Richiedi un invito"
+      }
+    },
+    "stepsTitle": "Come partecipare",
+    "subtitle": "Un amministratore dello spazio di lavoro deve invitare {email}.",
+    "title": "Entra in uno spazio di lavoro esistente"
+  },
   "LegalDocumentNotice": {
     "contractBody": "Abbiamo aggiornato i documenti legali elencati di seguito. Esaminali per il cliente aziendale e fai in modo che un amministratore di sistema autorizzato li accetti elettronicamente.",
     "contractDeadlineLabel": "Termine per l’opposizione e l’accettazione",
@@ -2417,8 +2452,26 @@
     "subtitle": "Questa pagina è andata in vacanza senza avvisarci",
     "title": "Ops! Sei finito nel vuoto"
   },
+  "OnboardingChoice": {
+    "create": {
+      "description": "Configura uno spazio di lavoro separato per un'azienda che possiedi o gestisci.",
+      "note": "Gratis per {days} giorni",
+      "title": "Crea un nuovo spazio di lavoro"
+    },
+    "footnote": "Non viene creato alcuno spazio di lavoro finché non scegli Crea e completi il tuo profilo.",
+    "join": {
+      "description": "Entra in un team che usa già Customermates. Avrai bisogno dell'invito di un amministratore.",
+      "note": "Non verrà creato alcuno spazio di lavoro",
+      "title": "Entra in uno spazio di lavoro esistente"
+    },
+    "optionsLabel": "Opzioni di configurazione dello spazio di lavoro",
+    "signedInAs": "Accesso effettuato come {email}",
+    "subtitle": "Crea uno spazio di lavoro per la tua azienda o entra in un team che usa già Customermates.",
+    "title": "Come vuoi iniziare?"
+  },
   "OnboardingForm": {
     "agreeToTerms": "Dichiaro di avere l’autorizzazione ad agire per il cliente aziendale e accetto i <termsOfServiceLink>Termini</termsOfServiceLink> e il <dpaLink>DPA</dpaLink>. Ho letto l’<dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>.",
+    "invitationFrom": "Invito da {inviterName}",
     "invitedAgreeToTerms": "Accetto di rispettare i <termsOfServiceLink>Termini</termsOfServiceLink> e ho letto il <dpaLink>DPA</dpaLink> e l’<dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>."
   },
   "OnboardingWizard": {
@@ -2550,6 +2603,7 @@
         "title": "Invita il tuo team"
       },
       "profile": {
+        "invitedSubtitle": "Completa il tuo profilo per richiedere l'accesso allo spazio di lavoro indicato nell'invito.",
         "subtitle": "Dicci chi sei così possiamo configurare la tua area di lavoro.",
         "title": "Il tuo profilo"
       }
@@ -2830,6 +2884,7 @@
     "agreeToTerms": "Continuando, accetti i nostri <termsOfServiceLink>Termini</termsOfServiceLink> e dichiari di aver letto la nostra <dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>. Consulta il nostro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Continua con {provider}",
     "forgotPassword": "Password dimenticata?",
+    "inviteSubtitle": "{inviterName} ti ha invitato a entrare nel suo spazio di lavoro. Accedi per controllare l'invito.",
     "or": "OPPURE",
     "rememberMe": "Ricordami",
     "signInCta": "Accedi",
@@ -2837,12 +2892,12 @@
     "switchToSignUp": "Non hai un account? <registerLink>Registrati</registerLink>"
   },
   "SignUpForm": {
-    "acceptInviteCta": "Accetta l'invito",
+    "acceptInviteCta": "Continua",
+    "accountSubtitle": "Crea prima il tuo account. Poi scegli se creare un nuovo spazio di lavoro o entrare in uno esistente.",
     "agreeToTerms": "Continuando, accetti i nostri <termsOfServiceLink>Termini</termsOfServiceLink> e dichiari di aver letto la nostra <dataPrivacyLink>Informativa sulla privacy</dataPrivacyLink>. Consulta il nostro <dpaLink>DPA</dpaLink>.",
     "buttonLabel": "Registrati con {provider}",
-    "inviteSubtitle": "Hai ricevuto un invito a unirti a un team su Customermates. Scegli il tuo metodo di accesso per accettare l’invito.",
+    "inviteSubtitle": "{inviterName} ti ha invitato a entrare nel suo spazio di lavoro su Customermates. Scegli come creare il tuo account.",
     "inviteTitle": "Accetta l'invito aziendale",
-    "newCompanySubtitle": "Registra una nuova azienda e prova Customermates gratis per {days} giorni. Nessuna carta di credito richiesta.",
     "or": "OPPURE",
     "signUpCta": "Crea un account",
     "switchToSignIn": "Hai già un account? <signInLink>Accedi</signInLink>",
@@ -3004,6 +3059,7 @@
   "VerifyEmailCard": {
     "body": "Ti abbiamo inviato un'e-mail di verifica. Controlla la tua posta in arrivo e clicca sul link per verificare il tuo indirizzo e-mail.",
     "ctaLabel": "Invia di nuovo l'e-mail di verifica",
+    "invitationFrom": "Invito da {inviterName}",
     "resendSuccess": "E-mail di verifica inviata correttamente.",
     "subtitle": "Verifica il tuo indirizzo e-mail per continuare.",
     "title": "Verifica dell'e-mail"

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -64,6 +64,7 @@ export const PUBLIC_ROUTES = [
   "/auth/pending",
   "/auth/error",
   "/auth/verify-email",
+  "/auth/invitation",
   "/invitation/:token",
   "/docs/openapi/:slug",
   "/docs/openapi",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -419,7 +419,7 @@
   --popover: var(--card);
   --popover-foreground: #fafafa;
   --primary: #7c6df2;
-  --primary-foreground: #ffffff;
+  --primary-foreground: var(--background);
   --secondary: var(--card);
   --secondary-foreground: #fafafa;
   --selected: rgb(255 255 255 / 5.5%);

--- a/tests/conventions/account-state-routes.test.ts
+++ b/tests/conventions/account-state-routes.test.ts
@@ -11,27 +11,62 @@ function source(path: string): string {
 
 describe("guarded account-state route contract", () => {
   it.each([
-    ["app/[locale]/(public)/auth/verify-email/page.tsx", /requireAccountState\(\s*"overdueVerification"\s*\)/],
-    ["app/[locale]/(public)/auth/pending/page.tsx", /requireAccountState\(\s*"pending"\s*\)/],
-    ["app/[locale]/(protected)/legal-update/page.tsx", /requireAccountState\(\s*\[\s*"allowed",\s*"legal"\s*\]\s*\)/],
+    [
+      "app/[locale]/(public)/auth/verify-email/page.tsx",
+      /requireAccountState\(\s*\[\s*"overdueVerification",\s*"unregistered"\s*\](?:\s*,|\s*\))/,
+    ],
+    [
+      "app/[locale]/(public)/auth/pending/page.tsx",
+      /requireAccountState\(\s*"pending"\s*\)/,
+    ],
+    [
+      "app/[locale]/(protected)/onboarding/page.tsx",
+      /requireAccountState\(\s*"unregistered"(?:\s*,|\s*\))/,
+    ],
+    [
+      "app/[locale]/(protected)/onboarding/join/page.tsx",
+      /requireAccountState\(\s*"unregistered"(?:\s*,|\s*\))/,
+    ],
+    [
+      "app/[locale]/(protected)/legal-update/page.tsx",
+      /requireAccountState\(\s*\[\s*"allowed",\s*"legal"\s*\]\s*\)/,
+    ],
     [
       "app/[locale]/(protected)/subscription-expired/page.tsx",
       /requireAccountState\(\s*"subscription",\s*"\/company\/subscription",?\s*\)/,
     ],
-    ["app/[locale]/(public)/auth/mcp-consent/page.tsx", /requireAccountState\(\s*"allowed"\s*\)/],
+    [
+      "app/[locale]/(public)/auth/mcp-consent/page.tsx",
+      /requireAccountState\(\s*"allowed"\s*\)/,
+    ],
   ])("server-gates %s with the canonical state resolver", (path, contract) => {
     expect(source(path)).toMatch(contract);
   });
 
   it("allows only pre-tenant or administrator onboarding states into the wizard", () => {
     const page = source("app/[locale]/(protected)/onboarding/wizard/page.tsx");
-    const actions = source("app/[locale]/(protected)/onboarding/wizard/actions.ts");
-    const registerInteractor = source("features/user/register/register-user.interactor.ts");
-    const completeInteractor = source("features/onboarding-wizard/complete-onboarding-wizard.interactor.ts");
+    const actions = source(
+      "app/[locale]/(protected)/onboarding/wizard/actions.ts",
+    );
+    const registerInteractor = source(
+      "features/user/register/register-user.interactor.ts",
+    );
+    const completeInteractor = source(
+      "features/onboarding-wizard/complete-onboarding-wizard.interactor.ts",
+    );
 
-    expect(page).toContain('requireAccountState(["unregistered", "onboarding"])');
-    expect(actions).toContain("getRegisterUserInteractor().invoke(data, { adAttribution })");
-    expect(actions).toContain("getCompleteOnboardingWizardInteractor().invoke()");
+    expect(page).toMatch(/requireAccountState\(\s*\[\s*"unregistered",\s*"onboarding"\s*\](?:\s*,|\s*\))/);
+    expect(actions).toMatch(
+      /getRegisterUserInteractor\(\)\.invoke\(\s*data,\s*\{\s*adAttribution,\s*target,?\s*\}\s*\)/,
+    );
+    expect(page).toContain("resolveOnboardingIntent(");
+    expect(page).toContain("canCreateCompany");
+    expect(actions).toContain("resolveOnboardingIntent(onboardingIntentValue)");
+    expect(actions).toContain('target = { type: "invitation"');
+    expect(actions).toContain('target = { type: "createCompany" }');
+    expect(actions).toContain(
+      "getCompleteOnboardingWizardInteractor().invoke()",
+    );
     expect(actions.match(/serializeResult\(/g)).toHaveLength(2);
     expect(actions).toContain("redirect(result.data.redirectTo)");
     expect(actions).not.toContain('redirect("/")');
@@ -58,33 +93,47 @@ describe("guarded account-state route contract", () => {
   });
 
   it("revalidates the whole blocker decision during recovery transitions", () => {
-    const navigation = source("app/components/navigation/navigation-switch.tsx");
+    const navigation = source(
+      "app/components/navigation/navigation-switch.tsx",
+    );
 
     expect(navigation).toContain("currentAccountState !== accountState");
     expect(navigation).toContain("router.refresh()");
     expect(navigation).toContain('searchParams.getAll("type")');
-    expect(source("app/[locale]/(public)/auth/pending/pending-card.tsx")).toContain("window.location.reload()");
-    expect(source("app/[locale]/(public)/auth/verify-email/verify-email-card.tsx")).toContain(
-      "window.location.reload()",
-    );
-    expect(source("app/[locale]/(protected)/onboarding/wizard/actions.ts")).toContain("refresh()");
-    expect(source("app/[locale]/(protected)/legal-update/actions.ts")).toContain("refresh()");
+    expect(
+      source("app/[locale]/(public)/auth/pending/pending-card.tsx"),
+    ).toContain("window.location.reload()");
+    expect(
+      source("app/[locale]/(public)/auth/verify-email/verify-email-card.tsx"),
+    ).toContain("window.location.reload()");
+    expect(
+      source("app/[locale]/(protected)/onboarding/wizard/actions.ts"),
+    ).toContain("refresh()");
+    expect(
+      source("app/[locale]/(protected)/legal-update/actions.ts"),
+    ).toContain("refresh()");
   });
 
   it("keeps tenant enhancements and keyboard search unmounted for restricted shells", () => {
     const layout = source("app/[locale]/(protected)/layout.tsx");
-    const navigation = source("app/components/navigation/navigation-switch.tsx");
-    const context = source("app/components/navigation/protected-enhancements-context.tsx");
+    const navigation = source(
+      "app/components/navigation/navigation-switch.tsx",
+    );
+    const context = source(
+      "app/components/navigation/protected-enhancements-context.tsx",
+    );
     const guardedMarkup = layout.indexOf("{protectedEnhancementsAllowed ? (");
 
-    expect(navigation).toContain("<ProtectedEnhancementsProvider allowed={protectedEnhancementsAllowed}>");
+    expect(navigation).toContain(
+      "<ProtectedEnhancementsProvider allowed={protectedEnhancementsAllowed}>",
+    );
     expect(context).toContain("createContext<boolean | null>(null)");
     expect(context).not.toContain("AccountState");
     expect(layout).toContain("useProtectedEnhancementsAllowed()");
     expect(layout).toContain("if (!protectedEnhancementsAllowed) return;");
-    expect(layout.indexOf("if (!protectedEnhancementsAllowed) return;")).toBeLessThan(
-      layout.indexOf('document.addEventListener("keydown"'),
-    );
+    expect(
+      layout.indexOf("if (!protectedEnhancementsAllowed) return;"),
+    ).toBeLessThan(layout.indexOf('document.addEventListener("keydown"'));
     expect(guardedMarkup).toBeGreaterThan(0);
     for (const component of [
       "<GlobalSearchModal />",
@@ -93,16 +142,24 @@ describe("guarded account-state route contract", () => {
       "<EntityDrawer />",
       "<ConnectedAccountModal />",
     ]) {
-      expect(layout.lastIndexOf(component), component).toBeGreaterThan(guardedMarkup);
+      expect(layout.lastIndexOf(component), component).toBeGreaterThan(
+        guardedMarkup,
+      );
     }
   });
 
   it("keeps mutation policy in interactors and page guards server-authoritative", () => {
     const authActions = source("app/[locale]/(public)/auth/actions.ts");
-    const consentInteractor = source("features/auth/decide-mcp-consent.interactor.ts");
+    const consentInteractor = source(
+      "features/auth/decide-mcp-consent.interactor.ts",
+    );
 
-    expect(authActions).toContain("getDecideMcpConsentInteractor().invoke(data)");
-    expect(authActions).toContain("serializeResult(getDecideMcpConsentInteractor().invoke(data))");
+    expect(authActions).toContain(
+      "getDecideMcpConsentInteractor().invoke(data)",
+    );
+    expect(authActions).toContain(
+      "serializeResult(getDecideMcpConsentInteractor().invoke(data))",
+    );
     expect(authActions).not.toContain("resolveRequestAccountState");
     expect(authActions).not.toContain("getAuthService");
     expect(consentInteractor).toContain('resolution.state !== "allowed"');
@@ -118,12 +175,18 @@ describe("guarded account-state route contract", () => {
     const sidebar = source("app/components/app-sidebar.tsx");
     expect(sidebar).toContain("<NavUser");
     expect(sidebar).toContain("signOutAction()");
-    expect(sidebar).toContain("if (!restricted) runUserAction(() => userStore.updateTheme(next))");
-    expect(source("app/[locale]/(protected)/legal-update/components/legal-update-view.tsx")).not.toContain(
-      "signOutAction",
+    expect(sidebar).toContain(
+      "if (!restricted) runUserAction(() => userStore.updateTheme(next))",
     );
     expect(
-      source("app/[locale]/(protected)/subscription-expired/components/subscription-expired-view.tsx"),
+      source(
+        "app/[locale]/(protected)/legal-update/components/legal-update-view.tsx",
+      ),
+    ).not.toContain("signOutAction");
+    expect(
+      source(
+        "app/[locale]/(protected)/subscription-expired/components/subscription-expired-view.tsx",
+      ),
     ).not.toContain("signOutAction");
   });
 });

--- a/tests/conventions/account-state-routes.test.ts
+++ b/tests/conventions/account-state-routes.test.ts
@@ -15,10 +15,7 @@ describe("guarded account-state route contract", () => {
       "app/[locale]/(public)/auth/verify-email/page.tsx",
       /requireAccountState\(\s*\[\s*"overdueVerification",\s*"unregistered"\s*\](?:\s*,|\s*\))/,
     ],
-    [
-      "app/[locale]/(public)/auth/pending/page.tsx",
-      /requireAccountState\(\s*"pending"\s*\)/,
-    ],
+    ["app/[locale]/(public)/auth/pending/page.tsx", /requireAccountState\(\s*"pending"\s*\)/],
     [
       "app/[locale]/(protected)/onboarding/page.tsx",
       /requireAccountState\(\s*"unregistered"(?:\s*,|\s*\))/,
@@ -27,36 +24,22 @@ describe("guarded account-state route contract", () => {
       "app/[locale]/(protected)/onboarding/join/page.tsx",
       /requireAccountState\(\s*"unregistered"(?:\s*,|\s*\))/,
     ],
-    [
-      "app/[locale]/(protected)/legal-update/page.tsx",
-      /requireAccountState\(\s*\[\s*"allowed",\s*"legal"\s*\]\s*\)/,
-    ],
+    ["app/[locale]/(protected)/legal-update/page.tsx", /requireAccountState\(\s*\[\s*"allowed",\s*"legal"\s*\]\s*\)/],
     [
       "app/[locale]/(protected)/subscription-expired/page.tsx",
       /requireAccountState\(\s*"subscription",\s*"\/company\/subscription",?\s*\)/,
     ],
-    [
-      "app/[locale]/(public)/auth/mcp-consent/page.tsx",
-      /requireAccountState\(\s*"allowed"\s*\)/,
-    ],
+    ["app/[locale]/(public)/auth/mcp-consent/page.tsx", /requireAccountState\(\s*"allowed"\s*\)/],
   ])("server-gates %s with the canonical state resolver", (path, contract) => {
     expect(source(path)).toMatch(contract);
   });
 
   it("allows only pre-tenant or administrator onboarding states into the wizard", () => {
     const page = source("app/[locale]/(protected)/onboarding/wizard/page.tsx");
-    const actions = source(
-      "app/[locale]/(protected)/onboarding/wizard/actions.ts",
-    );
-    const registerInteractor = source(
-      "features/user/register/register-user.interactor.ts",
-    );
-    const registrationBoundary = source(
-      "features/user/register/register-onboarding-profile.interactor.ts",
-    );
-    const completeInteractor = source(
-      "features/onboarding-wizard/complete-onboarding-wizard.interactor.ts",
-    );
+    const actions = source("app/[locale]/(protected)/onboarding/wizard/actions.ts");
+    const registerInteractor = source("features/user/register/register-user.interactor.ts");
+    const registrationBoundary = source("features/user/register/register-onboarding-profile.interactor.ts");
+    const completeInteractor = source("features/onboarding-wizard/complete-onboarding-wizard.interactor.ts");
 
     expect(page).toMatch(/requireAccountState\(\s*\[\s*"unregistered",\s*"onboarding"\s*\](?:\s*,|\s*\))/);
     expect(actions).toMatch(
@@ -67,9 +50,7 @@ describe("guarded account-state route contract", () => {
     expect(registrationBoundary).toContain("onboardingIntentService.resolve(");
     expect(registrationBoundary).toContain('target = { type: "invitation"');
     expect(registrationBoundary).toContain('target = { type: "createCompany" }');
-    expect(actions).toContain(
-      "getCompleteOnboardingWizardInteractor().invoke()",
-    );
+    expect(actions).toContain("getCompleteOnboardingWizardInteractor().invoke()");
     expect(actions.match(/serializeResult\(/g)).toHaveLength(2);
     expect(actions).toContain("redirect(result.data.redirectTo)");
     expect(actions).not.toContain('redirect("/")');
@@ -96,47 +77,33 @@ describe("guarded account-state route contract", () => {
   });
 
   it("revalidates the whole blocker decision during recovery transitions", () => {
-    const navigation = source(
-      "app/components/navigation/navigation-switch.tsx",
-    );
+    const navigation = source("app/components/navigation/navigation-switch.tsx");
 
     expect(navigation).toContain("currentAccountState !== accountState");
     expect(navigation).toContain("router.refresh()");
     expect(navigation).toContain('searchParams.getAll("type")');
-    expect(
-      source("app/[locale]/(public)/auth/pending/pending-card.tsx"),
-    ).toContain("window.location.reload()");
-    expect(
-      source("app/[locale]/(public)/auth/verify-email/verify-email-card.tsx"),
-    ).toContain("window.location.reload()");
-    expect(
-      source("app/[locale]/(protected)/onboarding/wizard/actions.ts"),
-    ).toContain("refresh()");
-    expect(
-      source("app/[locale]/(protected)/legal-update/actions.ts"),
-    ).toContain("refresh()");
+    expect(source("app/[locale]/(public)/auth/pending/pending-card.tsx")).toContain("window.location.reload()");
+    expect(source("app/[locale]/(public)/auth/verify-email/verify-email-card.tsx")).toContain(
+      "window.location.reload()",
+    );
+    expect(source("app/[locale]/(protected)/onboarding/wizard/actions.ts")).toContain("refresh()");
+    expect(source("app/[locale]/(protected)/legal-update/actions.ts")).toContain("refresh()");
   });
 
   it("keeps tenant enhancements and keyboard search unmounted for restricted shells", () => {
     const layout = source("app/[locale]/(protected)/layout.tsx");
-    const navigation = source(
-      "app/components/navigation/navigation-switch.tsx",
-    );
-    const context = source(
-      "app/components/navigation/protected-enhancements-context.tsx",
-    );
+    const navigation = source("app/components/navigation/navigation-switch.tsx");
+    const context = source("app/components/navigation/protected-enhancements-context.tsx");
     const guardedMarkup = layout.indexOf("{protectedEnhancementsAllowed ? (");
 
-    expect(navigation).toContain(
-      "<ProtectedEnhancementsProvider allowed={protectedEnhancementsAllowed}>",
-    );
+    expect(navigation).toContain("<ProtectedEnhancementsProvider allowed={protectedEnhancementsAllowed}>");
     expect(context).toContain("createContext<boolean | null>(null)");
     expect(context).not.toContain("AccountState");
     expect(layout).toContain("useProtectedEnhancementsAllowed()");
     expect(layout).toContain("if (!protectedEnhancementsAllowed) return;");
-    expect(
-      layout.indexOf("if (!protectedEnhancementsAllowed) return;"),
-    ).toBeLessThan(layout.indexOf('document.addEventListener("keydown"'));
+    expect(layout.indexOf("if (!protectedEnhancementsAllowed) return;")).toBeLessThan(
+      layout.indexOf('document.addEventListener("keydown"'),
+    );
     expect(guardedMarkup).toBeGreaterThan(0);
     for (const component of [
       "<GlobalSearchModal />",
@@ -145,24 +112,16 @@ describe("guarded account-state route contract", () => {
       "<EntityDrawer />",
       "<ConnectedAccountModal />",
     ]) {
-      expect(layout.lastIndexOf(component), component).toBeGreaterThan(
-        guardedMarkup,
-      );
+      expect(layout.lastIndexOf(component), component).toBeGreaterThan(guardedMarkup);
     }
   });
 
   it("keeps mutation policy in interactors and page guards server-authoritative", () => {
     const authActions = source("app/[locale]/(public)/auth/actions.ts");
-    const consentInteractor = source(
-      "features/auth/decide-mcp-consent.interactor.ts",
-    );
+    const consentInteractor = source("features/auth/decide-mcp-consent.interactor.ts");
 
-    expect(authActions).toContain(
-      "getDecideMcpConsentInteractor().invoke(data)",
-    );
-    expect(authActions).toContain(
-      "serializeResult(getDecideMcpConsentInteractor().invoke(data))",
-    );
+    expect(authActions).toContain("getDecideMcpConsentInteractor().invoke(data)");
+    expect(authActions).toContain("serializeResult(getDecideMcpConsentInteractor().invoke(data))");
     expect(authActions).not.toContain("resolveRequestAccountState");
     expect(authActions).not.toContain("getAuthService");
     expect(consentInteractor).toContain('resolution.state !== "allowed"');
@@ -178,18 +137,12 @@ describe("guarded account-state route contract", () => {
     const sidebar = source("app/components/app-sidebar.tsx");
     expect(sidebar).toContain("<NavUser");
     expect(sidebar).toContain("signOutAction()");
-    expect(sidebar).toContain(
-      "if (!restricted) runUserAction(() => userStore.updateTheme(next))",
+    expect(sidebar).toContain("if (!restricted) runUserAction(() => userStore.updateTheme(next))");
+    expect(source("app/[locale]/(protected)/legal-update/components/legal-update-view.tsx")).not.toContain(
+      "signOutAction",
     );
     expect(
-      source(
-        "app/[locale]/(protected)/legal-update/components/legal-update-view.tsx",
-      ),
-    ).not.toContain("signOutAction");
-    expect(
-      source(
-        "app/[locale]/(protected)/subscription-expired/components/subscription-expired-view.tsx",
-      ),
+      source("app/[locale]/(protected)/subscription-expired/components/subscription-expired-view.tsx"),
     ).not.toContain("signOutAction");
   });
 });

--- a/tests/conventions/account-state-routes.test.ts
+++ b/tests/conventions/account-state-routes.test.ts
@@ -51,19 +51,22 @@ describe("guarded account-state route contract", () => {
     const registerInteractor = source(
       "features/user/register/register-user.interactor.ts",
     );
+    const registrationBoundary = source(
+      "features/user/register/register-onboarding-profile.interactor.ts",
+    );
     const completeInteractor = source(
       "features/onboarding-wizard/complete-onboarding-wizard.interactor.ts",
     );
 
     expect(page).toMatch(/requireAccountState\(\s*\[\s*"unregistered",\s*"onboarding"\s*\](?:\s*,|\s*\))/);
     expect(actions).toMatch(
-      /getRegisterUserInteractor\(\)\.invoke\(\s*data,\s*\{\s*adAttribution,\s*target,?\s*\}\s*\)/,
+      /getRegisterOnboardingProfileInteractor\(\)\.invoke\(\s*data,\s*\{\s*adAttribution\s*\}\s*\)/,
     );
     expect(page).toContain("resolveOnboardingIntent(");
     expect(page).toContain("canCreateCompany");
-    expect(actions).toContain("resolveOnboardingIntent(onboardingIntentValue)");
-    expect(actions).toContain('target = { type: "invitation"');
-    expect(actions).toContain('target = { type: "createCompany" }');
+    expect(registrationBoundary).toContain("onboardingIntentService.resolve(");
+    expect(registrationBoundary).toContain('target = { type: "invitation"');
+    expect(registrationBoundary).toContain('target = { type: "createCompany" }');
     expect(actions).toContain(
       "getCompleteOnboardingWizardInteractor().invoke()",
     );

--- a/tests/conventions/env-config.test.ts
+++ b/tests/conventions/env-config.test.ts
@@ -195,7 +195,8 @@ describe("environment configuration", () => {
     expect(authConfig).not.toContain('protocol: "auto"');
     expect(authConfig).not.toContain("AUTH_USE_SECURE_COOKIES");
     expect(invitationRoute).toContain("resolveRequestOrigin(request.url, env.AUTH_ALLOWED_HOSTS, env.BASE_URL)");
-    expect(invitationRoute).toContain('secure: new URL(base).protocol === "https:"');
+    expect(invitationRoute).toContain("issueInvitationOnboardingIntent");
+    expect(invitationRoute).toContain("response.cookies.delete(INVITE_TOKEN_COOKIE_NAME)");
     expect(authConfig).toContain("productionURL: env.OAUTH_PROXY_URL");
     expect(authConfig).toContain("secret: env.OAUTH_PROXY_SECRET");
     expect(authConfig).not.toContain("currentURL:");

--- a/tests/conventions/env-config.test.ts
+++ b/tests/conventions/env-config.test.ts
@@ -195,7 +195,12 @@ describe("environment configuration", () => {
     expect(authConfig).not.toContain('protocol: "auto"');
     expect(authConfig).not.toContain("AUTH_USE_SECURE_COOKIES");
     expect(invitationRoute).toContain("resolveRequestOrigin(request.url, env.AUTH_ALLOWED_HOSTS, env.BASE_URL)");
-    expect(invitationRoute).toContain("issueInvitationOnboardingIntent");
+    expect(invitationRoute).toContain("getOpenInvitationInteractor().invoke({ token })");
+    const openInvitation = readFileSync(
+      new URL("../../features/company/open-invitation.interactor.ts", import.meta.url),
+      "utf8",
+    );
+    expect(openInvitation).toContain("this.onboardingIntentService.issueInvitation(data.token, result.data.expiresAt)");
     expect(invitationRoute).toContain("response.cookies.delete(INVITE_TOKEN_COOKIE_NAME)");
     expect(authConfig).toContain("productionURL: env.OAUTH_PROXY_URL");
     expect(authConfig).toContain("secret: env.OAUTH_PROXY_SECRET");

--- a/tests/conventions/i18n-key-resolution.test.ts
+++ b/tests/conventions/i18n-key-resolution.test.ts
@@ -236,7 +236,9 @@ const ENTITY_TIMELINE_TYPE_KEYS = [
 const ERROR_CARD_DYNAMIC_KEYS = [
   "ErrorCard.inactiveUser",
   "ErrorCard.invalidInviteLink",
+  "ErrorCard.invalidOnboardingIntent",
   "ErrorCard.inviteLinkExpired",
+  "ErrorCard.onboardingSessionExpired",
 ] as const;
 const AUTH_SOCIAL_ERROR_KEYS = socialErrorMessageKeys();
 const HOMEPAGE_PRICING_VARIABLE_KEYS = [

--- a/tests/conventions/internal-link-targets.test.ts
+++ b/tests/conventions/internal-link-targets.test.ts
@@ -89,6 +89,7 @@ const CODE_BACKED_ROUTE_FILES = {
   "/auth/pending": "app/[locale]/(public)/auth/pending/page.tsx",
   "/auth/error": "app/[locale]/(public)/auth/error/page.tsx",
   "/auth/verify-email": "app/[locale]/(public)/auth/verify-email/page.tsx",
+  "/auth/invitation": "app/[locale]/(public)/auth/invitation/page.tsx",
   "/invitation/:token": "app/[locale]/(public)/invitation/[token]/route.ts",
 } as const;
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u;

--- a/tests/conventions/legal-unipile-disclosure.test.ts
+++ b/tests/conventions/legal-unipile-disclosure.test.ts
@@ -552,7 +552,7 @@ describe("registration legal copy covers the DPA", () => {
     );
     const registration = readFileSync(join(REPO_ROOT, "features/user/register/register-user.interactor.ts"), "utf8");
 
-    expect(signInPage).toContain("getInviteTokenValidationInteractor");
+    expect(signInPage).toContain("resolveOnboardingIntent");
     expect(signInForm).toContain('appMode === "cloud" && !isInvited');
     expect(signUpForm).toContain('appMode === "cloud" && !isInvited');
     expect(onboarding).toContain('appMode === "cloud"');

--- a/tests/conventions/page-state-contract.test.ts
+++ b/tests/conventions/page-state-contract.test.ts
@@ -5,12 +5,10 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 const read = (path: string) => readFileSync(resolve(root, path), "utf8");
 const filesUnder = (directory: string): string[] =>
-  readdirSync(resolve(root, directory), { withFileTypes: true }).flatMap(
-    (entry) => {
-      const path = join(directory, entry.name);
-      return entry.isDirectory() ? filesUnder(path) : [path];
-    },
-  );
+  readdirSync(resolve(root, directory), { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(path) : [path];
+  });
 
 const protectedRoot = "app/[locale]/(protected)";
 const protectedPages = filesUnder(protectedRoot)
@@ -18,9 +16,7 @@ const protectedPages = filesUnder(protectedRoot)
   .map((path) => path.slice(protectedRoot.length + 1))
   .filter((path) => !path.startsWith("test/"))
   .sort();
-const protectedLoaders = protectedPages.map((page) =>
-  join(protectedRoot, dirname(page), "loading.tsx"),
-);
+const protectedLoaders = protectedPages.map((page) => join(protectedRoot, dirname(page), "loading.tsx"));
 
 const collectionViews = [
   "app/[locale]/(protected)/contacts/components/contacts-page-view.tsx",
@@ -54,26 +50,11 @@ const featureSkeletons = [
 ] as const;
 
 const exhaustiveResourceOwners = [
-  [
-    "app/[locale]/(protected)/dashboard/components/dashboard-page-view.tsx",
-    "switch (pageState)",
-  ],
-  [
-    "app/[locale]/(protected)/profile/components/api-keys-page-view.tsx",
-    "switch (pageState)",
-  ],
-  [
-    "app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx",
-    "switch (pageState)",
-  ],
-  [
-    "app/[locale]/(protected)/inbox/components/inbox-list.tsx",
-    "switch (pageState)",
-  ],
-  [
-    "app/[locale]/(protected)/inbox/components/thread-panel.tsx",
-    "switch (pageState.status)",
-  ],
+  ["app/[locale]/(protected)/dashboard/components/dashboard-page-view.tsx", "switch (pageState)"],
+  ["app/[locale]/(protected)/profile/components/api-keys-page-view.tsx", "switch (pageState)"],
+  ["app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx", "switch (pageState)"],
+  ["app/[locale]/(protected)/inbox/components/inbox-list.tsx", "switch (pageState)"],
+  ["app/[locale]/(protected)/inbox/components/thread-panel.tsx", "switch (pageState.status)"],
   ["components/entity-detail/entity-drawer.tsx", "switch (drawerState)"],
 ] as const;
 
@@ -82,14 +63,9 @@ describe("page-state ownership", () => {
     expect(protectedLoaders).toHaveLength(31);
     for (const path of protectedLoaders) {
       expect(existsSync(resolve(root, path)), path).toBe(true);
-      expect(
-        existsSync(resolve(root, dirname(path), "page.tsx")),
-        `${path}:page`,
-      ).toBe(true);
+      expect(existsSync(resolve(root, dirname(path), "page.tsx")), `${path}:page`).toBe(true);
       const source = read(path);
-      expect(source, path).not.toMatch(
-        /\bRouteLoading\b|\bPageSkeleton\b|route-registry/,
-      );
+      expect(source, path).not.toMatch(/\bRouteLoading\b|\bPageSkeleton\b|route-registry/);
       expect(source, path).toMatch(/PageState|EntityDetailRouteLoading/);
       expect(source, path).toMatch(/Skeleton|EntityDetailRouteLoading/);
       expect(source, path).not.toMatch(/\bfixed\b|\binset-0\b|z-\d+/);
@@ -108,19 +84,11 @@ describe("page-state ownership", () => {
     for (const path of collectionViews) {
       const source = read(path);
       expect(source, path).toContain("switch (pageState)");
-      for (const state of [
-        "error",
-        "loading",
-        "filtered-empty",
-        "true-empty",
-        "content",
-      ]) {
+      for (const state of ["error", "loading", "filtered-empty", "true-empty", "content"]) {
         expect(source, `${path}:${state}`).toContain(`case "${state}"`);
       }
       expect(source, path).toContain("const exhaustive: never = pageState");
-      expect(source, path).not.toMatch(
-        /DataViewContainer|useState\(|useEffect\(/,
-      );
+      expect(source, path).not.toMatch(/DataViewContainer|useState\(|useEffect\(/);
     }
   });
 
@@ -130,37 +98,24 @@ describe("page-state ownership", () => {
       "components/page-state/page-skeleton.tsx",
       "components/page-state/route-loading.tsx",
       "components/page-state/route-registry.ts",
-    ])
-      expect(existsSync(resolve(root, path)), path).toBe(false);
+    ]) expect(existsSync(resolve(root, path)), path).toBe(false);
 
     const productionFiles = ["app", "components", "core", "features"]
       .flatMap(filesUnder)
       .filter((path) => path.endsWith(".ts") || path.endsWith(".tsx"))
-      .filter(
-        (path) =>
-          !path.includes("/__tests__/") &&
-          !path.endsWith(".test.ts") &&
-          !path.endsWith(".test.tsx"),
-      );
+      .filter((path) => !path.includes("/__tests__/") && !path.endsWith(".test.ts") && !path.endsWith(".test.tsx"));
     const legacyPattern =
       /\bDataViewContainer\b|\bPageSkeletonSpec\b|\bPageSkeleton\b|\bRouteLoading\b|\bPROTECTED_ROUTE_REGISTRY\b|\bgetProtectedRouteSpec\b/;
-    for (const path of productionFiles)
-      expect(read(path), path).not.toMatch(legacyPattern);
-    expect(read("components/page-state/page-state.tsx")).not.toMatch(
-      /\bskeleton[?:=]/,
-    );
-    expect(read("core/base/base-data-view.store.ts")).not.toContain(
-      "refreshError",
-    );
+    for (const path of productionFiles) expect(read(path), path).not.toMatch(legacyPattern);
+    expect(read("components/page-state/page-state.tsx")).not.toMatch(/\bskeleton[?:=]/);
+    expect(read("core/base/base-data-view.store.ts")).not.toContain("refreshError");
   });
 
   it("keeps skeleton composition server-compatible and side-effect free", () => {
     for (const path of pureSkeletons) {
       const source = read(path);
       expect(source, path).not.toContain('"use client"');
-      expect(source, path).not.toMatch(
-        /use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/,
-      );
+      expect(source, path).not.toMatch(/use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/);
       expect(source, path).toContain("data-page-skeleton-loading");
       expect(source, path).toContain("data-page-skeleton-empty");
     }
@@ -168,33 +123,22 @@ describe("page-state ownership", () => {
     for (const path of featureSkeletons) {
       const source = read(path);
       expect(source, path).not.toContain('"use client"');
-      expect(source, path).not.toMatch(
-        /use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/,
-      );
+      expect(source, path).not.toMatch(/use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/);
     }
   });
 
   it("does not start connected-account work behind locked surfaces", () => {
-    expect(
-      read(
-        "app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx",
-      ),
-    ).toContain("if (locked) return;");
-    expect(
-      read("app/[locale]/(protected)/inbox/components/inbox-list.tsx"),
-    ).toContain("if (locked) return;");
+    expect(read("app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx")).toContain(
+      "if (locked) return;",
+    );
+    expect(read("app/[locale]/(protected)/inbox/components/inbox-list.tsx")).toContain("if (locked) return;");
   });
 
   it("keeps the neutral public and internal-test loaders generic", () => {
-    for (const path of [
-      "app/[locale]/(public)/loading.tsx",
-      "app/[locale]/(protected)/test/loading.tsx",
-    ]) {
+    for (const path of ["app/[locale]/(public)/loading.tsx", "app/[locale]/(protected)/test/loading.tsx"]) {
       const source = read(path);
       expect(source, path).toContain("GenericPageLoading");
-      expect(source, path).not.toMatch(
-        /PageState|PageSkeleton|RouteLoading|<main|\bfixed\b/,
-      );
+      expect(source, path).not.toMatch(/PageState|PageSkeleton|RouteLoading|<main|\bfixed\b/);
     }
   });
 
@@ -207,13 +151,8 @@ describe("page-state ownership", () => {
     // get the same 404 as a route that does not exist, so nothing above such a layout may carry one
     // either. That is why the (protected) group has no catch-all loader: its only pages without a
     // direct loader are the internal test routes, which hold one of their own.
-    expect(
-      existsSync(resolve(root, "app/[locale]/loading.tsx")),
-      "app/[locale]/loading.tsx",
-    ).toBe(false);
-    const staticLoaders = filesUnder("app/[locale]/(static)").filter((path) =>
-      path.endsWith("loading.tsx"),
-    );
+    expect(existsSync(resolve(root, "app/[locale]/loading.tsx")), "app/[locale]/loading.tsx").toBe(false);
+    const staticLoaders = filesUnder("app/[locale]/(static)").filter((path) => path.endsWith("loading.tsx"));
     expect(staticLoaders, "loading.tsx under (static)").toEqual([]);
 
     const guardedLayouts = filesUnder("app")
@@ -224,10 +163,7 @@ describe("page-state ownership", () => {
       let segment = dirname(dirname(layout));
       while (segment.startsWith("app")) {
         const loader = join(segment, "loading.tsx");
-        expect(
-          existsSync(resolve(root, loader)),
-          `${loader} sits above ${layout}`,
-        ).toBe(false);
+        expect(existsSync(resolve(root, loader)), `${loader} sits above ${layout}`).toBe(false);
         if (segment === "app") break;
         segment = dirname(segment);
       }
@@ -236,12 +172,8 @@ describe("page-state ownership", () => {
 
   it("keeps loading motion shape-only and disabled for reduced motion", () => {
     const styles = read("styles/globals.css");
-    expect(styles).toContain(
-      "[data-page-skeleton-loading] [data-skeleton-motion]",
-    );
-    expect(styles).toContain(
-      "[data-page-skeleton-loading] [data-skeleton-breathe]",
-    );
+    expect(styles).toContain("[data-page-skeleton-loading] [data-skeleton-motion]");
+    expect(styles).toContain("[data-page-skeleton-loading] [data-skeleton-breathe]");
     expect(styles).toContain("[data-page-skeleton-empty]");
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
     expect(styles).toContain("animation: none");

--- a/tests/conventions/page-state-contract.test.ts
+++ b/tests/conventions/page-state-contract.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 const read = (path: string) => readFileSync(resolve(root, path), "utf8");
 const filesUnder = (directory: string): string[] =>
-  readdirSync(resolve(root, directory), { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    return entry.isDirectory() ? filesUnder(path) : [path];
-  });
+  readdirSync(resolve(root, directory), { withFileTypes: true }).flatMap(
+    (entry) => {
+      const path = join(directory, entry.name);
+      return entry.isDirectory() ? filesUnder(path) : [path];
+    },
+  );
 
 const protectedRoot = "app/[locale]/(protected)";
 const protectedPages = filesUnder(protectedRoot)
@@ -16,7 +18,9 @@ const protectedPages = filesUnder(protectedRoot)
   .map((path) => path.slice(protectedRoot.length + 1))
   .filter((path) => !path.startsWith("test/"))
   .sort();
-const protectedLoaders = protectedPages.map((page) => join(protectedRoot, dirname(page), "loading.tsx"));
+const protectedLoaders = protectedPages.map((page) =>
+  join(protectedRoot, dirname(page), "loading.tsx"),
+);
 
 const collectionViews = [
   "app/[locale]/(protected)/contacts/components/contacts-page-view.tsx",
@@ -50,22 +54,42 @@ const featureSkeletons = [
 ] as const;
 
 const exhaustiveResourceOwners = [
-  ["app/[locale]/(protected)/dashboard/components/dashboard-page-view.tsx", "switch (pageState)"],
-  ["app/[locale]/(protected)/profile/components/api-keys-page-view.tsx", "switch (pageState)"],
-  ["app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx", "switch (pageState)"],
-  ["app/[locale]/(protected)/inbox/components/inbox-list.tsx", "switch (pageState)"],
-  ["app/[locale]/(protected)/inbox/components/thread-panel.tsx", "switch (pageState.status)"],
+  [
+    "app/[locale]/(protected)/dashboard/components/dashboard-page-view.tsx",
+    "switch (pageState)",
+  ],
+  [
+    "app/[locale]/(protected)/profile/components/api-keys-page-view.tsx",
+    "switch (pageState)",
+  ],
+  [
+    "app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx",
+    "switch (pageState)",
+  ],
+  [
+    "app/[locale]/(protected)/inbox/components/inbox-list.tsx",
+    "switch (pageState)",
+  ],
+  [
+    "app/[locale]/(protected)/inbox/components/thread-panel.tsx",
+    "switch (pageState.status)",
+  ],
   ["components/entity-detail/entity-drawer.tsx", "switch (drawerState)"],
 ] as const;
 
 describe("page-state ownership", () => {
   it("gives every protected product route a direct feature or family loader", () => {
-    expect(protectedLoaders).toHaveLength(29);
+    expect(protectedLoaders).toHaveLength(31);
     for (const path of protectedLoaders) {
       expect(existsSync(resolve(root, path)), path).toBe(true);
-      expect(existsSync(resolve(root, dirname(path), "page.tsx")), `${path}:page`).toBe(true);
+      expect(
+        existsSync(resolve(root, dirname(path), "page.tsx")),
+        `${path}:page`,
+      ).toBe(true);
       const source = read(path);
-      expect(source, path).not.toMatch(/\bRouteLoading\b|\bPageSkeleton\b|route-registry/);
+      expect(source, path).not.toMatch(
+        /\bRouteLoading\b|\bPageSkeleton\b|route-registry/,
+      );
       expect(source, path).toMatch(/PageState|EntityDetailRouteLoading/);
       expect(source, path).toMatch(/Skeleton|EntityDetailRouteLoading/);
       expect(source, path).not.toMatch(/\bfixed\b|\binset-0\b|z-\d+/);
@@ -84,11 +108,19 @@ describe("page-state ownership", () => {
     for (const path of collectionViews) {
       const source = read(path);
       expect(source, path).toContain("switch (pageState)");
-      for (const state of ["error", "loading", "filtered-empty", "true-empty", "content"]) {
+      for (const state of [
+        "error",
+        "loading",
+        "filtered-empty",
+        "true-empty",
+        "content",
+      ]) {
         expect(source, `${path}:${state}`).toContain(`case "${state}"`);
       }
       expect(source, path).toContain("const exhaustive: never = pageState");
-      expect(source, path).not.toMatch(/DataViewContainer|useState\(|useEffect\(/);
+      expect(source, path).not.toMatch(
+        /DataViewContainer|useState\(|useEffect\(/,
+      );
     }
   });
 
@@ -98,24 +130,37 @@ describe("page-state ownership", () => {
       "components/page-state/page-skeleton.tsx",
       "components/page-state/route-loading.tsx",
       "components/page-state/route-registry.ts",
-    ]) expect(existsSync(resolve(root, path)), path).toBe(false);
+    ])
+      expect(existsSync(resolve(root, path)), path).toBe(false);
 
     const productionFiles = ["app", "components", "core", "features"]
       .flatMap(filesUnder)
       .filter((path) => path.endsWith(".ts") || path.endsWith(".tsx"))
-      .filter((path) => !path.includes("/__tests__/") && !path.endsWith(".test.ts") && !path.endsWith(".test.tsx"));
+      .filter(
+        (path) =>
+          !path.includes("/__tests__/") &&
+          !path.endsWith(".test.ts") &&
+          !path.endsWith(".test.tsx"),
+      );
     const legacyPattern =
       /\bDataViewContainer\b|\bPageSkeletonSpec\b|\bPageSkeleton\b|\bRouteLoading\b|\bPROTECTED_ROUTE_REGISTRY\b|\bgetProtectedRouteSpec\b/;
-    for (const path of productionFiles) expect(read(path), path).not.toMatch(legacyPattern);
-    expect(read("components/page-state/page-state.tsx")).not.toMatch(/\bskeleton[?:=]/);
-    expect(read("core/base/base-data-view.store.ts")).not.toContain("refreshError");
+    for (const path of productionFiles)
+      expect(read(path), path).not.toMatch(legacyPattern);
+    expect(read("components/page-state/page-state.tsx")).not.toMatch(
+      /\bskeleton[?:=]/,
+    );
+    expect(read("core/base/base-data-view.store.ts")).not.toContain(
+      "refreshError",
+    );
   });
 
   it("keeps skeleton composition server-compatible and side-effect free", () => {
     for (const path of pureSkeletons) {
       const source = read(path);
       expect(source, path).not.toContain('"use client"');
-      expect(source, path).not.toMatch(/use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/);
+      expect(source, path).not.toMatch(
+        /use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/,
+      );
       expect(source, path).toContain("data-page-skeleton-loading");
       expect(source, path).toContain("data-page-skeleton-empty");
     }
@@ -123,22 +168,33 @@ describe("page-state ownership", () => {
     for (const path of featureSkeletons) {
       const source = read(path);
       expect(source, path).not.toContain('"use client"');
-      expect(source, path).not.toMatch(/use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/);
+      expect(source, path).not.toMatch(
+        /use(State|Effect|LayoutEffect|Reducer)|useRootStore|window\.|fetch\(|setTimeout|setInterval/,
+      );
     }
   });
 
   it("does not start connected-account work behind locked surfaces", () => {
-    expect(read("app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx")).toContain(
-      "if (locked) return;",
-    );
-    expect(read("app/[locale]/(protected)/inbox/components/inbox-list.tsx")).toContain("if (locked) return;");
+    expect(
+      read(
+        "app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx",
+      ),
+    ).toContain("if (locked) return;");
+    expect(
+      read("app/[locale]/(protected)/inbox/components/inbox-list.tsx"),
+    ).toContain("if (locked) return;");
   });
 
   it("keeps the neutral public and internal-test loaders generic", () => {
-    for (const path of ["app/[locale]/(public)/loading.tsx", "app/[locale]/(protected)/test/loading.tsx"]) {
+    for (const path of [
+      "app/[locale]/(public)/loading.tsx",
+      "app/[locale]/(protected)/test/loading.tsx",
+    ]) {
       const source = read(path);
       expect(source, path).toContain("GenericPageLoading");
-      expect(source, path).not.toMatch(/PageState|PageSkeleton|RouteLoading|<main|\bfixed\b/);
+      expect(source, path).not.toMatch(
+        /PageState|PageSkeleton|RouteLoading|<main|\bfixed\b/,
+      );
     }
   });
 
@@ -151,8 +207,13 @@ describe("page-state ownership", () => {
     // get the same 404 as a route that does not exist, so nothing above such a layout may carry one
     // either. That is why the (protected) group has no catch-all loader: its only pages without a
     // direct loader are the internal test routes, which hold one of their own.
-    expect(existsSync(resolve(root, "app/[locale]/loading.tsx")), "app/[locale]/loading.tsx").toBe(false);
-    const staticLoaders = filesUnder("app/[locale]/(static)").filter((path) => path.endsWith("loading.tsx"));
+    expect(
+      existsSync(resolve(root, "app/[locale]/loading.tsx")),
+      "app/[locale]/loading.tsx",
+    ).toBe(false);
+    const staticLoaders = filesUnder("app/[locale]/(static)").filter((path) =>
+      path.endsWith("loading.tsx"),
+    );
     expect(staticLoaders, "loading.tsx under (static)").toEqual([]);
 
     const guardedLayouts = filesUnder("app")
@@ -163,7 +224,10 @@ describe("page-state ownership", () => {
       let segment = dirname(dirname(layout));
       while (segment.startsWith("app")) {
         const loader = join(segment, "loading.tsx");
-        expect(existsSync(resolve(root, loader)), `${loader} sits above ${layout}`).toBe(false);
+        expect(
+          existsSync(resolve(root, loader)),
+          `${loader} sits above ${layout}`,
+        ).toBe(false);
         if (segment === "app") break;
         segment = dirname(segment);
       }
@@ -172,8 +236,12 @@ describe("page-state ownership", () => {
 
   it("keeps loading motion shape-only and disabled for reduced motion", () => {
     const styles = read("styles/globals.css");
-    expect(styles).toContain("[data-page-skeleton-loading] [data-skeleton-motion]");
-    expect(styles).toContain("[data-page-skeleton-loading] [data-skeleton-breathe]");
+    expect(styles).toContain(
+      "[data-page-skeleton-loading] [data-skeleton-motion]",
+    );
+    expect(styles).toContain(
+      "[data-page-skeleton-loading] [data-skeleton-breathe]",
+    );
     expect(styles).toContain("[data-page-skeleton-empty]");
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
     expect(styles).toContain("animation: none");

--- a/tests/conventions/tenant-write-scoping.test.ts
+++ b/tests/conventions/tenant-write-scoping.test.ts
@@ -28,10 +28,10 @@ const GUARD_EXEMPT_MODELS = new Set([
 
 const REACHED_ONLY_FROM_BYPASSED_CALLERS = new Set([
   "core/auth/better-auth.ts:79",
-  "features/user/prisma-user.repository.ts:680",
-  "features/user/prisma-user.repository.ts:690",
-  "features/user/prisma-user.repository.ts:700",
-  "features/user/prisma-user.repository.ts:710",
+  "features/user/prisma-user.repository.ts:673",
+  "features/user/prisma-user.repository.ts:683",
+  "features/user/prisma-user.repository.ts:693",
+  "features/user/prisma-user.repository.ts:703",
 ]);
 
 type WriteSite = {

--- a/tests/conventions/tenant-write-scoping.test.ts
+++ b/tests/conventions/tenant-write-scoping.test.ts
@@ -27,11 +27,11 @@ const GUARD_EXEMPT_MODELS = new Set([
 ]);
 
 const REACHED_ONLY_FROM_BYPASSED_CALLERS = new Set([
-  "core/auth/better-auth.ts:103",
-  "features/user/prisma-user.repository.ts:646",
-  "features/user/prisma-user.repository.ts:656",
-  "features/user/prisma-user.repository.ts:666",
-  "features/user/prisma-user.repository.ts:676",
+  "core/auth/better-auth.ts:79",
+  "features/user/prisma-user.repository.ts:680",
+  "features/user/prisma-user.repository.ts:690",
+  "features/user/prisma-user.repository.ts:700",
+  "features/user/prisma-user.repository.ts:710",
 ]);
 
 type WriteSite = {
@@ -44,7 +44,10 @@ type WriteSite = {
 
 function sourceFiles() {
   return SCANNED_DIRECTORIES.flatMap((dir) =>
-    walkFiles(join(REPO_ROOT, dir), (path) => path.endsWith(".ts") && !path.includes("__tests__")),
+    walkFiles(
+      join(REPO_ROOT, dir),
+      (path) => path.endsWith(".ts") && !path.includes("__tests__"),
+    ),
   );
 }
 
@@ -66,21 +69,29 @@ function declaresBypass(method: ts.MethodDeclaration): boolean {
   );
 }
 
-function methodsByName(source: ts.SourceFile): Map<string, ts.MethodDeclaration> {
+function methodsByName(
+  source: ts.SourceFile,
+): Map<string, ts.MethodDeclaration> {
   const found = new Map<string, ts.MethodDeclaration>();
   const visit = (node: ts.Node) => {
-    if (ts.isMethodDeclaration(node) && node.name) found.set(node.name.getText(source), node);
+    if (ts.isMethodDeclaration(node) && node.name)
+      found.set(node.name.getText(source), node);
     ts.forEachChild(node, visit);
   };
   visit(source);
   return found;
 }
 
-function callersOf(name: string, methods: Map<string, ts.MethodDeclaration>, source: ts.SourceFile): string[] {
+function callersOf(
+  name: string,
+  methods: Map<string, ts.MethodDeclaration>,
+  source: ts.SourceFile,
+): string[] {
   const callers: string[] = [];
   for (const [callerName, method] of methods) {
     if (callerName === name) continue;
-    if (new RegExp(`this\\.${name}\\s*\\(`).test(method.getText(source))) callers.push(callerName);
+    if (new RegExp(`this\\.${name}\\s*\\(`).test(method.getText(source)))
+      callers.push(callerName);
   }
   return callers;
 }
@@ -88,16 +99,25 @@ function callersOf(name: string, methods: Map<string, ts.MethodDeclaration>, sou
 function bypassedMethodNames(source: ts.SourceFile): Set<string> {
   const methods = methodsByName(source);
   const bypassed = new Set<string>();
-  for (const [name, method] of methods) if (declaresBypass(method)) bypassed.add(name);
+  for (const [name, method] of methods)
+    if (declaresBypass(method)) bypassed.add(name);
 
   for (let pass = 0; pass < methods.size; pass++) {
     let grew = false;
     for (const [name, method] of methods) {
       if (bypassed.has(name)) continue;
-      if (!(method.modifiers ?? []).some((m) => m.kind === ts.SyntaxKind.PrivateKeyword)) continue;
+      if (
+        !(method.modifiers ?? []).some(
+          (m) => m.kind === ts.SyntaxKind.PrivateKeyword,
+        )
+      )
+        continue;
 
       const callers = callersOf(name, methods, source);
-      if (callers.length > 0 && callers.every((caller) => bypassed.has(caller))) {
+      if (
+        callers.length > 0 &&
+        callers.every((caller) => bypassed.has(caller))
+      ) {
         bypassed.add(name);
         grew = true;
       }
@@ -108,27 +128,46 @@ function bypassedMethodNames(source: ts.SourceFile): Set<string> {
   return bypassed;
 }
 
-function whereInitializer(call: ts.CallExpression, source: ts.SourceFile): ts.Expression | undefined {
+function whereInitializer(
+  call: ts.CallExpression,
+  source: ts.SourceFile,
+): ts.Expression | undefined {
   const [arg] = call.arguments;
   if (!arg || !ts.isObjectLiteralExpression(arg)) return undefined;
 
   for (const property of arg.properties)
-    if (ts.isPropertyAssignment(property) && property.name.getText(source) === "where") return property.initializer;
+    if (
+      ts.isPropertyAssignment(property) &&
+      property.name.getText(source) === "where"
+    )
+      return property.initializer;
 
   return undefined;
 }
 
-function carriesCompanyId(where: ts.Expression | undefined, operation: string, source: ts.SourceFile): boolean {
+function carriesCompanyId(
+  where: ts.Expression | undefined,
+  operation: string,
+  source: ts.SourceFile,
+): boolean {
   if (!where || !ts.isObjectLiteralExpression(where)) return false;
 
   for (const property of where.properties) {
-    if (ts.isSpreadAssignment(property) && ACCESS_WHERE_HELPER.test(property.expression.getText(source))) return true;
+    if (
+      ts.isSpreadAssignment(property) &&
+      ACCESS_WHERE_HELPER.test(property.expression.getText(source))
+    )
+      return true;
 
     const name = property.name?.getText(source);
     if (name === "companyId") return true;
 
     const isCompoundSelector = operation === "upsert" && name?.includes("_");
-    if (isCompoundSelector && ts.isPropertyAssignment(property) && ts.isObjectLiteralExpression(property.initializer))
+    if (
+      isCompoundSelector &&
+      ts.isPropertyAssignment(property) &&
+      ts.isObjectLiteralExpression(property.initializer)
+    )
       for (const nested of property.initializer.properties)
         if (nested.name?.getText(source) === "companyId") return true;
   }
@@ -141,31 +180,56 @@ function writeSites(): WriteSite[] {
 
   for (const file of sourceFiles()) {
     const text = readFileSync(file, "utf8");
-    if (!WRITE_OPERATIONS.values().some((operation) => text.includes(`.${operation}(`))) continue;
+    if (
+      !WRITE_OPERATIONS.values().some((operation) =>
+        text.includes(`.${operation}(`),
+      )
+    )
+      continue;
 
-    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const source = ts.createSourceFile(
+      file,
+      text,
+      ts.ScriptTarget.Latest,
+      true,
+    );
     const bypassed = bypassedMethodNames(source);
 
     const visit = (node: ts.Node) => {
-      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression)
+      ) {
         const operation = node.expression.name.text;
         const target = node.expression.expression.getText(source);
 
         const model = target.split(".").pop() ?? "";
 
-        if (WRITE_OPERATIONS.has(operation) && PRISMA_TARGET.test(target) && !GUARD_EXEMPT_MODELS.has(model)) {
+        if (
+          WRITE_OPERATIONS.has(operation) &&
+          PRISMA_TARGET.test(target) &&
+          !GUARD_EXEMPT_MODELS.has(model)
+        ) {
           const method = enclosingMethod(node);
           const methodName = method?.name.getText(source) ?? "";
           const relativePath = relative(REPO_ROOT, file);
-          const line = source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+          const line =
+            source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
 
-          if (!bypassed.has(methodName) && !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`))
+          if (
+            !bypassed.has(methodName) &&
+            !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`)
+          )
             sites.push({
               file: relativePath,
               line,
               operation,
               method: method?.name.getText(source) ?? "(module scope)",
-              scoped: carriesCompanyId(whereInitializer(node, source), operation, source),
+              scoped: carriesCompanyId(
+                whereInitializer(node, source),
+                operation,
+                source,
+              ),
             });
         }
       }
@@ -182,13 +246,19 @@ function writeSites(): WriteSite[] {
 describe("tenant-scoped writes", () => {
   const sites = writeSites();
 
-  it.runIf(ENFORCED)("scopes every tenant-guarded update, updateMany and upsert by companyId in its where", () => {
-    const unscoped = sites
-      .filter((site) => !site.scoped)
-      .map((site) => `${site.file}:${site.line} ${site.operation} in ${site.method}`);
+  it.runIf(ENFORCED)(
+    "scopes every tenant-guarded update, updateMany and upsert by companyId in its where",
+    () => {
+      const unscoped = sites
+        .filter((site) => !site.scoped)
+        .map(
+          (site) =>
+            `${site.file}:${site.line} ${site.operation} in ${site.method}`,
+        );
 
-    expect(unscoped).toEqual([]);
-  });
+      expect(unscoped).toEqual([]);
+    },
+  );
 
   it("still finds the write sites it is meant to guard", () => {
     expect(sites.length).toBeGreaterThan(10);

--- a/tests/conventions/tenant-write-scoping.test.ts
+++ b/tests/conventions/tenant-write-scoping.test.ts
@@ -28,10 +28,10 @@ const GUARD_EXEMPT_MODELS = new Set([
 
 const REACHED_ONLY_FROM_BYPASSED_CALLERS = new Set([
   "core/auth/better-auth.ts:79",
-  "features/user/prisma-user.repository.ts:673",
-  "features/user/prisma-user.repository.ts:683",
-  "features/user/prisma-user.repository.ts:693",
-  "features/user/prisma-user.repository.ts:703",
+  "features/user/prisma-user.repository.ts:656",
+  "features/user/prisma-user.repository.ts:666",
+  "features/user/prisma-user.repository.ts:676",
+  "features/user/prisma-user.repository.ts:686",
 ]);
 
 type WriteSite = {
@@ -44,10 +44,7 @@ type WriteSite = {
 
 function sourceFiles() {
   return SCANNED_DIRECTORIES.flatMap((dir) =>
-    walkFiles(
-      join(REPO_ROOT, dir),
-      (path) => path.endsWith(".ts") && !path.includes("__tests__"),
-    ),
+    walkFiles(join(REPO_ROOT, dir), (path) => path.endsWith(".ts") && !path.includes("__tests__")),
   );
 }
 
@@ -69,29 +66,21 @@ function declaresBypass(method: ts.MethodDeclaration): boolean {
   );
 }
 
-function methodsByName(
-  source: ts.SourceFile,
-): Map<string, ts.MethodDeclaration> {
+function methodsByName(source: ts.SourceFile): Map<string, ts.MethodDeclaration> {
   const found = new Map<string, ts.MethodDeclaration>();
   const visit = (node: ts.Node) => {
-    if (ts.isMethodDeclaration(node) && node.name)
-      found.set(node.name.getText(source), node);
+    if (ts.isMethodDeclaration(node) && node.name) found.set(node.name.getText(source), node);
     ts.forEachChild(node, visit);
   };
   visit(source);
   return found;
 }
 
-function callersOf(
-  name: string,
-  methods: Map<string, ts.MethodDeclaration>,
-  source: ts.SourceFile,
-): string[] {
+function callersOf(name: string, methods: Map<string, ts.MethodDeclaration>, source: ts.SourceFile): string[] {
   const callers: string[] = [];
   for (const [callerName, method] of methods) {
     if (callerName === name) continue;
-    if (new RegExp(`this\\.${name}\\s*\\(`).test(method.getText(source)))
-      callers.push(callerName);
+    if (new RegExp(`this\\.${name}\\s*\\(`).test(method.getText(source))) callers.push(callerName);
   }
   return callers;
 }
@@ -99,25 +88,16 @@ function callersOf(
 function bypassedMethodNames(source: ts.SourceFile): Set<string> {
   const methods = methodsByName(source);
   const bypassed = new Set<string>();
-  for (const [name, method] of methods)
-    if (declaresBypass(method)) bypassed.add(name);
+  for (const [name, method] of methods) if (declaresBypass(method)) bypassed.add(name);
 
   for (let pass = 0; pass < methods.size; pass++) {
     let grew = false;
     for (const [name, method] of methods) {
       if (bypassed.has(name)) continue;
-      if (
-        !(method.modifiers ?? []).some(
-          (m) => m.kind === ts.SyntaxKind.PrivateKeyword,
-        )
-      )
-        continue;
+      if (!(method.modifiers ?? []).some((m) => m.kind === ts.SyntaxKind.PrivateKeyword)) continue;
 
       const callers = callersOf(name, methods, source);
-      if (
-        callers.length > 0 &&
-        callers.every((caller) => bypassed.has(caller))
-      ) {
+      if (callers.length > 0 && callers.every((caller) => bypassed.has(caller))) {
         bypassed.add(name);
         grew = true;
       }
@@ -128,46 +108,27 @@ function bypassedMethodNames(source: ts.SourceFile): Set<string> {
   return bypassed;
 }
 
-function whereInitializer(
-  call: ts.CallExpression,
-  source: ts.SourceFile,
-): ts.Expression | undefined {
+function whereInitializer(call: ts.CallExpression, source: ts.SourceFile): ts.Expression | undefined {
   const [arg] = call.arguments;
   if (!arg || !ts.isObjectLiteralExpression(arg)) return undefined;
 
   for (const property of arg.properties)
-    if (
-      ts.isPropertyAssignment(property) &&
-      property.name.getText(source) === "where"
-    )
-      return property.initializer;
+    if (ts.isPropertyAssignment(property) && property.name.getText(source) === "where") return property.initializer;
 
   return undefined;
 }
 
-function carriesCompanyId(
-  where: ts.Expression | undefined,
-  operation: string,
-  source: ts.SourceFile,
-): boolean {
+function carriesCompanyId(where: ts.Expression | undefined, operation: string, source: ts.SourceFile): boolean {
   if (!where || !ts.isObjectLiteralExpression(where)) return false;
 
   for (const property of where.properties) {
-    if (
-      ts.isSpreadAssignment(property) &&
-      ACCESS_WHERE_HELPER.test(property.expression.getText(source))
-    )
-      return true;
+    if (ts.isSpreadAssignment(property) && ACCESS_WHERE_HELPER.test(property.expression.getText(source))) return true;
 
     const name = property.name?.getText(source);
     if (name === "companyId") return true;
 
     const isCompoundSelector = operation === "upsert" && name?.includes("_");
-    if (
-      isCompoundSelector &&
-      ts.isPropertyAssignment(property) &&
-      ts.isObjectLiteralExpression(property.initializer)
-    )
+    if (isCompoundSelector && ts.isPropertyAssignment(property) && ts.isObjectLiteralExpression(property.initializer))
       for (const nested of property.initializer.properties)
         if (nested.name?.getText(source) === "companyId") return true;
   }
@@ -180,56 +141,31 @@ function writeSites(): WriteSite[] {
 
   for (const file of sourceFiles()) {
     const text = readFileSync(file, "utf8");
-    if (
-      !WRITE_OPERATIONS.values().some((operation) =>
-        text.includes(`.${operation}(`),
-      )
-    )
-      continue;
+    if (!WRITE_OPERATIONS.values().some((operation) => text.includes(`.${operation}(`))) continue;
 
-    const source = ts.createSourceFile(
-      file,
-      text,
-      ts.ScriptTarget.Latest,
-      true,
-    );
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
     const bypassed = bypassedMethodNames(source);
 
     const visit = (node: ts.Node) => {
-      if (
-        ts.isCallExpression(node) &&
-        ts.isPropertyAccessExpression(node.expression)
-      ) {
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
         const operation = node.expression.name.text;
         const target = node.expression.expression.getText(source);
 
         const model = target.split(".").pop() ?? "";
 
-        if (
-          WRITE_OPERATIONS.has(operation) &&
-          PRISMA_TARGET.test(target) &&
-          !GUARD_EXEMPT_MODELS.has(model)
-        ) {
+        if (WRITE_OPERATIONS.has(operation) && PRISMA_TARGET.test(target) && !GUARD_EXEMPT_MODELS.has(model)) {
           const method = enclosingMethod(node);
           const methodName = method?.name.getText(source) ?? "";
           const relativePath = relative(REPO_ROOT, file);
-          const line =
-            source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+          const line = source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
 
-          if (
-            !bypassed.has(methodName) &&
-            !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`)
-          )
+          if (!bypassed.has(methodName) && !REACHED_ONLY_FROM_BYPASSED_CALLERS.has(`${relativePath}:${line}`))
             sites.push({
               file: relativePath,
               line,
               operation,
               method: method?.name.getText(source) ?? "(module scope)",
-              scoped: carriesCompanyId(
-                whereInitializer(node, source),
-                operation,
-                source,
-              ),
+              scoped: carriesCompanyId(whereInitializer(node, source), operation, source),
             });
         }
       }
@@ -246,19 +182,13 @@ function writeSites(): WriteSite[] {
 describe("tenant-scoped writes", () => {
   const sites = writeSites();
 
-  it.runIf(ENFORCED)(
-    "scopes every tenant-guarded update, updateMany and upsert by companyId in its where",
-    () => {
-      const unscoped = sites
-        .filter((site) => !site.scoped)
-        .map(
-          (site) =>
-            `${site.file}:${site.line} ${site.operation} in ${site.method}`,
-        );
+  it.runIf(ENFORCED)("scopes every tenant-guarded update, updateMany and upsert by companyId in its where", () => {
+    const unscoped = sites
+      .filter((site) => !site.scoped)
+      .map((site) => `${site.file}:${site.line} ${site.operation} in ${site.method}`);
 
-      expect(unscoped).toEqual([]);
-    },
-  );
+    expect(unscoped).toEqual([]);
+  });
 
   it("still finds the write sites it is meant to guard", () => {
     expect(sites.length).toBeGreaterThan(10);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ const testEnvironment = {
   BETTER_AUTH_SECRET: "vitest-secret",
 };
 const domTestFiles = [
+  "app/[locale]/(public)/auth/reset-password/__tests__/reset-password-form.test.ts",
   "app/**/company/components/company-settings/__tests__/company-settings-form.test.ts",
   "app/**/dashboard/components/__tests__/widget-chart.test.ts",
   "app/[locale]/(protected)/__tests__/protected-layout.test.ts",


### PR DESCRIPTION
## Summary

- Preserve validated invitations as signed, per-tab onboarding intent through authentication, verification and password recovery.
- Require an explicit Create or Join choice for first-run users without an invitation. Reuse the existing option cards and numbered Steps in all five locales.
- Make existing-identity registration and operator deletion safe against obsolete company references, duplicate submissions, conflicting tabs and deleted identities.
- Align all identified consistency cases: auth intent and sign-in callbacks belong to form data; invitation, inbox linking and import orchestration belong to interactors; Company owns weighting configuration reads; the service quick-create default has one interactor owner.

## Context

[CUS-312](https://linear.app/customermates/issue/CUS-312/let-an-existing-account-accept-a-workspace-invitation) covers a signed-in visitor losing an invitation before validation and being sent into unintended workspace creation. Invitation binding previously only ran when an AuthUser was first inserted.

Direct Company deletion can leave an identity with an obsolete company reference. This is distinct from the current operator action, which deletes actual workspace-member identities and their sessions. The operator hardening also clears deleted-company references on unrelated tenantless identities without deleting those identities.

The current explicit invitation is authoritative until membership exists. Join creates no records and explains how to request an invitation. Create requires a deliberate, account-bound decision. Existing workspace members are never silently moved to another workspace.

The owner requested that the PR review principles be applied to every occurrence identified in the consistency audit, including the related inbox, import, weighting and service paths. These changes reuse the existing decorators, validation, repository ports, transactions and child interactors rather than introducing a new framework. All five existing review threads are resolved.

## Validation

- Node 24: typecheck, lint with zero warnings and production build passed. Build and dev never ran concurrently.
- Full database-enabled Vitest run: **5,199 passed, 2 skipped, 0 failed**. Conventions: 638 passed, 2 skipped. The two skips are rendered-output contracts covered by the separate rendered-hubs check.
- The full run uses one worker to avoid unrelated filesystem-scan/email-preview timeouts under heavy parallel host load. The previous parallel run had six such timeouts; the complete serial rerun passed. JSON reporter counts were checked directly.
- Added real DOM reset-form lifecycle tests, nullish-input validation tests, auth context refresh/clear tests, invitation interactor tests, inbox action/unit/DB tests, all-five-target import dispatch tests and a real import roundtrip, weighting isolation/rollback/deletion DB tests, and service quick-create validation/default tests.
- After the final test-only fixture color correction, weighting DB tests passed again: 6/6. No production code changed after the full build/test gates.
- Three independent final read-only code reviews found no blockers. Independent focused runs passed 189 and 56 tests. Final screenshot review found no blocking visual issue.
- Fresh UI verification used multiple synthetic accounts, invitations, separate operator/member sessions and competing same-session tabs on localhost, with database assertions for actual persistence:

| Local UI journey | Verified result |
| --- | --- |
| Existing identity follows invite; header Login and Continue setup | Invited profile, then Waiting for Approval in the correct workspace |
| New signup with and without an invitation | Invite bypasses chooser; ordinary signup shows Create/Join |
| Join, direct wizard entry, explicit Create | Join writes nothing; direct entry returns to choices; deliberate Create writes exactly one workspace after profile submission |
| Creator profile, invite and AI steps, Back, Next, Skip, Finish | Setup progress remains visible and completion reaches dashboard |
| Overdue unverified invitee | Real local verification callback retains the invitation and joins the invited workspace |
| Verification deadline crosses while creator profile is open | Submit requires verification; local callback returns to creator profile; submission creates one workspace |
| Deleted-company reference or different live pre-tenant binding | Current invitation wins; pending member in invited workspace |
| Existing active, pending or inactive membership opens another invite | Account-switch screen; no rebinding |
| Two invitation forms in the same session | Each retains its inviter; after the second joins, returning to the first reaches the pending guard without changing membership. Late/double-write races are additionally covered by DB tests |
| Operator deletes a workspace while owner browser remains live | Company, member, identity and sessions removed; audit recorded; old browser reaches fresh invitation signup |
| Deleted owner signs up again using the same email | Signup succeeds and joins invited workspace as pending; no extra workspace |
| Separate tenantless identity points at deleted workspace | Identity preserved, reference cleared; subsequent sign-in reaches choices |
| Expired invite, tampered intent, invite revoked after profile render | Explicit error; no accidental membership or workspace |
| Password recovery through invitation | Actual locally generated reset callback and final new-password submission succeed; subsequent sign-in retains invitation |
| Invalid reset token and invalid onboarding intent on recovery | Invalid-token retry retains valid intent; malformed intent does not block ordinary recovery |
| Five locales, narrow viewport, light/dark | Choice cards and shared Steps inspected; Join footer reachable, email wraps safely, no horizontal overflow |
| Inbox thread contact linking and unlinking | Actual modal actions persist; reopened settings retain link; unlink removes identifier |
| XLSX create and update for contacts, organizations, deals, services and tasks | All ten UI import runs succeed, one record per entity, updates do not duplicate records |
| Invalid service amount import | Row-level error shown; Add records disabled; no service created |
| Deal-specific and generic relation service quick-create | Both use amount 100; relations persist; ordinary imported amount 125.5 remains unchanged |
| Weighted deal and custom-field changes | 25% gives 50 on a 200 deal, 60% gives 120; unrelated field deletion preserves it; selected field deletion clears configuration and weighted value, preserving total 200 |

- Auth/onboarding/recovery ran in the cloud-mode dev server with local-only email capture. Under heavy host filesystem pressure, the protected inbox/operator/import/service/weighting tail also ran against the exact completed production build on localhost with outgoing email disabled. The dev server was restored afterwards.
- Final DB readbacks asserted imports, relation defaults, weighting cleanup, invitation memberships, no-write branches, operator cleanup and expected workspace counts.
- Restored the exact pre-test disposable database snapshot: 35 companies, 38 tenant users, 38 auth identities and zero new review fixtures. Before/after snapshots and screenshots remain local in `/tmp/pr154-consistency-e2e.hNBr7C`. Preview remains on port 4010.
- Earlier branch verification also covered shared primary/inverse controls and application-locale metadata boundaries. The shared primary foreground contrast is 4.92:1; its 97% hover remains at least 4.68:1.

Verification limits: real Google/Microsoft OAuth provider round trips were not performed; callback and continuation logic is covered by automated tests. Responsive checks used a browser viewport, not a physical device. No claim is made that every theoretical application scenario has been exhausted. Development-only warnings and automation/host timeouts were distinguished from completed UI results; the protected production-build run reported no browser errors.

## Impact and rollback

New users explicitly choose whether to create or join a workspace. Invitees retain their destination and join as Waiting for Approval; an administrator must assign both a role and active status. Existing workspace members are prompted to switch accounts.

The consistency changes preserve existing import targets, permissions, transactions, data shapes and the existing service default. They move ownership to the established architectural layers and add regression coverage.

No schema migration, dependency change, environment change or production backfill. Roll back by reverting this PR. Cleared references only point to deleted workspaces and do not require restoration. The owner alone merges and performs any production customer repair.
