### PR TITLE
fix: omit untrusted content dates from shallow Git history

### DIFF
--- a/core/fumadocs/README.md
+++ b/core/fumadocs/README.md
@@ -1,0 +1,13 @@
+# Content modification dates
+
+The last-modified plugin in `source.config.ts` uses `createGitLastModifiedResolver` to export only dates supported by the available Git history. The same export feeds sitemap `lastmod` and blog Article `dateModified`.
+
+In a shallow clone, Git treats the oldest available commit as a root. A file unchanged within that history window can therefore appear to have changed at the shallow boundary. The resolver omits that date because the file's actual modification is unknown. Changes visible after the boundary retain their author dates. Linked worktrees use Git's resolved shallow metadata path.
+
+Missing Git history, files absent from the current committed tree, and failed lookups also omit the generated date. Recreating a deleted path cannot inherit the deletion date, even when the new file is staged. The resolver never substitutes a build timestamp or file modification time and never fetches history. It reads repository boundaries and committed paths once per resolver instance; create a new instance after changing the available history.
+
+When no trustworthy generated date exists, the sitemap uses a valid declared blog publication date, or omits `lastmod` for undated pages. Blog Article metadata keeps its declared publication-date fallback. Builds that require more Git-derived dates must provide sufficient history before loading content.
+
+Dates track changes to the MDX file itself. Changes to shared components or substituted commercial tokens are not included in the file's Git history.
+
+`__tests__/git-last-modified.test.ts` creates disposable repositories to exercise full history, shallow history, deepening at the same revision, linked worktrees, literal paths, and absent history. `../seo/__tests__/sitemap.test.ts` verifies the publication-date fallback and omission for undated pages.

