### PR TITLE
perf: speed up list navigation and homepage demo loading

### DIFF
--- a/app/[locale]/(static)/components/hero-demo-iframe.tsx
+++ b/app/[locale]/(static)/components/hero-demo-iframe.tsx
@@ -18,7 +18,7 @@ export function HeroDemoIframe({ className, size = "full", src }: Props) {
 
   return (
     <div className={cn("mx-auto w-full", className)}>
-      <BrowserFrame size={size} src={demoSrc} title={t("BrowserFrame.liveDemoTitle")} />
+      <BrowserFrame loadAhead size={size} src={demoSrc} title={t("BrowserFrame.liveDemoTitle")} />
     </div>
   );
 }

--- a/components/chip/app-chip-stack.tsx
+++ b/components/chip/app-chip-stack.tsx
@@ -11,6 +11,29 @@ import { useNavigateToHref } from "@/components/entity-detail/hooks/use-entity-d
 
 import { AppChip } from "./app-chip";
 
+const moreWidthCache = new Map<string, number>();
+
+function digitsNeeded(itemCount: number): number[] {
+  const max = String(Math.max(1, itemCount)).length;
+
+  return Array.from({ length: max }, (_, index) => index + 1);
+}
+
+function moreWidthKey(size: string | null | undefined, variant: string | null | undefined, digits: number): string {
+  return `${size}|${variant}|${digits}`;
+}
+
+function itemsStamp<T extends ChipStackItem>(
+  items: T[],
+  size: string | null | undefined,
+  variant: string | null | undefined,
+): string {
+  let stamp = `${size}|${variant}`;
+  for (const item of items) stamp += `|${item.id}\u0000${item.label}`;
+
+  return stamp;
+}
+
 type ChipStackItem = {
   id: string;
   label: string;
@@ -43,7 +66,7 @@ export function AppChipStack<T extends ChipStackItem>({
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const measurerRef = useRef<HTMLDivElement | null>(null);
-  const moreMeasurerRef = useRef<HTMLSpanElement | null>(null);
+  const moreMeasureRefs = useRef<Map<number, HTMLSpanElement>>(new Map());
   const chipMeasureRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const [visibleCount, setVisibleCount] = useState<number>(items.length);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -51,13 +74,13 @@ export function AppChipStack<T extends ChipStackItem>({
   const singleVisibleMaxWidthRef = useRef<number | null>(null);
   const widthsRef = useRef<number[]>([]);
   const stampRef = useRef<string>("");
-  const moreWidthByDigitsRef = useRef<Record<number, number>>({});
   const lastDimsRef = useRef<{ width: number; itemCount: number }>({
     width: 0,
     itemCount: 0,
   });
   const rafIdRef = useRef<number | null>(null);
 
+  const needsOverflowHandling = items.length > 1;
   const ensuredVisibleCount = Math.max(1, visibleCount);
   const ensuredHiddenItems = items.slice(ensuredVisibleCount);
   const isSingleVisibleWithOverflow = ensuredVisibleCount === 1 && ensuredHiddenItems.length > 0;
@@ -74,15 +97,11 @@ export function AppChipStack<T extends ChipStackItem>({
 
   const measureMoreChipWidth = useCallback(
     (hiddenCount: number): number => {
-      const el = moreMeasurerRef.current;
+      const digits = Math.max(1, String(hiddenCount).length);
 
-      if (!el) return 0;
-      el.textContent = moreLabel(hiddenCount);
-      const rect = el.getBoundingClientRect();
-
-      return Math.ceil(rect.width);
+      return moreWidthCache.get(moreWidthKey(size, variant, digits)) ?? 0;
     },
-    [moreLabel],
+    [size, variant],
   );
 
   const recalc = useCallback(() => {
@@ -98,20 +117,7 @@ export function AppChipStack<T extends ChipStackItem>({
     while (low <= high) {
       const mid = Math.floor((low + high) / 2);
       const hiddenCount = items.length - mid;
-      const digits = hiddenCount > 0 ? String(hiddenCount).length : 0;
-      let moreWidth = 0;
-
-      if (hiddenCount > 0) {
-        if (moreWidthByDigitsRef.current[digits] == null) {
-          const widestLabel = moreLabel(Number("9".repeat(digits)) || 0);
-
-          if (moreMeasurerRef.current) {
-            moreMeasurerRef.current.textContent = widestLabel;
-            moreWidthByDigitsRef.current[digits] = Math.ceil(moreMeasurerRef.current.getBoundingClientRect().width);
-          } else moreWidthByDigitsRef.current[digits] = measureMoreChipWidth(hiddenCount);
-        }
-        moreWidth = moreWidthByDigitsRef.current[digits] || 0;
-      }
+      const moreWidth = hiddenCount > 0 ? measureMoreChipWidth(hiddenCount) : 0;
 
       let chipsWidth = 0;
 
@@ -145,29 +151,36 @@ export function AppChipStack<T extends ChipStackItem>({
       singleVisibleMaxWidthRef.current = null;
       setSingleVisibleMaxWidth(null);
     }
-  }, [items, measureMoreChipWidth, moreLabel, visibleCount]);
+  }, [items, measureMoreChipWidth, visibleCount]);
 
   useLayoutEffect(() => {
-    const stamp = JSON.stringify(items.map((i) => [i.id, i.label])) + `|${size}|${variant}`;
+    if (!needsOverflowHandling) return;
+
+    for (const digits of digitsNeeded(items.length)) {
+      const key = moreWidthKey(size, variant, digits);
+
+      if (moreWidthCache.has(key)) continue;
+      const el = moreMeasureRefs.current.get(digits);
+
+      if (el) moreWidthCache.set(key, Math.ceil(el.offsetWidth));
+    }
+
+    const stamp = itemsStamp(items, size, variant);
 
     if (stampRef.current !== stamp) {
       stampRef.current = stamp;
       widthsRef.current = items.map((it) => {
         const el = chipMeasureRefs.current.get(it.id);
 
-        if (!el) return 0;
-        const ow = (el as HTMLElement).offsetWidth;
-
-        return Math.ceil(ow || el.getBoundingClientRect().width) || 0;
+        return el ? Math.ceil(el.offsetWidth) : 0;
       });
-      moreWidthByDigitsRef.current = {};
     }
 
     recalc();
-  }, [items, size, variant, recalc]);
+  }, [items, size, variant, recalc, needsOverflowHandling]);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current || !needsOverflowHandling) return;
     const ro = new ResizeObserver(() => {
       if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
       rafIdRef.current = requestAnimationFrame(() => {
@@ -187,7 +200,7 @@ export function AppChipStack<T extends ChipStackItem>({
       if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
       ro.disconnect();
     };
-  }, [items.length, recalc]);
+  }, [items.length, recalc, needsOverflowHandling]);
 
   if (!items?.length) return null;
 
@@ -197,36 +210,46 @@ export function AppChipStack<T extends ChipStackItem>({
       className="relative flex min-w-0 overflow-hidden flex-nowrap whitespace-nowrap"
       style={{ gap: GAP_PX, maxWidth }}
     >
-      <div aria-hidden className="absolute left-0 top-0 -z-50 opacity-0 pointer-events-none">
-        <div
-          ref={measurerRef}
-          className="flex flex-nowrap"
-          style={{ gap: GAP_PX }}
-          tabIndex={-1}
-          onFocus={(e) => e.target.blur()}
-        >
-          {items.map((item) => (
-            <div key={item.id} ref={setChipMeasureRef(item.id)} className="flex-none">
-              <AppChip
-                className="max-w-full cursor-pointer"
-                size={size}
-                startContent={item.startContent}
-                variant={variant}
-              >
-                <span className="truncate whitespace-nowrap">{item.label}</span>
-              </AppChip>
-            </div>
-          ))}
+      {needsOverflowHandling && (
+        <div aria-hidden className="absolute left-0 top-0 -z-50 opacity-0 pointer-events-none">
+          <div
+            ref={measurerRef}
+            className="flex flex-nowrap"
+            style={{ gap: GAP_PX }}
+            tabIndex={-1}
+            onFocus={(e) => e.target.blur()}
+          >
+            {items.map((item) => (
+              <div key={item.id} ref={setChipMeasureRef(item.id)} className="flex-none">
+                <AppChip
+                  className="max-w-full cursor-pointer"
+                  size={size}
+                  startContent={item.startContent}
+                  variant={variant}
+                >
+                  <span className="truncate whitespace-nowrap">{item.label}</span>
+                </AppChip>
+              </div>
+            ))}
 
-          <div className="flex-none">
-            <AppChip className="max-w-full" size={size} variant={variant}>
-              <span ref={moreMeasurerRef} className="truncate whitespace-nowrap">
-                +0
-              </span>
-            </AppChip>
+            {digitsNeeded(items.length).map((digits) => (
+              <div key={digits} className="flex-none">
+                <AppChip className="max-w-full" size={size} variant={variant}>
+                  <span
+                    ref={(el) => {
+                      if (el) moreMeasureRefs.current.set(digits, el);
+                      else moreMeasureRefs.current.delete(digits);
+                    }}
+                    className="truncate whitespace-nowrap"
+                  >
+                    {`+${"9".repeat(digits)}`}
+                  </span>
+                </AppChip>
+              </div>
+            ))}
           </div>
         </div>
-      </div>
+      )}
 
       <TooltipProvider>
         {items.slice(0, ensuredVisibleCount).map((item) => {

--- a/components/marketing/__tests__/browser-frame.test.tsx
+++ b/components/marketing/__tests__/browser-frame.test.tsx
@@ -1,0 +1,111 @@
+import type { Root } from "react-dom/client";
+import type { ReactNode } from "react";
+import type * as ReactDOM from "react-dom";
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resourceHints = vi.hoisted(() => ({
+  preconnect: vi.fn(),
+  prefetchDNS: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: () => (key: string) => key,
+}));
+vi.mock("react-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactDOM>()),
+  preconnect: resourceHints.preconnect,
+  prefetchDNS: resourceHints.prefetchDNS,
+}));
+
+import { HeroDemoIframe } from "@/app/[locale]/(static)/components/hero-demo-iframe";
+import { ProductDemo } from "../product-demo";
+
+const observer = {
+  callback: undefined as IntersectionObserverCallback | undefined,
+  disconnect: vi.fn(),
+  observe: vi.fn(),
+  options: undefined as IntersectionObserverInit | undefined,
+};
+const roots = new Set<Root>();
+
+function mount(node: ReactNode): HTMLElement {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.add(root);
+
+  act(() => root.render(node));
+
+  return host;
+}
+
+function setIntersection(isIntersecting: boolean): void {
+  act(() => {
+    observer.callback?.([{ isIntersecting } as IntersectionObserverEntry], {} as IntersectionObserver);
+  });
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  observer.callback = undefined;
+  observer.disconnect.mockReset();
+  observer.observe.mockReset();
+  observer.options = undefined;
+  resourceHints.preconnect.mockReset();
+  resourceHints.prefetchDNS.mockReset();
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+        observer.callback = callback;
+        observer.options = options;
+      }
+
+      disconnect = observer.disconnect;
+      observe = observer.observe;
+    },
+  );
+});
+
+afterEach(() => {
+  for (const root of roots) act(() => root.unmount());
+  roots.clear();
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+describe("BrowserFrame", () => {
+  it("keeps shared frames lazy until they intersect", () => {
+    const host = mount(<ProductDemo path="/dashboard" />);
+
+    expect(observer.options).toBeUndefined();
+    expect(host.querySelector("iframe")).toBeNull();
+    expect(resourceHints.preconnect).not.toHaveBeenCalled();
+    expect(resourceHints.prefetchDNS).not.toHaveBeenCalled();
+
+    setIntersection(false);
+    expect(host.querySelector("iframe")).toBeNull();
+
+    setIntersection(true);
+    const frame = host.querySelector("iframe");
+    expect(frame?.getAttribute("loading")).toBe("lazy");
+    expect(frame?.getAttribute("src")).toBe("https://demo.customermates.com/en/dashboard?agentChat=closed");
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("warms the origin and eagerly mounts a load-ahead frame at the observer boundary", () => {
+    const host = mount(<HeroDemoIframe src="https://demo.customermates.com/en/dashboard?agentChat=open" />);
+
+    expect(observer.options).toStrictEqual({ rootMargin: "400px 0px" });
+    expect(resourceHints.prefetchDNS).toHaveBeenCalledWith("https://demo.customermates.com");
+    expect(resourceHints.preconnect).toHaveBeenCalledWith("https://demo.customermates.com");
+    expect(host.querySelector("iframe")).toBeNull();
+
+    setIntersection(true);
+    expect(host.querySelector("iframe")?.getAttribute("loading")).toBe("eager");
+  });
+});

--- a/components/marketing/browser-frame.tsx
+++ b/components/marketing/browser-frame.tsx
@@ -4,13 +4,17 @@ import { useEffect, useRef, useState } from "react";
 
 import { ArrowUpRight } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { preconnect, prefetchDNS } from "react-dom";
 
 type Props = {
   fallbackMessage?: string;
+  loadAhead?: boolean;
   src: string;
   title: string;
   size?: "article" | "full";
 };
+
+const LOAD_AHEAD_MARGIN = "400px 0px";
 
 const FRAME_HEIGHT_CLASS = {
   article: "h-[420px] sm:h-[520px] lg:h-[600px]",
@@ -25,13 +29,27 @@ function getHostname(src: string): string {
   }
 }
 
-export function BrowserFrame({ fallbackMessage, size = "full", src, title }: Props) {
+function getOrigin(src: string): string | null {
+  try {
+    return new URL(src).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function BrowserFrame({ fallbackMessage, loadAhead = false, size = "full", src, title }: Props) {
   const t = useTranslations();
   const [loaded, setLoaded] = useState(false);
   const [shouldMount, setShouldMount] = useState(false);
   const [timedOut, setTimedOut] = useState(false);
   const frameRef = useRef<HTMLDivElement | null>(null);
   const hostname = getHostname(src);
+  const origin = getOrigin(src);
+
+  if (loadAhead && origin) {
+    prefetchDNS(origin);
+    preconnect(origin);
+  }
 
   useEffect(() => {
     const el = frameRef.current;
@@ -39,15 +57,18 @@ export function BrowserFrame({ fallbackMessage, size = "full", src, title }: Pro
       setShouldMount(true);
       return;
     }
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some((e) => e.isIntersecting)) {
-        setShouldMount(true);
-        observer.disconnect();
-      }
-    });
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setShouldMount(true);
+          observer.disconnect();
+        }
+      },
+      loadAhead ? { rootMargin: LOAD_AHEAD_MARGIN } : undefined,
+    );
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
+  }, [loadAhead]);
 
   useEffect(() => {
     if (!fallbackMessage || !shouldMount || loaded) return;
@@ -129,7 +150,7 @@ export function BrowserFrame({ fallbackMessage, size = "full", src, title }: Pro
           {shouldMount ? (
             <iframe
               className={`block size-full border-0 bg-background transition-opacity duration-300 ${loaded ? "opacity-100" : "opacity-0"}`}
-              loading="lazy"
+              loading={loadAhead ? "eager" : "lazy"}
               referrerPolicy="strict-origin-when-cross-origin"
               sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
               src={src}

--- a/core/base/__tests__/base-get-groupable-without-entity-type.test.ts
+++ b/core/base/__tests__/base-get-groupable-without-entity-type.test.ts
@@ -97,7 +97,7 @@ describe("a repository without an entity type but with groupable specs", () => {
     expect(result.data.grouping).toBeUndefined();
   });
 
-  it("resolves a grouped request against those specs and scopes every group fetch", async () => {
+  it("resolves a grouped request against those specs and fetches rows only for non-empty groups", async () => {
     const repo = new OperatorLikeRepo();
     const result = await new OperatorLikeInteractor(repo).invoke({ grouping: { field: "status" } });
 
@@ -109,11 +109,7 @@ describe("a repository without an entity type but with groupable specs", () => {
       ["pendingAuthorization", 0, []],
     ]);
     expect(result.data.groupCounts).toEqual({ active: 2, inactive: 1, pendingAuthorization: 0 });
-    expect(repo.getItems.mock.calls.map(([params]) => params.groupScope?.key)).toEqual([
-      "active",
-      "inactive",
-      "pendingAuthorization",
-    ]);
+    expect(repo.getItems.mock.calls.map(([params]) => params.groupScope?.key)).toEqual(["active", "inactive"]);
   });
 
   it("still keeps value sums behind the entity type", async () => {

--- a/core/base/base-get.interactor.ts
+++ b/core/base/base-get.interactor.ts
@@ -77,6 +77,12 @@ export abstract class BaseGetRepo<T> {
   abstract getSearchableFields(): SearchableField[];
   abstract getFilterableFields(): Promise<FilterableField[]>;
   abstract getCustomColumns(): Promise<CustomColumnDto[]>;
+  customColumnsOnce(): Promise<CustomColumnDto[]> {
+    return this.getCustomColumns();
+  }
+  filterableFieldsOnce(): Promise<FilterableField[]> {
+    return this.getFilterableFields();
+  }
   getGroupableFields(_customColumns?: readonly CustomColumnDto[]): Promise<GroupableFieldSpec[]> {
     return Promise.resolve([]);
   }
@@ -160,8 +166,8 @@ export abstract class BaseGetInteractor<T> {
     const pagination: PaginationRequest = { page, pageSize };
 
     const [filterableFields, customColumns] = await Promise.all([
-      this.repo.getFilterableFields(),
-      this.repo.getCustomColumns(),
+      this.repo.filterableFieldsOnce(),
+      this.repo.customColumnsOnce(),
     ]);
     const sortableFields = this.repo.getSortableFields();
 
@@ -297,7 +303,9 @@ export abstract class BaseGetInteractor<T> {
     });
 
     const collapsed = new Set(page.collapsed ?? []);
-    const materialised = axis.groups.filter((group) => !collapsed.has(group.key)).slice(0, MAX_MATERIALISED_GROUPS);
+    const materialised = axis.groups
+      .filter((group) => !collapsed.has(group.key) && group.count > 0)
+      .slice(0, MAX_MATERIALISED_GROUPS);
     const wantsSums = page.includeValueSums !== false && this.groupValueSumFields.length > 0 && spec.kind !== "enum";
 
     const pages = await Promise.all(

--- a/core/base/base-query-builder.ts
+++ b/core/base/base-query-builder.ts
@@ -111,6 +111,19 @@ export abstract class BaseQueryBuilder<TWhereInput extends Record<string, unknow
     return Promise.resolve([]);
   }
 
+  private memoCustomColumns?: Promise<Array<CustomColumnDto>>;
+  private memoFilterableFields?: Promise<Array<FilterableField>>;
+
+  customColumnsOnce(): Promise<Array<CustomColumnDto>> {
+    this.memoCustomColumns ??= this.getCustomColumns();
+    return this.memoCustomColumns;
+  }
+
+  filterableFieldsOnce(): Promise<Array<FilterableField>> {
+    this.memoFilterableFields ??= this.getFilterableFields();
+    return this.memoFilterableFields;
+  }
+
   getGroupableFields(_customColumns?: readonly CustomColumnDto[]): Promise<Array<GroupableFieldSpec>> {
     return Promise.resolve([]);
   }
@@ -121,7 +134,7 @@ export abstract class BaseQueryBuilder<TWhereInput extends Record<string, unknow
 
   async buildQueryArgs(params: GetQueryParams, baseWhere: TWhereInput = {} as TWhereInput) {
     const where = await this.buildWhereClause(params, baseWhere);
-    const customColumns = await this.getCustomColumns();
+    const customColumns = await this.customColumnsOnce();
     const customSort = resolveCustomSort(params.sortDescriptor, customColumns);
     const orderBy = customSort ? [] : this.buildOrderBy({ sortDescriptor: params.sortDescriptor });
     const pagination =
@@ -173,10 +186,10 @@ export abstract class BaseQueryBuilder<TWhereInput extends Record<string, unknow
     baseWhere: TWhereInput = {} as TWhereInput,
   ): Promise<TWhereInput> {
     const where = { ...baseWhere } as WithDynamicFields<TWhereInput> & WithLogicalOperators<TWhereInput>;
-    const filterableFields = await this.getFilterableFields();
+    const filterableFields = await this.filterableFieldsOnce();
     const validFilters = this.validateFilters({ filters: params.filters, filterableFields });
 
-    const customColumns = validFilters.some((f) => isCustomField(f.field)) ? await this.getCustomColumns() : [];
+    const customColumns = validFilters.some((f) => isCustomField(f.field)) ? await this.customColumnsOnce() : [];
     const customColumnTypeById = new Map(customColumns.map((c) => [c.id, c.type]));
 
     for (const filter of validFilters) this.applyFieldFilter(where, filter, filterableFields, customColumnTypeById);

--- a/core/decorators/resolve-tenant-user.ts
+++ b/core/decorators/resolve-tenant-user.ts
@@ -1,0 +1,18 @@
+import type { TenantUser } from "@/features/user/user.schema";
+
+import { cache } from "react";
+
+const resolveOnce = cache((): { promise?: Promise<TenantUser> } => ({}));
+
+export async function resolveActiveTenantUser(load: () => Promise<TenantUser>): Promise<TenantUser> {
+  let slot: { promise?: Promise<TenantUser> };
+  try {
+    slot = resolveOnce();
+  } catch {
+    return load();
+  }
+
+  slot.promise ??= load();
+
+  return slot.promise;
+}

--- a/core/decorators/tenant-interactor.decorator.ts
+++ b/core/decorators/tenant-interactor.decorator.ts
@@ -3,6 +3,7 @@ import type { Resource, Action } from "@/generated/prisma";
 import { isAllowedInDemoMode } from "./allow-in-demo-mode.decorator";
 
 import { runWithTenant, tenantStorage } from "@/core/decorators/tenant-context";
+import { resolveActiveTenantUser } from "@/core/decorators/resolve-tenant-user";
 import { env } from "@/env";
 import { DemoModeError, ForbiddenError } from "@/core/errors/app-errors";
 
@@ -42,7 +43,7 @@ export function TenantInteractor<T extends { new (...args: any[]): object }>(
       if (!user) {
         const { getUserService } = await import("@/core/di");
 
-        user = await getUserService().getActiveUserOrThrow();
+        user = await resolveActiveTenantUser(() => getUserService().getActiveUserOrThrow());
       }
 
       if (normalizedRequirement) {

--- a/tests/conventions/homepage-visual-system.test.ts
+++ b/tests/conventions/homepage-visual-system.test.ts
@@ -215,7 +215,7 @@ describe("homepage visual-system adoption", () => {
     expect(liveDemo).toContain('className="marketing-grid mx-auto max-w-[84rem] items-end gap-y-6"');
     expect(liveDemo).toContain('<HeroDemoIframe size="full" src={demoSrc} />');
     expect(demoIframe).toContain('size = "full"');
-    expect(demoIframe).toContain("<BrowserFrame size={size}");
+    expect(demoIframe).toContain("<BrowserFrame loadAhead size={size}");
   });
 
   it("authors page-specific visuals from the approved native fixture layer", () => {

--- a/tests/conventions/product-demo-contract.test.ts
+++ b/tests/conventions/product-demo-contract.test.ts
@@ -179,7 +179,7 @@ describe("seeded public product demo", () => {
     expect(componentRegistry).toMatch(/\n\s*ProductDemo,\n/u);
   });
 
-  it("keeps disclosure, accessibility and lazy sandboxing in the shared component", () => {
+  it("keeps disclosure, accessibility, bounded preloading and sandboxing in the shared component", () => {
     const demo = read("components/marketing/product-demo.tsx");
     const frame = read("components/marketing/browser-frame.tsx");
     const proxy = read("proxy.ts");
@@ -215,7 +215,15 @@ describe("seeded public product demo", () => {
     expect(frame).toContain('size?: "article" | "full"');
     expect(frame).toContain('article: "h-[420px] sm:h-[520px] lg:h-[600px]"');
     expect(frame).toContain("IntersectionObserver");
-    expect(frame).toContain('loading="lazy"');
+    expect(frame).toContain('loadAhead?: boolean');
+    expect(frame).toContain('const LOAD_AHEAD_MARGIN = "400px 0px"');
+    expect(frame).toContain("loadAhead ? { rootMargin: LOAD_AHEAD_MARGIN } : undefined");
+    expect(frame).toContain("prefetchDNS(origin)");
+    expect(frame).toContain("preconnect(origin)");
+    expect(frame).toContain('loading={loadAhead ? "eager" : "lazy"}');
+    expect(read("app/[locale]/(static)/components/hero-demo-iframe.tsx")).toContain(
+      "<BrowserFrame loadAhead",
+    );
     expect(frame).toContain(
       'sandbox="allow-scripts allow-same-origin allow-popups allow-forms"',
     );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,6 +49,7 @@ const domTestFiles = [
   "components/entity-detail/__tests__/entity-detail-visibility.test.tsx",
   "components/entity-detail/__tests__/entity-drawer-personalization.test.ts",
   "components/entity-detail/__tests__/use-entity-detail-server-snapshot.test.ts",
+  "components/marketing/__tests__/browser-frame.test.tsx",
   "components/forms/__tests__/form-context.test.ts",
   "components/forms/__tests__/selection-command.test.ts",
   "components/editor/__tests__/email-markdown-editor.test.ts",


### PR DESCRIPTION
## Summary

Removes three independently measured causes of slow page readiness. Tracking issue: [CUS-326](https://linear.app/customermates/issue/CUS-326/remove-the-measured-list-navigation-and-homepage-demo-load-stalls).

**Server list rendering.** Request-scoped memoization now resolves the tenant user, custom columns, and filterable fields once per render instead of repeating the same reads across interactors and groups. Groups already known to contain zero rows remain visible with their count but no longer trigger a row fetch.

**Client list rendering.** `AppChipStack` now measures one `+N` template per size, variant, and digit count, then reuses that width. The layout effect is read-only, and single-chip stacks skip the hidden measurer and resize observer entirely.

**Homepage demo readiness.** The homepage-only `BrowserFrame` path now emits DNS-prefetch and preconnect hints, observes with a bounded 400px margin, and mounts the iframe eagerly once that boundary is reached. Feature, blog, industry, and docs demos retain their original intersection-only `loading="lazy"` behavior.

## Context

Entity overview pages for tasks, contacts, and organizations felt stalled during navigation. Profiling found both repeated server queries and a larger client layout-thrashing problem: one contacts navigation spent **36.8 s of 45 s in `getBoundingClientRect`** while hundreds of chip stacks repeatedly invalidated and forced layout over a roughly 6,000-node table.

The homepage live demo had a separate double-lazy path. The component waited for intersection before mounting an iframe that itself used native lazy loading, so the nested app could still begin late. The new policy is deliberately opt-in at `HeroDemoIframe`; it does not change shared demo embeds elsewhere.

## Validation

Original list-page measurements used two production builds against the same seeded local PostgreSQL database (3,030 contacts, 1,515 tasks, 619 organizations) with a 10 ms database-latency proxy.

| route | SQL statements | render |
| --- | --- | --- |
| `/en/contacts` | 25 → 16 | 223 → 178 ms |
| `/en/tasks` | 51 → 25 | 412 → 282 ms |
| `/en/organizations` | 25 → 16 | 310 → 246 ms |
| `/en/deals` | — | 257 → 185 ms |
| `/en/contacts?groupBy=organizationIds` | 102 → 43 | 395 → 320 ms |
| `/en/contacts?groupBy=createdAt` | 80 → 40 | 225 → 170 ms |

Client-side navigation, headless Chrome at 4x CPU throttle, median of three runs:

| navigation | time to rows | blocking time |
| --- | --- | --- |
| dashboard → contacts | 36,830 → 1,626 ms | 36,302 → 910 ms |
| organizations → contacts | 35,674 → 1,470 ms | 35,250 → 901 ms |
| contacts → organizations | 3,882 → 763 ms | 3,481 → 398 ms |
| contacts → tasks | 1,192 → 439 ms | 836 → 23 ms |

Contacts document size fell from 1,545,772 to 1,193,087 bytes and DOM nodes from 6,257 to 4,247. Across **723 chip stacks** on contacts, organizations, and deals at 1440, 1100, and 900px widths, visible chips and `+N` labels were identical; hidden measurement nodes fell from 7,143 to 861. The existing 10-journey interactive list suite remained clean.

Final verification on rebased head `fec98afb` and current base `c8b9de1d`:

- Browser-frame/homepage/product-demo focus: 3 files, 20 tests passed.
- Full disposable-database suite: 681 files passed, 1 skipped; 6,161 tests passed, 2 skipped.
- `yarn typecheck`, `yarn lint`, and `yarn build` passed; generated OpenAPI and raw-doc outputs remained clean.
- Fresh local desktop and mobile renders mounted the homepage iframe at `scrollY = 0` with `loading="eager"`, the local-only demo URL, and both resource hints present. The 1440×900 layout places the frame 278px below the fold, inside the 400px observer margin. No horizontal overflow or visual regression was found. The only console output was the known local placeholder Sentry DSN error.
- Two independent read-only reviews found no unresolved high- or medium-severity issue.

Residual low risks: starting the nested homepage app after hydration can contend with homepage network/CPU work, and no throttled before/after LCP comparison was recorded. The chip-width cache assumes a stable inherited font/layout context; the 723-stack equivalence check mitigates that risk.

## Impact and rollback

The list fixes preserve visible grouping, tenant scoping, and chip-overflow behavior. The homepage change is intentionally scoped to one consumer; shared `BrowserFrame` users remain lazy, and the existing sandbox, referrer policy, loaded state, timeout, and fallback behavior are unchanged.

The three commits are independent. Revert `fec98afb` to restore the homepage's prior intersection-only plus native-lazy behavior, or revert either list-performance commit independently. There is no schema, data, dependency, or environment rollback.
