### PR TITLE
feat(demo): render seeded email fixtures through the signature composer

### DIFF
--- a/prisma/__tests__/demo-messaging-fixtures.test.ts
+++ b/prisma/__tests__/demo-messaging-fixtures.test.ts
@@ -3,6 +3,13 @@ import type { PrismaClient } from "@/generated/prisma";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SYNTHETIC_COMPANY_USERS } from "@/core/config/synthetic-seed-user";
+import {
+  EmailSettingsSchema,
+  SIGNATURE_LOGO_URL,
+  SignatureTemplate,
+  emailLinkContrast,
+} from "@/ee/messaging/email-settings";
+import { SIGNATURE_DELIMITER } from "@/ee/messaging/outbound/email-signature";
 
 import { seedDemoMessagingFixtures } from "../seeds/messaging/seed";
 import {
@@ -230,6 +237,22 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
       expect(call.where).toEqual({
         unipileAccountId: call.create.unipileAccountId,
       });
+    }
+
+    for (const account of accounts) {
+      const isEmailAccount = account.provider === "google" || account.provider === "outlook";
+      if (!isEmailAccount) {
+        expect(account.signature).toBeUndefined();
+        expect(account.signatureFields).toBeUndefined();
+        continue;
+      }
+
+      expect(String(account.signature)).toContain(String(context.seedUserEmail));
+      const settings = EmailSettingsSchema.safeParse(account.signatureFields);
+      expect(settings.success).toBe(true);
+      expect(settings.data?.signature.template).toBe(SignatureTemplate.plain);
+      expect(settings.data?.signature.enabled).toBe(true);
+      expect(emailLinkContrast(String(settings.data?.appearance.linkHex)).readable).toBe(true);
     }
     for (const call of records.contactIdentifiers) {
       expect(call.where).toEqual({
@@ -679,7 +702,17 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
 
       if (message.provider === "google" || message.provider === "outlook") {
         const folderPrefix = message.provider === "google" ? "google" : "outlook";
-        expect(String(message.bodyHtml)).toContain("<p>");
+        expect(String(message.bodyHtml)).toContain('data-customermates-email-markdown="true"');
+        expect(String(message.bodyHtml).match(/data-customermates-signature/g)).toHaveLength(1);
+        expect(String(message.bodyHtml)).not.toMatch(/<img/i);
+        expect(String(message.bodyHtml)).not.toContain(SIGNATURE_LOGO_URL);
+
+        const linkHexes = [...String(message.bodyHtml).matchAll(/<a[^>]*color:(#[0-9a-f]{6})/gi)].map(
+          (match) => match[1],
+        );
+        expect(linkHexes.length).toBeGreaterThan(0);
+        for (const hex of linkHexes) expect(emailLinkContrast(hex).readable).toBe(true);
+
         expect(message.folderIds).toEqual(
           message.direction === "outbound" ? [`demo-${folderPrefix}-sent`] : [`demo-${folderPrefix}-inbox`],
         );
@@ -699,8 +732,13 @@ describe.each(["demo", "cloud"] as const)("synthetic messaging fixtures in APP_M
         .toSorted((left, right) => (left.sentAt as Date).getTime() - (right.sentAt as Date).getTime())
         .at(-1);
       expect(latest?.sentAt).toEqual(thread.lastMessageAt);
-      expect(latest?.bodyText).toBe(thread.lastMessagePreview);
+      expect(String(latest?.bodyText).split(SIGNATURE_DELIMITER)[0]).toBe(thread.lastMessagePreview);
       expect(latest?.direction === "outbound").toBe(thread.lastMessageIsSender);
+
+      const orderedBodies = threadMessages
+        .toSorted((left, right) => (left.sentAt as Date).getTime() - (right.sentAt as Date).getTime())
+        .map((message) => String(message.bodyText).split(SIGNATURE_DELIMITER)[0]);
+      expect(orderedBodies).toEqual(threadFixtures[threadIndex].messages.map((message) => message.text));
     }
 
     const resetContracts = [

--- a/prisma/seeds/messaging/seed.ts
+++ b/prisma/seeds/messaging/seed.ts
@@ -1,6 +1,16 @@
 import type { MessagingProvider, Prisma, PrismaClient } from "@/generated/prisma";
 
+import type { EmailSettings } from "@/ee/messaging/email-settings";
+
 import { SYNTHETIC_COMPANY_USERS } from "@/core/config/synthetic-seed-user";
+import {
+  DEFAULT_LINK_HEX,
+  EmailFontFamily,
+  EmailLinkStyle,
+  SignatureTemplate,
+  defaultEmailSettings,
+} from "@/ee/messaging/email-settings";
+import { composeEmailBodies } from "@/ee/messaging/outbound/email-signature";
 
 import { SYNTHETIC_AVATAR_URLS } from "../avatars";
 import { fixtureId } from "../helpers";
@@ -44,12 +54,61 @@ function isEmailFixtureProvider(provider: MessagingProvider): provider is EmailF
   return provider === "google" || provider === "outlook";
 }
 
-function emailHtml(text: string): string {
-  const escaped = text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-  return escaped
-    .split("\n\n")
-    .map((paragraph) => `<p>${paragraph}</p>`)
-    .join("");
+const MARKDOWN_LINE_BREAK = "\\\n";
+
+function workspaceSignature(seedUserEmail: string): string {
+  return [
+    `**${SYNTHETIC_COMPANY_USERS.maxBergmann.name}**`,
+    "Customer Success, Customermates",
+    `[${seedUserEmail}](mailto:${seedUserEmail})`,
+    "<https://customermates.com>",
+  ].join(MARKDOWN_LINE_BREAK);
+}
+
+function workspaceEmailSettings(): EmailSettings {
+  const base = defaultEmailSettings();
+  return {
+    ...base,
+    appearance: {
+      ...base.appearance,
+      fontFamily: EmailFontFamily.sansSerif,
+      fontSize: 14,
+      linkHex: DEFAULT_LINK_HEX,
+      linkStyle: EmailLinkStyle.underlined,
+    },
+    signature: { ...base.signature, enabled: true, template: SignatureTemplate.plain },
+  };
+}
+
+function correspondentEmailSettings(): EmailSettings {
+  const base = defaultEmailSettings();
+  return {
+    ...base,
+    appearance: {
+      ...base.appearance,
+      fontFamily: EmailFontFamily.serif,
+      fontSize: 14,
+      linkHex: "#2f6fd0",
+      linkStyle: EmailLinkStyle.plain,
+    },
+    signature: { ...base.signature, enabled: true, template: SignatureTemplate.plain },
+  };
+}
+
+function correspondentSignature(personKey: PersonKey): string | null {
+  const person = people[personKey];
+  if (!person.email) return null;
+
+  const role = person.occupation ?? person.headline;
+  return [`**${person.displayName}**`, ...(role ? [role] : []), `[${person.email}](mailto:${person.email})`].join(
+    MARKDOWN_LINE_BREAK,
+  );
+}
+
+function emailBodies(text: string, sender: ThreadFixture["messages"][number]["sender"], seedUserEmail: string) {
+  return sender === "self"
+    ? composeEmailBodies(text, workspaceSignature(seedUserEmail), workspaceEmailSettings(), "markdown")
+    : composeEmailBodies(text, correspondentSignature(sender), correspondentEmailSettings(), "markdown");
 }
 
 function providerFor(account: ThreadFixture["account"]): ThreadFixture["account"] {
@@ -306,6 +365,12 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
       folders: inputJson(account.folders),
       selectedFolderIds: account.selectedFolderIds,
       foldersSyncedAt: isEmailFixtureProvider(account.provider) ? new Date(anchor.getTime() - 5 * MINUTE) : null,
+      ...(isEmailFixtureProvider(account.provider)
+        ? {
+            signature: workspaceSignature(context.seedUserEmail),
+            signatureFields: inputJson(workspaceEmailSettings()),
+          }
+        : {}),
       linkedinProducts: account.linkedinProducts,
       shared: false,
       syncing: false,
@@ -648,6 +713,9 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
           : personAttendee(message.reaction.sender, provider)
         : null;
       const unipileMessageId = `demo-fixture-message-${messageIndex}`;
+      const composedBodies = isEmailFixtureProvider(provider)
+        ? emailBodies(message.text, message.sender, context.seedUserEmail)
+        : null;
       const data = {
         companyId: context.companyId,
         connectedAccountId,
@@ -672,8 +740,8 @@ export async function seedDemoMessagingFixtures(prisma: PrismaClient, context: S
             : [],
         ),
         subject: fixture.subject,
-        bodyText: message.text,
-        bodyHtml: isEmailFixtureProvider(provider) ? emailHtml(message.text) : null,
+        bodyText: composedBodies ? composedBodies.plainText : message.text,
+        bodyHtml: composedBodies ? composedBodies.html : null,
         attachmentsMeta: inputJson([]),
         folderIds: emailFolderIds(provider, message.sender === "self"),
         isEvent: false,


### PR DESCRIPTION
## Summary

Seeded demo email threads are now rendered by the product's own signature composer instead of a seed-local HTML stub, so the demo environment shows what Customermates email actually looks like: a styled body plus a per-account signature.

`prisma/seeds/messaging/seed.ts` drops its local `emailHtml` helper and calls `composeEmailBodies(...)` from `ee/messaging/outbound/email-signature.ts` with a real `EmailSettings` profile. Seeded email `ConnectedAccount` rows now carry `signature` and `signatureFields`, so the Settings UI and the reply composer have something to read.

Closes CUS-322.

## Context

CUS-313 (#153) shipped customizable email signatures. The demo seed predates it: it escaped the fixture text, wrapped each paragraph in `<p>`, and wrote no signature at all. The feature was therefore invisible in the one environment prospects look at, and seeded accounts had empty signature fields.

Two distinct appearance profiles are seeded on purpose: the workspace account uses sans-serif with the default link colour, correspondents use serif with a different (also contrast-readable) link colour. That makes it visible in the demo that signature appearance is per-account rather than hardcoded.

Signatures are deliberately text-only: every template stays `plain`, so no logo renders. The seeded `signatureFields` keep the product's default `logoUrl` rather than blanking it, so a seeded account is in exactly the same state as a freshly connected real one and switching to a logo template in Settings still validates.

## Validation

Run from the change worktree against a provisioned loopback database, Node 24.18.

- `yarn typecheck` — clean.
- `yarn lint` — clean.
- Full `vitest` suite — 5536 passed, 2 skipped, 0 failed.
- `yarn build` — production build succeeds.
- Reseeded the demo database and queried the result: **56 emails | 0 containing `<img>` | 0 containing a logo URL | 56 with exactly one `data-customermates-signature` block**. Both seeded email accounts report `template: plain`, and each account's signature contains that account's own address.
- Exercised the locally served app in `APP_MODE=demo`. Read back from the rendered DOM: every message frame has exactly one signature block and zero `<img>` elements. Thread list previews show the message body with the signature stripped, an opened thread shows the outbound and inbound signatures, and the reply composer shows the account signature below the editor.
- **Negative controls.** The two new gates were proven to fail on planted regressions before being trusted: switching the seeded template to one with a logo fails the new `<img>` assertion, and making one mid-thread fixture body diverge under markdown rendering fails the new round-trip assertion. Both pass on the clean tree.
- Independent read-only review of the final diff before the first push, then a recheck of the changed areas.

### Review findings applied

The first review returned changes-requested. Applied before this push:

- Added a regression gate for the image-free requirement, which previously had none (it was only checked by a manual query).
- Removed a `logoUrl: ""` override that put the demo account into a state no real account is in and that would make a demo user hit a validation error when switching to a logo template. The rendered output is unchanged.
- Extended the markdown round-trip assertion from each thread's last message to every message; the renderer is not identity on prose containing a URL or a bullet list, so the gap was latent rather than theoretical.
- Replaced a correspondent link colour that the product's own `emailLinkContrast` reports as unreadable.
- Made the workspace signature derive from `context.seedUserEmail` instead of hardcoding an address that could diverge from the account's.
- Added test coverage for the new `ConnectedAccount` signature write, which nothing asserted.

## Impact and rollback

No migration, no schema change, no environment variable, no API or UI code touched. The change is confined to `prisma/seeds/**` and its fixture test, so it affects only synthetic demo data, which is regenerated from source on every reset and deploy.

Rollback is `git revert` of the single commit; the next seed run restores the previous demo data with no manual cleanup and no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