--- a/core/fumadocs/__tests__/git-last-modified.test.ts
+++ b/core/fumadocs/__tests__/git-last-modified.test.ts
@@ -1,0 +1,169 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createGitLastModifiedResolver } from "../git-last-modified";
+
+const execFileAsync = promisify(execFile);
+const ORIGINAL_DATE = "2026-01-01T10:00:00.000Z";
+const BOUNDARY_DATE = "2026-01-02T10:00:00.000Z";
+const MODIFIED_DATE = "2026-01-03T10:00:00.000Z";
+const LATEST_DATE = "2026-01-04T10:00:00.000Z";
+
+let directory: string;
+let repository: string;
+
+async function git(cwd: string, args: string[], env: Partial<NodeJS.ProcessEnv> = {}) {
+  const { stdout } = await execFileAsync("git", args, { cwd, env: { ...process.env, ...env } });
+
+  return stdout.trim();
+}
+
+async function commit(file: string, contents: string, date: string) {
+  await writeFile(path.join(repository, file), contents);
+  await git(repository, ["add", "--", file]);
+  await git(repository, ["-c", "commit.gpgsign=false", "commit", "-m", file], {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date,
+  });
+}
+
+async function cloneShallow() {
+  const clone = path.join(directory, "shallow");
+
+  await git(directory, ["clone", "--depth=3", pathToFileURL(repository).href, clone]);
+
+  return clone;
+}
+
+beforeEach(async () => {
+  directory = await mkdtemp(path.join(tmpdir(), "content-last-modified-"));
+  repository = path.join(directory, "repository");
+  await mkdir(repository);
+  await git(repository, ["init", "--initial-branch=main"]);
+  await git(repository, ["config", "user.name", "Content date test"]);
+  await git(repository, ["config", "user.email", "content-date@example.test"]);
+  await mkdir(path.join(repository, "content"));
+  await writeFile(path.join(repository, "content", "modified.mdx"), "Original content");
+  await git(repository, ["add", "content/modified.mdx"]);
+  await commit("content/old article.mdx", "Original article", ORIGINAL_DATE);
+  await commit("unrelated.txt", "Boundary change", BOUNDARY_DATE);
+  await commit("content/modified.mdx", "Updated content", MODIFIED_DATE);
+  await commit("unrelated.txt", "Latest unrelated change", LATEST_DATE);
+});
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe("Git content modification dates", () => {
+  it("keeps the actual content date across unrelated commits in full history", async () => {
+    const resolve = createGitLastModifiedResolver(repository);
+
+    expect((await resolve(path.join(repository, "content/old article.mdx")))?.toISOString()).toBe(ORIGINAL_DATE);
+    expect((await resolve("content/modified.mdx"))?.toISOString()).toBe(MODIFIED_DATE);
+
+    await commit("unrelated.txt", "Another deployment", "2026-01-05T10:00:00.000Z");
+
+    expect((await createGitLastModifiedResolver(repository)("content/old article.mdx"))?.toISOString()).toBe(
+      ORIGINAL_DATE,
+    );
+  });
+
+  it("rejects the shallow boundary that Git presents as an old file's modification", async () => {
+    const clone = await cloneShallow();
+    const reportedDate = await git(clone, ["log", "-1", "--format=%aI", "--", "content/old article.mdx"]);
+
+    expect(new Date(reportedDate).toISOString()).toBe(BOUNDARY_DATE);
+    expect(await createGitLastModifiedResolver(clone)("content/old article.mdx")).toBeNull();
+  });
+
+  it("retains a real content modification inside the shallow history window", async () => {
+    const clone = await cloneShallow();
+
+    expect((await createGitLastModifiedResolver(clone)("content/modified.mdx"))?.toISOString()).toBe(MODIFIED_DATE);
+  });
+
+  it("recovers the original date after history is deepened without changing HEAD", async () => {
+    const clone = await cloneShallow();
+    const head = await git(clone, ["rev-parse", "HEAD"]);
+
+    expect(await createGitLastModifiedResolver(clone)("content/old article.mdx")).toBeNull();
+    await git(clone, ["fetch", "--unshallow"]);
+
+    expect(await git(clone, ["rev-parse", "HEAD"])).toBe(head);
+    expect((await createGitLastModifiedResolver(clone)("content/old article.mdx"))?.toISOString()).toBe(ORIGINAL_DATE);
+  });
+
+  it("finds shallow metadata through a linked worktree and a nested working directory", async () => {
+    const clone = await cloneShallow();
+    const worktree = path.join(directory, "linked-worktree");
+
+    await git(clone, ["worktree", "add", "--detach", worktree]);
+    const resolve = createGitLastModifiedResolver(path.join(worktree, "content"));
+
+    expect(await resolve("old article.mdx")).toBeNull();
+    expect((await resolve("modified.mdx"))?.toISOString()).toBe(MODIFIED_DATE);
+  });
+
+  it("resolves repository and file paths through a directory symlink", async () => {
+    const linked = path.join(directory, "linked-repository");
+
+    await symlink(repository, linked, "dir");
+
+    expect(
+      (await createGitLastModifiedResolver(linked)(path.join(linked, "content/old article.mdx")))?.toISOString(),
+    ).toBe(ORIGINAL_DATE);
+  });
+
+  it("omits dates for untracked and missing files instead of using file or build time", async () => {
+    await writeFile(path.join(repository, "content", "generated.mdx"), "Generated documentation");
+    const resolve = createGitLastModifiedResolver(repository);
+
+    expect(await resolve("content/generated.mdx")).toBeNull();
+    expect(await resolve("content/missing.mdx")).toBeNull();
+  });
+
+  it("does not reuse a deletion date when an untracked or staged file recreates that path", async () => {
+    const file = "content/old article.mdx";
+    const deletionDate = "2026-01-05T10:00:00.000Z";
+
+    await git(repository, ["rm", "--", file]);
+    await git(repository, ["-c", "commit.gpgsign=false", "commit", "-m", "Remove article"], {
+      GIT_AUTHOR_DATE: deletionDate,
+      GIT_COMMITTER_DATE: deletionDate,
+    });
+    await writeFile(path.join(repository, file), "New generated content");
+
+    expect(new Date(await git(repository, ["log", "-1", "--format=%aI", "--", file])).toISOString()).toBe(deletionDate);
+    expect(await createGitLastModifiedResolver(repository)(file)).toBeNull();
+
+    await git(repository, ["add", "--", file]);
+
+    expect(await createGitLastModifiedResolver(repository)(file)).toBeNull();
+  });
+
+  it("omits dates when Git history is unavailable", async () => {
+    const exported = path.join(directory, "exported");
+
+    await mkdir(exported);
+    await writeFile(path.join(exported, "article.mdx"), "Exported content");
+
+    expect(await createGitLastModifiedResolver(exported)("article.mdx")).toBeNull();
+    expect(await createGitLastModifiedResolver(path.join(directory, "missing"))("article.mdx")).toBeNull();
+  });
+
+  it("treats special characters in content paths literally", async () => {
+    await commit("content/[draft].mdx", "Literal path", "2026-01-05T10:00:00.000Z");
+    await commit("content/d.mdx", "Similar path", "2026-01-06T10:00:00.000Z");
+
+    expect((await createGitLastModifiedResolver(repository)("content/[draft].mdx"))?.toISOString()).toBe(
+      "2026-01-05T10:00:00.000Z",
+    );
+  });
+});

