### PR TITLE
feat(agent-chat): show live waiting feedback and normalize durable tool input

### DIFF
--- a/app/components/agent-chat/__tests__/agent-chat-interrupted-notice.test.ts
+++ b/app/components/agent-chat/__tests__/agent-chat-interrupted-notice.test.ts
@@ -1,0 +1,61 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createTranslator } from "next-intl";
+import type * as IntlModule from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+
+import de from "@/i18n/locales/de.json";
+import en from "@/i18n/locales/en.json";
+import es from "@/i18n/locales/es.json";
+import fr from "@/i18n/locales/fr.json";
+import itLocale from "@/i18n/locales/it.json";
+
+const context = vi.hoisted(() => ({ translator: (key: string) => key }));
+
+vi.mock("next-intl", async (importOriginal) => ({
+  ...(await importOriginal<typeof IntlModule>()),
+  useTranslations: () => context.translator,
+}));
+vi.mock("@/core/stores/root-store.provider", () => ({
+  useRootStore: () => ({ agentChatStore: {} }),
+}));
+vi.mock("@/core/utils/use-copy-to-clipboard", () => ({
+  useCopyToClipboard: () => vi.fn(),
+}));
+vi.mock("@/components/entity-terminology/use-entity-terminology", () => ({
+  useEntityTerminology: () => ({ plural: (entity: string) => entity }),
+}));
+vi.mock("@/components/ai-elements/message", () => ({
+  MessageResponse: () => null,
+}));
+
+import { AgentChatItemView } from "../agent-chat-items";
+
+describe("Interrupted agent turn notice", () => {
+  it.each([
+    ["de", de],
+    ["en", en],
+    ["es", es],
+    ["fr", fr],
+    ["it", itLocale],
+  ] as const)("renders a localized alert without a retry action in %s", (locale, messages) => {
+    const translator = createTranslator({ locale, messages });
+    context.translator = translator as unknown as (key: string) => string;
+    const markup = renderToStaticMarkup(
+      createElement(AgentChatItemView, {
+        item: {
+          kind: "turn_interrupted",
+          id: "notice-1",
+          messageId: "user-message-1",
+        },
+      }),
+    );
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain('data-testid="agent-turn-interrupted"');
+    expect(markup).not.toContain("AgentChat.ui.turnInterrupted");
+    expect(markup).not.toContain("<button");
+    expect(markup).not.toContain(messages.AgentChat.ui.retryTurn);
+    expect(translator("AgentChat.ui.turnInterrupted")).toBe(messages.AgentChat.ui.turnInterrupted);
+  });
+});

--- a/app/components/agent-chat/__tests__/agent-chat.store.test.ts
+++ b/app/components/agent-chat/__tests__/agent-chat.store.test.ts
@@ -443,6 +443,96 @@ describe("AgentChatStore", () => {
     expect(store.isAwaitingAssistantResponse).toBe(false);
   });
 
+  it("keeps lifecycle progress transient and resets it for a new turn", () => {
+    const store = new AgentChatStore(root() as never);
+    const internal = store as unknown as {
+      beginActiveTurnMutationTracking: () => number;
+      handleEvent: (event: Record<string, unknown>) => void;
+      resetConversation: (id: string | null) => void;
+    };
+    store.items = [{ kind: "user", id: "u1", messageId: "u1", text: "Long request" }];
+    store.isWorking = true;
+    internal.beginActiveTurnMutationTracking();
+    expect(store.progressPhase).toBe("starting");
+    expect(store.progressStartedAt).toEqual(expect.any(Number));
+    internal.handleEvent({ seq: 0, type: "progress", phase: "working", secret: "not copied" });
+    expect(store.progressPhase).toBe("working");
+    internal.handleEvent({ seq: 1, type: "progress", phase: "preparing_action" });
+    expect(store.progressPhase).toBe("preparing_action");
+    internal.handleEvent({ seq: 2, type: "progress", phase: "untrusted" });
+    expect(store.progressPhase).toBe("preparing_action");
+    expect(store.items).toEqual([{ kind: "user", id: "u1", messageId: "u1", text: "Long request" }]);
+    internal.handleEvent({ seq: 3, type: "delta", text: "Answer" });
+    expect(store.progressPhase).toBeNull();
+    internal.handleEvent({ seq: 4, type: "progress", phase: "working" });
+    expect(store.progressPhase).toBeNull();
+    internal.resetConversation(null);
+    expect(store.progressStartedAt).toBeNull();
+    internal.beginActiveTurnMutationTracking();
+    expect(store.progressPhase).toBe("starting");
+  });
+
+  it.each(["turn_done", "error", "stop"])("does not resurrect progress after %s", (terminal) => {
+    const store = new AgentChatStore(root() as never);
+    const internal = store as unknown as {
+      handleEvent: (event: Record<string, unknown>) => void;
+      activeTurnStopRequested: boolean;
+    };
+    store.items = [{ kind: "user", id: "u1", messageId: "u1", text: "Long request" }];
+    store.isWorking = true;
+    store.progressPhase = "working";
+    if (terminal === "stop") {
+      internal.activeTurnStopRequested = true;
+      store.progressPhase = null;
+      store.streamStatus = "stopping";
+    } else internal.handleEvent({ seq: 0, type: terminal });
+    internal.handleEvent({ seq: 1, type: "progress", phase: "working" });
+    expect(store.progressPhase).toBeNull();
+    if (terminal === "stop") expect(store.streamStatus).toBe("stopping");
+  });
+
+  it("accepts progress when reattaching after a failed turn", () => {
+    const store = new AgentChatStore(root() as never);
+    const internal = store as unknown as {
+      beginActiveTurnMutationTracking: () => number;
+      handleEvent: (event: Record<string, unknown>) => void;
+    };
+    store.items = [{ kind: "user", id: "failed-user", messageId: "failed-user", text: "Previous request" }];
+    store.isWorking = true;
+    internal.beginActiveTurnMutationTracking();
+    internal.handleEvent({ seq: 0, type: "error" });
+    expect(store.progressPhase).toBeNull();
+
+    store.items = [{ kind: "user", id: "running-user", messageId: "running-user", text: "Another running request" }];
+    internal.beginActiveTurnMutationTracking();
+    store.streamStatus = "reconnecting";
+    internal.handleEvent({ seq: 0, type: "progress", phase: "working" });
+    expect(store.progressPhase).toBe("working");
+    expect(store.streamStatus).toBe("working");
+  });
+
+  it("deduplicates replayed progress and ignores a previous turn's stream", async () => {
+    const store = new AgentChatStore(root() as never);
+    const internal = store as unknown as {
+      beginActiveTurnMutationTracking: () => number;
+      readStream: (stream: ReadableStream<Uint8Array>, generation: number) => Promise<void>;
+    };
+    store.items = [{ kind: "user", id: "u1", messageId: "u1", text: "Long request" }];
+    store.isWorking = true;
+    const generation = internal.beginActiveTurnMutationTracking();
+    const stream = new Response(
+      'data: {"seq":0,"type":"progress","phase":"working"}\n\ndata: {"seq":0,"type":"progress","phase":"preparing_action"}\n\n',
+    ).body;
+    if (!stream) throw new Error("Missing synthetic stream");
+    await internal.readStream(stream, generation);
+    expect(store.progressPhase).toBe("working");
+    internal.beginActiveTurnMutationTracking();
+    const oldStream = new Response('data: {"seq":1,"type":"progress","phase":"preparing_action"}\n\n').body;
+    if (!oldStream) throw new Error("Missing synthetic stream");
+    await internal.readStream(oldStream, generation);
+    expect(store.progressPhase).toBe("starting");
+  });
+
   it("shows explicit continuation progress after an approval is acknowledged", () => {
     const store = new AgentChatStore(root() as never);
     store.isWorking = true;
@@ -2656,6 +2746,413 @@ describe("AgentChatStore", () => {
     expect(store.routeRefreshRevision).toBe(1);
     expect(store.routeSyncStatus).toBe("waiting");
     expect(store.streamStatus).toBe("idle");
+    expect(store.items.filter((item) => item.kind === "turn_interrupted")).toHaveLength(1);
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+    fetchMock.mockRestore();
+  });
+
+  it("shows a durable non-retry notice for an uncertain turn with no saved assistant response", async () => {
+    const conversationId = "00000000-0000-4000-8000-000000000111";
+    const clientRequestId = "00000000-0000-4000-8000-000000000112";
+    const userMessage = {
+      id: "persisted-user-uncertain",
+      role: "user",
+      parts: [{ type: "text", text: "Check my deals" }],
+      createdAt: new Date(0),
+      turn: {
+        clientRequestId,
+        status: "uncertain",
+        assistantMessageId: null,
+        terminalCode: null,
+      },
+    };
+    actionsMock.getAgentConversationAction.mockResolvedValue({
+      id: conversationId,
+      activeTurn: false,
+      messages: [userMessage],
+      nextCursor: null,
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", {
+        headers: {
+          "content-type": "text/event-stream",
+          "x-conversation-id": conversationId,
+        },
+      }),
+    );
+    const store = new AgentChatStore(root() as never);
+
+    await store.sendMessage("Check my deals", { messageId: clientRequestId });
+
+    expect(store.items.filter((item) => item.kind === "turn_interrupted")).toEqual([
+      expect.objectContaining({ messageId: clientRequestId }),
+    ]);
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "assistant" }));
+    expect(store.hasInSessionTerminalResult).toBe(false);
+    expect(store.isWorking).toBe(false);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const reloaded = new AgentChatStore(root() as never);
+    await reloaded.selectConversation(conversationId);
+    expect(reloaded.items.filter((item) => item.kind === "turn_interrupted")).toEqual([
+      expect.objectContaining({ messageId: userMessage.id }),
+    ]);
+    expect(reloaded.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    reloaded.newConversation();
+    expect(reloaded.items).toEqual([]);
+    expect(reloaded.conversationId).toBeNull();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    fetchMock.mockRestore();
+  });
+
+  it.each(["completed", "partial", "cancelled"])(
+    "restores a saved %s result when its terminal stream event was lost",
+    async (terminalCode) => {
+      const conversationId = "00000000-0000-4000-8000-000000000113";
+      const clientRequestId = "00000000-0000-4000-8000-000000000114";
+      actionsMock.getAgentConversationAction.mockResolvedValue({
+        id: conversationId,
+        activeTurn: false,
+        messages: [
+          {
+            id: "persisted-user-completed",
+            role: "user",
+            parts: [{ type: "text", text: "Check my deals" }],
+            turn: {
+              clientRequestId,
+              status: "completed",
+              assistantMessageId: "saved-assistant",
+              terminalCode,
+            },
+          },
+          {
+            id: "saved-assistant",
+            role: "assistant",
+            parts: [{ type: "text", text: "The saved result." }],
+          },
+        ],
+        nextCursor: null,
+      });
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response('data: {"seq":1,"type":"delta","text":"Incomplete streamed result"}\n\n', {
+          headers: {
+            "content-type": "text/event-stream",
+            "x-conversation-id": conversationId,
+          },
+        }),
+      );
+      const store = new AgentChatStore(root() as never);
+
+      await store.sendMessage("Check my deals", { messageId: clientRequestId });
+
+      expect(store.items.filter((item) => item.kind === "assistant")).toEqual([
+        expect.objectContaining({
+          messageId: "saved-assistant",
+          text: "The saved result.",
+          streaming: false,
+        }),
+      ]);
+      expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_interrupted" }));
+      expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+      expect((store as unknown as { activeTurnFailed: boolean }).activeTurnFailed).toBe(terminalCode !== "completed");
+      expect(store.isWorking).toBe(false);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      fetchMock.mockRestore();
+    },
+  );
+
+  it.each(["missing-answer", "different-request"])(
+    "does not treat %s metadata as a confirmed successful response",
+    async (scenario) => {
+      const conversationId = "00000000-0000-4000-8000-000000000115";
+      const clientRequestId = "00000000-0000-4000-8000-000000000116";
+      actionsMock.getAgentConversationAction.mockResolvedValue({
+        id: conversationId,
+        activeTurn: false,
+        messages: [
+          {
+            id: "persisted-user-unconfirmed",
+            role: "user",
+            parts: [{ type: "text", text: "Check my deals" }],
+            turn: {
+              clientRequestId: scenario === "different-request" ? "another-request" : clientRequestId,
+              status: "completed",
+              assistantMessageId: "saved-assistant",
+              terminalCode: "completed",
+            },
+          },
+          ...(scenario === "different-request"
+            ? [
+                {
+                  id: "saved-assistant",
+                  role: "assistant",
+                  parts: [{ type: "text", text: "Another request's answer" }],
+                },
+              ]
+            : []),
+        ],
+        nextCursor: null,
+      });
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("", {
+          headers: {
+            "content-type": "text/event-stream",
+            "x-conversation-id": conversationId,
+          },
+        }),
+      );
+      const store = new AgentChatStore(root() as never);
+
+      await store.sendMessage("Check my deals", { messageId: clientRequestId });
+
+      expect(store.items.filter((item) => item.kind === "turn_interrupted")).toHaveLength(1);
+      expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "assistant" }));
+      expect(store.hasInSessionTerminalResult).toBe(false);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      fetchMock.mockRestore();
+    },
+  );
+
+  it("does not apply a late recovery snapshot after navigation to a new conversation", async () => {
+    const conversationId = "00000000-0000-4000-8000-000000000117";
+    let resolveSnapshot!: (snapshot: { activeTurn: boolean; messages: never[]; nextCursor: null }) => void;
+    actionsMock.getAgentConversationAction.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", {
+        headers: {
+          "content-type": "text/event-stream",
+          "x-conversation-id": conversationId,
+        },
+      }),
+    );
+    const store = new AgentChatStore(root() as never);
+    const sending = store.sendMessage("Check my deals");
+    await vi.waitFor(() => expect(actionsMock.getAgentConversationAction).toHaveBeenCalled());
+
+    (store as unknown as { beginNewConversation: () => void }).beginNewConversation();
+    resolveSnapshot({ activeTurn: false, messages: [], nextCursor: null });
+    await sending;
+
+    expect(store.conversationId).toBeNull();
+    expect(store.items).toEqual([]);
+    expect(store.routeRefreshRevision).toBe(0);
+    expect(store.isWorking).toBe(false);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    fetchMock.mockRestore();
+  });
+
+  it("keeps the exact request identity and does not re-submit an uncertain busy-turn recovery", async () => {
+    const conversationId = "00000000-0000-4000-8000-000000000120";
+    const clientRequestId = "00000000-0000-4000-8000-000000000121";
+    actionsMock.getAgentConversationAction.mockResolvedValue({
+      id: conversationId,
+      activeTurn: false,
+      nextCursor: null,
+      messages: [
+        {
+          id: "another-user",
+          role: "user",
+          parts: [{ type: "text", text: "Another question" }],
+          turn: {
+            clientRequestId: "another-request",
+            status: "completed",
+            assistantMessageId: "another-assistant",
+            terminalCode: "completed",
+          },
+        },
+        { id: "another-assistant", role: "assistant", parts: [{ type: "text", text: "Another answer" }] },
+      ],
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ disposition: "running", conversationId, clientRequestId }), {
+          status: 409,
+          headers: { "content-type": "application/json", "x-conversation-id": conversationId },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { headers: { "content-type": "text/event-stream" } }));
+    const store = new AgentChatStore(root() as never);
+
+    await store.sendMessage("Check my deals", { messageId: clientRequestId });
+    await vi.waitFor(() => expect(store.items).toContainEqual(expect.objectContaining({ kind: "turn_interrupted" })));
+    await Promise.resolve();
+
+    expect(store.items.filter((item) => item.kind === "turn_interrupted")).toEqual([
+      expect.objectContaining({ messageId: clientRequestId }),
+    ]);
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "assistant" }));
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+    expect(store.hasInSessionTerminalResult).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.filter((call) => call[1]?.method === "POST")).toHaveLength(1);
+    fetchMock.mockRestore();
+  });
+
+  it("does not replay a completed history result when a reattached stream has no known request identity", async () => {
+    const conversationId = "00000000-0000-4000-8000-000000000122";
+    actionsMock.getAgentConversationAction.mockResolvedValue({
+      id: conversationId,
+      activeTurn: false,
+      nextCursor: null,
+      messages: [
+        {
+          id: "unknown-user",
+          role: "user",
+          parts: [{ type: "text", text: "Unknown question" }],
+          turn: {
+            clientRequestId: "unknown-request",
+            status: "completed",
+            assistantMessageId: "unknown-assistant",
+            terminalCode: "completed",
+          },
+        },
+        { id: "unknown-assistant", role: "assistant", parts: [{ type: "text", text: "Unconfirmed answer" }] },
+      ],
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    const store = new AgentChatStore(root() as never);
+    store.conversationId = conversationId;
+    store.items = [{ kind: "user", id: "local-user", messageId: "local-request", text: "Check my deals" }];
+
+    await (store as unknown as { reattachStream: (id: string, version: number) => Promise<void> }).reattachStream(
+      conversationId,
+      0,
+    );
+
+    expect(store.items.filter((item) => item.kind === "turn_interrupted")).toEqual([
+      expect.objectContaining({ messageId: "local-request" }),
+    ]);
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "assistant" }));
+    expect(store.hasInSessionTerminalResult).toBe(false);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    fetchMock.mockRestore();
+  });
+
+  it("shows an interrupted notice when admission reports an already uncertain request", async () => {
+    const clientRequestId = "00000000-0000-4000-8000-000000000123";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ disposition: "uncertain" }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const store = new AgentChatStore(root() as never);
+
+    await store.sendMessage("Check my deals", { messageId: clientRequestId });
+
+    expect(store.items.filter((item) => item.kind === "turn_interrupted")).toEqual([
+      expect.objectContaining({ messageId: clientRequestId }),
+    ]);
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+    expect(fetchMock).toHaveBeenCalledOnce();
+    fetchMock.mockRestore();
+  });
+
+  it("shows the interruption notice after reattaching a persisted active turn", async () => {
+    const conversationId = "00000000-0000-4000-8000-000000000118";
+    const userMessage = {
+      id: "persisted-user-reattached",
+      role: "user",
+      parts: [{ type: "text", text: "Check my deals" }],
+      turn: {
+        clientRequestId: "reattached-request",
+        status: "running",
+        assistantMessageId: null,
+        terminalCode: null,
+      },
+    };
+    actionsMock.getAgentConversationAction
+      .mockResolvedValueOnce({
+        id: conversationId,
+        activeTurn: true,
+        messages: [userMessage],
+        nextCursor: null,
+      })
+      .mockResolvedValue({
+        id: conversationId,
+        activeTurn: false,
+        messages: [
+          {
+            ...userMessage,
+            turn: { ...userMessage.turn, status: "uncertain" },
+          },
+        ],
+        nextCursor: null,
+      });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    const store = new AgentChatStore(root() as never);
+
+    await store.selectConversation(conversationId);
+    await vi.waitFor(() => expect(store.isWorking).toBe(false));
+
+    expect(store.items.filter((item) => item.kind === "turn_interrupted")).toEqual([
+      expect.objectContaining({ messageId: userMessage.id }),
+    ]);
+    expect(store.items).not.toContainEqual(expect.objectContaining({ kind: "turn_error" }));
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(`/api/agent/conversations/${conversationId}/stream`);
+    fetchMock.mockRestore();
+  });
+
+  it("hydrates uncertain notices in older history without duplicating them or retrying the turn", async () => {
+    const conversationId = "00000000-0000-4000-8000-000000000119";
+    actionsMock.getAgentConversationAction
+      .mockResolvedValueOnce({
+        id: conversationId,
+        activeTurn: false,
+        nextCursor: "50",
+        messages: [
+          {
+            id: "newer-user",
+            role: "user",
+            parts: [{ type: "text", text: "A later question" }],
+          },
+        ],
+      })
+      .mockResolvedValue({
+        id: conversationId,
+        activeTurn: false,
+        nextCursor: "40",
+        messages: [
+          {
+            id: "older-user",
+            role: "user",
+            parts: [{ type: "text", text: "An older question" }],
+            turn: {
+              clientRequestId: "older-request",
+              status: "uncertain",
+              assistantMessageId: null,
+              terminalCode: null,
+            },
+          },
+        ],
+      });
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const store = new AgentChatStore(root() as never);
+
+    await store.selectConversation(conversationId);
+    await store.loadOlderMessages();
+    await store.loadOlderMessages();
+
+    expect(store.items.map((item) => item.kind)).toEqual(["user", "turn_interrupted", "user"]);
+    expect(fetchMock).not.toHaveBeenCalled();
     fetchMock.mockRestore();
   });
 

