### PR TITLE
fix(ui): let detail sections close and lift the hero action above the fold

### DIFF
--- a/app/[locale]/(static)/components/homepage-hero.tsx
+++ b/app/[locale]/(static)/components/homepage-hero.tsx
@@ -31,7 +31,7 @@ export function HomepageHero({ heroSection }: Props) {
       <GridPattern className="z-0" fade="bottom" />
 
       <MarketingContainer className="relative z-10">
-        <div className="flex flex-col items-center py-16 text-center sm:py-20 lg:py-28">
+        <div className="flex flex-col items-center py-12 text-center sm:py-16 lg:py-20">
           <AgplGithubBadge />
 
           <h1 className="text-hero mt-7 max-w-6xl">
@@ -58,18 +58,16 @@ export function HomepageHero({ heroSection }: Props) {
             </span>
           </h1>
 
-          <div className="mt-10 w-full max-w-[820px] rounded-card border border-border bg-card p-5 text-left shadow-[0_20px_70px_-48px_rgba(0,0,0,0.7)] sm:p-6">
-            <p className="text-eyebrow">{heroSection.useCaseEyebrow}</p>
-
-            <p className="mt-3 max-w-[700px] text-base leading-relaxed font-medium text-foreground sm:text-lg">
+          <div className="order-last mt-8 w-full max-w-[820px] rounded-card border border-border bg-card p-5 text-left shadow-[0_20px_70px_-48px_rgba(0,0,0,0.7)] sm:order-none sm:p-6">
+            <p className="max-w-[700px] text-base leading-relaxed font-medium text-foreground sm:text-lg">
               {heroSection.useCase}
             </p>
 
-            <p className="mt-4 max-w-[700px] text-[15px] leading-relaxed text-muted-foreground sm:text-base">
+            <p className="mt-3 max-w-[700px] text-[15px] leading-relaxed text-muted-foreground sm:text-base">
               {heroSection.subtitle}
             </p>
 
-            <div className="mt-7">
+            <div className="mt-6">
               <ul className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-2.5">
                 {SUPPORTED_INBOX_PROVIDERS.map((provider) => (
                   <li
@@ -107,7 +105,7 @@ export function HomepageHero({ heroSection }: Props) {
             </Button>
           </div>
 
-          <p className="text-meta mt-5">{heroSection.startFree}</p>
+          <p className="text-meta mt-4">{heroSection.startFree}</p>
         </div>
       </MarketingContainer>
     </section>

--- a/components/entity-detail/__tests__/entity-detail-layout.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-layout.test.ts
@@ -210,7 +210,9 @@ describe("EntityDetailLayout", () => {
     expect(html).toContain('data-detail-panel="notes"');
     const switcherClasses = html.match(/data-detail-panel-switcher="true" class="([^"]+)"/)?.[1].split(" ");
     expect(switcherClasses).not.toContain("border-t");
-    expect(html).toContain("after:-bottom-px");
+    const tabClasses = html.match(/role="tab"[^>]*class="([^"]+)"/)?.[1].split(" ") ?? [];
+    expect(tabClasses).toContain("group-data-[orientation=horizontal]/tabs:after:-bottom-px");
+    expect(tabClasses).not.toContain("group-data-[orientation=horizontal]/tabs:after:bottom-[-5px]");
     expect(html).toContain("Common.details");
     expect(html).toContain("EntityDetail.sections.notes");
     expect(html).toContain("EntityTimeline.types.activities");

--- a/components/entity-detail/__tests__/entity-detail-personalization.test.ts
+++ b/components/entity-detail/__tests__/entity-detail-personalization.test.ts
@@ -204,7 +204,6 @@ describe("entity detail custom field order", () => {
 describe("entity detail single-open section state", () => {
   it("defaults legacy ambiguous section preferences to Base data", () => {
     expect(resolveSingleOpenSectionId(detailSectionIds, [], defaultCollapsedSectionIds)).toBe("base");
-    expect(resolveSingleOpenSectionId(detailSectionIds, detailSectionIds, defaultCollapsedSectionIds)).toBe("base");
     expect(resolveSingleOpenSectionId(detailSectionIds, ["relations"], defaultCollapsedSectionIds)).toBe("base");
     expect(reconcileSingleOpenSections(detailSectionIds, [], defaultCollapsedSectionIds)).toEqual(
       defaultCollapsedSectionIds,
@@ -216,6 +215,20 @@ describe("entity detail single-open section state", () => {
       "relations",
     );
     expect(collapsedSectionIdsForOpenSection(detailSectionIds, "relations")).toEqual(["base", "customFields"]);
+  });
+
+  it("keeps every section closed once the reader collapses the last open one", () => {
+    expect(resolveSingleOpenSectionId(detailSectionIds, detailSectionIds, defaultCollapsedSectionIds)).toBeUndefined();
+    expect(collapsedSectionIdsForOpenSection(detailSectionIds, undefined)).toEqual(detailSectionIds);
+    expect(reconcileSingleOpenSections(detailSectionIds, detailSectionIds, defaultCollapsedSectionIds)).toEqual(
+      detailSectionIds,
+    );
+  });
+
+  it("still opens the default section for a reader who has never chosen one", () => {
+    expect(resolveSingleOpenSectionId(detailSectionIds, defaultCollapsedSectionIds, defaultCollapsedSectionIds)).toBe(
+      "base",
+    );
   });
 });
 
@@ -376,8 +389,7 @@ describe("entity detail section", () => {
     expect(trigger?.querySelector("span")?.className).not.toContain("uppercase");
     expect(trigger?.getAttribute("aria-label")).toBeNull();
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
-    expect(trigger?.getAttribute("aria-disabled")).toBe("true");
-    expect(trigger?.className).toContain("aria-disabled:cursor-default");
+    expect(trigger?.getAttribute("aria-disabled")).toBeNull();
     expect(trigger?.getAttribute("aria-controls")).toBe(content?.id);
     expect(content?.getAttribute("aria-labelledby")).toBe(trigger?.id);
     expect(content?.getAttribute("role")).toBe("region");
@@ -386,10 +398,20 @@ describe("entity detail section", () => {
 
     act(() => trigger?.click());
 
-    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("opens exactly one section and does not let the active section close", () => {
+  it("answers a pointer over the header row with a visible surface and label change", () => {
+    const { container } = mountNode(sectionView());
+    const trigger = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="base"]');
+    const label = trigger?.querySelector("span");
+
+    expect(trigger?.className).toContain("group");
+    expect(trigger?.className).toContain("hover:bg-accent");
+    expect(label?.className).toContain("group-hover:text-foreground");
+  });
+
+  it("opens one section at a time and lets the reader close the open one", () => {
     const stored: P13nEntry = {
       p13nId: "contact-detail",
       columnOrder: [],
@@ -401,21 +423,24 @@ describe("entity detail section", () => {
     const customFields = container.querySelector<HTMLButtonElement>('[data-detail-section-trigger="customFields"]');
 
     expect(base?.getAttribute("aria-expanded")).toBe("true");
-    expect(base?.getAttribute("aria-disabled")).toBe("true");
     expect(relations?.getAttribute("aria-expanded")).toBe("false");
     expect(customFields?.getAttribute("aria-expanded")).toBe("false");
 
     act(() => relations?.click());
 
     expect(base?.getAttribute("aria-expanded")).toBe("false");
-    expect(base?.getAttribute("aria-disabled")).toBeNull();
     expect(relations?.getAttribute("aria-expanded")).toBe("true");
-    expect(relations?.getAttribute("aria-disabled")).toBe("true");
     expect(customFields?.getAttribute("aria-expanded")).toBe("false");
 
     act(() => relations?.click());
 
-    expect(relations?.getAttribute("aria-expanded")).toBe("true");
+    expect(base?.getAttribute("aria-expanded")).toBe("false");
+    expect(relations?.getAttribute("aria-expanded")).toBe("false");
+    expect(customFields?.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => customFields?.click());
+
+    expect(customFields?.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("supports arrow-key navigation between section triggers", () => {

--- a/components/entity-detail/entity-detail-layout.tsx
+++ b/components/entity-detail/entity-detail-layout.tsx
@@ -371,7 +371,7 @@ export const EntityDetailLayout = observer(function EntityDetailLayout<
                 >
                   <TabsTrigger
                     aria-controls={`${formId}-details-panel`}
-                    className="h-full rounded-none px-4 after:-bottom-px after:z-10"
+                    className="h-full rounded-none px-4 after:z-10 group-data-[orientation=horizontal]/tabs:after:-bottom-px"
                     id={`${formId}-details-tab`}
                     value="details"
                   >
@@ -381,7 +381,7 @@ export const EntityDetailLayout = observer(function EntityDetailLayout<
                   {showNotesPanel && (
                     <TabsTrigger
                       aria-controls={`${formId}-notes-panel`}
-                      className="h-full rounded-none px-4 after:-bottom-px after:z-10"
+                      className="h-full rounded-none px-4 after:z-10 group-data-[orientation=horizontal]/tabs:after:-bottom-px"
                       id={`${formId}-notes-tab`}
                       value="notes"
                     >
@@ -392,7 +392,7 @@ export const EntityDetailLayout = observer(function EntityDetailLayout<
                   {canSeeHistory && (
                     <TabsTrigger
                       aria-controls={`${formId}-activities-panel`}
-                      className="h-full rounded-none px-4 after:-bottom-px after:z-10"
+                      className="h-full rounded-none px-4 after:z-10 group-data-[orientation=horizontal]/tabs:after:-bottom-px"
                       id={`${formId}-activities-tab`}
                       value="activities"
                     >

--- a/components/entity-detail/entity-detail-personalization.tsx
+++ b/components/entity-detail/entity-detail-personalization.tsx
@@ -44,7 +44,7 @@ type EntityDetailPersonalizationValue = {
   setIsPersonalizing: (value: boolean) => void;
   toggleStarredField: (fieldId: string) => void;
   toggleFieldVisibility: (fieldId: string) => void;
-  setOpenSection: (sectionId: string) => void;
+  setOpenSection: (sectionId: string | undefined) => void;
   moveColumn: (columnId: string, direction: MoveDirection) => void;
   setPreviewFieldValue: (fieldId: string, items: EntityDetailPreviewItem[]) => void;
 };
@@ -261,9 +261,9 @@ export function EntityDetailPersonalizationProvider({
   );
 
   const setOpenSection = useCallback(
-    (sectionId: string) => {
+    (sectionId: string | undefined) => {
       const sectionIds = sectionStamp === undefined ? undefined : sectionStamp.split("|");
-      if (!sectionIds?.includes(sectionId)) return;
+      if (sectionId !== undefined && !sectionIds?.includes(sectionId)) return;
       setCollapsedSectionIds((current) => {
         const next = collapsedSectionIdsForOpenSection(sectionIds, sectionId);
         return next.length === current.length && next.every((id, index) => id === current[index]) ? current : next;

--- a/components/entity-detail/entity-detail-personalization.utils.ts
+++ b/components/entity-detail/entity-detail-personalization.utils.ts
@@ -22,6 +22,7 @@ export function resolveSingleOpenSectionId(
   const collapsed = new Set(reconcileAvailableIds(collapsedSectionIds, availableSectionIds));
   const openSectionIds = availableSectionIds.filter((id) => !collapsed.has(id));
   if (openSectionIds.length === 1) return openSectionIds[0];
+  if (openSectionIds.length === 0) return undefined;
 
   const defaultCollapsed = new Set(reconcileAvailableIds(defaultCollapsedSectionIds, availableSectionIds));
   const defaultOpenSectionIds = availableSectionIds.filter((id) => !defaultCollapsed.has(id));
@@ -33,7 +34,8 @@ export function collapsedSectionIdsForOpenSection(
   openSectionId: string | undefined,
 ): string[] {
   const availableSectionIds = uniqueIds(sectionIds ?? []);
-  if (!openSectionId || !availableSectionIds.includes(openSectionId)) return [];
+  if (openSectionId === undefined) return availableSectionIds;
+  if (!availableSectionIds.includes(openSectionId)) return [];
   return availableSectionIds.filter((id) => id !== openSectionId);
 }
 

--- a/components/entity-detail/entity-detail-section.tsx
+++ b/components/entity-detail/entity-detail-section.tsx
@@ -21,13 +21,12 @@ export function EntityDetailSectionGroup({ children, className }: GroupProps) {
 
   return (
     <Accordion
+      collapsible
       data-detail-section-group
       className={cn("-mx-4 -mt-4 flex w-auto flex-col", className)}
       type="single"
-      value={openSectionId}
-      onValueChange={(sectionId) => {
-        if (sectionId) setOpenSection(sectionId);
-      }}
+      value={openSectionId ?? ""}
+      onValueChange={(sectionId) => setOpenSection(sectionId || undefined)}
     >
       {children}
     </Accordion>
@@ -42,10 +41,12 @@ export function EntityDetailSection({ sectionId, label, children, className }: P
       value={sectionId}
     >
       <AccordionTrigger
-        className="group w-full cursor-pointer items-center gap-4 rounded-none p-4 text-left text-sm font-medium outline-none transition-colors hover:no-underline hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50 aria-disabled:cursor-default [&_svg]:motion-reduce:transition-none"
+        className="group w-full cursor-pointer items-center gap-4 rounded-none p-4 text-left text-sm font-medium outline-none transition-colors hover:bg-accent hover:no-underline focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50 [&_svg]:motion-reduce:transition-none"
         data-detail-section-trigger={sectionId}
       >
-        <span className="text-sm font-medium text-foreground/85">{label}</span>
+        <span className="text-sm font-medium text-foreground/85 transition-colors group-hover:text-foreground motion-reduce:transition-none">
+          {label}
+        </span>
       </AccordionTrigger>
 
       <AccordionContent className="flex flex-col gap-4 px-4 pb-4" data-detail-section-content={sectionId}>

--- a/content/homepage/de/homepage.mdx
+++ b/content/homepage/de/homepage.mdx
@@ -18,9 +18,8 @@ hero:
     - für Hermes Agent.
     - für OpenClaw.
     - für n8n.
-  useCaseEyebrow: Ein konkreter Ablauf
   useCase: Lassen Sie ChatGPT das nächste Follow-up für einen interessierten Lead vorbereiten. Prüfen Sie den Entwurf in Customermates und senden Sie ihn anschließend per E-Mail oder LinkedIn.
-  subtitle: "Verwalten Sie Kontakte und Deals gemeinsam mit einem Posteingang für E-Mail, LinkedIn, WhatsApp, Instagram und Telegram. Verbinden Sie ChatGPT, Claude, Gemini oder Cursor über MCP und prüfen Sie jeden Entwurf und jede CRM-Aktualisierung."
+  subtitle: "Ein Posteingang für E-Mail, LinkedIn, WhatsApp, Instagram und Telegram. Verbinden Sie ChatGPT, Claude, Gemini oder Cursor über MCP und prüfen Sie jeden Entwurf und jede CRM-Aktualisierung."
   buttonLeftText: "[[commercial.trial.days]]-Tage-Testphase für 0€ starten"
   buttonLeftHref: /auth/signup
   buttonRightText: Live-Demo erkunden

--- a/content/homepage/en/homepage.mdx
+++ b/content/homepage/en/homepage.mdx
@@ -18,9 +18,8 @@ hero:
     - for Hermes Agent.
     - for OpenClaw.
     - for n8n.
-  useCaseEyebrow: A real workflow
   useCase: Ask ChatGPT to prepare the next follow-up for a warm lead. Review the draft in Customermates, then send it through email or LinkedIn.
-  subtitle: "Manage contacts and deals alongside one inbox for email, LinkedIn, WhatsApp, Instagram, and Telegram. Connect ChatGPT, Claude, Gemini, or Cursor through MCP—and review every draft and CRM update."
+  subtitle: "One inbox for email, LinkedIn, WhatsApp, Instagram and Telegram. Connect ChatGPT, Claude, Gemini or Cursor through MCP, and review every draft and CRM update."
   buttonLeftText: Start a [[commercial.trial.days]]-day trial for 0€
   buttonLeftHref: /auth/signup
   buttonRightText: Explore the live demo

--- a/core/fumadocs/schemas/homepage.ts
+++ b/core/fumadocs/schemas/homepage.ts
@@ -43,7 +43,6 @@ export const heroSchema = z.object({
   titleAccent: z.string().optional(),
   titleAccentRotations: z.array(z.string()).optional(),
   useCase: z.string(),
-  useCaseEyebrow: z.string(),
 });
 export type Hero = z.infer<typeof heroSchema>;
 

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -123,8 +123,10 @@ describe("homepage visual-system adoption", () => {
     expect(hero).not.toMatch(/HomepageAgentRecordVisual|GoogleCalendar|OutlookCalendar|Messenger|XTwitter/u);
     expect(englishHomepage).toContain("title: The open-source CRM");
     expect(englishHomepage).toContain("titleAccent: for AI agents.");
-    expect(hero).toContain("heroSection.useCaseEyebrow");
+    expect(hero).not.toContain("useCaseEyebrow");
     expect(hero).toContain("heroSection.useCase");
+    expect(hero).toContain("order-last");
+    expect(hero).toContain("sm:order-none");
   });
 
   it("rotates a width-reserved, accessible hero reel only while motion is appropriate", () => {
@@ -191,8 +193,12 @@ describe("homepage visual-system adoption", () => {
     ]) {
       expect(germanHomepage).toContain(`    - ${label}`);
     }
-    expect(englishHomepage).toContain("useCaseEyebrow: A real workflow");
-    expect(germanHomepage).toContain("useCaseEyebrow: Ein konkreter Ablauf");
+    expect(englishHomepage).not.toContain("useCaseEyebrow");
+    expect(germanHomepage).not.toContain("useCaseEyebrow");
+    expect(englishHomepage).toContain("  useCase: Ask ChatGPT");
+    expect(germanHomepage).toContain("  useCase: Lassen Sie ChatGPT");
+    expect(englishHomepage).not.toContain("\u2014");
+    expect(germanHomepage).not.toContain("\u2014");
   });
 
   it("keeps the live workspace on-page and gives the walkthrough the contrasting story band", () => {


### PR DESCRIPTION
## Summary

Three pieces of entity-detail chrome and the marketing hero, each broken in a way that read as intentional.

- **Detail sections could not all be closed.** The accordion was `type="single"` with no `collapsible`, so Radix marked the open trigger `aria-disabled`; the group dropped the empty value Radix sends on collapse; and underneath, the persistence model enforced exactly-one-open, repairing a zero-open state to the first section and writing an *empty* collapsed set when nothing was open, which meant everything open. All four layers now allow zero-or-one.
- **The section header had no visible hover.** `hover:text-foreground` sat on the button while the label span set its own `text-foreground/85`, which wins over an inherited colour, so hovering changed nothing at all. The row now lifts to `hover:bg-accent` and the label reaches full strength through `group-hover`.
- **The active tab indicator floated below the divider** instead of sitting on it. The layout already passed `after:-bottom-px` intending exactly that, but `cn` merges through tailwind-merge, which treats a bare utility and a `group-data` variant as unrelated, so both survived and the base offset won on specificity. Matching the variant lets the merge resolve it.
- **The hero pushed its primary action off the first screen.** Copy is shorter, rhythm is tighter, and below `sm` the card moves under the actions.

## Context

The hero's card carried three text blocks. The eyebrow labelled the sentence directly beneath it, and the muted paragraph opened by listing the provider icons rendered immediately below it and the word CRM already in the headline. What survives is the bold workflow sentence and the one claim nothing else on the page makes: that a person reviews every draft. Removing the eyebrow also removed `useCaseEyebrow` from the fumadocs schema and both locale files, so no orphaned content is left behind.

Contrast was measured before any of this and was not the problem: eyebrow 7.1, body 17.5, subtitle 7.1, trust line 7.6, all WCAG AAA. No colours were changed.

The English hero copy also carried an em dash, against house style. A test now fails if one returns to either locale.

## Validation

`yarn typecheck`, `yarn lint` and the full suite pass (679 files, 6144 tests, database tests enabled), each exit code read directly rather than through a pipe.

Hero call-to-action against the viewport, measured in a browser at each size:

| viewport | before | after |
| --- | --- | --- |
| 375x667 iPhone SE | **164px below the fold** | 340px clear |
| 390x844 iPhone 15 | 54px clear | 514px clear |
| 768x1024 iPad | 285px clear | 375px clear |
| 1280x800 laptop | **35px below the fold** | 71px clear |
| 1440x900 | 43px clear | 149px clear |

The two that passed before did so by 43 to 54px, which a bookmarks bar or a phone URL bar erases.

Tab indicator against the divider, measured in the browser: the indicator ran 204.7 to 206.7 while the divider sat at 201.7 to 202.7; it now runs 200.7 to 202.7 and shares the divider's bottom edge.

Section hover, both headers read in one measurement so there is no ambiguity about pointer position: the unhovered header is `rgba(0,0,0,0)` with an 85% label, the hovered one is `rgba(255,255,255,0.027)` with a full-strength label.

Collapse behaviour verified in the browser, not only in tests: closing the open section leaves all three `aria-expanded="false"` with no `aria-disabled`, the preference persists as all three ids, it survives a reload, and a plain page load leaves the stored row and its `updatedAt` untouched, so nothing writes without a click. A reader on the legacy ambiguous preference still lands on Base data open.

Eight mutants, each caught by a named test: removing the zero-open branch, writing an empty collapsed set, dropping `collapsible`, dropping `hover:bg-accent`, dropping `group-hover:text-foreground`, reverting the tab variant, restoring the eyebrow copy, and reintroducing the em dash.

One deliberate non-change: a 4px tightening of the `h1` margin was reverted, because a convention test pins that exact class as a design contract and the fold already had headroom without it.

## Impact and rollback

Presentation only. No schema migration, no data change, no API surface. The one persisted behaviour change is that `collapsedSectionIds` can now hold every section id; older clients reading such a value would repair it to the first section rather than break. If a detail section is ever removed from a config, a reader who had exactly that section open now lands on all-collapsed instead of the default, which seems the better outcome but is a behaviour change worth naming.

Revert the commit. Nothing to undo in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
