### PR TITLE
fix(inbox): never destroy a record on an email folder move

### DIFF
--- a/app/[locale]/(protected)/inbox/components/__tests__/inbox-page-views.test.ts
+++ b/app/[locale]/(protected)/inbox/components/__tests__/inbox-page-views.test.ts
@@ -271,7 +271,7 @@ describe("Inbox page-state owners", () => {
       "utf8",
     );
 
-    expect(surface).toContain("<DataViewViewsRail joinsTopBar store={messagingThreadsStore} />");
+    expect(surface).toContain('<DataViewViewsRail joinsTopBar detailParam="threadId" store={messagingThreadsStore} />');
     expect(surface).toContain("useDataViewSync(messagingThreadsStore, threads)");
 
     const page = readFileSync(resolve(process.cwd(), "app/[locale]/(protected)/inbox/page.tsx"), "utf8");

--- a/app/[locale]/(protected)/inbox/components/inbox-surface.tsx
+++ b/app/[locale]/(protected)/inbox/components/inbox-surface.tsx
@@ -22,7 +22,7 @@ export const InboxSurface = observer(function InboxSurface({ children, threads }
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <DataViewViewsRail joinsTopBar store={messagingThreadsStore} />
+      <DataViewViewsRail joinsTopBar detailParam="threadId" store={messagingThreadsStore} />
 
       {children}
     </div>

--- a/app/[locale]/(protected)/inbox/components/messaging-thread-detail.store.ts
+++ b/app/[locale]/(protected)/inbox/components/messaging-thread-detail.store.ts
@@ -146,7 +146,9 @@ export class MessagingThreadDetailStore extends BaseStore {
         return;
       }
 
-      this.folderContext = { ...context, currentFolderIds: [result.data.folderId] };
+      runInAction(() => {
+        this.folderContext = { ...context, currentFolderIds: [result.data.folderId] };
+      });
 
       this.toastSuccess(result.data.hiddenFromInbox ? "Inbox.folders.movedHidden" : "Inbox.folders.moved", {
         values: { folder: result.data.folderName },

--- a/app/[locale]/(protected)/inbox/components/thread-panel.tsx
+++ b/app/[locale]/(protected)/inbox/components/thread-panel.tsx
@@ -138,7 +138,13 @@ export const ThreadPanel = observer(({ threadDetail, locked = false }: Props) =>
 
           <ThreadTopBar thread={thread} />
 
-          <MessagesScrollContainer scrollKey={`thread:${thread.id}`} onTopReach={store.loadOlderMessages}>
+          <MessagesScrollContainer
+            jumpToLatestLabel={t("Inbox.jumpToLatest")}
+            latestItemKey={store.messages.at(-1)?.id}
+            scrollKey={`thread:${thread.id}`}
+            scrollRegionLabel={t("Inbox.conversationRegion")}
+            onTopReach={store.loadOlderMessages}
+          >
             <div className="flex flex-col gap-1">
               {store.loadingOlder ? (
                 <div className="flex justify-center py-2">

--- a/app/[locale]/(protected)/inbox/components/thread-reply-composer.tsx
+++ b/app/[locale]/(protected)/inbox/components/thread-reply-composer.tsx
@@ -110,6 +110,7 @@ export const ThreadReplyComposer = observer(
     const initializedThreadId = useRef<string | null>(null);
     const mounted = useRef(false);
     const [emojiOpen, setEmojiOpen] = useState(false);
+    const [expanded, setExpanded] = useState(false);
 
     useEffect(() => {
       mounted.current = true;
@@ -117,6 +118,10 @@ export const ThreadReplyComposer = observer(
         mounted.current = false;
       };
     }, []);
+
+    useEffect(() => {
+      setExpanded(false);
+    }, [threadId]);
 
     function insertEmoji(emoji: string) {
       if (threadComposeStore.isEmail) {
@@ -215,6 +220,14 @@ export const ThreadReplyComposer = observer(
       if (name && account.emailAddress && name !== account.emailAddress) return `${name} · ${account.emailAddress}`;
       return account.emailAddress ?? name ?? t("Common.unnamed");
     };
+
+    const hasWorkInProgress =
+      Boolean(threadComposeStore.form.body?.trim()) ||
+      attachments.length > 0 ||
+      Boolean(editingDraftId) ||
+      isNewThread ||
+      isLoading;
+    const isOpen = expanded || hasWorkInProgress;
 
     const form = (
       <AppForm className="flex flex-col" store={threadComposeStore} onSubmit={threadComposeStore.send}>
@@ -544,7 +557,26 @@ export const ThreadReplyComposer = observer(
     return (
       <div className="bg-background shrink-0 px-4 pt-2 pb-4">
         <div className="bg-input-background focus-within:ring-ring/50 flex flex-col rounded-xl border border-input shadow-xs transition-[color,box-shadow] focus-within:ring-[3px] focus-within:ring-inset">
-          {form}
+          {isOpen ? (
+            form
+          ) : (
+            <button
+              aria-expanded={false}
+              className="group text-muted-foreground hover:text-foreground/90 focus-visible:ring-ring/50 flex w-full items-center gap-2 rounded-xl px-3 py-2.5 text-left text-sm outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-inset motion-reduce:transition-none"
+              id="inbox-reply-expand"
+              type="button"
+              onClick={() => setExpanded(true)}
+            >
+              <span className="truncate">
+                {isEmail ? t("Inbox.compose.writeReply") : t("Inbox.compose.typeMessage")}
+              </span>
+
+              <Send
+                aria-hidden
+                className="text-muted-foreground/70 group-hover:text-primary ml-auto size-4 shrink-0 transition-colors motion-reduce:transition-none"
+              />
+            </button>
+          )}
         </div>
       </div>
     );

--- a/components/data-view/__tests__/data-view-views-rail-interaction.test.ts
+++ b/components/data-view/__tests__/data-view-views-rail-interaction.test.ts
@@ -15,11 +15,20 @@ const harness = vi.hoisted(() => ({
   confirmations: [] as { entityName?: string; onConfirm: () => Promise<boolean> }[],
   deleteDataViewAction: vi.fn(),
   menuCloseAutoFocus: { current: undefined as ((event: Event) => void) | undefined },
+  routerPush: vi.fn(),
+  searchParams: { current: "" },
   upsertDataViewAction: vi.fn(),
 }));
 
 vi.mock("mobx-react-lite", () => ({ observer: <T>(component: T) => component }));
-vi.mock("next/navigation", () => ({ usePathname: () => "/en/deals" }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/deals",
+  useSearchParams: () => new URLSearchParams(harness.searchParams.current),
+}));
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ push: harness.routerPush }),
+  usePathname: () => "/deals",
+}));
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, values?: Record<string, unknown>) =>
     values ? `${key}(${Object.values(values).join(",")})` : key,
@@ -140,13 +149,16 @@ function store(overrides: Partial<BaseDataViewStore<Item>> = {}): BaseDataViewSt
 let root: ReactRoot | undefined;
 let container: HTMLDivElement | undefined;
 
-function render(value: BaseDataViewStore<Item>): HTMLDivElement {
+function render(value: BaseDataViewStore<Item>, detailParam?: string): HTMLDivElement {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
     root?.render(
-      createElement(DataViewViewsRail<Item>, { store: value } as { store: BaseDataViewStore<Item> }) as ReactNode,
+      createElement(DataViewViewsRail<Item>, { detailParam, store: value } as {
+        detailParam?: string;
+        store: BaseDataViewStore<Item>;
+      }) as ReactNode,
     );
   });
   return container;
@@ -207,6 +219,8 @@ beforeEach(() => {
   harness.calls.length = 0;
   harness.confirmations.length = 0;
   harness.deleteDataViewAction.mockReset().mockResolvedValue({ data: { id: "v-a" }, ok: true });
+  harness.routerPush.mockReset();
+  harness.searchParams.current = "";
   harness.upsertDataViewAction.mockReset().mockResolvedValue({ data: view({ id: "v-new", name: "Hot" }), ok: true });
   window.history.replaceState(null, "", "/en/deals");
   document.addEventListener("click", swallowNavigation);
@@ -277,6 +291,30 @@ describe("data view rail interaction", () => {
 
     expect(value.applyView).toHaveBeenCalledOnce();
     expect(pushState).toHaveBeenCalledOnce();
+  });
+
+  it("closes an open detail by routing, and routes without the locale the router adds back", () => {
+    harness.searchParams.current = "threadId=t-1";
+    const value = store();
+    const host = render(value, "threadId");
+    const pushState = vi.spyOn(window.history, "pushState");
+
+    act(() => chips(host)[1].click());
+
+    expect(harness.routerPush).toHaveBeenCalledExactlyOnceWith("/deals?view=v-a");
+    expect(value.applyView).not.toHaveBeenCalled();
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it("selects in place when no detail is open", () => {
+    harness.searchParams.current = "";
+    const value = store();
+    const host = render(value, "threadId");
+
+    act(() => chips(host)[1].click());
+
+    expect(harness.routerPush).not.toHaveBeenCalled();
+    expect(value.applyView).toHaveBeenCalledExactlyOnceWith("v-a");
   });
 
   it("shows a draft tab while creating, then saves the current query as a view and activates it", async () => {

--- a/components/data-view/__tests__/data-view-views-rail.test.ts
+++ b/components/data-view/__tests__/data-view-views-rail.test.ts
@@ -15,7 +15,11 @@ const harness = vi.hoisted(() => ({
 }));
 
 vi.mock("mobx-react-lite", () => ({ observer: <T>(component: T) => component }));
-vi.mock("next/navigation", () => ({ usePathname: () => "/en/deals" }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/deals",
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/i18n/navigation", () => ({ useRouter: () => ({ push: vi.fn() }), usePathname: () => "/deals" }));
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, values?: Record<string, unknown>) =>
     values ? `${key}(${Object.values(values).join(",")})` : key,

--- a/components/data-view/views/data-view-views-rail.tsx
+++ b/components/data-view/views/data-view-views-rail.tsx
@@ -9,7 +9,8 @@ import { ChevronDownIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useRouter, usePathname as useLocalePathname } from "@/i18n/navigation";
 
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -29,6 +30,7 @@ import { useViewCommands } from "./use-view-commands";
 
 type Props<E extends HasId> = {
   joinsTopBar?: boolean;
+  detailParam?: string;
   store: BaseDataViewStore<E>;
 };
 
@@ -45,10 +47,14 @@ function isPlainClick(event: MouseEvent<HTMLAnchorElement>): boolean {
 
 export const DataViewViewsRail = observer(function DataViewViewsRail<E extends HasId>({
   joinsTopBar = false,
+  detailParam,
   store,
 }: Props<E>) {
   const t = useTranslations();
   const pathname = usePathname();
+  const localePathname = useLocalePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [meta, setMeta] = useState<ViewMetaDraft | null>(null);
   const offersViews = Boolean(store.p13nId);
 
@@ -98,6 +104,12 @@ export const DataViewViewsRail = observer(function DataViewViewsRail<E extends H
     if (!isPlainClick(event)) return;
 
     event.preventDefault();
+
+    if (detailParam && searchParams.get(detailParam)) {
+      router.push(viewHref(localePathname, viewKey));
+      return;
+    }
+
     commands.select(viewKey);
   };
 

--- a/content/docs/de/app-inbox.mdx
+++ b/content/docs/de/app-inbox.mdx
@@ -22,6 +22,7 @@ Die Route ist `/inbox`. Alle App-Routen tragen ein Locale-Präfix, zum Beispiel 
 | Antworten                         | Composer am unteren Ende eines Threads | `#inbox-reply-input` / `#inbox-reply-send` | Tippen, dann auf dem Kanal des Threads senden                                         |
 | Thread-Status setzen              | State-Select im Thread-Header          | `#inbox-thread-state`                      | unread, open, closed oder spam wählen                                                 |
 | E-Mail in Ordner verschieben      | Ordner-Select im Thread-Header         | `#inbox-thread-folder`                     | Legt die Konversation im echten Postfach ab; Sent und Drafts sind keine Ziele         |
+| Antwort-Composer öffnen           | Eingeklappte Zeile unter dem Thread    | `#inbox-reply-expand`                      | Klappt den Composer auf; er bleibt offen, solange Entwurf oder Anhang vorhanden sind  |
 | Thread mit dem Team teilen        | Thread-Einstellungen                   | `#thread-shared`                           | Diesen einzelnen Thread in einem Tarif mit Messaging für CRM-Teammitglieder freigeben |
 | Teilnehmer mit Contact verknüpfen | Thread-Einstellungen                   | none                                       | Thread-Einstellungen öffnen, dann pro Teilnehmer verknüpfen                           |
 

--- a/content/docs/en/app-inbox.mdx
+++ b/content/docs/en/app-inbox.mdx
@@ -22,6 +22,7 @@ The route is `/inbox`. All app routes are locale-prefixed, for example `https://
 | Reply                       | Composer at the bottom of a thread  | `#inbox-reply-input` / `#inbox-reply-send` | Type, then send on the thread channel                                      |
 | Set thread state            | Thread header state select          | `#inbox-thread-state`                      | Choose unread, open, closed, or spam                                       |
 | Move email to a folder      | Thread header folder select         | `#inbox-thread-folder`                     | Files the conversation in the real mailbox; Sent and Drafts are not targets |
+| Open the reply composer     | Collapsed row under the thread      | `#inbox-reply-expand`                      | Expands the composer; it stays open while a draft or attachment is present |
 | Share thread with the team  | Thread settings panel               | `#thread-shared`                           | Expose this individual thread to CRM teammates on a messaging-enabled plan |
 | Link participant to contact | Thread settings panel               | none                                       | Open thread settings, then link per participant                            |
 

--- a/core/errors/app-errors.ts
+++ b/core/errors/app-errors.ts
@@ -1,5 +1,6 @@
 const APP_ERROR_BRAND = Symbol.for("customermates.appError");
 const UNMAPPABLE_WEBHOOK_PAYLOAD_BRAND = Symbol.for("customermates.unmappableWebhookPayload");
+const DEFERRED_WEBHOOK_BRAND = Symbol.for("customermates.deferredWebhook");
 
 export enum AppErrorCode {
   unauthenticated = "unauthenticated",
@@ -114,6 +115,18 @@ export class UnmappableWebhookPayloadError extends Error {
 
   static [Symbol.hasInstance](value: unknown): value is UnmappableWebhookPayloadError {
     return hasBrand(value, UNMAPPABLE_WEBHOOK_PAYLOAD_BRAND);
+  }
+}
+
+export class DeferredWebhookError extends Error {
+  constructor(reason: string) {
+    super(`Unipile webhook deferred for a later attempt: ${reason}`);
+    this.name = "DeferredWebhookError";
+    (this as Record<symbol, unknown>)[DEFERRED_WEBHOOK_BRAND] = true;
+  }
+
+  static [Symbol.hasInstance](value: unknown): value is DeferredWebhookError {
+    return hasBrand(value, DEFERRED_WEBHOOK_BRAND);
   }
 }
 

--- a/ee/messaging/__tests__/email-move-targets.test.ts
+++ b/ee/messaging/__tests__/email-move-targets.test.ts
@@ -23,14 +23,26 @@ const CATALOG = [
 ];
 
 describe("emailMoveTargets", () => {
-  it("offers only folders a conversation may actually be filed into", () => {
-    expect(emailMoveTargets(CATALOG, "mail").map((entry) => entry.id)).toEqual(["archive", "inbox"]);
+  it("offers every folder a conversation may be filed into, ordered by name", () => {
+    expect(emailMoveTargets(CATALOG, "mail").map((entry) => entry.id)).toEqual([
+      "archive",
+      "inbox",
+      "junk",
+      "spam",
+      "trash",
+    ]);
   });
 
-  it("never offers Trash, Junk or Spam, whose relocation hard-deletes the local record", () => {
+  it("offers Trash, Junk and Spam, which people file into deliberately", () => {
     const ids = emailMoveTargets(CATALOG, "mail").map((entry) => entry.id);
 
-    for (const excluded of ["trash", "junk", "spam"]) expect(ids).not.toContain(excluded);
+    for (const target of ["trash", "junk", "spam"]) expect(ids).toContain(target);
+  });
+
+  it("offers a custom folder whose name merely reads like a system one", () => {
+    const custom = [folder("a", "Archive", "ARCHIVE"), folder("d", "Deleted projects", null)];
+
+    expect(emailMoveTargets(custom, "mail").map((entry) => entry.id)).toContain("d");
   });
 
   it("never offers Sent or Drafts", () => {
@@ -48,9 +60,10 @@ describe("emailMoveTargets", () => {
     expect(emailMoveTargets(CATALOG, "whatsapp")).toEqual([]);
   });
 
-  it("recognises a skipped folder by name when the provider reports no role", () => {
-    const byName = [folder("a", "Archive", null), folder("t", "Deleted Items", null)];
+  it("still refuses Sent and Drafts by role", () => {
+    const ids = emailMoveTargets(CATALOG, "mail").map((entry) => entry.id);
 
-    expect(emailMoveTargets(byName, "mail").map((entry) => entry.id)).toEqual(["a"]);
+    expect(ids).not.toContain("sent");
+    expect(ids).not.toContain("drafts");
   });
 });

--- a/ee/messaging/email-folders.ts
+++ b/ee/messaging/email-folders.ts
@@ -106,7 +106,7 @@ export function isMovableEmailFolder(folder: { role?: string | null; name?: stri
 }
 
 export function isEmailMoveTarget(folder: { role?: string | null; name?: string | null }): boolean {
-  return isMovableEmailFolder(folder) && !isSkippedEmailFolder(folder);
+  return isMovableEmailFolder(folder);
 }
 
 export function emailMoveTargets(folders: EmailFolder[], provider: MessagingProvider): EmailFolder[] {

--- a/ee/messaging/inbox/__tests__/move-email-thread.interactor.test.ts
+++ b/ee/messaging/inbox/__tests__/move-email-thread.interactor.test.ts
@@ -241,10 +241,22 @@ describe("MoveEmailThreadInteractor", () => {
 });
 
 describe("MoveEmailThreadInteractor safety", () => {
-  it("refuses Trash as a destination, because relocation there hard-deletes the local record", async () => {
-    const parts = setup({ messages: [{ id: "a", unipileMessageId: "old-a", folderIds: ["inbox"] }] });
+  it("accepts Trash as a destination, which people file into deliberately", async () => {
+    const parts = setup({
+      messages: [{ id: "a", unipileMessageId: "old-a", folderIds: ["inbox"] }],
+      moveResults: [{ ok: true, data: { id: "new-a", folderIds: ["trash"] } }],
+    });
 
     const result = await invoke(parts, { threadId: THREAD_ID, folderId: "trash" });
+
+    expect(result.ok).toBe(true);
+    expect(parts.messagingService.moveEmail).toHaveBeenCalledWith(expect.objectContaining({ folderId: "trash" }));
+  });
+
+  it("still refuses Sent as a destination", async () => {
+    const parts = setup({ messages: [{ id: "a", unipileMessageId: "old-a", folderIds: ["inbox"] }] });
+
+    const result = await invoke(parts, { threadId: THREAD_ID, folderId: "sent" });
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(JSON.stringify(result.error)).toContain(CustomErrorCode.emailFolderNotMovable);

--- a/ee/messaging/persistence/__tests__/prisma-messaging-repository-dedupe.test.ts
+++ b/ee/messaging/persistence/__tests__/prisma-messaging-repository-dedupe.test.ts
@@ -303,6 +303,61 @@ describe("PrismaMessagingRepo recovery after a folder move", () => {
     expect(fakeDb.messages[0].unipileMessageId).toBe("id-while-in-archive");
   });
 
+  it("files a relocated message where the provider says it is, not where it also used to be", async () => {
+    fakeDb.messages.push({
+      id: "msg-existing",
+      companyId: COMPANY_ID,
+      messagingThreadId: "thread-existing",
+      connectedAccountId: CONNECTED_ACCOUNT_ID,
+      unipileMessageId: "id-while-in-inbox",
+      providerMessageId: "rfc-msg-1",
+      provider: "google",
+      direction: "outbound",
+      origin: "unipile",
+      folderIds: ["inbox"],
+      isHidden: false,
+      sender: { attendeeId: "", displayName: null, identifier: "me@company.com" },
+    });
+
+    await new PrismaMessagingRepo().ingestMessageUnscoped({
+      companyId: COMPANY_ID,
+      connectedAccountId: CONNECTED_ACCOUNT_ID,
+      message: outboundEmail({ unipileMessageId: "id-in-archive", folderIds: ["archive"] }) as never,
+      backfill: false,
+    });
+
+    expect(fakeDb.messages).toHaveLength(1);
+    expect(fakeDb.messages[0].folderIds).toEqual(["archive"]);
+    expect(fakeDb.messages[0].unipileMessageId).toBe("id-in-archive");
+  });
+
+  it("accumulates folders across a backfill that walks one folder at a time", async () => {
+    fakeDb.messages.push({
+      id: "msg-existing",
+      companyId: COMPANY_ID,
+      messagingThreadId: "thread-existing",
+      connectedAccountId: CONNECTED_ACCOUNT_ID,
+      unipileMessageId: "id-seen-in-inbox",
+      providerMessageId: "rfc-msg-1",
+      provider: "google",
+      direction: "outbound",
+      origin: "unipile",
+      folderIds: ["inbox"],
+      isHidden: false,
+      sender: { attendeeId: "", displayName: null, identifier: "me@company.com" },
+    });
+
+    await new PrismaMessagingRepo().ingestMessageUnscoped({
+      companyId: COMPANY_ID,
+      connectedAccountId: CONNECTED_ACCOUNT_ID,
+      message: outboundEmail({ unipileMessageId: "id-seen-in-sent", folderIds: ["sent"] }) as never,
+      backfill: true,
+    });
+
+    expect(fakeDb.messages).toHaveLength(1);
+    expect(fakeDb.messages[0].folderIds.toSorted()).toEqual(["inbox", "sent"]);
+  });
+
   it("leaves a message hidden when it still belongs to no folder", async () => {
     hiddenAfterMissedMove();
 

--- a/ee/messaging/persistence/prisma-messaging.repository.ts
+++ b/ee/messaging/persistence/prisma-messaging.repository.ts
@@ -1778,7 +1778,11 @@ export class PrismaMessagingRepo
       if (duplicate) {
         const duplicateSender = duplicate.sender as unknown as MessagingAttendee;
         const upgradeSender = hasLetter(safeMessage.sender.displayName) && !hasLetter(duplicateSender.displayName);
-        const folderIds = [...new Set([...duplicate.folderIds, ...(safeMessage.folderIds ?? [])])];
+        const incomingFolderIds = safeMessage.folderIds ?? [];
+        const folderIds =
+          backfill || incomingFolderIds.length === 0
+            ? [...new Set([...duplicate.folderIds, ...incomingFolderIds])]
+            : incomingFolderIds;
 
         await this.prisma.messagingMessage.update({
           where: { id: duplicate.id },

--- a/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/prisma/db", () => MOCK_PRISMA_DB_MODULE);
 
 import { ProcessEmailDeleteWebhookInteractor } from "../email/process-email-delete-webhook.interactor";
 import { UnipileRequestError } from "../../messaging.service";
+import { DeferredWebhookError } from "@/core/errors/app-errors";
 
 const account = {
   id: "acc-1",
@@ -160,15 +161,71 @@ describe("ProcessEmailDeleteWebhookInteractor", () => {
     expect(eventService.publish).toHaveBeenCalledTimes(1);
   });
 
-  it("skips verification during delete bursts and deletes directly", async () => {
+  it("still runs the single-call search during a burst and deletes a message that really went away", async () => {
+    vi.useFakeTimers();
     const { interactor, ingest, eventService, messagingService } = build({ recentDeletes: 50 });
 
-    await interactor.invoke(envelope);
+    const run = interactor.invoke(envelope);
+    await vi.runAllTimersAsync();
+    await run;
+    vi.useRealTimers();
 
-    expect(messagingService.listEmails).not.toHaveBeenCalled();
+    expect(messagingService.listEmails).toHaveBeenCalledTimes(1);
     expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
     expect(ingest.deleteMessageUnscoped).toHaveBeenCalled();
     expect(eventService.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers instead of destroying when a burst leaves the relocation unverifiable", async () => {
+    vi.useFakeTimers();
+    const { interactor, ingest, eventService, messagingService } = build({
+      recentDeletes: 50,
+      listEmails: () => Promise.reject(new UnipileRequestError(501, "api/not_implemented", "")),
+    });
+
+    const run = interactor.invoke(envelope).catch((err: unknown) => err);
+    await vi.runAllTimersAsync();
+    await expect(run).resolves.toBeInstanceOf(DeferredWebhookError);
+    vi.useRealTimers();
+
+    expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
+    expect(ingest.moveEmailMessageUnscoped).not.toHaveBeenCalled();
+    expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
+    expect(eventService.publish).not.toHaveBeenCalled();
+  });
+
+  it("relocates during a burst when the single-call search finds the message", async () => {
+    vi.useFakeTimers();
+    const { interactor, ingest, messagingService } = build({
+      recentDeletes: 50,
+      listEmails: () => Promise.resolve({ data: [relocatedEmail] }),
+    });
+
+    const run = interactor.invoke(envelope);
+    await vi.runAllTimersAsync();
+    await run;
+    vi.useRealTimers();
+
+    expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
+    expect(ingest.moveEmailMessageUnscoped).toHaveBeenCalledWith(
+      expect.objectContaining({ newUnipileMessageId: "NEW_ID_ARCHIVE", folderIds: ["F_ARCHIVE"] }),
+    );
+    expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("does not destroy a row during a burst when the relocation adopted it under a new identifier", async () => {
+    vi.useFakeTimers();
+    const { interactor, ingest, messagingService } = build({ recentDeletes: 50 });
+    ingest.findMessageByUnipileIdUnscoped.mockResolvedValueOnce(existingRow).mockResolvedValueOnce(null);
+
+    const run = interactor.invoke(envelope);
+    await vi.runAllTimersAsync();
+    await run;
+    vi.useRealTimers();
+
+    expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
+    expect(messagingService.listEmails).not.toHaveBeenCalled();
+    expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
   });
 
   it("skips verification when the stored row has no rfc822 message id", async () => {

--- a/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
@@ -21,6 +21,7 @@ import * as Sentry from "@sentry/node";
 import { ProcessUnipileWebhookInteractor } from "../process-unipile-webhook.interactor";
 import { UnmappableWebhookPayloadError } from "@/core/errors/app-errors";
 import { UnipileRequestError } from "../../messaging.service";
+import { DeferredWebhookError } from "@/core/errors/app-errors";
 
 const EVENT_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -108,6 +109,21 @@ describe("ProcessUnipileWebhookInteractor classification", () => {
     await invoke(interactor);
 
     expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledWith(
+      expect.objectContaining({ id: EVENT_ID, terminal: false }),
+    );
+  });
+
+  it("retries a deferred webhook without reporting it", async () => {
+    const handler = { invoke: vi.fn().mockRejectedValue(new DeferredWebhookError("burst")) };
+    const { interactor, events } = build(row({ type: "email.delete", account_id: "acc_1", payload: {} }), {
+      "email.delete": handler,
+    });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(events.markWebhookEventProcessedUnscoped).not.toHaveBeenCalled();
     expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledWith(
       expect.objectContaining({ id: EVENT_ID, terminal: false }),
     );

--- a/ee/messaging/webhooks/email/process-email-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/email/process-email-delete-webhook.interactor.ts
@@ -18,6 +18,7 @@ import { DomainEvent } from "@/features/event/domain-events";
 import { getUnipileStatus } from "../../messaging.service";
 import { EmailFolderSchema, isSkippedEmailFolder } from "../../email-folders";
 import { UnipileEmailSchema } from "../../unipile.schema";
+import { DeferredWebhookError } from "@/core/errors/app-errors";
 
 const Schema = z.object({
   type: z.literal("email.delete"),
@@ -32,9 +33,15 @@ type Payload = z.infer<typeof Schema>;
 const BURST_WINDOW_MS = 60_000;
 const BURST_LIMIT = 10;
 const SEARCH_WINDOW_MS = 1_000;
+const RELOCATION_GRACE_MS = 8_000;
 const SEARCH_LIMIT = 25;
 
 type Candidate = { email: UnipileEmail; folderIds: string[] };
+
+type Relocation =
+  | { status: "relocated"; email: UnipileEmail; folderIds: string[] }
+  | { status: "absent" }
+  | { status: "unsearchable" };
 
 function parseEmails(data: unknown[] | null | undefined): UnipileEmail[] {
   return (data ?? []).flatMap((raw) => {
@@ -69,23 +76,38 @@ export class ProcessEmailDeleteWebhookInteractor {
     });
     if (!existing) return;
 
-    const relocated = await this.findRelocatedEmail(
+    const burst = await this.isDeleteBurst(account);
+    if (burst) {
+      await this.waitForRelocation();
+
+      const stillPresent = await this.ingest.findMessageByUnipileIdUnscoped({
+        connectedAccountId: account.id,
+        unipileMessageId: envelope.payload.email.id,
+      });
+      if (!stillPresent) return;
+    }
+
+    const relocation = await this.findRelocation(
       account,
       existing.providerMessageId ?? null,
       existing.sentAt,
       envelope,
+      burst,
     );
-    if (relocated) {
+    if (relocation.status === "relocated") {
       await this.ingest.moveEmailMessageUnscoped({
         companyId: account.companyId,
         connectedAccountId: account.id,
         unipileMessageId: envelope.payload.email.id,
-        newUnipileMessageId: relocated.email.id,
-        folderIds: relocated.folderIds,
+        newUnipileMessageId: relocation.email.id,
+        folderIds: relocation.folderIds,
       });
 
       return;
     }
+
+    if (relocation.status === "unsearchable")
+      throw new DeferredWebhookError("relocation cannot be verified during a delete burst");
 
     const deleted = await this.ingest.deleteMessageUnscoped({
       companyId: account.companyId,
@@ -109,30 +131,35 @@ export class ProcessEmailDeleteWebhookInteractor {
     );
   }
 
-  private async findRelocatedEmail(
-    account: ConnectedAccount,
-    providerMessageId: string | null,
-    sentAt: Date,
-    envelope: Payload,
-  ): Promise<Candidate | null> {
-    if (!providerMessageId) return null;
-
+  private async isDeleteBurst(account: ConnectedAccount): Promise<boolean> {
     const recentDeletes = await this.events.countRecentEmailDeletesUnscoped({
       unipileAccountId: account.unipileAccountId,
       since: new Date(Date.now() - BURST_WINDOW_MS),
     });
-    if (recentDeletes > BURST_LIMIT) return null;
+
+    return recentDeletes > BURST_LIMIT;
+  }
+
+  private waitForRelocation(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, RELOCATION_GRACE_MS));
+  }
+
+  private async findRelocation(
+    account: ConnectedAccount,
+    providerMessageId: string | null,
+    sentAt: Date,
+    envelope: Payload,
+    burst: boolean,
+  ): Promise<Relocation> {
+    if (!providerMessageId) return { status: "absent" };
 
     const folders = parseFolderCatalog(account.folders);
-    const candidates = await this.listCandidates(
-      account.unipileAccountId,
-      sentAt,
-      folders,
-      envelope.payload.folder_id ?? null,
-    );
+    const originFolderId = envelope.payload.folder_id ?? null;
+    const candidates = await this.listCandidates(account.unipileAccountId, sentAt, folders, originFolderId, burst);
+    if (!candidates) return { status: "unsearchable" };
+
     const catalogById = new Map(folders.map((folder) => [folder.id, folder]));
 
-    const originFolderId = envelope.payload.folder_id ?? null;
     for (const candidate of candidates) {
       if (candidate.email.message_id?.trim() !== providerMessageId) continue;
 
@@ -141,12 +168,12 @@ export class ProcessEmailDeleteWebhookInteractor {
         const folder = catalogById.get(id);
         return !folder || !isSkippedEmailFolder(folder);
       });
-      if (visibleFolderIds.length === 0) return null;
+      if (visibleFolderIds.length === 0) return { status: "absent" };
 
-      return { email: candidate.email, folderIds: remainingFolderIds };
+      return { status: "relocated", email: candidate.email, folderIds: remainingFolderIds };
     }
 
-    return null;
+    return { status: "absent" };
   }
 
   private async listCandidates(
@@ -154,7 +181,8 @@ export class ProcessEmailDeleteWebhookInteractor {
     sentAt: Date,
     folders: EmailFolder[],
     originFolderId: string | null,
-  ): Promise<Candidate[]> {
+    burst: boolean,
+  ): Promise<Candidate[] | null> {
     const after = new Date(sentAt.getTime() - SEARCH_WINDOW_MS).toISOString();
     const before = new Date(sentAt.getTime() + SEARCH_WINDOW_MS).toISOString();
 
@@ -171,6 +199,8 @@ export class ProcessEmailDeleteWebhookInteractor {
     } catch (err) {
       if (getUnipileStatus(err) !== 501) throw err;
     }
+
+    if (burst) return null;
 
     const candidates: Candidate[] = [];
     for (const folder of folders) {

--- a/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
+++ b/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
@@ -8,7 +8,7 @@ import type { WebhookEventRepo } from "./webhook-event.repo";
 import type { UnipileWebhookEnvelope } from "../unipile.schema";
 
 import { UnipileWebhookEnvelopeSchema } from "../unipile.schema";
-import { UnmappableWebhookPayloadError } from "@/core/errors/app-errors";
+import { DeferredWebhookError, UnmappableWebhookPayloadError } from "@/core/errors/app-errors";
 import { isUnipileDisconnectedAccount, isUnipileProviderUnprocessable, isUnipileTimeout } from "../messaging.service";
 
 export type UnipileWebhookHandlerMap = Partial<
@@ -65,6 +65,12 @@ export class ProcessUnipileWebhookInteractor {
           terminal: true,
           unipileMessageId: err.unipileMessageId,
         });
+
+        return;
+      }
+
+      if (err instanceof DeferredWebhookError) {
+        await this.events.markWebhookEventFailedUnscoped({ id, error: err.message, terminal: false });
 
         return;
       }

--- a/features/mcp-tools/__tests__/messaging-move-targets.test.ts
+++ b/features/mcp-tools/__tests__/messaging-move-targets.test.ts
@@ -30,17 +30,10 @@ const context: ThreadFolderContext = {
 };
 
 describe("threadFolder move targets offered to an agent", () => {
-  it("offers only folders a move may actually land in", () => {
+  it("offers every folder a move may land in, including the ones filed into deliberately", () => {
     const names = threadFolder(context, "mail")?.moveTargets.map((entry) => entry.name);
 
-    expect(names).toEqual(["Archive", "INBOX"]);
-  });
-
-  it("never offers Trash or Junk, whose relocation hard-deletes the local record", () => {
-    const ids = threadFolder(context, "mail")?.moveTargets.map((entry) => entry.id) ?? [];
-
-    expect(ids).not.toContain("trash");
-    expect(ids).not.toContain("junk");
+    expect(names).toEqual(["Archive", "INBOX", "Junk", "Trash"]);
   });
 
   it("never offers Sent or Drafts", () => {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -2323,6 +2323,7 @@
       "updateDraft": "Entwurf aktualisieren",
       "writeReply": "Antwort schreiben…"
     },
+    "conversationRegion": "Konversation",
     "dateToday": "Heute",
     "dateYesterday": "Gestern",
     "edited": "(bearbeitet)",
@@ -2344,6 +2345,7 @@
     },
     "groupThread": "Gruppe ({count, plural, one {# Mitglied} other {# Mitglieder}})",
     "hideQuotedText": "Zitierten Text ausblenden",
+    "jumpToLatest": "Zum neuesten springen",
     "learnMore": "Mehr erfahren",
     "linkedinContact": "LinkedIn-Kontakt",
     "loadMedia": "Medien laden",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2323,6 +2323,7 @@
       "updateDraft": "Update draft",
       "writeReply": "Write a reply..."
     },
+    "conversationRegion": "Conversation",
     "dateToday": "Today",
     "dateYesterday": "Yesterday",
     "edited": "(edited)",
@@ -2344,6 +2345,7 @@
     },
     "groupThread": "Group ({count, plural, one {# member} other {# members}})",
     "hideQuotedText": "Hide quoted text",
+    "jumpToLatest": "Jump to latest",
     "learnMore": "Learn more",
     "linkedinContact": "LinkedIn contact",
     "loadMedia": "Load media",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -2323,6 +2323,7 @@
       "updateDraft": "Actualizar el borrador",
       "writeReply": "Escribe una respuesta..."
     },
+    "conversationRegion": "Conversación",
     "dateToday": "Hoy",
     "dateYesterday": "Ayer",
     "edited": "(editado)",
@@ -2344,6 +2345,7 @@
     },
     "groupThread": "Grupo ({count, plural, one {# miembro} other {# miembros}})",
     "hideQuotedText": "Ocultar el texto citado",
+    "jumpToLatest": "Ir a lo más reciente",
     "learnMore": "Saber más",
     "linkedinContact": "Contacto de LinkedIn",
     "loadMedia": "Cargar el contenido multimedia",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -2323,6 +2323,7 @@
       "updateDraft": "Mettre à jour le brouillon",
       "writeReply": "Écrivez une réponse..."
     },
+    "conversationRegion": "Fil de conversation",
     "dateToday": "Aujourd'hui",
     "dateYesterday": "Hier",
     "edited": "(modifié)",
@@ -2344,6 +2345,7 @@
     },
     "groupThread": "Groupe ({count, plural, one {# membre} other {# membres}})",
     "hideQuotedText": "Masquer le texte cité",
+    "jumpToLatest": "Aller au plus récent",
     "learnMore": "En savoir plus",
     "linkedinContact": "Contact LinkedIn",
     "loadMedia": "Charger le média",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -2323,6 +2323,7 @@
       "updateDraft": "Aggiorna la bozza",
       "writeReply": "Scrivi una risposta..."
     },
+    "conversationRegion": "Conversazione",
     "dateToday": "Oggi",
     "dateYesterday": "Ieri",
     "edited": "(modificato)",
@@ -2344,6 +2345,7 @@
     },
     "groupThread": "Gruppo ({count, plural, one {# membro} other {# membri}})",
     "hideQuotedText": "Nascondi il testo citato",
+    "jumpToLatest": "Vai al più recente",
     "learnMore": "Scopri di più",
     "linkedinContact": "Contatto LinkedIn",
     "loadMedia": "Carica il contenuto multimediale",


### PR DESCRIPTION
## Summary

An IMAP move is a delete plus a re-add under a new provider id, so every move arrives as an `email.delete` for an id that no longer exists. Two defects turned that into data loss, and this fixes both, then enables the remaining folder targets on top.

- **CUS-325.** The dedupe branch that adopts a relocated email unioned the old and new folder sets, so a moved message stayed listed in the folder it had left. The union is still correct for backfill, which walks folder by folder and must accumulate, so the incoming set now replaces only when the webhook is the source.
- **CUS-324.** The delete handler skipped relocation verification entirely during a burst of more than ten deletes and then hard-deleted. A burst now waits briefly for the relocation to land, still runs the single-call search, and skips only the expensive per-folder sweep. When that leaves the outcome unknown, the event is deferred for the hourly reprocessor (`DeferredWebhookError`, non-terminal, no Sentry) instead of deleting.
- **Trash, Junk and Spam become move targets.** They are not watched folders, so the thread leaves the inbox while the record and its CRM links survive. Sent and Drafts stay excluded.

Also in this PR, because they were found while testing the above:

- The reply composer collapses to a single row until it is needed, and stays open while a draft, attachment or in-flight send is present.
- Long threads get a jump-to-latest control.
- Selecting a view now closes an open thread. The first version of this 404'd: `usePathname` from `next/navigation` carries the locale and the `@/i18n/navigation` router adds it again, giving `/en/en/inbox`.
- The folder-context write in `moveToFolder` is wrapped in `runInAction`, so the move no longer trips MobX strict mode.

## Context

Filed after the Unipile V2 migration. V2 has no move event: `trigger_events` carries no `mail_moved`, confirmed both from the 2.41.0 SDK enum and by the live API rejecting it, so a move can only ever be inferred from the delete/new pair.

The user-visible semantics for Trash, Junk and Spam is keep-and-hide: the record is retained and re-keyed, and the thread drops out of the inbox because those folders are not watched. This was measured, not assumed. The alternative, hard-deleting the local row, only ever happened when the burst guard fired, which is the defect this PR removes.

## Validation

`yarn typecheck`, `yarn lint` and the full suite pass on this base (679 files, 6150 tests, database tests enabled), each exit code checked directly rather than through a pipe.

Verified live against two real IMAP mailboxes with a tunnelled webhook endpoint, tracking `MessagingMessage.id` rather than row counts, because a destroyed row is re-created seconds later by `email.new` and a count never moves:

| Run | Deletes in burst | Rows destroyed |
| --- | --- | --- |
| Fix reverted (control) | 13 | 4 of 13, re-created with new primary keys |
| Grace window only | 13 | 2 of 13, one lost permanently |
| This PR | 11, then 13 | 0 |

The permanent loss in the middle run has a cause worth recording: the provider does not always emit `email.new` for a moved message. One run logged 11 `email.delete` against 9 `email.new`. Under the old rule every missing one became a hard delete.

Also verified live, each confirmed at the provider and in the database: moves to Archive, Trash, Junk and Spam; the folder menu offering exactly those plus INBOX and never Sent or Drafts; a moved thread leaving the inbox list; and the three UI changes in the browser.

Mutation-tested rather than assumed. Reverting each of these makes a named test fail: the burst suppression of the per-folder sweep, the deferral branch in the interactor, the deferral branch in the webhook processor, burst detection itself, and both halves of the view-switch fix.

Not exercised live, and stated rather than glossed: the deferral branch never fired against the real mailboxes, because `email.new` always arrived inside the grace window. It is covered by the mutation-verified unit tests only. It is also the conservative branch, doing nothing where the old code deleted.

## Impact and rollback

Behaviour changes for email accounts only. Bursts of more than ten deletes in sixty seconds now cost one extra cheap list call per delete and may defer, so a genuine bulk delete of that size clears from the inbox on the next reprocessor pass rather than instantly. A deferred row holds a stale provider id until then, and an in-app move of that thread fails with the existing not-found toast; this already happens whenever the webhook lags a move made in the user's own mail client. If it needs shortening, the lever is the `reprocess-webhook-events` cron frequency in `vercel.json`, not application logic.

Revert the commit. No schema change, no migration, no data backfill, and nothing to undo in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