--- a/app/components/agent-chat/__tests__/agent-status-announcer.test.ts
+++ b/app/components/agent-chat/__tests__/agent-status-announcer.test.ts
@@ -2,7 +2,9 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-const testContext = vi.hoisted(() => ({ store: {} as Record<string, unknown> }));
+const testContext = vi.hoisted(() => ({
+  store: {} as Record<string, unknown>,
+}));
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -14,7 +16,7 @@ vi.mock("../agent-chat-items", () => ({
   useAgentActivityTerminology: () => ({}),
 }));
 
-import { AgentStatusAnnouncer } from "../agent-status-announcer";
+import { AgentInitialProgress, AgentStatusAnnouncer } from "../agent-status-announcer";
 
 function renderStatus(overrides: Record<string, unknown> = {}) {
   testContext.store = {
@@ -30,9 +32,63 @@ function renderStatus(overrides: Record<string, unknown> = {}) {
 }
 
 describe("AgentStatusAnnouncer", () => {
+  it.each([
+    ["starting", "startingRequest"],
+    ["working", "workingOnRequest"],
+    ["preparing_action", "preparingAction"],
+  ])("announces %s once without adding a second live region", (phase, key) => {
+    const markup = renderStatus({
+      isWorking: true,
+      isAwaitingAssistantResponse: true,
+      streamStatus: "working",
+      progressPhase: phase,
+    });
+    expect(markup).toContain(`AgentChat.ui.${key}`);
+    expect(markup.match(/aria-live=/g)).toHaveLength(1);
+    const visible = renderToStaticMarkup(createElement(AgentInitialProgress));
+    expect(visible).toContain(`AgentChat.ui.${key}`);
+    expect(visible).not.toContain("aria-live");
+    expect(visible).toContain("motion-reduce:animate-none");
+  });
+
+  it.each(["stopping", "reconnecting", "resuming"])("prioritizes %s over initial progress", (streamStatus) => {
+    const markup = renderStatus({
+      isWorking: true,
+      isAwaitingAssistantResponse: true,
+      streamStatus,
+      progressPhase: "working",
+    });
+    expect(markup).not.toContain("AgentChat.ui.workingOnRequest");
+    expect(markup).toContain(streamStatus);
+    expect(renderToStaticMarkup(createElement(AgentInitialProgress))).toBe("");
+  });
+
+  it("hides initial feedback after the first item and after terminal cleanup", () => {
+    renderStatus({
+      isWorking: true,
+      isAwaitingAssistantResponse: false,
+      streamStatus: "working",
+      progressPhase: "working",
+    });
+    expect(renderToStaticMarkup(createElement(AgentInitialProgress))).toBe("");
+    renderStatus({
+      isWorking: true,
+      isAwaitingAssistantResponse: true,
+      streamStatus: "working",
+      progressPhase: null,
+    });
+    expect(renderToStaticMarkup(createElement(AgentInitialProgress))).toBe("");
+  });
   it("does not announce a historical result hydrated into a closed assistant", () => {
     const historical = renderStatus({
-      items: [{ kind: "assistant", id: "historical", text: "Old answer", streaming: false }],
+      items: [
+        {
+          kind: "assistant",
+          id: "historical",
+          text: "Old answer",
+          streaming: false,
+        },
+      ],
     });
 
     expect(historical).not.toContain("AgentChat.ui.responseComplete");
@@ -40,14 +96,28 @@ describe("AgentStatusAnnouncer", () => {
 
   it("keeps route-sync announcements global and announces only current-session terminal results", () => {
     const waiting = renderStatus({
-      items: [{ kind: "assistant", id: "historical", text: "Old answer", streaming: false }],
+      items: [
+        {
+          kind: "assistant",
+          id: "historical",
+          text: "Old answer",
+          streaming: false,
+        },
+      ],
       routeSyncStatus: "waiting",
     });
     expect(waiting).toContain("AgentChat.ui.routeSyncWaiting");
 
     const completed = renderStatus({
       hasInSessionTerminalResult: true,
-      items: [{ kind: "assistant", id: "current", text: "New answer", streaming: false }],
+      items: [
+        {
+          kind: "assistant",
+          id: "current",
+          text: "New answer",
+          streaming: false,
+        },
+      ],
     });
     expect(completed).toContain("AgentChat.ui.responseComplete");
   });

--- a/app/components/agent-chat/agent-chat-items.tsx
+++ b/app/components/agent-chat/agent-chat-items.tsx
@@ -96,6 +96,18 @@ export const AgentChatItemView = observer(function AgentChatItemView({
     );
   }
 
+  if (item.kind === "turn_interrupted") {
+    return (
+      <div
+        className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs"
+        data-testid="agent-turn-interrupted"
+        role="alert"
+      >
+        {t("AgentChat.ui.turnInterrupted")}
+      </div>
+    );
+  }
+
   if (item.kind === "turn_error") {
     const copy = chatUiCopy(t);
     return (

--- a/app/components/agent-chat/agent-chat.store.ts
+++ b/app/components/agent-chat/agent-chat.store.ts
@@ -2,8 +2,10 @@ import { makeObservable, observable, action, computed, reaction, runInAction } f
 
 import type { RootStore } from "@/core/stores/root.store";
 import type { AgentUsageSummary } from "@/ee/agent-chat/agent-usage.service";
+import type { AgentMessageTurn } from "@/ee/agent-chat/agent-history";
 import {
   clientSafeAgentMessageParts,
+  hasRenderableAgentMessageParts,
   type AgentConversationSummary,
   type AgentDataCounts,
   type AgentMessagePart,
@@ -38,6 +40,7 @@ import { internalToolIdentity } from "@/ee/agent-chat/tool-identity";
 
 export type AgentChatItem =
   | { kind: "user"; id: string; messageId: string; text: string; at?: Date }
+  | { kind: "turn_interrupted"; id: string; messageId: string; at?: Date }
   | {
       kind: "assistant";
       id: string;
@@ -86,6 +89,8 @@ export type AgentStreamStatus =
   | "finalizing";
 
 export type AgentRouteSyncStatus = "idle" | "queued" | "waiting" | "refreshing";
+
+export type AgentProgressPhase = "starting" | "working" | "preparing_action";
 
 let itemSeq = 0;
 const nextItemId = () => `item-${++itemSeq}`;
@@ -187,6 +192,8 @@ export class AgentChatStore extends BaseStore {
   queuedPromptNeedsAttention = false;
   routeRefreshRevision = 0;
   streamStatus: AgentStreamStatus = "idle";
+  progressPhase: AgentProgressPhase | null = null;
+  progressStartedAt: number | null = null;
   routeSyncStatus: AgentRouteSyncStatus = "idle";
   autoOpenedPages = new Set<string>();
   isWorking = false;
@@ -258,6 +265,8 @@ export class AgentChatStore extends BaseStore {
         routeRefreshRevision: observable,
         consumedRouteRefreshRevision: observable,
         streamStatus: observable,
+        progressPhase: observable,
+        progressStartedAt: observable,
         routeSyncStatus: observable,
         isWorking: observable,
         hasInSessionTerminalResult: observable,
@@ -508,6 +517,8 @@ export class AgentChatStore extends BaseStore {
     this.isWorking = false;
     this.hasInSessionTerminalResult = false;
     this.streamStatus = "idle";
+    this.progressPhase = null;
+    this.progressStartedAt = null;
     this.activeTurnNextStreamIndex = 0;
     this.activeTurnAdmissionConfirmed = false;
     this.activeTurnStopRequested = false;
@@ -559,7 +570,12 @@ export class AgentChatStore extends BaseStore {
         this.appendMessages(data.messages);
       });
 
-      if (data.activeTurn) void this.reattachStream(id, loadVersion);
+      if (data.activeTurn) {
+        const activeMessage = data.messages.findLast(
+          (message) => message.role === "user" && message.turn?.status === "running",
+        );
+        void this.reattachStream(id, loadVersion, undefined, activeMessage?.turn?.clientRequestId);
+      }
     } catch {
       if (loadVersion !== this.conversationLoadVersion) return;
       runInAction(() => {
@@ -605,6 +621,7 @@ export class AgentChatStore extends BaseStore {
       role: string;
       parts: unknown;
       createdAt?: Date | string | null;
+      turn?: AgentMessageTurn | null;
     }[],
   ) {
     for (const message of messages) {
@@ -621,8 +638,19 @@ export class AgentChatStore extends BaseStore {
         activity?: unknown;
       }[];
       for (const part of parts) this.appendPart(message.role, part, at, message.id);
+      if (message.role === "user" && message.turn?.status === "uncertain") this.appendInterruptedTurn(message.id, at);
       if (message.role === "assistant") this.persistedAssistantMessageIds.add(message.id);
     }
+  }
+
+  private appendInterruptedTurn(messageId: string, at?: Date) {
+    if (this.items.some((item) => item.kind === "turn_interrupted" && item.messageId === messageId)) return;
+    this.items.push({
+      kind: "turn_interrupted",
+      id: nextItemId(),
+      messageId,
+      at,
+    });
   }
 
   private appendPart(
@@ -761,6 +789,7 @@ export class AgentChatStore extends BaseStore {
     activeController?.abort();
     runInAction(() => {
       this.streamStatus = "stopping";
+      this.progressPhase = null;
     });
   };
 
@@ -804,6 +833,8 @@ export class AgentChatStore extends BaseStore {
   }
 
   private clearStreaming = () => {
+    this.progressPhase = null;
+    this.progressStartedAt = null;
     for (const item of this.items) if (item.kind === "assistant") item.streaming = false;
   };
 
@@ -1190,8 +1221,10 @@ export class AgentChatStore extends BaseStore {
             descriptionKey:
               typeof message === "string" && response.status === 429 ? "AgentChat.errors.limitReached" : undefined,
           });
-        } else if (disposition === "uncertain" || disposition === "conflict")
+        } else if (disposition === "uncertain" || disposition === "conflict") {
+          if (disposition === "uncertain") runInAction(() => this.appendInterruptedTurn(messageId, new Date()));
           this.toastError("AgentChat.errors.sendFailed");
+        }
         return;
       }
 
@@ -1201,6 +1234,7 @@ export class AgentChatStore extends BaseStore {
 
       await this.followActiveTurn({
         conversationId: this.conversationId ?? conversationId,
+        clientRequestId: messageId,
         generation: turnGeneration,
         initialBody: response.body,
         loadVersion: this.conversationLoadVersion,
@@ -1215,6 +1249,7 @@ export class AgentChatStore extends BaseStore {
       ) {
         await this.followActiveTurn({
           conversationId: recoveryConversationId,
+          clientRequestId: messageId,
           generation: turnGeneration,
           initialBody: null,
           loadVersion: this.conversationLoadVersion,
@@ -1329,14 +1364,14 @@ export class AgentChatStore extends BaseStore {
       this.conversationId !== conversationId
     )
       return;
-    await this.reattachStream(conversationId, loadVersion, generation);
+    await this.reattachStream(conversationId, loadVersion, generation, resend.messageId);
     if (
       generation !== this.activeTurnGeneration ||
       loadVersion !== this.conversationLoadVersion ||
       this.conversationId !== conversationId
     )
       return;
-    if (this.abortController || this.isWorking) return;
+    if (this.abortController || this.isWorking || this.activeTurnDisposition === "uncertain") return;
     void this.sendMessage(resend.text, {
       appendUser: false,
       conversationId,
@@ -1347,7 +1382,12 @@ export class AgentChatStore extends BaseStore {
     });
   };
 
-  private reattachStream = async (conversationId: string, loadVersion: number, existingGeneration?: number) => {
+  private reattachStream = async (
+    conversationId: string,
+    loadVersion: number,
+    existingGeneration?: number,
+    clientRequestId?: string,
+  ) => {
     if (this.abortController) return;
 
     const generation = existingGeneration ?? this.beginActiveTurnMutationTracking();
@@ -1359,6 +1399,7 @@ export class AgentChatStore extends BaseStore {
     try {
       await this.followActiveTurn({
         conversationId,
+        clientRequestId,
         generation,
         initialBody: null,
         loadVersion,
@@ -1381,11 +1422,13 @@ export class AgentChatStore extends BaseStore {
 
   private followActiveTurn = async ({
     conversationId,
+    clientRequestId,
     generation,
     initialBody,
     loadVersion,
   }: {
     conversationId: string | null;
+    clientRequestId?: string;
     generation: number;
     initialBody: ReadableStream<Uint8Array> | null;
     loadVersion: number;
@@ -1435,11 +1478,48 @@ export class AgentChatStore extends BaseStore {
 
       if (!reconnectImmediately) {
         const snapshot = await getAgentConversationAction(conversationId).catch(() => null);
+        if (generation !== this.activeTurnGeneration || loadVersion !== this.conversationLoadVersion) return;
         if (snapshot && !snapshot.activeTurn) {
           runInAction(() => {
+            const userMessage = snapshot.messages.findLast(
+              (message) =>
+                message.role === "user" &&
+                Boolean(clientRequestId) &&
+                message.turn?.clientRequestId === clientRequestId,
+            );
+            const turn = userMessage?.turn;
+            const assistantMessage = snapshot.messages.find(
+              (message) => message.role === "assistant" && message.id === turn?.assistantMessageId,
+            );
+            const replayable =
+              turn?.status === "completed" &&
+              turn.terminalCode !== null &&
+              assistantMessage &&
+              hasRenderableAgentMessageParts(clientSafeAgentMessageParts(assistantMessage.parts));
+            const userIndex = this.items.findLastIndex(
+              (item) =>
+                item.kind === "user" &&
+                (item.messageId === userMessage?.id || item.messageId === (clientRequestId ?? turn?.clientRequestId)),
+            );
+            const canReplaceCurrentTurn =
+              userIndex >= 0 && !this.items.slice(userIndex + 1).some((item) => item.kind === "user");
+            if (replayable && canReplaceCurrentTurn) {
+              this.items = this.items.slice(0, userIndex + 1);
+              this.loadedMessageIds.delete(assistantMessage.id);
+              this.persistedAssistantMessageIds.delete(assistantMessage.id);
+              this.recordReplayedMutations(clientSafeAgentMessageParts(assistantMessage.parts));
+              this.appendMessages([assistantMessage]);
+            } else {
+              const noticeMessageId =
+                userIndex >= 0
+                  ? (this.items[userIndex] as Extract<AgentChatItem, { kind: "user" }>).messageId
+                  : (clientRequestId ?? this.items.findLast((item) => item.kind === "user")?.messageId);
+              if (noticeMessageId) this.appendInterruptedTurn(noticeMessageId, new Date());
+            }
             this.activeTurnCompleted = true;
-            this.activeTurnFailed = true;
-            this.activeTurnDisposition = "uncertain";
+            this.activeTurnFailed = !replayable || !canReplaceCurrentTurn || turn.terminalCode !== "completed";
+            this.activeTurnDisposition = replayable && canReplaceCurrentTurn ? "stream" : "uncertain";
+            this.hasInSessionTerminalResult = Boolean(replayable && canReplaceCurrentTurn);
             this.clearStreaming();
             this.requestRouteRefreshForActiveTurn(null, true);
           });
@@ -1620,12 +1700,27 @@ export class AgentChatStore extends BaseStore {
   private handleEvent = (event: { seq: number; type: string } & Record<string, unknown>) => {
     runInAction(() => {
       switch (event.type) {
+        case "progress": {
+          if (
+            this.activeTurnCompleted ||
+            this.activeTurnFailed ||
+            this.activeTurnStopRequested ||
+            !this.isAwaitingAssistantResponse ||
+            (event.phase !== "working" && event.phase !== "preparing_action")
+          )
+            break;
+          this.progressPhase = event.phase;
+          this.streamStatus = "working";
+          break;
+        }
         case "delta": {
+          this.progressPhase = null;
           if (!this.activeTurnStopRequested) this.streamStatus = "working";
           this.currentAssistantItem().text += String(event.text ?? "");
           break;
         }
         case "message_replay": {
+          this.progressPhase = null;
           const messageId = typeof event.messageId === "string" ? event.messageId : null;
           const parts = clientSafeAgentMessageParts(event.parts);
           this.recordReplayedMutations(parts);
@@ -1650,6 +1745,7 @@ export class AgentChatStore extends BaseStore {
           if (!this.activeTurnStopRequested) this.streamStatus = "working";
           const activity = AgentActivityDescriptorSchema.safeParse(event.activity);
           if (!activity.success) break;
+          this.progressPhase = null;
           const providerCallId = String(event.id);
           const existing = this.items.findLast(
             (item): item is Extract<AgentChatItem, { kind: "activity" }> =>
@@ -1704,6 +1800,7 @@ export class AgentChatStore extends BaseStore {
         case "approval_request": {
           const activity = AgentActivityDescriptorSchema.safeParse(event.activity);
           if (!activity.success) break;
+          this.progressPhase = null;
           const requestId = String(event.requestId);
           const existing = this.items.find(
             (item): item is Extract<AgentChatItem, { kind: "approval" }> =>
@@ -1785,6 +1882,7 @@ export class AgentChatStore extends BaseStore {
   private beginActiveTurnMutationTracking() {
     this.activeTurnGeneration += 1;
     this.activeTurnCompleted = false;
+    this.activeTurnFailed = false;
     this.hasInSessionTerminalResult = false;
     this.activeTurnHasSuccessfulMutation = false;
     this.activeTurnRefreshRequested = false;
@@ -1794,6 +1892,8 @@ export class AgentChatStore extends BaseStore {
     this.activeTurnStopPromise = null;
     this.activeStreamKey = `stream-${++this.streamSequence}`;
     this.streamStatus = "working";
+    this.progressPhase = "starting";
+    this.progressStartedAt = Date.now();
     return this.activeTurnGeneration;
   }
 

--- a/app/components/agent-chat/agent-chat.tsx
+++ b/app/components/agent-chat/agent-chat.tsx
@@ -20,9 +20,9 @@ import { IconContainer } from "@/components/shared/icon-container";
 import { OVERLAY_SCROLL_REGION } from "@/components/ui/overlay-contract";
 import { cn } from "@/core/utils/cn";
 
-import { ActionTooltip, chatUiCopy, TypingDots } from "./chat-ui";
+import { ActionTooltip, chatUiCopy } from "./chat-ui";
 import { AgentActivity, AgentChatItemView, consecutiveActivityItems } from "./agent-chat-items";
-import { AgentProgressStatus, AgentStatusAnnouncer } from "./agent-status-announcer";
+import { AgentInitialProgress, AgentProgressStatus, AgentStatusAnnouncer } from "./agent-status-announcer";
 import { ArchiveUndo, ConversationHistory } from "./conversation-history";
 import { CreditBlockedNotice } from "./credit-blocked-notice";
 import { QueuedPrompt } from "./queued-prompt";
@@ -321,11 +321,7 @@ const AgentChatPanel = observer(function AgentChatPanel() {
               );
             })}
 
-            {store.isAwaitingAssistantResponse && (
-              <div aria-hidden="true" className="flex items-center gap-1 py-1">
-                <TypingDots />
-              </div>
-            )}
+            <AgentInitialProgress />
           </div>
         </MessagesScrollContainer>
       )}

--- a/app/components/agent-chat/agent-status-announcer.tsx
+++ b/app/components/agent-chat/agent-status-announcer.tsx
@@ -3,13 +3,14 @@
 import { observer } from "mobx-react-lite";
 import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import type { AgentChatItem } from "./agent-chat.store";
 
 import { agentActivityCopy } from "@/ee/agent-chat/agent-activity";
 
 import { useRootStore } from "@/core/stores/root-store.provider";
-import { chatUiCopy } from "./chat-ui";
+import { agentProgressLabel, chatUiCopy, TypingDots } from "./chat-ui";
 import { useAgentActivityTerminology } from "./agent-chat-items";
 
 export const AgentStatusAnnouncer = observer(function AgentStatusAnnouncer() {
@@ -31,7 +32,9 @@ export const AgentStatusAnnouncer = observer(function AgentStatusAnnouncer() {
   else if (store.isWorking && latestTurnActivity?.status === "running") {
     const activity = agentActivityCopy(latestTurnActivity.activity, t, terminology);
     status = activity.running;
-  } else if (store.isWorking) status = copy.assistantWorking;
+  } else if (store.isAwaitingAssistantResponse && store.streamStatus === "working")
+    status = agentProgressLabel(store.progressPhase, t);
+  else if (store.isWorking) status = copy.assistantWorking;
   else if (store.routeSyncStatus === "refreshing") status = copy.routeSyncRefreshing;
   else if (store.routeSyncStatus === "waiting") status = copy.routeSyncWaiting;
   else if (store.streamStatus === "finalizing") status = copy.finalizing;
@@ -49,6 +52,43 @@ export const AgentStatusAnnouncer = observer(function AgentStatusAnnouncer() {
     <span aria-atomic="true" aria-live="polite" className="sr-only" role="status">
       {status}
     </span>
+  );
+});
+
+export const AgentInitialProgress = observer(function AgentInitialProgress() {
+  const { agentChatStore: store } = useRootStore();
+  const t = useTranslations();
+  const startedAt = store.progressStartedAt;
+  const [clock, setClock] = useState<{
+    startedAt: number;
+    seconds: number;
+  } | null>(null);
+  const visible = store.isAwaitingAssistantResponse && store.streamStatus === "working" && store.progressPhase !== null;
+
+  useEffect(() => {
+    if (!visible || startedAt === null) return;
+    const timer = setInterval(() => {
+      setClock({
+        startedAt,
+        seconds: Math.max(0, Math.floor((Date.now() - startedAt) / 1000)),
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [visible, startedAt]);
+
+  if (!visible) return null;
+  const seconds = clock?.startedAt === startedAt ? (clock?.seconds ?? 0) : 0;
+
+  return (
+    <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground" data-testid="agent-initial-progress">
+      <span aria-hidden="true">
+        <TypingDots />
+      </span>
+
+      <span>{agentProgressLabel(store.progressPhase, t)}</span>
+
+      {seconds >= 5 && <span className="tabular-nums">{t("AgentChat.ui.waitElapsed", { seconds })}</span>}
+    </div>
   );
 });
 
@@ -74,7 +114,7 @@ export const AgentProgressStatus = observer(function AgentProgressStatus() {
 
   return (
     <div className="flex items-center gap-2 px-4 py-1 text-xs text-muted-foreground">
-      <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+      <Loader2 aria-hidden="true" className="size-3.5 animate-spin motion-reduce:animate-none" />
 
       <span>{label}</span>
     </div>

--- a/app/components/agent-chat/chat-ui.tsx
+++ b/app/components/agent-chat/chat-ui.tsx
@@ -2,6 +2,7 @@
 
 import { observer } from "mobx-react-lite";
 import type { useTranslations } from "next-intl";
+import type { AgentProgressPhase } from "./agent-chat.store";
 
 import { useHydratedIntlStore } from "@/core/stores/use-hydrated-intl-store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -17,6 +18,12 @@ export function ActionTooltip({ children, label }: { children: React.ReactNode; 
 }
 
 export type ChatTranslator = ReturnType<typeof useTranslations>;
+
+export function agentProgressLabel(phase: AgentProgressPhase | null, t: ChatTranslator) {
+  if (phase === "starting") return t("AgentChat.ui.startingRequest");
+  if (phase === "preparing_action") return t("AgentChat.ui.preparingAction");
+  return t("AgentChat.ui.workingOnRequest");
+}
 
 export function chatUiCopy(t: ChatTranslator) {
   return {

--- a/core/utils/background-task.service.ts
+++ b/core/utils/background-task.service.ts
@@ -1,4 +1,4 @@
-import { resumeHook, start } from "workflow/api";
+import { getRun, resumeHook, start } from "workflow/api";
 import { HookNotFoundError } from "workflow/errors";
 
 import type { WorkflowId, WorkflowPayload } from "@/workflows/registry";
@@ -31,6 +31,11 @@ export class BackgroundTaskService {
 
   async dispatchTracked<TId extends WorkflowId>(id: TId, payload: WorkflowPayload<TId>): Promise<string> {
     return this.startWorkflow(id, payload);
+  }
+
+  async isWorkflowTerminal(externalRunId: string): Promise<boolean> {
+    const status = await getRun(externalRunId).status;
+    return status === "completed" || status === "failed" || status === "cancelled";
   }
 
   async resume(token: string, payload: Record<string, unknown>): Promise<boolean> {

--- a/ee/agent-chat/__tests__/agent-access.test.ts
+++ b/ee/agent-chat/__tests__/agent-access.test.ts
@@ -869,6 +869,55 @@ describe("agent access", () => {
     expect(result.ok && result.data.activeTurn).toBe(false);
   });
 
+  it.each(["uncertain", "completed", "running"])(
+    "returns safe %s turn metadata with its user message",
+    async (status) => {
+      const turn = {
+        clientRequestId: CLIENT_REQUEST_ID,
+        status,
+        assistantMessageId: status === "completed" ? "assistant-1" : null,
+        terminalCode: status === "completed" ? "completed" : null,
+      };
+      const repo = {
+        findConversation: vi.fn().mockResolvedValue({ id: CONVERSATION_ID, title: "Result" }),
+        hasRunningTurn: vi.fn().mockResolvedValue(status === "running"),
+        listMessagePage: vi.fn().mockResolvedValue(
+          messagePage([
+            {
+              id: MESSAGE_ID,
+              role: "user",
+              parts: [{ type: "text", text: "Check my deals" }],
+              createdAt: new Date(0),
+              turnRequest: {
+                ...turn,
+                externalRunId: "private-workflow-id",
+                text: "private-server-context",
+                modelSpec: "private-model",
+              },
+            },
+            {
+              id: "assistant-1",
+              role: "assistant",
+              parts: [{ type: "text", text: "Saved answer" }],
+              createdAt: new Date(0),
+              turnRequest: turn,
+            },
+          ]),
+        ),
+      };
+
+      const result = await new GetAgentConversationInteractor(repo as never, mockEntitlementService()).invoke({
+        conversationId: CONVERSATION_ID,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.messages[0]?.turn).toEqual(turn);
+      expect(result.data.messages[1]?.turn).toBeNull();
+      expect(JSON.stringify(result.data)).not.toContain("private-");
+    },
+  );
+
   it("records UI feedback only for an owned conversation", async () => {
     const repo = {
       findConversation: vi.fn().mockResolvedValue({ id: CONVERSATION_ID }),

--- a/ee/agent-chat/__tests__/agent-cancel-wake.test.ts
+++ b/ee/agent-chat/__tests__/agent-cancel-wake.test.ts
@@ -26,6 +26,8 @@ function repoWith(cancelling: boolean) {
   return {
     findConversation: vi.fn().mockResolvedValue({ id: CONVERSATION_ID }),
     requestAgentTurnCancellation: vi.fn().mockResolvedValue(cancelling),
+    findRunningAgentTurnForCancellation: vi.fn().mockResolvedValue(null),
+    reconcileInterruptedAgentTurnUnscoped: vi.fn().mockResolvedValue({ reconciled: true }),
   };
 }
 
@@ -77,5 +79,62 @@ describe("stopping a durable agent turn", () => {
 
     expect(result.ok && result.data.cancelling).toBe(false);
     expect(backgroundTasks.resume).not.toHaveBeenCalled();
+  });
+});
+
+describe("stopping an already-terminated workflow", () => {
+  const turn = {
+    id: "turn-1",
+    conversationId: CONVERSATION_ID,
+    companyId: "company-1",
+    userId: "user-1",
+    runId: "attempt-1",
+    externalRunId: "workflow-1",
+  };
+
+  it("reconciles a confirmed terminal workflow using its exact recorded identity", async () => {
+    const repo = repoWith(true);
+    repo.findRunningAgentTurnForCancellation.mockResolvedValue(turn);
+    const backgroundTasks = {
+      resume: vi.fn().mockResolvedValue(false),
+      isWorkflowTerminal: vi.fn().mockResolvedValue(true),
+    };
+
+    const result = await new CancelAgentTurnInteractor(
+      repo as never,
+      mockEntitlementService(),
+      backgroundTasks as never,
+    ).invoke({ conversationId: CONVERSATION_ID });
+
+    expect(result.ok && result.data.cancelling).toBe(true);
+    expect(backgroundTasks.isWorkflowTerminal).toHaveBeenCalledWith("workflow-1");
+    expect(repo.reconcileInterruptedAgentTurnUnscoped).toHaveBeenCalledWith({
+      turnRequestId: turn.id,
+      conversationId: turn.conversationId,
+      companyId: turn.companyId,
+      userId: turn.userId,
+      runId: turn.runId,
+      externalRunId: turn.externalRunId,
+    });
+    expect(backgroundTasks.resume).not.toHaveBeenCalled();
+  });
+
+  it.each(["running", "unavailable"])("does not settle when status is %s", async (status) => {
+    const repo = repoWith(true);
+    repo.findRunningAgentTurnForCancellation.mockResolvedValue(turn);
+    const backgroundTasks = {
+      resume: vi.fn().mockResolvedValue(true),
+      isWorkflowTerminal:
+        status === "running"
+          ? vi.fn().mockResolvedValue(false)
+          : vi.fn().mockRejectedValue(new Error("status unavailable")),
+    };
+
+    await new CancelAgentTurnInteractor(repo as never, mockEntitlementService(), backgroundTasks as never).invoke({
+      conversationId: CONVERSATION_ID,
+    });
+
+    expect(repo.reconcileInterruptedAgentTurnUnscoped).not.toHaveBeenCalled();
+    expect(backgroundTasks.resume).toHaveBeenCalledWith(agentApprovalHookToken(CONVERSATION_ID), { cancelled: true });
   });
 });

--- a/ee/agent-chat/__tests__/agent-durable-stream.test.ts
+++ b/ee/agent-chat/__tests__/agent-durable-stream.test.ts
@@ -14,13 +14,23 @@ function read(chunks: unknown[]) {
 describe("agent durable stream reader", () => {
   it("turns a tool call into a running activity before the tool has executed", () => {
     expect(
-      read([{ type: "tool-call", toolCallId: "call-1", toolName: "list_records", input: { entity: "contact" } }]),
+      read([
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "list_records",
+          input: { entity: "contact" },
+        },
+      ]),
     ).toEqual([
       {
         type: "activity",
         payload: {
           id: "call-1",
-          activity: expect.objectContaining({ kind: "records.read", resource: "contacts" }),
+          activity: expect.objectContaining({
+            kind: "records.read",
+            resource: "contacts",
+          }),
         },
       },
     ]);
@@ -36,14 +46,22 @@ describe("agent durable stream reader", () => {
       },
     ]);
 
-    expect(events).toEqual([{ type: "activity_result", payload: { id: "call-1", isError: false, status: "done" } }]);
+    expect(events).toEqual([
+      {
+        type: "activity_result",
+        payload: { id: "call-1", isError: false, status: "done" },
+      },
+    ]);
     expect(JSON.stringify(events)).not.toContain("ada@example.com");
   });
 
   it("never forwards model identifiers, usage or cost", () => {
     const events = read([
-      { type: "model-call-start", model: "openai/gpt-5.6-luna" },
-      { type: "model-call-end", usage: { inputTokens: 100 }, providerMetadata: { gateway: { cost: "0.004" } } },
+      {
+        type: "model-call-end",
+        usage: { inputTokens: 100 },
+        providerMetadata: { gateway: { cost: "0.004" } },
+      },
       { type: "model-call-response-metadata", modelId: "gpt-5.6-luna" },
       { type: "finish-step", usage: { outputTokens: 20 } },
       { type: "reset-step" },
@@ -53,10 +71,48 @@ describe("agent durable stream reader", () => {
     expect(events).toEqual([]);
   });
 
+  it("derives enum-only progress without forwarding lifecycle metadata or reasoning", () => {
+    const events = read([
+      {
+        type: "model-call-start",
+        model: "private-model",
+        warnings: ["private-warning"],
+        payload: { secret: "secret" },
+      },
+      {
+        type: "tool-input-start",
+        id: "private-id",
+        toolName: "private-tool",
+        providerMetadata: { secret: "secret" },
+      },
+      { type: "reasoning-start", id: "private-reasoning" },
+      { type: "reasoning-delta", text: "private-thought" },
+      { type: "tool-input-delta", delta: "private-argument" },
+      { type: "progress", payload: { phase: "private-untrusted-phase" } },
+    ]);
+
+    expect(events).toEqual([
+      { type: "progress", payload: { phase: "working" } },
+      { type: "progress", payload: { phase: "preparing_action" } },
+    ]);
+    expect(JSON.stringify(events)).not.toMatch(/private|secret/);
+  });
+
   it("reports a structured tool failure as an error the user can see", () => {
-    expect(read([{ type: "tool-result", toolCallId: "call-1", output: { ok: false, result: "not allowed" } }])).toEqual(
-      [{ type: "activity_result", payload: { id: "call-1", isError: true, status: "error" } }],
-    );
+    expect(
+      read([
+        {
+          type: "tool-result",
+          toolCallId: "call-1",
+          output: { ok: false, result: "not allowed" },
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "activity_result",
+        payload: { id: "call-1", isError: true, status: "error" },
+      },
+    ]);
   });
 
   it("reports a declined tool as cancelled rather than an error", () => {
@@ -65,30 +121,68 @@ describe("agent durable stream reader", () => {
         {
           type: "tool-result",
           toolCallId: "call-1",
-          output: { agentToolStatus: "cancelled", reason: "rejected", message: "declined" },
+          output: {
+            agentToolStatus: "cancelled",
+            reason: "rejected",
+            message: "declined",
+          },
         },
       ]),
-    ).toEqual([{ type: "activity_result", payload: { id: "call-1", isError: false, status: "cancelled" } }]);
+    ).toEqual([
+      {
+        type: "activity_result",
+        payload: { id: "call-1", isError: false, status: "cancelled" },
+      },
+    ]);
     expect(read([{ type: "tool-output-denied", toolCallId: "call-2" }])).toEqual([
-      { type: "activity_result", payload: { id: "call-2", isError: false, status: "cancelled" } },
+      {
+        type: "activity_result",
+        payload: { id: "call-2", isError: false, status: "cancelled" },
+      },
     ]);
   });
 
   it("unwraps a tool output that arrives in the provider's json envelope", () => {
     expect(
-      read([{ type: "tool-result", toolCallId: "call-1", output: { type: "json", value: { ok: false } } }]),
-    ).toEqual([{ type: "activity_result", payload: { id: "call-1", isError: true, status: "error" } }]);
+      read([
+        {
+          type: "tool-result",
+          toolCallId: "call-1",
+          output: { type: "json", value: { ok: false } },
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "activity_result",
+        payload: { id: "call-1", isError: true, status: "error" },
+      },
+    ]);
   });
 
   it("passes through the workflow events the client cannot derive itself", () => {
     expect(
       read([
-        { type: "approval_request", payload: { requestId: "turn:call-1", activity: { kind: "records.delete" } } },
-        { type: "approval_resolved", payload: { requestId: "turn:call-1", decision: "approve" } },
+        {
+          type: "approval_request",
+          payload: {
+            requestId: "turn:call-1",
+            activity: { kind: "records.delete" },
+          },
+        },
+        {
+          type: "approval_resolved",
+          payload: { requestId: "turn:call-1", decision: "approve" },
+        },
         { type: "activity_superseded", payload: { id: "call-0" } },
-        { type: "ui_command", payload: { commandId: "call-9", name: "navigate", input: {} } },
+        {
+          type: "ui_command",
+          payload: { commandId: "call-9", name: "navigate", input: {} },
+        },
         { type: "delta", payload: { text: "Stopped early." } },
-        { type: "activity_result", payload: { id: "call-9", isError: false, status: "done" } },
+        {
+          type: "activity_result",
+          payload: { id: "call-9", isError: false, status: "done" },
+        },
         { type: "turn_done", payload: { terminalCode: "completed" } },
         { type: "activity", payload: { id: "call-9" } },
       ]).map((event) => event?.type),
@@ -115,9 +209,21 @@ describe("agent durable stream reader", () => {
   });
 
   it("shares one outcome rule with the persisted transcript", () => {
-    expect(agentToolOutcomeStatus({ ok: true })).toEqual({ status: "done", failed: false });
-    expect(agentToolOutcomeStatus({ ok: false })).toEqual({ status: "error", failed: true });
-    expect(agentToolOutcomeStatus({ agentToolStatus: "cancelled", reason: "timeout", message: "x" })).toEqual({
+    expect(agentToolOutcomeStatus({ ok: true })).toEqual({
+      status: "done",
+      failed: false,
+    });
+    expect(agentToolOutcomeStatus({ ok: false })).toEqual({
+      status: "error",
+      failed: true,
+    });
+    expect(
+      agentToolOutcomeStatus({
+        agentToolStatus: "cancelled",
+        reason: "timeout",
+        message: "x",
+      }),
+    ).toEqual({
       status: "cancelled",
       failed: false,
     });

--- a/ee/agent-chat/__tests__/agent-interruption.database.test.ts
+++ b/ee/agent-chat/__tests__/agent-interruption.database.test.ts
@@ -1,0 +1,377 @@
+import { randomUUID } from "node:crypto";
+
+import { Client } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runWithTenant } from "@/core/decorators/tenant-context";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { createMockUser } from "@/tests/helpers/mock-user";
+
+import type { PrismaAgentChatRepo } from "../prisma-agent-chat.repository";
+
+vi.mock("@/core/validation/zod-error-map-server", () => ({
+  getZodParseContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+const databaseUrl = getLocalDatabaseTestUrl();
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase("interrupted agent attempts against PostgreSQL", () => {
+  const client = new Client({ connectionString: databaseUrl ?? undefined });
+  const companyId = randomUUID();
+  const userId = randomUUID();
+  const conversationId = randomUUID();
+  let repo: PrismaAgentChatRepo;
+  const tenant = createMockUser({ id: userId, companyId });
+  const asTenant = <T>(run: () => Promise<T>) => runWithTenant(tenant, run);
+
+  async function retryTerminatedAttempt() {
+    const prior = await seed(false);
+    const stored = await client.query('SELECT "userMessageId" FROM "AgentTurnRequest" WHERE id = $1', [
+      prior.turnRequestId,
+    ]);
+    const userMessageId: string = stored.rows[0].userMessageId;
+    await client.query(
+      `INSERT INTO "AgentMessage" ("id","companyId","conversationId","turnRequestId","role","parts")
+       VALUES ($1,$2,$3,$4,'user','[{"type":"text","text":"synthetic retry fixture"}]'::jsonb)`,
+      [userMessageId, companyId, conversationId, prior.turnRequestId],
+    );
+    expect(await asTenant(() => repo.requestAgentTurnCancellation({ conversationId }))).toBe(true);
+    expect(await repo.heartbeatAgentRunUnscoped(prior)).toBe(true);
+    expect(await repo.reconcileInterruptedAgentTurnUnscoped(prior)).toEqual({ reconciled: true });
+
+    const runId = randomUUID();
+    const reservationId = randomUUID();
+    await client.query(
+      `INSERT INTO "AgentUsageEvent"
+       ("id","companyId","userId","state","reservedCredits","chargedCredits",
+        "planSnapshot","subscriptionStatusSnapshot","allowanceCreditsSnapshot","periodStart","periodEnd")
+       VALUES ($1,$2,$3,'reserved',7,0,'pro','active',1000,CURRENT_TIMESTAMP,
+               CURRENT_TIMESTAMP + INTERVAL '1 month')`,
+      [reservationId, companyId, userId],
+    );
+    await client.query(
+      `INSERT INTO "AgentRunLease" ("conversationId","companyId","userId","runId","expiresAt")
+       VALUES ($1,$2,$3,$4,CURRENT_TIMESTAMP + INTERVAL '5 minutes')`,
+      [conversationId, companyId, userId, runId],
+    );
+    await asTenant(() =>
+      repo.admitAgentTurnOrThrow({
+        conversationId,
+        title: null,
+        runId,
+        reservationId,
+        modelSpec: "openai/gpt-5-nano",
+        servingProvider: "openai",
+        recentMessageLimit: 10,
+        turn: {
+          kind: "retry",
+          turnRequestId: prior.turnRequestId,
+          priorRunId: prior.runId,
+          priorAttemptCount: 1,
+          userMessageId,
+        },
+      }),
+    );
+    return { prior, runId, reservationId };
+  }
+
+  async function attemptIdentity(turnRequestId: string) {
+    const result = await client.query(
+      `SELECT "runId","externalRunId","cancellationRequestedAt","heartbeatAt","status","attemptCount"
+       FROM "AgentTurnRequest" WHERE id = $1 AND "companyId" = $2`,
+      [turnRequestId, companyId],
+    );
+    return result.rows[0];
+  }
+
+  async function seed(started: boolean) {
+    const turnRequestId = randomUUID();
+    const runId = randomUUID();
+    const externalRunId = `wrun_fixture_${randomUUID()}`;
+    const providerStartedAt = started ? new Date() : null;
+    await client.query(
+      `INSERT INTO "AgentTurnRequest"
+       ("id","companyId","userId","conversationId","clientRequestId","text","status","runId",
+        "externalRunId","userMessageId","modelSpec","providerStartedAt","updatedAt")
+       VALUES ($1,$2,$3,$4,$5,'synthetic interruption fixture','running',$6,$7,$8,
+               'openai/gpt-5-nano',$9,CURRENT_TIMESTAMP)`,
+      [
+        turnRequestId,
+        companyId,
+        userId,
+        conversationId,
+        randomUUID(),
+        runId,
+        externalRunId,
+        randomUUID(),
+        providerStartedAt,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "AgentUsageEvent"
+       ("id","companyId","userId","turnRequestId","state","reservedCredits","chargedCredits",
+        "planSnapshot","subscriptionStatusSnapshot","allowanceCreditsSnapshot","periodStart","periodEnd","providerStartedAt")
+       VALUES ($1,$2,$3,$4,'reserved',7,0,'pro','active',1000,CURRENT_TIMESTAMP,
+               CURRENT_TIMESTAMP + INTERVAL '1 month',$5)`,
+      [randomUUID(), companyId, userId, turnRequestId, providerStartedAt],
+    );
+    await client.query(
+      `INSERT INTO "AgentRunLease" ("conversationId","companyId","userId","runId","expiresAt")
+       VALUES ($1,$2,$3,$4,CURRENT_TIMESTAMP + INTERVAL '5 minutes')`,
+      [conversationId, companyId, userId, runId],
+    );
+    return {
+      turnRequestId,
+      conversationId,
+      companyId,
+      userId,
+      runId,
+      externalRunId,
+    };
+  }
+
+  async function snapshot(turnRequestId: string) {
+    const result = await client.query(
+      `SELECT t."status", t."terminalAt", t."terminalCode", t."assistantMessageId",
+              u."state", u."reservedCredits", u."chargedCredits", u."settledAt", u."providerStartedAt",
+              (SELECT COUNT(*)::int FROM "AgentRunLease" l WHERE l."companyId" = t."companyId") AS leases,
+              (SELECT COUNT(*)::int FROM "AgentRunRound" r WHERE r."turnRequestId" = t.id) AS rounds
+       FROM "AgentTurnRequest" t JOIN "AgentUsageEvent" u ON u."turnRequestId" = t.id
+       WHERE t.id = $1 AND t."companyId" = $2`,
+      [turnRequestId, companyId],
+    );
+    return result.rows[0];
+  }
+
+  beforeAll(async () => {
+    const { PrismaAgentChatRepo } = await import("../prisma-agent-chat.repository");
+    repo = new PrismaAgentChatRepo();
+    await client.connect();
+    await client.query('INSERT INTO "Company" ("id","updatedAt") VALUES ($1,CURRENT_TIMESTAMP)', [companyId]);
+    await client.query(
+      `INSERT INTO "User" ("id","email","firstName","lastName","companyId","updatedAt")
+       VALUES ($1,$2,'Interruption','Fixture',$3,CURRENT_TIMESTAMP)`,
+      [userId, `${userId}@example.invalid`, companyId],
+    );
+    await client.query(
+      `INSERT INTO "AgentConversation" ("id","companyId","userId","updatedAt")
+       VALUES ($1,$2,$3,CURRENT_TIMESTAMP)`,
+      [conversationId, companyId, userId],
+    );
+  });
+
+  beforeEach(async () => {
+    await client.query('DELETE FROM "AgentMessage" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "AgentUsageEvent" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "AgentRunLease" WHERE "companyId" = $1', [companyId]);
+    await client.query('DELETE FROM "AgentTurnRequest" WHERE "companyId" = $1', [companyId]);
+  });
+
+  afterAll(async () => {
+    await client.query('DELETE FROM "Company" WHERE "id" = $1', [companyId]);
+    await client.end();
+  });
+
+  it("releases only a provably pre-provider reservation without requiring a tenant session", async () => {
+    const turn = await seed(false);
+
+    expect(await repo.reconcileInterruptedAgentTurnUnscoped(turn)).toEqual({
+      reconciled: true,
+    });
+    expect(await snapshot(turn.turnRequestId)).toMatchObject({
+      status: "failed",
+      state: "released",
+      chargedCredits: 0,
+      reservedCredits: 7,
+      terminalAt: expect.any(Date),
+      settledAt: expect.any(Date),
+      leases: 0,
+      rounds: 0,
+    });
+  });
+
+  it("retains the full reservation after provider start even with no recorded rounds", async () => {
+    const turn = await seed(true);
+
+    await repo.reconcileInterruptedAgentTurnUnscoped(turn);
+
+    expect(await snapshot(turn.turnRequestId)).toMatchObject({
+      status: "uncertain",
+      state: "retained",
+      chargedCredits: 7,
+      reservedCredits: 7,
+      terminalAt: expect.any(Date),
+      settledAt: expect.any(Date),
+      leases: 0,
+      rounds: 0,
+    });
+  });
+
+  it("is idempotent under concurrent compensation and does not move settlement timestamps", async () => {
+    const turn = await seed(true);
+    const results = await Promise.all([
+      repo.reconcileInterruptedAgentTurnUnscoped(turn),
+      repo.reconcileInterruptedAgentTurnUnscoped(turn),
+    ]);
+    expect(results.filter((result) => result.reconciled)).toHaveLength(1);
+    const settled = await snapshot(turn.turnRequestId);
+
+    expect(await repo.reconcileInterruptedAgentTurnUnscoped(turn)).toEqual({
+      reconciled: false,
+    });
+    expect(await snapshot(turn.turnRequestId)).toEqual(settled);
+  });
+
+  it.each(["turnRequestId", "conversationId", "companyId", "userId", "runId", "externalRunId"] as const)(
+    "does not change an attempt with a mismatched %s",
+    async (key) => {
+      const turn = await seed(true);
+      const before = await snapshot(turn.turnRequestId);
+
+      expect(
+        await repo.reconcileInterruptedAgentTurnUnscoped({
+          ...turn,
+          [key]: randomUUID(),
+        }),
+      ).toEqual({ reconciled: false });
+      expect(await snapshot(turn.turnRequestId)).toEqual(before);
+    },
+  );
+
+  it("fences a stale catch after a replacement attempt took over the same turn", async () => {
+    const stale = await seed(false);
+    const replacementRunId = randomUUID();
+    await client.query('UPDATE "AgentTurnRequest" SET "runId" = $1 WHERE id = $2', [
+      replacementRunId,
+      stale.turnRequestId,
+    ]);
+    await client.query('UPDATE "AgentRunLease" SET "runId" = $1 WHERE "conversationId" = $2', [
+      replacementRunId,
+      conversationId,
+    ]);
+    const before = await snapshot(stale.turnRequestId);
+
+    expect(await repo.reconcileInterruptedAgentTurnUnscoped(stale)).toEqual({
+      reconciled: false,
+    });
+    expect(await snapshot(stale.turnRequestId)).toEqual(before);
+  });
+
+  it("leaves committed completion and measured credits unchanged after a late stream error", async () => {
+    const turn = await seed(true);
+    const assistantMessageId = randomUUID();
+    await client.query(
+      `UPDATE "AgentTurnRequest" SET status = 'completed', "terminalCode" = 'completed',
+       "terminalAt" = CURRENT_TIMESTAMP, "assistantMessageId" = $1 WHERE id = $2`,
+      [assistantMessageId, turn.turnRequestId],
+    );
+    await client.query(
+      `UPDATE "AgentUsageEvent" SET state = 'settled', "chargedCredits" = 2, "costSource" = 'measured',
+       "settledAt" = CURRENT_TIMESTAMP WHERE "turnRequestId" = $1`,
+      [turn.turnRequestId],
+    );
+    await client.query('DELETE FROM "AgentRunLease" WHERE "conversationId" = $1', [conversationId]);
+    const before = await snapshot(turn.turnRequestId);
+
+    expect(await repo.reconcileInterruptedAgentTurnUnscoped(turn)).toEqual({
+      reconciled: false,
+    });
+    expect(await snapshot(turn.turnRequestId)).toEqual(before);
+    expect(before).toMatchObject({
+      status: "completed",
+      state: "settled",
+      chargedCredits: 2,
+      assistantMessageId,
+    });
+  });
+
+  it("rolls back rather than refunding inconsistent provider-start markers", async () => {
+    const turn = await seed(false);
+    await client.query(
+      'UPDATE "AgentUsageEvent" SET "providerStartedAt" = CURRENT_TIMESTAMP WHERE "turnRequestId" = $1',
+      [turn.turnRequestId],
+    );
+    const before = await snapshot(turn.turnRequestId);
+
+    await expect(repo.reconcileInterruptedAgentTurnUnscoped(turn)).rejects.toThrow("could not be released");
+    expect(await snapshot(turn.turnRequestId)).toEqual(before);
+    expect(before).toMatchObject({
+      status: "running",
+      state: "reserved",
+      leases: 1,
+    });
+  });
+
+  it("starts retry B without observing terminated A's workflow, cancellation, or heartbeat", async () => {
+    const { prior, runId } = await retryTerminatedAttempt();
+
+    expect(await attemptIdentity(prior.turnRequestId)).toEqual({
+      runId,
+      externalRunId: null,
+      cancellationRequestedAt: null,
+      heartbeatAt: null,
+      status: "running",
+      attemptCount: 2,
+    });
+    expect(await asTenant(() => repo.findAgentTurnExternalRun(conversationId))).toBeNull();
+    expect(await asTenant(() => repo.findRunningAgentTurnForCancellation(conversationId))).toBeNull();
+    expect(await repo.isAgentTurnCancellationRequestedUnscoped(prior)).toBe(false);
+
+    expect(await repo.reconcileInterruptedAgentTurnUnscoped({ ...prior, runId })).toEqual({ reconciled: false });
+    expect((await attemptIdentity(prior.turnRequestId)).status).toBe("running");
+  });
+
+  it("ignores late A linkage, accepts current B linkage, and never overwrites an established link", async () => {
+    const { prior, runId } = await retryTerminatedAttempt();
+    const workflowB = `wrun_fixture_${randomUUID()}`;
+
+    await asTenant(() => repo.recordAgentTurnExternalRun(prior.turnRequestId, prior.runId, prior.externalRunId));
+    expect((await attemptIdentity(prior.turnRequestId)).externalRunId).toBeNull();
+
+    await asTenant(() => repo.recordAgentTurnExternalRun(prior.turnRequestId, runId, workflowB));
+    expect(await asTenant(() => repo.findAgentTurnExternalRun(conversationId))).toBe(workflowB);
+
+    await asTenant(() => repo.recordAgentTurnExternalRun(prior.turnRequestId, prior.runId, prior.externalRunId));
+    await asTenant(() => repo.recordAgentTurnExternalRun(prior.turnRequestId, runId, "wrun_conflicting_duplicate"));
+    expect((await attemptIdentity(prior.turnRequestId)).externalRunId).toBe(workflowB);
+  });
+
+  it("normal Stop before B linkage only requests cancellation and does not compensate B using A", async () => {
+    const { prior, runId, reservationId } = await retryTerminatedAttempt();
+    const { CancelAgentTurnInteractor } = await import("../cancel-agent-turn.interactor");
+    const backgroundTasks = {
+      isWorkflowTerminal: vi.fn().mockResolvedValue(true),
+      resume: vi.fn().mockResolvedValue(true),
+    };
+    const entitlements = { require: vi.fn().mockResolvedValue(null) };
+    const result = await asTenant(() =>
+      new CancelAgentTurnInteractor(repo, entitlements as never, backgroundTasks as never).invoke({ conversationId }),
+    );
+
+    expect(result.ok && result.data.cancelling).toBe(true);
+    expect(backgroundTasks.isWorkflowTerminal).not.toHaveBeenCalled();
+    expect(backgroundTasks.resume).toHaveBeenCalledTimes(1);
+    expect(await asTenant(() => repo.findRunningAgentTurnForCancellation(conversationId))).toMatchObject({
+      id: prior.turnRequestId,
+      runId,
+      externalRunId: null,
+    });
+    expect(await attemptIdentity(prior.turnRequestId)).toMatchObject({
+      status: "running",
+      runId,
+      externalRunId: null,
+      cancellationRequestedAt: expect.any(Date),
+    });
+    const reservation = await client.query(
+      'SELECT state, "chargedCredits", "settledAt" FROM "AgentUsageEvent" WHERE id = $1 AND "companyId" = $2',
+      [reservationId, companyId],
+    );
+    expect(reservation.rows[0]).toEqual({ state: "reserved", chargedCredits: 0, settledAt: null });
+    const lease = await client.query(
+      'SELECT "runId" FROM "AgentRunLease" WHERE "conversationId" = $1 AND "companyId" = $2',
+      [conversationId, companyId],
+    );
+    expect(lease.rows).toEqual([{ runId }]);
+  });
+});

--- a/ee/agent-chat/__tests__/agent-tool-input.test.ts
+++ b/ee/agent-chat/__tests__/agent-tool-input.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { createAgentToolInputResolver, type AgentToolInputResult } from "../agent-tool-input";
+
+describe("durable agent tool input snapshots", () => {
+  it("normalizes once across approval, execution, and concurrent consumers", async () => {
+    const schema = z.object({ name: z.string().transform((name) => `${name}!`), page: z.coerce.number().default(1) });
+    const normalize = vi.fn(
+      async (_name: string, input: unknown): Promise<AgentToolInputResult> => ({
+        ok: true,
+        input: await schema.parseAsync(input),
+      }),
+    );
+    const resolve = createAgentToolInputResolver(normalize);
+    const input = { name: "Ada" };
+
+    const results = await Promise.all([
+      resolve("lookup", "call-1", input),
+      resolve("lookup", "call-1", input),
+      resolve("lookup", "call-1", { name: "Ada" }),
+    ]);
+
+    expect(results).toEqual(Array.from({ length: 3 }, () => ({ ok: true, input: { name: "Ada!", page: 1 } })));
+    expect(normalize).toHaveBeenCalledTimes(1);
+    expect(input).toEqual({ name: "Ada" });
+  });
+
+  it.each([
+    ["lookup", { page: 2 }],
+    ["delete_records", { page: 1 }],
+  ])("rejects conflicting reuse for %s and invalidates the original snapshot", async (toolName, input) => {
+    const normalize = vi.fn(
+      (_name: string, value: unknown): Promise<AgentToolInputResult> =>
+        Promise.resolve({
+          ok: true,
+          input: value,
+        }),
+    );
+    const resolve = createAgentToolInputResolver(normalize);
+
+    await expect(resolve("lookup", "same-call", { page: 1 })).resolves.toMatchObject({ ok: true });
+    await expect(resolve(toolName, "same-call", input)).resolves.toMatchObject({ ok: false });
+    await expect(resolve("lookup", "same-call", { page: 1 })).resolves.toMatchObject({ ok: false });
+    expect(normalize).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects both concurrent consumers when input identity conflicts before parsing completes", async () => {
+    let finish!: (result: AgentToolInputResult) => void;
+    const resolve = createAgentToolInputResolver(
+      () =>
+        new Promise<AgentToolInputResult>((complete) => {
+          finish = complete;
+        }),
+    );
+    const first = resolve("lookup", "same-call", { page: 1 });
+    const second = resolve("lookup", "same-call", { page: 2 });
+    finish({ ok: true, input: { page: 1 } });
+
+    await expect(first).resolves.toMatchObject({ ok: false });
+    await expect(second).resolves.toMatchObject({ ok: false });
+  });
+
+  it("keeps failures stable without reparsing or exposing a value", async () => {
+    const normalize = vi.fn(
+      (): Promise<AgentToolInputResult> => Promise.resolve({ ok: false, result: "Invalid input." }),
+    );
+    const resolve = createAgentToolInputResolver(normalize);
+
+    await expect(resolve("lookup", "call-1", {})).resolves.toEqual({ ok: false, result: "Invalid input." });
+    await expect(resolve("lookup", "call-1", {})).resolves.toEqual({ ok: false, result: "Invalid input." });
+    expect(normalize).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share snapshots across calls or turns", async () => {
+    const normalize = vi.fn(
+      (_name: string, input: unknown): Promise<AgentToolInputResult> => Promise.resolve({ ok: true, input }),
+    );
+    const firstTurn = createAgentToolInputResolver(normalize);
+    const nextTurn = createAgentToolInputResolver(normalize);
+
+    await firstTurn("lookup", "call-1", {});
+    await firstTurn("lookup", "call-2", {});
+    await nextTurn("lookup", "call-1", {});
+    expect(normalize).toHaveBeenCalledTimes(3);
+  });
+});

--- a/ee/agent-chat/__tests__/agent-tool-receipt.database.test.ts
+++ b/ee/agent-chat/__tests__/agent-tool-receipt.database.test.ts
@@ -54,6 +54,8 @@ const { prisma } = await import("@/prisma/db");
 const { runWithoutTenant, runWithTenant } = await import("@/core/decorators/tenant-context");
 const { runInTransaction } = await import("@/core/decorators/transaction-runner");
 const { PrismaAgentChatRepo } = await import("@/ee/agent-chat/prisma-agent-chat.repository");
+const { getAgentAiTools, normalizeAgentAiToolInput } = await import("@/ee/agent-chat/agent-tools");
+const { createAgentToolInputResolver } = await import("@/ee/agent-chat/agent-tool-input");
 
 const company = randomUUID();
 const user = randomUUID();
@@ -63,6 +65,12 @@ const describeDatabase = getLocalDatabaseTestUrl() ? describe : describe.skip;
 
 async function createContact(firstName: string) {
   return executeMcpTool(createContactsTool, [{ contacts: [{ firstName, lastName: "Receipt" }] }]);
+}
+
+function executeTool(tools: ReturnType<typeof getAgentAiTools>, name: string, input: unknown, toolCallId: string) {
+  const execute = tools[name].execute;
+  if (typeof execute !== "function") throw new Error(`Tool ${name} cannot execute.`);
+  return execute(input, { toolCallId, messages: [], context: undefined });
 }
 
 describeDatabase("agent tool receipts wrap a real mutation", { timeout: 120_000 }, () => {
@@ -159,5 +167,110 @@ describeDatabase("agent tool receipts wrap a real mutation", { timeout: 120_000 
     expect(outcome.ok, outcome.result).toBe(true);
     expect(receipt.state).toBe("settled");
     expect(contacts).toBe(1);
+  });
+
+  it("executes a default-filled read through the real tenant interactor without pagination errors", async () => {
+    const tools = getAgentAiTools({
+      runInCallerContext: (run) => runWithTenant(tenantUser, run),
+      runExactlyOnce: (_call, _tool, run) => run(),
+      requestApproval: () => Promise.resolve("reject"),
+      resolveApprovalContext: (_tool, input) => Promise.resolve({ ok: true, input }),
+      runUiCommand: () => Promise.resolve({ ok: false, result: "not used" }),
+      createSupportTicket: () => Promise.resolve({ ok: true, result: "not used" }),
+      resultMaxChars: 6000,
+    });
+    const normalized = await normalizeAgentAiToolInput("list_users", { searchTerm: "Receipt" }, 6000);
+    expect(normalized).toEqual({ ok: true, input: { searchTerm: "Receipt", page: 1, pageSize: 100 } });
+    if (!normalized.ok) throw new Error("Read normalization failed.");
+
+    const unnormalized = await executeTool(tools, "list_users", { searchTerm: "Receipt" }, randomUUID());
+    expect(unnormalized).toMatchObject({ ok: false });
+    expect(JSON.stringify(unnormalized)).toContain("pagination.page");
+
+    const result = await executeTool(tools, "list_users", normalized.input, randomUUID());
+
+    expect(result).toMatchObject({ ok: true });
+    expect(JSON.stringify(result)).toContain(user);
+    expect(JSON.stringify(result)).not.toContain("Validation error:");
+  });
+
+  it("normalizes a mutation once and replays its receipt without a second write", async () => {
+    const repo = new PrismaAgentChatRepo();
+    const conversationId = randomUUID();
+    const turnRequestId = randomUUID();
+    const toolCallId = randomUUID();
+    await runWithoutTenant(async () => {
+      await prisma.agentConversation.create({ data: { id: conversationId, companyId: company, userId: user } });
+      await prisma.agentTurnRequest.create({
+        data: {
+          id: turnRequestId,
+          companyId: company,
+          userId: user,
+          conversationId,
+          clientRequestId: randomUUID(),
+          text: "create once",
+          status: "running",
+          runId: randomUUID(),
+          userMessageId: randomUUID(),
+          affectedResources: [],
+        },
+      });
+    });
+    const tools = getAgentAiTools({
+      runInCallerContext: (run) => runWithTenant(tenantUser, run),
+      runExactlyOnce: async (callId, toolName, run) => {
+        const receipt = await repo.claimAgentToolReceiptUnscoped({
+          turnRequestId,
+          companyId: company,
+          toolCallId: callId,
+          toolName,
+        });
+        if (receipt.state === "settled") return receipt.resultJson as Awaited<ReturnType<typeof run>>;
+        return runInTransaction(async () => {
+          const result = await run();
+          await repo.settleAgentToolReceiptUnscoped({
+            turnRequestId,
+            companyId: company,
+            toolCallId: callId,
+            resultJson: result as never,
+          });
+          return result;
+        });
+      },
+      requestApproval: () => Promise.resolve("reject"),
+      resolveApprovalContext: (_tool, input) => Promise.resolve({ ok: true, input }),
+      runUiCommand: () => Promise.resolve({ ok: false, result: "not used" }),
+      createSupportTicket: () => Promise.resolve({ ok: true, result: "not used" }),
+      resultMaxChars: 6000,
+    });
+    const normalize = vi.fn((name: string, input: unknown) => normalizeAgentAiToolInput(name, input, 6000));
+    const resolve = createAgentToolInputResolver(normalize);
+    const raw = { contacts: [{ firstName: "Normalized", lastName: "Replay" }] };
+    const run = async (input: unknown) => {
+      const prepared = await resolve("create_contacts", toolCallId, input);
+      return prepared.ok ? executeTool(tools, "create_contacts", prepared.input, toolCallId) : prepared;
+    };
+
+    const first = await run(raw);
+    await expect(resolve("create_contacts", toolCallId, raw)).resolves.toMatchObject({
+      ok: true,
+      input: { contacts: [{ firstName: "Normalized", organizationIds: [], userIds: [], dealIds: [], taskIds: [] }] },
+    });
+    const replay = await run(raw);
+    const conflict = await run({ contacts: [{ firstName: "Different", lastName: "Replay" }] });
+    const [count, receipts] = await runWithoutTenant(() =>
+      Promise.all([
+        prisma.contact.count({ where: { companyId: company, firstName: "Normalized", lastName: "Replay" } }),
+        prisma.agentToolReceipt.findMany({ where: { companyId: company, turnRequestId } }),
+      ]),
+    );
+
+    expect(first).toMatchObject({ ok: true });
+    expect(replay).toEqual(first);
+    expect(conflict).toMatchObject({ ok: false });
+    expect(normalize).toHaveBeenCalledTimes(1);
+    expect(count).toBe(1);
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].state).toBe("settled");
   });
 });

--- a/ee/agent-chat/__tests__/agent-tools.test.ts
+++ b/ee/agent-chat/__tests__/agent-tools.test.ts
@@ -46,6 +46,7 @@ import {
   hasNonTransactionalEffect,
   getAgentAiToolDefinitions,
   getAgentAiTools,
+  normalizeAgentAiToolInput,
   isAgentToolCancellation,
   type AgentToolDeps,
 } from "../agent-tools";
@@ -409,6 +410,93 @@ describe("agent tools", () => {
     expect(result).toEqual({
       success: true,
       value: { query: "contacts", locale: "en", source: "docs" },
+    });
+  });
+
+  it.each([
+    ["list_users", { searchTerm: "Sofia" }, { searchTerm: "Sofia", page: 1, pageSize: 100 }],
+    [
+      "list_users",
+      { searchTerm: "Sofia", page: "2", pageSize: " 10 " },
+      { searchTerm: "Sofia", page: 2, pageSize: 10 },
+    ],
+    ["list_records", { entity: "contact" }, { entity: "contact", page: 1, pageSize: 10 }],
+    [
+      "get_records",
+      { items: [{ entity: "contact", id: "record-1" }] },
+      { items: [{ entity: "contact", id: "record-1", include: "masterData" }] },
+    ],
+    ["search_docs", { query: "contacts" }, { query: "contacts", locale: "en", source: "docs" }],
+  ])("restores authoritative defaults and coercions for durable %s input", async (name, input, expected) => {
+    const serialized = JSON.parse(JSON.stringify(input));
+    await expect(normalizeAgentAiToolInput(name, serialized, 6000)).resolves.toEqual({
+      ok: true,
+      input: expected,
+    });
+    expect(serialized).toEqual(input);
+  });
+
+  it("applies panel refinements and transforms before a command can be emitted", async () => {
+    await expect(normalizeAgentAiToolInput("navigate", {}, 6000)).resolves.toMatchObject({ ok: false });
+    await expect(
+      normalizeAgentAiToolInput(
+        "start_tour",
+        {
+          steps: [
+            { targetId: "nav-contacts", note: " Contacts " },
+            { targetId: "contacts-add", note: " Add " },
+          ],
+        },
+        6000,
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      input: {
+        steps: [
+          { targetId: "nav-contacts", note: "Contacts" },
+          { targetId: "contacts-add", note: "Add" },
+        ],
+      },
+    });
+    await expect(
+      normalizeAgentAiToolInput(
+        "start_tour",
+        {
+          steps: [
+            { targetId: "nav-contacts", note: "   " },
+            { targetId: "contacts-add", note: " Add " },
+          ],
+        },
+        6000,
+      ),
+    ).resolves.toMatchObject({ ok: false });
+  });
+
+  it.each(["not-a-tool", "__proto__", "constructor"])("rejects unknown tool identity %s", async (name) => {
+    await expect(normalizeAgentAiToolInput(name, {}, 6000)).resolves.toEqual({
+      ok: false,
+      result: "The requested tool is not available.",
+    });
+  });
+
+  it("returns bounded validation failures without executing a mutation", async () => {
+    const target = ALL_MCP_TOOLS.find((item) => item.name === "create_contacts");
+    if (!target) throw new Error("Missing create_contacts tool.");
+    const mutation = vi.spyOn(target, "execute");
+    const result = await normalizeAgentAiToolInput("create_contacts", { contacts: [{ firstName: "Only" }] }, 32);
+
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok) throw new Error("Invalid tool input passed.");
+    expect(result.result.length).toBeLessThanOrEqual(32);
+    expect(mutation).not.toHaveBeenCalled();
+    mutation.mockRestore();
+  });
+
+  it("rejects a nonblank-text refinement before a write can execute", async () => {
+    await expect(
+      normalizeAgentAiToolInput("create_contacts", { contacts: [{ firstName: "   ", lastName: "Test" }] }, 6000),
+    ).resolves.toMatchObject({
+      ok: false,
     });
   });
 

--- a/ee/agent-chat/__tests__/prisma-agent-chat.repository.test.ts
+++ b/ee/agent-chat/__tests__/prisma-agent-chat.repository.test.ts
@@ -348,6 +348,9 @@ describe("PrismaAgentChatRepo tenant boundaries", () => {
         status: "running",
         runId: "run-2",
         attemptCount: { increment: 1 },
+        externalRunId: null,
+        cancellationRequestedAt: null,
+        heartbeatAt: null,
         terminalAt: null,
         terminalCode: null,
         modelSpec: "openai/gpt-5.6-luna",
@@ -509,6 +512,17 @@ describe("PrismaAgentChatRepo tenant boundaries", () => {
       },
       orderBy: { sequence: "desc" },
       take: 51,
+      include: {
+        turnRequest: {
+          where: { companyId: user.companyId, userId: user.id, conversationId: "conversation-1" },
+          select: {
+            clientRequestId: true,
+            status: true,
+            assistantMessageId: true,
+            terminalCode: true,
+          },
+        },
+      },
     });
   });
 
@@ -1420,6 +1434,7 @@ describe("PrismaAgentChatRepo tenant boundaries", () => {
         companyId: user.companyId,
         userId: user.id,
         state: "reserved",
+        providerStartedAt: null,
       },
       data: { state: "released", chargedCredits: 0, settledAt: now },
     });

--- a/ee/agent-chat/agent-durable-stream.ts
+++ b/ee/agent-chat/agent-durable-stream.ts
@@ -19,9 +19,15 @@ export const AGENT_CLIENT_PASSTHROUGH_EVENTS = [
   "turn_done",
 ] as const;
 
-export type AgentClientEvent = { type: string; payload: Record<string, unknown> };
+export type AgentClientEvent = {
+  type: string;
+  payload: Record<string, unknown>;
+};
 
-export function agentToolOutcomeStatus(output: unknown): { status: AgentActivityStatus; failed: boolean } {
+export function agentToolOutcomeStatus(output: unknown): {
+  status: AgentActivityStatus;
+  failed: boolean;
+} {
   if (isAgentToolCancellation(output)) return { status: "cancelled", failed: false };
   const failed = Boolean(output && typeof output === "object" && (output as { ok?: unknown }).ok === false);
   return { status: failed ? "error" : "done", failed };
@@ -49,6 +55,10 @@ export class AgentDurableStreamReader {
 
     if (part.type === "text-delta" && part.text) return { type: "delta", payload: { text: part.text } };
 
+    if (part.type === "model-call-start") return { type: "progress", payload: { phase: "working" } };
+
+    if (part.type === "tool-input-start") return { type: "progress", payload: { phase: "preparing_action" } };
+
     if (part.type === "tool-call" && part.toolCallId && part.toolName) {
       return {
         type: "activity",
@@ -61,14 +71,25 @@ export class AgentDurableStreamReader {
 
     if (part.type === "tool-result" && part.toolCallId) {
       const { status, failed } = agentToolOutcomeStatus(unwrapToolOutput(part.output));
-      return { type: "activity_result", payload: { id: part.toolCallId, isError: failed, status } };
+      return {
+        type: "activity_result",
+        payload: { id: part.toolCallId, isError: failed, status },
+      };
     }
 
-    if (part.type === "tool-error" && part.toolCallId)
-      return { type: "activity_result", payload: { id: part.toolCallId, isError: true, status: "error" } };
+    if (part.type === "tool-error" && part.toolCallId) {
+      return {
+        type: "activity_result",
+        payload: { id: part.toolCallId, isError: true, status: "error" },
+      };
+    }
 
-    if (part.type === "tool-output-denied" && part.toolCallId)
-      return { type: "activity_result", payload: { id: part.toolCallId, isError: false, status: "cancelled" } };
+    if (part.type === "tool-output-denied" && part.toolCallId) {
+      return {
+        type: "activity_result",
+        payload: { id: part.toolCallId, isError: false, status: "cancelled" },
+      };
+    }
 
     return null;
   }

--- a/ee/agent-chat/agent-history.ts
+++ b/ee/agent-chat/agent-history.ts
@@ -7,6 +7,15 @@ import { AgentConversationSummarySchema } from "./agent-chat.schema";
 export const AGENT_CONVERSATION_PAGE_SIZE = 25;
 export const AGENT_MESSAGE_PAGE_SIZE = 50;
 
+export const AgentMessageTurnSchema = z.object({
+  clientRequestId: z.string(),
+  status: z.enum(["running", "waitingBudget", "needsAttention", "completed", "failed", "uncertain"]),
+  assistantMessageId: z.string().nullable(),
+  terminalCode: z.enum(["completed", "partial", "error", "cancelled", "policyBreach"]).nullable(),
+});
+
+export type AgentMessageTurn = Data<typeof AgentMessageTurnSchema>;
+
 export const ListAgentConversationsSchema = z.object({
   kind: z.enum(["active", "archived", "both"]).default("both"),
   cursor: z.string().max(500).nullable().optional(),

--- a/ee/agent-chat/agent-tool-input.ts
+++ b/ee/agent-chat/agent-tool-input.ts
@@ -1,0 +1,25 @@
+export type AgentToolInputResult = { ok: true; input: unknown } | { ok: false; result: string };
+
+export function createAgentToolInputResolver(
+  normalize: (toolName: string, input: unknown) => Promise<AgentToolInputResult>,
+) {
+  const entries = new Map<
+    string,
+    { toolName: string; source: string | undefined; conflicted: boolean; result: Promise<AgentToolInputResult> }
+  >();
+
+  return async (toolName: string, toolCallId: string, input: unknown): Promise<AgentToolInputResult> => {
+    const source = JSON.stringify(input);
+    let entry = entries.get(toolCallId);
+    if (entry && (entry.toolName !== toolName || entry.source !== source)) entry.conflicted = true;
+    if (!entry) {
+      entry = { toolName, source, conflicted: false, result: normalize(toolName, input) };
+      entries.set(toolCallId, entry);
+    }
+
+    const result = await entry.result;
+    return entry.conflicted
+      ? { ok: false, result: "The tool call identity was reused with different input, so this action was not run." }
+      : result;
+  };
+}

--- a/ee/agent-chat/agent-tools.ts
+++ b/ee/agent-chat/agent-tools.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 import { asSchema, tool, jsonSchema, type ToolSet } from "ai";
 
 import { ALL_MCP_TOOLS, MCP_TOOL_GROUPS } from "@/features/mcp-tools/tool-registry";
-import { executeMcpTool, expectedMcpToolFailure, type McpToolExecutionResult } from "@/features/mcp-tools/mcp-tool";
+import {
+  executeMcpTool,
+  expectedMcpToolFailure,
+  validationError,
+  type McpToolExecutionResult,
+} from "@/features/mcp-tools/mcp-tool";
 import { RequestSupportSchema } from "@/features/mcp-tools/support.mcp-tools";
 import { redactUnexpectedError } from "@/core/errors/redact-unexpected-error";
 
@@ -20,6 +25,7 @@ import { AgentTourSchema } from "./agent-tours";
 import { OpenRecordSchema } from "./ui-operations";
 import type { AgentApprovalContextResolution } from "./agent-external-approval-context";
 import { internalToolIdentity } from "./tool-identity";
+import type { AgentToolInputResult } from "./agent-tool-input";
 
 export { isAgentToolCancellation, type AgentToolCancellation } from "./agent-tool-cancellation";
 
@@ -339,4 +345,26 @@ const TOOL_DEFINITION_DEPS: AgentToolDeps = {
 
 export function getAgentAiToolDefinitions(): AgentAiToolDefinition[] {
   return describeAgentAiTools(getAgentAiTools(TOOL_DEFINITION_DEPS));
+}
+
+export async function normalizeAgentAiToolInput(
+  toolName: string,
+  input: unknown,
+  maxChars: number,
+): Promise<AgentToolInputResult> {
+  const tools = getAgentAiTools(TOOL_DEFINITION_DEPS);
+  if (!Object.hasOwn(tools, toolName)) return { ok: false, result: "The requested tool is not available." };
+  const agentTool = tools[toolName];
+  const schema = asSchema(agentTool.inputSchema);
+  if (!schema.validate) throw new Error("The agent tool has no authoritative input validator.");
+  const result = await schema.validate(input);
+  if (result.success) return { ok: true, input: result.value };
+
+  return {
+    ok: false,
+    result:
+      result.error instanceof z.ZodError
+        ? validationError(result.error).slice(0, maxChars)
+        : "The tool input does not match its required schema.",
+  };
 }

--- a/ee/agent-chat/cancel-agent-turn.interactor.ts
+++ b/ee/agent-chat/cancel-agent-turn.interactor.ts
@@ -38,9 +38,33 @@ export class CancelAgentTurnInteractor extends AuthenticatedInteractor<CancelAge
     if (!conversation) return failNotFound(CustomErrorCode.agentConversationNotFound, ["conversationId"]);
 
     const cancelling = await this.repo.requestAgentTurnCancellation({ conversationId: data.conversationId });
-    if (cancelling) await this.wakeSuspendedRun(data.conversationId);
+    if (cancelling && !(await this.reconcileTerminatedRun(data.conversationId)))
+      await this.wakeSuspendedRun(data.conversationId);
 
     return { ok: true as const, data: { cancelling } };
+  }
+
+  private async reconcileTerminatedRun(conversationId: string): Promise<boolean> {
+    const turn = await this.repo.findRunningAgentTurnForCancellation(conversationId);
+    if (!turn?.externalRunId) return false;
+
+    let terminal: boolean;
+    try {
+      terminal = await this.backgroundTaskService.isWorkflowTerminal(turn.externalRunId);
+    } catch {
+      return false;
+    }
+    if (!terminal) return false;
+
+    const result = await this.repo.reconcileInterruptedAgentTurnUnscoped({
+      turnRequestId: turn.id,
+      conversationId: turn.conversationId,
+      companyId: turn.companyId,
+      userId: turn.userId,
+      runId: turn.runId,
+      externalRunId: turn.externalRunId,
+    });
+    return result.reconciled;
   }
 
   private async wakeSuspendedRun(conversationId: string) {

--- a/ee/agent-chat/get-agent-conversation.interactor.ts
+++ b/ee/agent-chat/get-agent-conversation.interactor.ts
@@ -11,7 +11,7 @@ import type { EntitlementService } from "@/ee/subscription/entitlement.service";
 import type { PrismaAgentChatRepo } from "./prisma-agent-chat.repository";
 import { clientSafeAgentMessageParts } from "./agent-chat.schema";
 import { sanitizeAgentConversationTitle } from "./agent-output-safety";
-import { AgentMessagePageSchema, type AgentMessagePageData } from "./agent-history";
+import { AgentMessagePageSchema, AgentMessageTurnSchema, type AgentMessagePageData } from "./agent-history";
 import { failNotFound } from "@/core/validation/interactor-failure-server";
 import { CustomErrorCode } from "@/core/validation/validation.types";
 
@@ -28,6 +28,7 @@ const OutputSchema = z.object({
       role: z.string(),
       parts: z.array(z.any()),
       createdAt: z.date(),
+      turn: AgentMessageTurnSchema.nullable(),
     }),
   ),
   nextCursor: z.string().nullable(),
@@ -71,6 +72,15 @@ export class GetAgentConversationInteractor extends AuthenticatedInteractor<
         stripLegacyUserContext: message.role === "user",
       }),
       createdAt: message.createdAt,
+      turn:
+        message.role === "user" && message.turnRequest
+          ? {
+              clientRequestId: message.turnRequest.clientRequestId,
+              status: message.turnRequest.status,
+              assistantMessageId: message.turnRequest.assistantMessageId,
+              terminalCode: message.turnRequest.terminalCode,
+            }
+          : null,
     }));
     return {
       ok: true as const,

--- a/ee/agent-chat/prisma-agent-chat.repository.ts
+++ b/ee/agent-chat/prisma-agent-chat.repository.ts
@@ -426,6 +426,9 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
             status: "running",
             runId: args.runId,
             attemptCount: { increment: 1 },
+            externalRunId: null,
+            cancellationRequestedAt: null,
+            heartbeatAt: null,
             terminalAt: null,
             terminalCode: null,
             modelSpec: args.modelSpec,
@@ -659,6 +662,17 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
       },
       orderBy: { sequence: "desc" },
       take: AGENT_MESSAGE_PAGE_SIZE + 1,
+      include: {
+        turnRequest: {
+          where: { companyId: this.companyId, userId: this.userId, conversationId },
+          select: {
+            clientRequestId: true,
+            status: true,
+            assistantMessageId: true,
+            terminalCode: true,
+          },
+        },
+      },
     });
     const pageRows = rows.slice(0, AGENT_MESSAGE_PAGE_SIZE);
     const oldest = pageRows.at(-1);
@@ -888,14 +902,15 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
     now: Date,
     model: string,
     requireLease: boolean,
+    scope: { companyId: string; userId: string } = { companyId: this.companyId, userId: this.userId },
   ): Promise<"failed" | "uncertain"> {
     const nextStatus = row.providerStartedAt ? "uncertain" : "failed";
     if (nextStatus === "uncertain") {
       const reservation = await this.prisma.agentUsageEvent.findFirst({
         where: {
           turnRequestId: row.id,
-          companyId: this.companyId,
-          userId: this.userId,
+          companyId: scope.companyId,
+          userId: scope.userId,
           state: "reserved",
         },
         select: { id: true, reservedCredits: true },
@@ -904,8 +919,8 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
       const settled = await this.prisma.agentUsageEvent.updateMany({
         where: {
           id: reservation.id,
-          companyId: this.companyId,
-          userId: this.userId,
+          companyId: scope.companyId,
+          userId: scope.userId,
           state: "reserved",
         },
         data: {
@@ -922,9 +937,10 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
       const released = await this.prisma.agentUsageEvent.updateMany({
         where: {
           turnRequestId: row.id,
-          companyId: this.companyId,
-          userId: this.userId,
+          companyId: scope.companyId,
+          userId: scope.userId,
           state: "reserved",
+          providerStartedAt: null,
         },
         data: { state: "released", chargedCredits: 0, settledAt: now },
       });
@@ -934,8 +950,9 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
     const updated = await this.prisma.agentTurnRequest.updateMany({
       where: {
         id: row.id,
-        companyId: this.companyId,
-        userId: this.userId,
+        conversationId: row.conversationId,
+        companyId: scope.companyId,
+        userId: scope.userId,
         runId: row.runId,
         status: "running",
       },
@@ -950,13 +967,43 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
 
     const deleted = await this.prisma.agentRunLease.deleteMany({
       where: {
-        companyId: this.companyId,
-        userId: this.userId,
+        conversationId: row.conversationId,
+        companyId: scope.companyId,
+        userId: scope.userId,
         runId: row.runId,
       },
     });
     if (requireLease && deleted.count !== 1) throw new Error("Interrupted agent run lease could not be reconciled.");
     return nextStatus;
+  }
+
+  @BypassTenantGuard
+  async reconcileInterruptedAgentTurnUnscoped(args: {
+    turnRequestId: string;
+    conversationId: string;
+    companyId: string;
+    userId: string;
+    runId: string;
+    externalRunId?: string;
+  }): Promise<{ reconciled: boolean }> {
+    return this.withCompanyTransaction(args.companyId, async () => {
+      const turn = await this.prisma.agentTurnRequest.findFirst({
+        where: {
+          id: args.turnRequestId,
+          conversationId: args.conversationId,
+          companyId: args.companyId,
+          userId: args.userId,
+          runId: args.runId,
+          ...(args.externalRunId ? { externalRunId: args.externalRunId } : {}),
+          status: "running",
+        },
+        select: this.agentTurnSelect,
+      });
+      if (!turn) return { reconciled: false };
+
+      await this.settleInterruptedTurn(turn, new Date(), turn.modelSpec ?? "unknown", false, args);
+      return { reconciled: true };
+    });
   }
 
   async normalizeExpiredAgentRunLease(now: Date, model: string) {
@@ -1331,6 +1378,26 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
     });
   }
 
+  async findRunningAgentTurnForCancellation(conversationId: string) {
+    return this.prisma.agentTurnRequest.findFirst({
+      where: {
+        conversationId,
+        companyId: this.companyId,
+        userId: this.userId,
+        status: "running",
+        cancellationRequestedAt: { not: null },
+      },
+      select: {
+        id: true,
+        conversationId: true,
+        companyId: true,
+        userId: true,
+        runId: true,
+        externalRunId: true,
+      },
+    });
+  }
+
   async requestAgentTurnCancellation(args: { conversationId: string }): Promise<boolean> {
     const requested = await this.prisma.agentTurnRequest.updateMany({
       where: {
@@ -1366,12 +1433,14 @@ export class PrismaAgentChatRepo extends BaseRepository implements AgentUsageRep
     return Boolean(turn?.cancellationRequestedAt);
   }
 
-  async recordAgentTurnExternalRun(turnRequestId: string, externalRunId: string): Promise<void> {
+  async recordAgentTurnExternalRun(turnRequestId: string, runId: string, externalRunId: string): Promise<void> {
     await this.prisma.agentTurnRequest.updateMany({
       where: {
         id: turnRequestId,
         companyId: this.companyId,
         userId: this.userId,
+        runId,
+        externalRunId: null,
       },
       data: { externalRunId },
     });

--- a/ee/agent-chat/send-agent-message.interactor.ts
+++ b/ee/agent-chat/send-agent-message.interactor.ts
@@ -297,7 +297,7 @@ export class SendAgentMessageInteractor extends AuthenticatedInteractor<SendAgen
         turnBudget: reservation.budget,
         tenant: { userId: user.id, companyId: user.companyId },
       });
-      await this.repo.recordAgentTurnExternalRun(turnRequestId, externalRunId);
+      await this.repo.recordAgentTurnExternalRun(turnRequestId, runId, externalRunId);
 
       return {
         ok: true as const,

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -675,6 +675,7 @@
       "newChat": "Neuer Chat",
       "noChats": "Noch keine Chats",
       "noChatsBody": "Starte einen Chat, um Fragen und Arbeitsschritte später wiederzufinden.",
+      "preparingAction": "Die nächste Aktion wird vorbereitet…",
       "queued": "Als Nächstes",
       "reconnecting": "Verbindung zu Mate wird wiederhergestellt…",
       "refreshHistoryFailed": "Der Chatverlauf konnte nicht aktualisiert werden. Deine vorhandenen Chats bleiben sichtbar.",
@@ -684,13 +685,17 @@
       "retryTurn": "Erneut versuchen",
       "routeSyncRefreshing": "Seite wird aktualisiert…",
       "routeSyncWaiting": "Die Seitenaktualisierung wartet, bis deine Änderungen abgeschlossen sind…",
+      "startingRequest": "Wird gestartet…",
       "stepsTook": "{steps, plural, one {# Schritt} other {# Schritte}} · {seconds}s",
       "stopping": "Mate wird angehalten…",
       "tableCopied": "Tabelle kopiert",
       "thinking": "Denkt nach",
       "turnFailed": "Diese Antwort konnte nicht abgeschlossen werden.",
+      "turnInterrupted": "Die Antwort wurde unterbrochen. Änderungen wurden möglicherweise bereits vorgenommen. Prüfe die aktuellen Datensätze, bevor du eine neue Anfrage sendest.",
       "undo": "Rückgängig",
-      "untitled": "Neuer Chat"
+      "untitled": "Neuer Chat",
+      "waitElapsed": "{seconds} s vergangen",
+      "workingOnRequest": "Deine Anfrage wird bearbeitet…"
     }
   },
   "AgplGithubBadge": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -675,6 +675,7 @@
       "newChat": "New chat",
       "noChats": "No chats yet",
       "noChatsBody": "Start a chat to return to your questions and completed work later.",
+      "preparingAction": "Preparing the next action…",
       "queued": "Up next",
       "reconnecting": "Reconnecting to Mate…",
       "refreshHistoryFailed": "Chat history couldn’t be refreshed. Your existing chats remain visible.",
@@ -684,13 +685,17 @@
       "retryTurn": "Try again",
       "routeSyncRefreshing": "Refreshing the page…",
       "routeSyncWaiting": "Page update waiting for your edits to finish…",
+      "startingRequest": "Starting…",
       "stepsTook": "{steps, plural, one {# step} other {# steps}} · {seconds}s",
       "stopping": "Stopping Mate…",
       "tableCopied": "Table copied",
       "thinking": "Thinking",
       "turnFailed": "This response couldn’t be completed.",
+      "turnInterrupted": "The response was interrupted. Changes may already have been applied. Check current records before sending a new request.",
       "undo": "Undo",
-      "untitled": "New chat"
+      "untitled": "New chat",
+      "waitElapsed": "{seconds}s elapsed",
+      "workingOnRequest": "Working on your request…"
     }
   },
   "AgplGithubBadge": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -675,6 +675,7 @@
       "newChat": "Nuevo chat",
       "noChats": "Aún no hay chats",
       "noChatsBody": "Inicie un chat para volver más tarde a sus preguntas y al trabajo completado.",
+      "preparingAction": "Preparando la siguiente acción…",
       "queued": "A continuación",
       "reconnecting": "Reconectando con Mate…",
       "refreshHistoryFailed": "No se ha podido actualizar el historial de chats. Sus chats existentes siguen visibles.",
@@ -684,13 +685,17 @@
       "retryTurn": "Reintentar",
       "routeSyncRefreshing": "Actualizando la página…",
       "routeSyncWaiting": "La actualización de la página espera a que termines tus cambios…",
+      "startingRequest": "Iniciando…",
       "stepsTook": "{steps, plural, one {# paso} other {# pasos}} · {seconds}s",
       "stopping": "Deteniendo a Mate…",
       "tableCopied": "Tabla copiada",
       "thinking": "Pensando",
       "turnFailed": "No se ha podido completar esta respuesta.",
+      "turnInterrupted": "La respuesta se ha interrumpido. Es posible que ya se hayan aplicado cambios. Revisa los registros actuales antes de enviar una nueva solicitud.",
       "undo": "Deshacer",
-      "untitled": "Nuevo chat"
+      "untitled": "Nuevo chat",
+      "waitElapsed": "{seconds} s transcurridos",
+      "workingOnRequest": "Procesando tu solicitud…"
     }
   },
   "AgplGithubBadge": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -675,6 +675,7 @@
       "newChat": "Nouvelle discussion",
       "noChats": "Aucun chat pour l’instant",
       "noChatsBody": "Démarrez une discussion pour retrouver plus tard vos questions et le travail effectué.",
+      "preparingAction": "Préparation de la prochaine action…",
       "queued": "À suivre",
       "reconnecting": "Reconnexion à Mate…",
       "refreshHistoryFailed": "L’historique des discussions n’a pas pu être actualisé. Vos discussions existantes restent visibles.",
@@ -684,13 +685,17 @@
       "retryTurn": "Réessayer",
       "routeSyncRefreshing": "Actualisation de la page…",
       "routeSyncWaiting": "La mise à jour de la page attend la fin de vos modifications…",
+      "startingRequest": "Démarrage…",
       "stepsTook": "{steps, plural, one {# étape} other {# étapes}} · {seconds}s",
       "stopping": "Arrêt de Mate…",
       "tableCopied": "Tableau copié",
       "thinking": "Réflexion",
       "turnFailed": "Cette réponse n’a pas pu être terminée.",
+      "turnInterrupted": "La réponse a été interrompue. Des modifications ont peut-être déjà été appliquées. Vérifiez les données actuelles avant d’envoyer une nouvelle demande.",
       "undo": "Annuler",
-      "untitled": "Nouvelle discussion"
+      "untitled": "Nouvelle discussion",
+      "waitElapsed": "{seconds} s écoulées",
+      "workingOnRequest": "Traitement de votre demande…"
     }
   },
   "AgplGithubBadge": {

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -675,6 +675,7 @@
       "newChat": "Nuova chat",
       "noChats": "Ancora nessuna chat",
       "noChatsBody": "Avvia una chat per ritrovare in seguito le domande e il lavoro completato.",
+      "preparingAction": "Preparazione della prossima azione…",
       "queued": "In coda",
       "reconnecting": "Riconnessione a Mate…",
       "refreshHistoryFailed": "Non è stato possibile aggiornare la cronologia delle chat. Le chat esistenti restano visibili.",
@@ -684,13 +685,17 @@
       "retryTurn": "Riprova",
       "routeSyncRefreshing": "Aggiornamento della pagina…",
       "routeSyncWaiting": "L’aggiornamento della pagina attende il completamento delle modifiche…",
+      "startingRequest": "Avvio…",
       "stepsTook": "{steps, plural, one {# passaggio} other {# passaggi}} · {seconds}s",
       "stopping": "Arresto di Mate…",
       "tableCopied": "Tabella copiata",
       "thinking": "Sta pensando",
       "turnFailed": "Non è stato possibile completare questa risposta.",
+      "turnInterrupted": "La risposta è stata interrotta. Alcune modifiche potrebbero essere già state applicate. Controlla i record attuali prima di inviare una nuova richiesta.",
       "undo": "Annulla",
-      "untitled": "Nuova chat"
+      "untitled": "Nuova chat",
+      "waitElapsed": "{seconds} s trascorsi",
+      "workingOnRequest": "Elaborazione della tua richiesta…"
     }
   },
   "AgplGithubBadge": {

--- a/tests/conventions/agent-model-boundary.test.ts
+++ b/tests/conventions/agent-model-boundary.test.ts
@@ -44,6 +44,8 @@ describe("agent model budget boundary", () => {
     const workflow = readFileSync(`${REPO_ROOT}/workflows/agent-turn.ts`, "utf8");
 
     expect(workflow).toContain("model: payload.turnBudget.modelSpec");
-    expect(workflow).toContain("gateway: { only: [payload.turnBudget.servingProvider] }");
+    expect(workflow).toMatch(
+      /gateway:\s*\{\s*only: \[payload\.turnBudget\.servingProvider\],\s*zeroDataRetention: true,\s*disallowPromptTraining: true,/,
+    );
   });
 });

--- a/workflows/__tests__/agent-turn-hosted-ai-gate.test.ts
+++ b/workflows/__tests__/agent-turn-hosted-ai-gate.test.ts
@@ -1,11 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+type WorkflowTool = {
+  needsApproval: (input: unknown, options: { toolCallId: string }) => Promise<boolean>;
+  execute?: (input: unknown, options: { toolCallId: string }) => Promise<unknown>;
+};
+
+type StreamOptions = { tools: Record<string, WorkflowTool>; messages: unknown[] };
+
 const state = vi.hoisted(() => ({
   gateResults: [] as boolean[],
   providerCalls: 0,
   writes: [] as unknown[],
   markProviderStarted: vi.fn<() => Promise<boolean>>(),
   finalize: vi.fn(),
+  reconcile: vi.fn(),
+  close: vi.fn(),
+  reportFailure: vi.fn(),
+  toolLoadFailure: false,
+  providerOptions: null as unknown,
+  definitions: [] as { name: string; description: string; inputSchema: unknown }[],
+  normalize: vi.fn(),
+  execute: vi.fn(),
+  runTools: null as null | ((options: StreamOptions) => Promise<unknown>),
+  createApproval: vi.fn(),
+  readApproval: vi.fn(),
+  takeUiResult: vi.fn(),
+  readCancellation: vi.fn(),
 }));
 
 vi.mock("@ai-sdk/workflow", () => ({
@@ -13,10 +33,15 @@ vi.mock("@ai-sdk/workflow", () => ({
     constructor(
       private readonly options: {
         prepareStep: () => Promise<unknown>;
+        providerOptions: unknown;
+        tools: Record<string, WorkflowTool>;
       },
-    ) {}
+    ) {
+      state.providerOptions = options.providerOptions;
+    }
 
-    async stream() {
+    async stream({ messages }: { messages: unknown[] }) {
+      if (state.runTools) return state.runTools({ tools: this.options.tools, messages });
       await this.options.prepareStep();
       state.providerCalls += 1;
 
@@ -29,9 +54,14 @@ vi.mock("@ai-sdk/workflow", () => ({
 }));
 
 vi.mock("workflow", () => ({
-  createHook: () => ({ dispose: vi.fn() }),
+  createHook: () => ({
+    dispose: vi.fn(),
+    async *[Symbol.asyncIterator]() {
+      yield await Promise.resolve({ requestId: "turn-1:call-1" });
+    },
+  }),
   getWritable: () => ({
-    close: vi.fn().mockResolvedValue(undefined),
+    close: state.close,
     getWriter: () => ({
       releaseLock: vi.fn(),
       write: (value: unknown) => {
@@ -56,16 +86,32 @@ vi.mock("@/core/di", () => ({
   getAgentChatRepo: () => ({
     canStartNextHostedAiProviderRoundUnscoped: vi.fn(() => Promise.resolve(state.gateResults.shift() ?? false)),
     finalizeAgentTurnOrThrowUnscoped: state.finalize,
-    isAgentTurnCancellationRequestedUnscoped: vi.fn().mockResolvedValue(false),
+    reconcileInterruptedAgentTurnUnscoped: state.reconcile,
+    isAgentTurnCancellationRequestedUnscoped: state.readCancellation,
     markAgentTurnProviderStartedUnscoped: state.markProviderStarted,
+    extendAgentRunLeaseForSuspensionUnscoped: vi.fn().mockResolvedValue(undefined),
+    createPendingApprovalRequestOrThrowUnscoped: state.createApproval,
+    findApprovalDecisionUnscoped: state.readApproval,
+    discardPendingApprovalRequestUnscoped: vi.fn().mockResolvedValue(undefined),
+    takeUiCommandResultUnscoped: state.takeUiResult,
   }),
 }));
 
 vi.mock("@/ee/agent-chat/agent-tools", () => ({
-  getAgentAiToolDefinitions: () => [],
-  getAgentAiTools: () => ({}),
+  getAgentAiToolDefinitions: () => {
+    if (state.toolLoadFailure) throw new Error("tool shell unavailable");
+    return state.definitions;
+  },
+  getAgentAiTools: () => Object.fromEntries(state.definitions.map(({ name }) => [name, { execute: state.execute }])),
+  normalizeAgentAiToolInput: state.normalize,
 }));
-vi.mock("@/features/mcp-tools/tool-registry", () => ({ ALL_MCP_TOOLS: [] }));
+vi.mock("@/features/mcp-tools/tool-registry", () => ({
+  ALL_MCP_TOOLS: [
+    { name: "list_users", annotations: { readOnlyHint: true } },
+    { name: "manage_widgets", annotations: { readOnlyHint: false } },
+    { name: "delete_records", annotations: { readOnlyHint: false } },
+  ],
+}));
 vi.mock("@/ee/agent-chat/system-prompt", () => ({ buildAgentSystemPrompt: () => "system" }));
 vi.mock("@/ee/agent-chat/agent-provider-context", () => ({
   buildAgentProviderContext: (_system: string, messages: unknown[]) => ({ messages }),
@@ -76,7 +122,7 @@ vi.mock("@/i18n/get-translator", () => ({
 }));
 vi.mock("@/i18n/locale-registry", () => ({ appLocaleOrDefault: (locale: string) => locale }));
 vi.mock("../capture-failure", () => ({
-  reportFailure: vi.fn().mockResolvedValue(undefined),
+  reportFailure: state.reportFailure,
   toWorkflowFailure: (error: unknown) => error,
 }));
 
@@ -109,6 +155,19 @@ beforeEach(() => {
   state.gateResults = [];
   state.providerCalls = 0;
   state.writes = [];
+  state.toolLoadFailure = false;
+  state.providerOptions = null;
+  state.definitions = [];
+  state.runTools = null;
+  state.normalize.mockReset();
+  state.execute.mockReset().mockResolvedValue({ ok: true, result: "done" });
+  state.createApproval.mockReset().mockResolvedValue(undefined);
+  state.readApproval.mockReset();
+  state.takeUiResult.mockReset().mockResolvedValue({ ok: true, result: "shown" });
+  state.readCancellation.mockReset().mockResolvedValue(false);
+  state.reconcile.mockReset().mockResolvedValue({ reconciled: true });
+  state.close.mockReset().mockResolvedValue(undefined);
+  state.reportFailure.mockReset().mockResolvedValue(undefined);
   state.markProviderStarted.mockReset().mockResolvedValue(true);
   state.finalize.mockReset().mockImplementation((args) =>
     Promise.resolve({
@@ -138,8 +197,267 @@ describe("agent-turn hosted-AI provider gates", () => {
     await runAgentTurn(payload);
 
     expect(state.providerCalls).toBe(1);
+    expect(state.providerOptions).toEqual({
+      gateway: {
+        only: [payload.turnBudget.servingProvider],
+        zeroDataRetention: true,
+        disallowPromptTraining: true,
+      },
+      openai: { parallelToolCalls: false },
+    });
     expect(state.finalize).toHaveBeenCalledWith(expect.objectContaining({ terminalCode: "partial" }));
     expect(JSON.stringify(state.writes)).toContain("localized:AgentChat.runner.hostedAiUnavailable");
     expect(JSON.stringify(state.writes)).not.toMatch(/operator_paused|global_spend_cap/u);
+  });
+});
+
+describe("agent-turn outer failure compensation", () => {
+  it("reconciles the exact admitted attempt and closes after an early exception", async () => {
+    state.markProviderStarted.mockRejectedValueOnce(new Error("admission interrupted"));
+
+    await expect(runAgentTurn(payload)).rejects.toThrow("admission interrupted");
+
+    expect(state.reconcile).toHaveBeenCalledWith({
+      turnRequestId: payload.turnRequestId,
+      conversationId: payload.conversationId,
+      companyId: payload.companyId,
+      userId: payload.userId,
+      runId: payload.runId,
+    });
+    expect(state.finalize).not.toHaveBeenCalled();
+    expect(state.providerCalls).toBe(0);
+    expect(state.close).toHaveBeenCalled();
+  });
+
+  it("does not use an empty measured settlement after provider-start was persisted", async () => {
+    state.toolLoadFailure = true;
+
+    await expect(runAgentTurn(payload)).rejects.toThrow("tool shell unavailable");
+
+    expect(state.markProviderStarted).toHaveBeenCalled();
+    expect(state.reconcile).toHaveBeenCalledTimes(1);
+    expect(state.finalize).not.toHaveBeenCalled();
+    expect(state.providerCalls).toBe(0);
+    expect(state.close).toHaveBeenCalled();
+  });
+
+  it.each(["reconcile", "reportFailure", "close"] as const)(
+    "preserves the original failure when %s throws",
+    async (operation) => {
+      const original = new Error("admission interrupted");
+      state.markProviderStarted.mockRejectedValueOnce(original);
+      state[operation].mockRejectedValueOnce(new Error("cleanup unavailable"));
+
+      await expect(runAgentTurn(payload)).rejects.toBe(original);
+
+      expect(state.reconcile).toHaveBeenCalledTimes(1);
+      expect(state.reportFailure).toHaveBeenCalledWith("agent-turn", original, payload.tenant);
+      expect(state.close).toHaveBeenCalled();
+    },
+  );
+});
+
+describe("agent-turn authoritative tool inputs", () => {
+  function executeTool(tool: WorkflowTool, input: unknown) {
+    if (!tool.execute) throw new Error("Tool cannot execute.");
+    return tool.execute(input, { toolCallId: "call-1" });
+  }
+
+  function define(name: string) {
+    state.definitions.push({ name, description: name, inputSchema: { type: "object" } });
+  }
+
+  function pendingMessage(toolName: string, input: unknown) {
+    return { role: "assistant", content: [{ type: "tool-call", toolName, toolCallId: "call-1", input }] };
+  }
+
+  function finish() {
+    return { finishReason: "stop", messages: [], steps: [] };
+  }
+
+  it("executes the normalized default-filled read input once after serialized schema reconstruction", async () => {
+    define("list_users");
+    const raw = { searchTerm: "Sofia" };
+    const normalized = { searchTerm: "Sofia", page: 1, pageSize: 100 };
+    state.normalize.mockResolvedValue({ ok: true, input: normalized });
+    state.runTools = async ({ tools }) => {
+      expect(await tools.list_users.needsApproval(raw, { toolCallId: "call-1" })).toBe(false);
+      await executeTool(tools.list_users, raw);
+      return finish();
+    };
+
+    await runAgentTurn(payload);
+
+    expect(state.normalize).toHaveBeenCalledTimes(1);
+    expect(state.normalize).toHaveBeenCalledWith("list_users", raw, 1000);
+    expect(state.execute).toHaveBeenCalledWith(normalized, { toolCallId: "call-1", messages: [] });
+    expect(state.createApproval).not.toHaveBeenCalled();
+  });
+
+  it("uses normalized action values for approval policy", async () => {
+    define("manage_widgets");
+    const raw = { action: " list " };
+    state.normalize.mockResolvedValue({ ok: true, input: { action: "list" } });
+    state.runTools = async ({ tools }) => {
+      expect(await tools.manage_widgets.needsApproval(raw, { toolCallId: "call-1" })).toBe(false);
+      await executeTool(tools.manage_widgets, raw);
+      return finish();
+    };
+
+    await runAgentTurn(payload);
+
+    expect(state.execute).toHaveBeenCalledWith({ action: "list" }, expect.anything());
+    expect(state.createApproval).not.toHaveBeenCalled();
+  });
+
+  it("does not approve or execute invalid write input", async () => {
+    define("delete_records");
+    const invalid = { ok: false, result: "Validation error: missing ids" };
+    state.normalize.mockResolvedValue(invalid);
+    state.runTools = async ({ tools }) => {
+      expect(await tools.delete_records.needsApproval({}, { toolCallId: "call-1" })).toBe(false);
+      expect(await executeTool(tools.delete_records, {})).toEqual(invalid);
+      return finish();
+    };
+
+    await runAgentTurn(payload);
+
+    expect(state.normalize).toHaveBeenCalledTimes(1);
+    expect(state.execute).not.toHaveBeenCalled();
+    expect(state.createApproval).not.toHaveBeenCalled();
+  });
+
+  it.each(["approve", "reject", "timeout"])(
+    "preserves one normalized snapshot through approval %s",
+    async (decision) => {
+      define("delete_records");
+      const raw = { entity: "contact", ids: ["original"] };
+      const normalized = { entity: "contact", ids: ["normalized-once"] };
+      state.normalize.mockResolvedValue({ ok: true, input: normalized });
+      state.readApproval.mockResolvedValue(decision === "timeout" ? null : { toolName: "delete_records", decision });
+      let round = 0;
+      state.runTools = async ({ tools, messages }) => {
+        if (round++ === 0) {
+          expect(await tools.delete_records.needsApproval(raw, { toolCallId: "call-1" })).toBe(true);
+          return { finishReason: "tool-calls", messages: [pendingMessage("delete_records", raw)], steps: [] };
+        }
+        expect(JSON.stringify(messages)).toContain(`"approved":${decision === "approve"}`);
+        if (decision === "approve") {
+          expect(await tools.delete_records.needsApproval(raw, { toolCallId: "call-1" })).toBe(true);
+          await executeTool(tools.delete_records, raw);
+        }
+        return finish();
+      };
+
+      await runAgentTurn(payload);
+
+      expect(state.normalize).toHaveBeenCalledTimes(1);
+      expect(state.createApproval).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: "turn-1:call-1",
+          toolName: "delete_records",
+          companyId: "company-1",
+          userId: "user-1",
+        }),
+      );
+      if (decision === "approve") expect(state.execute).toHaveBeenCalledWith(normalized, expect.anything());
+      else expect(state.execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([true, false])("validates panel commands before emission (valid=%s)", async (valid) => {
+    define("navigate");
+    const raw = valid ? { targetId: " nav-contacts " } : {};
+    state.normalize.mockResolvedValue(
+      valid
+        ? { ok: true, input: { targetId: "nav-contacts" } }
+        : { ok: false, result: "Validation error: missing targetId" },
+    );
+    let round = 0;
+    state.runTools = async ({ tools, messages }) => {
+      if (round++ === 0) {
+        expect(await tools.navigate.needsApproval(raw, { toolCallId: "call-1" })).toBe(false);
+        expect(tools.navigate.execute).toBeUndefined();
+        return { finishReason: "tool-calls", messages: [pendingMessage("navigate", raw)], steps: [] };
+      }
+      expect(JSON.stringify(messages)).toContain(valid ? "shown" : "Validation error: missing targetId");
+      return finish();
+    };
+
+    await runAgentTurn(payload);
+
+    const commands = state.writes.filter((event) => (event as { type: string }).type === "ui_command");
+    expect(commands).toEqual(
+      valid
+        ? [
+            {
+              type: "ui_command",
+              payload: { commandId: "call-1", name: "navigate", input: { targetId: "nav-contacts" } },
+            },
+          ]
+        : [],
+    );
+    expect(state.normalize).toHaveBeenCalledTimes(1);
+    expect(state.execute).not.toHaveBeenCalled();
+    expect(state.createApproval).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [true, "approve"],
+    [true, "reject"],
+    [true, "cancel"],
+    [false, "approve"],
+    [false, "reject"],
+  ])("settles mixed panel and approval calls before resuming (panel=%s, decision=%s)", async (valid, decision) => {
+    define("navigate");
+    define("delete_records");
+    const panelInput = valid ? { targetId: "nav-contacts" } : {};
+    const mutationInput = { entity: "contact", ids: ["record-1"] };
+    state.normalize.mockImplementation((name: string, input: unknown) =>
+      Promise.resolve(
+        name === "navigate" && !valid ? { ok: false, result: "Invalid panel input" } : { ok: true, input },
+      ),
+    );
+    state.readApproval.mockResolvedValue({ toolName: "delete_records", decision });
+    let round = 0;
+    state.runTools = async ({ tools, messages }) => {
+      if (round++ === 0) {
+        expect(await tools.navigate.needsApproval(panelInput, { toolCallId: "panel-1" })).toBe(false);
+        expect(await tools.delete_records.needsApproval(mutationInput, { toolCallId: "call-1" })).toBe(true);
+        if (decision === "cancel") state.readCancellation.mockResolvedValue(true);
+        return {
+          finishReason: "tool-calls",
+          steps: [],
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "tool-call", toolName: "navigate", toolCallId: "panel-1", input: panelInput },
+                { type: "tool-call", toolName: "delete_records", toolCallId: "call-1", input: mutationInput },
+              ],
+            },
+          ],
+        };
+      }
+      expect(state.createApproval).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(messages)).toContain(valid ? "shown" : "Invalid panel input");
+      expect(JSON.stringify(messages)).toContain(`"approved":${decision === "approve"}`);
+      if (decision === "approve") await executeTool(tools.delete_records, mutationInput);
+      return finish();
+    };
+
+    await runAgentTurn(payload);
+
+    expect(round).toBe(decision === "cancel" ? 1 : 2);
+    if (decision === "cancel") {
+      expect(state.createApproval).not.toHaveBeenCalled();
+      expect(state.finalize).toHaveBeenCalledWith(expect.objectContaining({ terminalCode: "cancelled" }));
+    }
+    expect(state.normalize).toHaveBeenCalledTimes(2);
+    expect(state.execute).toHaveBeenCalledTimes(decision === "approve" ? 1 : 0);
+    expect(state.writes.filter((event) => (event as { type: string }).type === "ui_command")).toHaveLength(
+      valid ? 1 : 0,
+    );
+    expect(state.reportFailure).not.toHaveBeenCalled();
   });
 });

--- a/workflows/agent-turn.ts
+++ b/workflows/agent-turn.ts
@@ -51,6 +51,7 @@ import { getAgentChatRepo } from "@/core/di";
 import { internalToolIdentity } from "@/ee/agent-chat/tool-identity";
 import { readAgentProviderCharge } from "@/ee/agent-chat/gateway-cost";
 import { requiresApproval } from "@/ee/agent-chat/gated-tools";
+import { createAgentToolInputResolver, type AgentToolInputResult } from "@/ee/agent-chat/agent-tool-input";
 import { resolveAgentApprovalContext } from "@/ee/agent-chat/agent-external-approval-context";
 import { resolveAgentToolResultMaxChars } from "@/ee/agent-chat/agent-budget-policy";
 import { runAsBackgroundTenant } from "@/core/decorators/background-tenant";
@@ -227,6 +228,19 @@ async function executeAgentTool(
   return execute(input, { toolCallId, messages: [] });
 }
 executeAgentTool.maxRetries = 0;
+
+async function normalizeAgentToolInput(
+  payload: AgentTurnWorkflowPayload,
+  toolName: string,
+  input: unknown,
+): Promise<AgentToolInputResult> {
+  "use step";
+  const { normalizeAgentAiToolInput } = await import("@/ee/agent-chat/agent-tools");
+  return runAsBackgroundTenant(payload.userId, () =>
+    normalizeAgentAiToolInput(toolName, input, resolveAgentToolResultMaxChars(payload.turnBudget.maxToolResultChars)),
+  );
+}
+normalizeAgentToolInput.maxRetries = 0;
 
 async function publishTranscriptEvents(events: AgentTranscriptEvent[]): Promise<void> {
   "use step";
@@ -513,6 +527,17 @@ async function closeTurnStreamAfterFailure(): Promise<void> {
 }
 closeTurnStreamAfterFailure.maxRetries = 0;
 
+async function reconcileFailedTurn(payload: AgentTurnWorkflowPayload): Promise<void> {
+  "use step";
+  await getAgentChatRepo().reconcileInterruptedAgentTurnUnscoped({
+    turnRequestId: payload.turnRequestId,
+    conversationId: payload.conversationId,
+    companyId: payload.companyId,
+    userId: payload.userId,
+    runId: payload.runId,
+  });
+}
+
 async function finalizeTurn(
   payload: AgentTurnWorkflowPayload,
   outcome: {
@@ -631,6 +656,9 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
     let finishReason = "unknown";
     const ledger: RoundLedgerEntry[] = [];
     const grants = new Map<string, ToolApprovalGrant>();
+    const resolveToolInput = createAgentToolInputResolver((toolName, input) =>
+      normalizeAgentToolInput(payload, toolName, input),
+    );
     const completedTools: ({ toolCallId: string; toolName: string } & ({ output: unknown } | { threw: true }))[] = [];
 
     const continuationSteps: AgentContinuationStep[] = [];
@@ -662,6 +690,10 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
       const pending = deferredRound;
       deferredRound = null;
       recordContinuationRound(pending.step, [...pending.outcomes, ...resumed]);
+    };
+
+    const appendDeferredOutcomes = (outcomes: readonly AgentToolOutcome[]) => {
+      if (deferredRound) deferredRound.outcomes.push(...outcomes);
     };
 
     const settleToolOutcome = (toolCallId: string, toolName: string | undefined, output: unknown) => {
@@ -778,28 +810,39 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
             {
               description: shell.description,
               inputSchema: jsonSchema(shell.inputSchema as never),
-              needsApproval: shell.gated
-                ? (input: unknown) =>
-                    requiresApproval(internalToolIdentity(shell.name), { annotations: shell.annotations }, input)
-                : false,
+              needsApproval: async (input: unknown, options: { toolCallId: string }) => {
+                const prepared = await resolveToolInput(shell.name, options.toolCallId, input);
+                return (
+                  prepared.ok &&
+                  shell.gated &&
+                  requiresApproval(internalToolIdentity(shell.name), { annotations: shell.annotations }, prepared.input)
+                );
+              },
               ...(isAgentPanelTool(shell.name)
                 ? {}
                 : {
-                    execute: (input: unknown, options: { toolCallId: string }) =>
-                      executeAgentTool(
+                    execute: async (input: unknown, options: { toolCallId: string }) => {
+                      const prepared = await resolveToolInput(shell.name, options.toolCallId, input);
+                      if (!prepared.ok) return prepared;
+                      return executeAgentTool(
                         payload,
                         shell.name,
                         options.toolCallId,
-                        input,
+                        prepared.input,
                         grants.get(options.toolCallId) ?? "not-required",
-                      ),
+                      );
+                    },
                   }),
             },
           ]),
         ),
         maxOutputTokens: payload.turnBudget.maxOutputTokens,
         providerOptions: {
-          gateway: { only: [payload.turnBudget.servingProvider] },
+          gateway: {
+            only: [payload.turnBudget.servingProvider],
+            zeroDataRetention: true,
+            disallowPromptTraining: true,
+          },
           openai: { parallelToolCalls: false },
         },
         prepareStep: async () => {
@@ -854,7 +897,7 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
 
       if (abandoned) break;
 
-      const pending = pendingApprovalCalls(result.messages);
+      let pending = pendingApprovalCalls(result.messages);
       if (pending.length === 0) {
         if (finishReason === "stop") break;
         if (cancelled || budgetStop || safetyStop !== null || roundFailure !== null) break;
@@ -880,6 +923,28 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
         continue;
       }
 
+      const preparedPending = await Promise.all(
+        pending.map(async (call) => ({
+          call,
+          prepared: await resolveToolInput(call.toolName, call.toolCallId, call.input),
+        })),
+      );
+      const invalidResults = preparedPending.flatMap(({ call, prepared }) =>
+        prepared.ok ? [] : [{ toolCallId: call.toolCallId, toolName: call.toolName, output: prepared }],
+      );
+      let resumableMessages = withToolResults(result.messages, invalidResults);
+      for (const outcome of invalidResults) settleToolOutcome(outcome.toolCallId, outcome.toolName, outcome.output);
+      appendDeferredOutcomes(invalidResults);
+      pending = preparedPending.flatMap(({ call, prepared }) =>
+        prepared.ok ? [{ ...call, input: prepared.input }] : [],
+      );
+      if (pending.length === 0) {
+        resolveDeferredRound([]);
+        await publishTranscriptEvents(queued.splice(0));
+        messages = resumableMessages;
+        continue;
+      }
+
       const panelCalls = pending.filter((call) => isAgentPanelTool(call.toolName));
       if (panelCalls.length > 0) {
         const commands = panelCalls.map((call) => ({
@@ -901,12 +966,21 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
 
         cancelled = await readCancellation(payload);
         const resumed = await readUiCommandResults(payload, commands);
-        resolveDeferredRound(resumed.map((entry) => ({ ...entry })));
         for (const outcome of resumed) settleToolOutcome(outcome.toolCallId, outcome.toolName, outcome.output);
         await publishTranscriptEvents(queued.splice(0));
 
-        messages = withToolResults(result.messages, resumed);
-        continue;
+        resumableMessages = withToolResults(resumableMessages, resumed);
+        if (cancelled) {
+          resolveDeferredRound(resumed.map((entry) => ({ ...entry })));
+          break;
+        }
+        pending = pending.filter((call) => !isAgentPanelTool(call.toolName));
+        if (pending.length === 0) {
+          resolveDeferredRound(resumed.map((entry) => ({ ...entry })));
+          messages = resumableMessages;
+          continue;
+        }
+        appendDeferredOutcomes(resumed);
       }
 
       const requests: PendingApproval[] = pending.map((call) => ({
@@ -975,7 +1049,7 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
           },
         })),
       );
-      messages = withApprovalResponses(result.messages, outcomes);
+      messages = withApprovalResponses(resumableMessages, outcomes);
     }
 
     if (abandoned) {
@@ -1026,8 +1100,22 @@ export async function runAgentTurn(payload: AgentTurnWorkflowPayload): Promise<v
     });
     await closeTurnStream();
   } catch (error) {
-    await reportFailure(WORKFLOW_NAME, toWorkflowFailure(error), payload.tenant);
-    await closeTurnStreamAfterFailure();
+    const failures = [error];
+    try {
+      await reconcileFailedTurn(payload);
+    } catch (cleanupError) {
+      failures.push(cleanupError);
+    }
+    try {
+      await closeTurnStreamAfterFailure();
+    } catch (closeError) {
+      failures.push(closeError);
+    }
+    for (const failure of failures) {
+      try {
+        await reportFailure(WORKFLOW_NAME, toWorkflowFailure(failure), payload.tenant);
+      } catch {}
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

Give the AI chat honest, live feedback while the model is thinking, and repair a durable-workflow defect that silently stripped tool input validation and schema defaults. Three related changes, developed and verified together:

1. **Live waiting feedback.** From send until the first token the chat showed only animated dots, which reads as a hang on long questions that call no tools. It now shows a truthful phase label driven by real workflow lifecycle events (`Starting`, `Working on your request`, `Preparing the next action`), plus elapsed seconds once a wait passes five. There are no fabricated stages, no fake percentages, no raw reasoning, and no extra model call to narrate progress. The `progress` event is deliberately non-durable: it never persists as an assistant message, never enters a later prompt, and is dropped once the turn is completed, failed or stop-requested.

2. **Durable tool input normalization.** Exporting a tool to the durable workflow reconstructed its JSON schema with `jsonSchema(shell.inputSchema)`, which drops the runtime validator that `providerSafeSchema` attaches. JSON Schema defaults are annotations, not applied values, so Zod defaults, coercions, transforms and refinements never ran. A valid model call that omitted an optional field (for example `mcpPage`, which carries `.default(1)`) reached stricter downstream code as `undefined` and failed validation. `normalizeAgentAiToolInput` now runs the authoritative validator, and a per-`toolCallId` resolver guarantees that the approval check and the execution see the same normalized value, computed exactly once. Invalid input is settled as a tool failure and is neither approved nor executed. A reused `toolCallId` carrying different input is refused rather than executed twice.

3. **Interrupted turn reconciliation.** A failed workflow could leave the chat stuck on "Reconnecting" or "Stopping" with a credit reservation still held. The workflow catch block now reconciles every failure rather than only the first, `recordAgentTurnExternalRun` is fenced on `runId` plus a null `externalRunId`, reservation release is guarded on `providerStartedAt: null`, and the user sees an explicit `role="alert"` notice telling them changes may already have been applied.

Every production gateway round now also asserts `zeroDataRetention: true` and `disallowPromptTraining: true`, pinned by `tests/conventions/agent-model-boundary.test.ts`.

## Context

Linear: CUS-314.

The tool-input defect was found while benchmarking the agent against synthetic CRM fixtures: identical prompts failed on some rounds with pagination validation errors that the models had not caused. Preserved execution outputs confirmed the mechanism. It is not a pagination bug. It affects any tool whose schema relies on defaults, coercions, transforms or refinements, including write tools, which is why the repair lands at the dispatch boundary rather than by hardcoding a default.

The waiting-feedback work came from the same observation: on questions that call no tools the interface gave no signal at all for the entire model round.

The ZDR and no-prompt-training flags began as a requirement of that benchmark and are kept here deliberately. They move the privacy posture from "the team-wide account setting is enabled" to "every request asserts it", which is a stronger and more durable claim. Reviewers should note this constrains provider routing: a serving provider that cannot honour both flags will be refused rather than silently downgraded.

## Validation

Run against this branch rebased onto `main`, in a clean worktree with no benchmark instrumentation present:

- `yarn typecheck` passed.
- `yarn lint` passed with `--max-warnings 0` in 58.67s.
- `yarn i18n:audit` reported advisory findings only, none of them from these keys.
- `yarn test` with `RUN_DATABASE_TESTS=true` against local PostgreSQL: 5287 passed, 3 skipped, across 593 files.
- `yarn build` passed: compiled successfully in 45s, TypeScript and route generation clean, public OpenAPI unchanged.

All five locales carry the five new keys with full parity and real translations. New and extended test coverage includes: normalize-once across the approval and execution paths, `toolCallId` identity conflict refusal, panel tool refinements and transforms before command emission, bounded validation failure that executes no mutation, a real-tenant interactor read that succeeds without pagination errors, nine database-level interruption and compensation cases, and store coverage for the uncertain-turn notice and replay.

Behaviour was additionally exercised end to end during the benchmark that produced this work: 72 local episodes across five model configurations over 12 synthetic CRM scenarios, on synthetic fixtures only, with no real records touched and no outbound messages sent. First visible feedback measured at a median of 6.6 ms across 63 samples.

## Impact and rollback

User-visible: the chat replaces bare dots with a phase label and, after five seconds, an elapsed counter; an interrupted turn now shows an explicit notice instead of appearing to hang.

Behavioural: tool calls are validated and normalized before approval and execution, so calls that previously failed downstream now succeed with their schema defaults applied, and malformed calls now fail cleanly without executing. Every gateway round asserts zero data retention and no prompt training.

Risk: the gateway flag change is the only item that alters outbound provider behaviour. If a serving provider cannot honour both flags the round is refused rather than silently downgraded, which is the intended failure mode but would surface as an agent turn failure rather than a degraded answer.

Rollback: revert the merge commit. The change is additive, adds no migration, and touches no schema. Reverting restores the previous `gateway: { only: [servingProvider] }` shape, the bare typing dots, and the unnormalized dispatch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