--- a/core/fumadocs/git-last-modified.ts
+++ b/core/fumadocs/git-last-modified.ts
@@ -1,0 +1,78 @@
+import { execFile } from "node:child_process";
+import { readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+type RepositoryHistory = { root: string; shallowCommits: Set<string>; committedFiles: Set<string> };
+
+async function readRepositoryHistory(cwd: string): Promise<RepositoryHistory | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel", "--git-path", "shallow"], { cwd });
+    const [root, shallowPath] = stdout.trim().split("\n");
+
+    if (!root || !shallowPath) return null;
+
+    const { stdout: files } = await execFileAsync("git", ["ls-tree", "-r", "-z", "--name-only", "HEAD"], {
+      cwd: root,
+    });
+
+    let shallow = "";
+
+    try {
+      shallow = await readFile(path.resolve(cwd, shallowPath), "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return null;
+    }
+
+    return {
+      root,
+      shallowCommits: new Set(shallow.split(/\s+/).filter(Boolean)),
+      committedFiles: new Set(files.split("\0").filter(Boolean)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function createGitLastModifiedResolver(cwd = process.cwd()): (filePath: string) => Promise<Date | null> {
+  let repositoryHistory: Promise<RepositoryHistory | null> | undefined;
+
+  return async (filePath) => {
+    repositoryHistory ??= readRepositoryHistory(cwd);
+    const repository = await repositoryHistory;
+
+    if (!repository) return null;
+
+    try {
+      const absolutePath = await realpath(path.resolve(cwd, filePath));
+      const relativePath = path.relative(repository.root, absolutePath);
+
+      if (
+        !relativePath ||
+        relativePath === ".." ||
+        relativePath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativePath)
+      )
+        return null;
+
+      if (!repository.committedFiles.has(relativePath.split(path.sep).join("/"))) return null;
+
+      const { stdout } = await execFileAsync(
+        "git",
+        ["--literal-pathspecs", "log", "-1", "--format=%H%n%aI", "--", relativePath],
+        { cwd: repository.root },
+      );
+      const [commit, timestamp] = stdout.trim().split("\n");
+
+      if (!commit || !timestamp || repository.shallowCommits.has(commit)) return null;
+
+      const date = new Date(timestamp);
+
+      return Number.isNaN(date.getTime()) ? null : date;
+    } catch {
+      return null;
+    }
+  };
+}

--- a/core/fumadocs/source.config.ts
+++ b/core/fumadocs/source.config.ts
@@ -18,6 +18,7 @@ import { hubSchema } from "./schemas/hub";
 import { legalSchema } from "./schemas/legal";
 import { pricingSchema } from "./schemas/pricing";
 import { commercialTokens } from "./commercial-tokens";
+import { createGitLastModifiedResolver } from "./git-last-modified";
 
 export const blog = defineCollections({
   type: "doc",
@@ -140,5 +141,5 @@ export const affiliate = defineCollections({
 });
 
 export default defineConfig({
-  plugins: [commercialTokens(), jsonSchema(), lastModified()],
+  plugins: [commercialTokens(), jsonSchema(), lastModified({ versionControl: createGitLastModifiedResolver() })],
 });

--- a/core/seo/__tests__/sitemap.test.ts
+++ b/core/seo/__tests__/sitemap.test.ts
@@ -129,6 +129,16 @@ describe("sitemap page dates", () => {
     );
     expect(resolvePageLastModified({ blogPost: { date: "not-a-date" } })).toBeUndefined();
   });
+
+  it("keeps the publication fallback explicit when a Git date is unavailable or invalid", () => {
+    for (const lastModified of [undefined, null, new Date("not-a-date")]) {
+      expect(resolvePageLastModified({ lastModified, blogPost: { date: "2026-03-01" } })?.toISOString()).toBe(
+        "2026-03-01T00:00:00.000Z",
+      );
+      expect(resolvePageLastModified({ lastModified })).toBeUndefined();
+      expect(resolvePageLastModified({ lastModified, blogPost: { date: "not-a-date" } })).toBeUndefined();
+    }
+  });
 });
 
 describe("alternate languages", () => {


### PR DESCRIPTION
## Summary

Only export a content modification date when the available Git history supports it. This prevents shallow clones from assigning an unrelated history-boundary commit's timestamp to sitemap `lastmod` and blog Article `dateModified`.

## Context

Part of [CUS-278](https://linear.app/customermates/issue/CUS-278/deliver-measurable-inbound-acquisition-and-a-french-market-pilot).

Task key: `growth:seo-paid-search-rebuild`.

Git treats a shallow boundary as a root commit, so `git log -1` can report that boundary as the last change to every older file. The shared Fumadocs resolver now rejects boundary dates and accepts history only for files present in the current committed tree. Linked worktrees, physical paths, absent Git history and recreated deleted files are covered. The existing publication-date fallback remains explicit.

## Validation

- Real disposable Git repositories exercise full history, shallow false dates, genuine changes inside the shallow window, deepening at the same revision, linked worktrees, symlinks, absent history, recreated paths and literal path characters. The focused resolver/sitemap suite passes all 23 tests.
- `yarn openapi:generate`, `yarn raw-docs:generate` and the tracked generated-file diff check pass.
- `yarn typecheck` and `yarn lint` pass with zero lint warnings.
- Convention suite: 636 passed, two HTTP E2E checks skipped without a running server.
- Complete suite with `RUN_DATABASE_TESTS=true` against disposable PostgreSQL 17: 5,001 passed, the same two HTTP E2E checks skipped. Default assertions and timeouts retained.
- `yarn build` passes on Node 24.18.0.
- Locally served base/branch metadata is byte-identical for 13 representative pages and all 412 sitemap entries, including 402 dates, reciprocal alternates and Article JSON-LD. Browser checks show normal homepage/article rendering without an error overlay.
- Independent pre-push review of the complete staged diff passed with no unresolved findings.
- Hosted branch verification preserves all 412 route and language-alternate sets. All 146 exported dates match a full-history source date or a declared publication date; undated pricing/feature pages omit uncertain dates, and sampled EN/DE Article metadata matches the sitemap fallback. Required CI, repository policy, rendered-hub checks, CodeQL, PostgreSQL 16 compatibility and Vercel deployment passed on this head.

## Impact and rollback

Shallow or Git-free builds may publish fewer Git-derived dates. Blogs retain a valid declared publication-date fallback; undated pages omit `lastmod`. The resolver never substitutes build time, file modification time or the current time, and never fetches history. Changes to shared components or substituted tokens remain outside the MDX file's Git history.

This requires no database migration or environment change. Revert this commit through a pull request to restore the previous date resolver.
