### PR TITLE
feat(ui): add chat starters to empty states

### DIFF
--- a/app/[locale]/(protected)/contacts/components/contacts-page-view.tsx
+++ b/app/[locale]/(protected)/contacts/components/contacts-page-view.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "next-intl";
 import { EntityType } from "@/generated/prisma";
 
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { DataViewContent } from "@/components/data-view/data-view-content";
 import { DataViewEmpty } from "@/components/data-view/data-view-empty";
 import { DataViewLayout } from "@/components/data-view/data-view-layout";
@@ -103,6 +104,20 @@ export const ContactsPageView = observer(function ContactsPageView({ contacts }:
     case "true-empty":
       body = (
         <DataViewEmpty
+          action={
+            <AgentStarterActions
+              fallback={
+                contactsStore.canManage ? (
+                  <Button size="sm" variant="secondary" onClick={handleAdd}>
+                    {emptyActionLabel}
+                  </Button>
+                ) : undefined
+              }
+              pageId="contacts"
+              state="empty"
+              surface="page"
+            />
+          }
           actionLabel={emptyActionLabel}
           background={<ContactsPageSkeleton animated={false} view={view} />}
           reason="true-empty"

--- a/app/[locale]/(protected)/dashboard/components/dashboard-page-view.tsx
+++ b/app/[locale]/(protected)/dashboard/components/dashboard-page-view.tsx
@@ -15,6 +15,7 @@ import { useTranslations } from "next-intl";
 
 import "@/styles/react-grid-layout.css";
 
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
 import { PageState } from "@/components/page-state/page-state";
 import { resolveResourcePageState } from "@/components/page-state/resource-page-state";
@@ -158,15 +159,22 @@ export const DashboardPageView = observer(function DashboardPageView({
       body = (
         <PageState
           action={
-            canAddWidget ? (
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => widgetModalStore.add(t("Dashboard.activityWidget.title"))}
-              >
-                {t("Dashboard.addCard")}
-              </Button>
-            ) : undefined
+            <AgentStarterActions
+              fallback={
+                canAddWidget ? (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => widgetModalStore.add(t("Dashboard.activityWidget.title"))}
+                  >
+                    {t("Dashboard.addCard")}
+                  </Button>
+                ) : undefined
+              }
+              pageId="dashboard"
+              state="empty"
+              surface="page"
+            />
           }
           background={<DashboardPageSkeleton animated={false} />}
           description={t("Common.emptyState.dashboardBody")}

--- a/app/[locale]/(protected)/deals/components/deals-page-view.tsx
+++ b/app/[locale]/(protected)/deals/components/deals-page-view.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "next-intl";
 import { EntityType } from "@/generated/prisma";
 
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { DataViewContent } from "@/components/data-view/data-view-content";
 import { DataViewEmpty } from "@/components/data-view/data-view-empty";
 import { DataViewLayout } from "@/components/data-view/data-view-layout";
@@ -97,6 +98,20 @@ export const DealsPageView = observer(function DealsPageView({ deals }: Props) {
     case "true-empty":
       body = (
         <DataViewEmpty
+          action={
+            <AgentStarterActions
+              fallback={
+                dealsStore.canManage ? (
+                  <Button size="sm" variant="secondary" onClick={handleAdd}>
+                    {emptyActionLabel}
+                  </Button>
+                ) : undefined
+              }
+              pageId="deals"
+              state="empty"
+              surface="page"
+            />
+          }
           actionLabel={emptyActionLabel}
           background={<DealsPageSkeleton animated={false} view={view} />}
           reason="true-empty"

--- a/app/[locale]/(protected)/inbox/components/inbox-list.tsx
+++ b/app/[locale]/(protected)/inbox/components/inbox-list.tsx
@@ -11,6 +11,7 @@ import { Cable, RefreshCw } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { IntlLink as Link, useRouter, usePathname } from "@/i18n/navigation";
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
@@ -203,15 +204,22 @@ export const InboxList = observer(({ canConnect, threads, selectedThreadId, lock
       listBody = (
         <PageState
           action={
-            canConnect ? (
-              <Button asChild size="sm" variant="secondary">
-                <Link href="/profile/connected-accounts">
-                  <Cable className="size-3.5" />
+            <AgentStarterActions
+              fallback={
+                canConnect ? (
+                  <Button asChild size="sm" variant="secondary">
+                    <Link href="/profile/connected-accounts">
+                      <Cable className="size-3.5" />
 
-                  {t("ConnectedAccountsCard.title")}
-                </Link>
-              </Button>
-            ) : undefined
+                      {t("ConnectedAccountsCard.title")}
+                    </Link>
+                  </Button>
+                ) : undefined
+              }
+              pageId="inbox"
+              state="empty"
+              surface="page"
+            />
           }
           background={<InboxPageSkeleton animated={false} view="list" />}
           className="h-full"

--- a/app/[locale]/(protected)/organizations/components/organizations-page-view.tsx
+++ b/app/[locale]/(protected)/organizations/components/organizations-page-view.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "next-intl";
 import { EntityType } from "@/generated/prisma";
 
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { DataViewContent } from "@/components/data-view/data-view-content";
 import { DataViewEmpty } from "@/components/data-view/data-view-empty";
 import { DataViewLayout } from "@/components/data-view/data-view-layout";
@@ -115,6 +116,20 @@ export const OrganizationsPageView = observer(function OrganizationsPageView({ o
     case "true-empty":
       body = (
         <DataViewEmpty
+          action={
+            <AgentStarterActions
+              fallback={
+                organizationsStore.canManage ? (
+                  <Button size="sm" variant="secondary" onClick={handleAdd}>
+                    {emptyActionLabel}
+                  </Button>
+                ) : undefined
+              }
+              pageId="organizations"
+              state="empty"
+              surface="page"
+            />
+          }
           actionLabel={emptyActionLabel}
           background={<OrganizationsPageSkeleton animated={false} view={view} />}
           reason="true-empty"

--- a/app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx
+++ b/app/[locale]/(protected)/profile/components/connected-accounts-page-view.tsx
@@ -11,6 +11,7 @@ import { Cable, Info, Loader2 } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo } from "react";
 import { Action, Resource } from "@/generated/prisma";
 
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { Alert } from "@/components/shared/alert";
 import { AppChip } from "@/components/chip/app-chip";
 import { AvatarStack } from "@/components/shared/avatar-stack";
@@ -225,7 +226,16 @@ export const ConnectedAccountsPageView = observer(({ accounts, locked = false }:
       body = (
         <PageState
           action={
-            canConnect ? <ConnectAction id="profile-connected-accounts-connect-empty" variant="secondary" /> : undefined
+            <AgentStarterActions
+              fallback={
+                canConnect ? (
+                  <ConnectAction id="profile-connected-accounts-connect-empty" variant="secondary" />
+                ) : undefined
+              }
+              pageId="connected-accounts"
+              state="empty"
+              surface="page"
+            />
           }
           background={<ConnectedAccountsPageSkeleton animated={false} />}
           description={t("ConnectedAccountsCard.emptyState")}

--- a/app/[locale]/(protected)/services/components/services-page-view.tsx
+++ b/app/[locale]/(protected)/services/components/services-page-view.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "next-intl";
 import { EntityType } from "@/generated/prisma";
 
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { DataViewContent } from "@/components/data-view/data-view-content";
 import { DataViewEmpty } from "@/components/data-view/data-view-empty";
 import { DataViewLayout } from "@/components/data-view/data-view-layout";
@@ -97,6 +98,20 @@ export const ServicesPageView = observer(function ServicesPageView({ services }:
     case "true-empty":
       body = (
         <DataViewEmpty
+          action={
+            <AgentStarterActions
+              fallback={
+                servicesStore.canManage ? (
+                  <Button size="sm" variant="secondary" onClick={handleAdd}>
+                    {emptyActionLabel}
+                  </Button>
+                ) : undefined
+              }
+              pageId="services"
+              state="empty"
+              surface="page"
+            />
+          }
           actionLabel={emptyActionLabel}
           background={<ServicesPageSkeleton animated={false} view={view} />}
           reason="true-empty"

--- a/app/[locale]/(protected)/tasks/components/tasks-page-view.tsx
+++ b/app/[locale]/(protected)/tasks/components/tasks-page-view.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from "next-intl";
 import { EntityType } from "@/generated/prisma";
 
 import { useSetTopBarActions } from "@/app/components/topbar-actions-context";
+import { AgentStarterActions } from "@/app/components/agent-chat/suggested-questions";
 import { DataViewContent } from "@/components/data-view/data-view-content";
 import { DataViewEmpty } from "@/components/data-view/data-view-empty";
 import { DataViewLayout } from "@/components/data-view/data-view-layout";
@@ -97,6 +98,20 @@ export const TasksPageView = observer(function TasksPageView({ tasks }: Props) {
     case "true-empty":
       body = (
         <DataViewEmpty
+          action={
+            <AgentStarterActions
+              fallback={
+                tasksStore.canManage ? (
+                  <Button size="sm" variant="secondary" onClick={handleAdd}>
+                    {emptyActionLabel}
+                  </Button>
+                ) : undefined
+              }
+              pageId="tasks"
+              state="empty"
+              surface="page"
+            />
+          }
           actionLabel={emptyActionLabel}
           background={<TasksPageSkeleton animated={false} view={view} />}
           reason="true-empty"

--- a/app/components/agent-chat/__tests__/agent-chat.store.test.ts
+++ b/app/components/agent-chat/__tests__/agent-chat.store.test.ts
@@ -208,7 +208,7 @@ describe("AgentChatStore", () => {
     expect(store.isOpen).toBe(false);
   });
 
-  it("auto-opens after onboarding on a widget-empty dashboard and persists that default", async () => {
+  it("keeps Mate closed on an empty dashboard until a starter action is chosen", async () => {
     const stored = stubBrowser("/en/dashboard");
     actionsMock.getAgentConfigAction.mockResolvedValue({
       ok: true,
@@ -227,8 +227,8 @@ describe("AgentChatStore", () => {
 
     await store.loadConfig();
 
-    expect(store.isOpen).toBe(true);
-    expect([...stored.values()]).toEqual(["true"]);
+    expect(store.isOpen).toBe(false);
+    expect(stored.size).toBe(0);
   });
 
   it("does not auto-open a dashboard that already has a widget", async () => {
@@ -245,6 +245,20 @@ describe("AgentChatStore", () => {
     expect(stored.size).toBe(0);
   });
 
+  it("opens the composer with a starter prompt without submitting it", () => {
+    const stored = stubBrowser("/en/contacts");
+    const store = new AgentChatStore(root() as never);
+    store.isHistoryOpen = true;
+
+    store.openWithDraft("Help me create my first contact.");
+
+    expect(store.isOpen).toBe(true);
+    expect(store.isHistoryOpen).toBe(false);
+    expect(store.composerDraft).toBe("Help me create my first contact.");
+    expect(store.items).toEqual([]);
+    expect([...stored.values()]).toEqual(["true"]);
+  });
+
   it("keeps an explicitly closed Assistant closed on an empty page", async () => {
     stubBrowser("/en/dashboard");
     const first = new AgentChatStore(root() as never);
@@ -259,7 +273,7 @@ describe("AgentChatStore", () => {
   });
 
   it("uses an open URL override without changing the saved closed preference", async () => {
-    const storageKey = "customermates:agentChat:open:v1:company-1:user-1";
+    const storageKey = "customermates:agentChat:open:v2:company-1:user-1";
     const values = new Map([[storageKey, "false"]]);
     stubBrowser("/en/dashboard", { search: "?agentChat=open", values });
     const store = new AgentChatStore(root() as never);
@@ -276,7 +290,7 @@ describe("AgentChatStore", () => {
   });
 
   it("uses a closed URL override without changing the saved open preference or auto-opening", async () => {
-    const storageKey = "customermates:agentChat:open:v1:company-1:user-1";
+    const storageKey = "customermates:agentChat:open:v2:company-1:user-1";
     const values = new Map([[storageKey, "true"]]);
     stubBrowser("/en/dashboard", {
       hostname: "demo.customermates.test",
@@ -299,6 +313,19 @@ describe("AgentChatStore", () => {
       values,
     });
     expect(new AgentChatStore(root() as never).isOpen).toBe(true);
+  });
+
+  it("ignores a legacy open preference written by empty-page auto-open", async () => {
+    const legacyStorageKey = "customermates:agentChat:open:v1:company-1:user-1";
+    const values = new Map([[legacyStorageKey, "true"]]);
+    stubBrowser("/en/dashboard", { values });
+    const store = new AgentChatStore(root() as never);
+
+    await store.loadConfig();
+
+    expect(store.isOpen).toBe(false);
+    expect(values.get(legacyStorageKey)).toBe("true");
+    expect(values.has("customermates:agentChat:open:v2:company-1:user-1")).toBe(false);
   });
 
   it.each(["?agentChat=", "?agentChat=OPEN", "?agentChat=open&agentChat=closed"])(

--- a/app/components/agent-chat/__tests__/suggested-questions.test.ts
+++ b/app/components/agent-chat/__tests__/suggested-questions.test.ts
@@ -1,0 +1,124 @@
+import type { Root as ReactRoot } from "react-dom/client";
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  focusComposer: vi.fn(),
+  openWithDraft: vi.fn(),
+  root: {} as Record<string, unknown>,
+}));
+
+vi.mock("mobx-react-lite", () => ({
+  observer: <T>(component: T) => component,
+}));
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: () => (key: string) => key,
+}));
+vi.mock("@/i18n/navigation", () => ({ usePathname: () => "/contacts" }));
+vi.mock("@/core/stores/root-store.provider", () => ({
+  useRootStore: () => harness.root,
+}));
+vi.mock("@/components/entity-terminology/use-entity-terminology", () => ({
+  useEntityTerminology: () => ({ map: () => ({}) }),
+}));
+vi.mock("../chat-ui", () => ({ focusAgentComposer: harness.focusComposer }));
+
+import { AgentStarterActions } from "../suggested-questions";
+
+let container: HTMLDivElement;
+let reactRoot: ReactRoot;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  reactRoot = createRoot(container);
+  harness.root = {
+    agentChatStore: {
+      counts: null,
+      enabled: true,
+      openWithDraft: harness.openWithDraft,
+    },
+    userStore: { can: () => true },
+  };
+});
+
+afterEach(() => {
+  act(() => reactRoot.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+describe("AgentStarterActions", () => {
+  it("opens Mate with the page-specific empty-state prompt", () => {
+    act(() => {
+      reactRoot.render(
+        createElement(AgentStarterActions, {
+          pageId: "contacts",
+          state: "empty",
+          surface: "page",
+        }),
+      );
+    });
+
+    const buttons = container.querySelectorAll("button");
+    expect(container.querySelector('[data-testid="empty-page-agent-suggestions"]')).not.toBeNull();
+    expect(buttons).toHaveLength(3);
+
+    act(() => buttons[0]?.click());
+
+    expect(harness.openWithDraft).toHaveBeenCalledWith(
+      "AgentChat.suggestions.pages.contacts.empty.setup-contacts.prompt",
+    );
+    expect(harness.focusComposer).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the manual action when Mate is unavailable", () => {
+    harness.root = {
+      agentChatStore: { counts: null, enabled: false },
+      userStore: { can: () => true },
+    };
+
+    act(() => {
+      reactRoot.render(
+        createElement(AgentStarterActions, {
+          fallback: createElement("button", null, "Manual add"),
+          pageId: "contacts",
+          state: "empty",
+          surface: "page",
+        }),
+      );
+    });
+
+    expect(container.textContent).toBe("Manual add");
+    expect(container.querySelector('[data-testid="empty-page-agent-suggestions"]')).toBeNull();
+  });
+
+  it("keeps the manual action when Mate is blocked", () => {
+    harness.root = {
+      agentChatStore: {
+        counts: null,
+        enabled: true,
+        openWithDraft: harness.openWithDraft,
+        usage: { blockedReason: "credits_exhausted" },
+      },
+      userStore: { can: () => true },
+    };
+
+    act(() => {
+      reactRoot.render(
+        createElement(AgentStarterActions, {
+          fallback: createElement("button", null, "Manual add"),
+          pageId: "contacts",
+          state: "empty",
+          surface: "page",
+        }),
+      );
+    });
+
+    expect(container.textContent).toBe("Manual add");
+    expect(harness.openWithDraft).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/agent-chat/agent-chat.store.ts
+++ b/app/components/agent-chat/agent-chat.store.ts
@@ -16,7 +16,6 @@ import {
   describeAgentTool,
   type AgentActivityDescriptor,
 } from "@/ee/agent-chat/agent-activity";
-import { agentPageState, agentActionPageFromPathname } from "@/ee/agent-chat/agent-page-actions";
 
 import { isDemoEnvironment, reportApplicationError } from "@/core/errors/report-application-error";
 
@@ -93,7 +92,7 @@ const UI_COMMAND_NAMES = ["navigate", "highlight_element", "start_tour", "click_
 const AGENT_CONFIG_LOAD_TIMEOUT_MS = 15000;
 const AGENT_STREAM_RECONNECT_DELAYS_MS = [250, 500, 1000, 2000, 5000] as const;
 const AGENT_CANCEL_RETRY_DELAYS_MS = [0, 500, 1500, 4000] as const;
-const AGENT_CHAT_OPEN_STORAGE_PREFIX = "customermates:agentChat:open:v1";
+const AGENT_CHAT_OPEN_STORAGE_PREFIX = "customermates:agentChat:open:v2";
 type UiCommandName = (typeof UI_COMMAND_NAMES)[number];
 export type AgentConfigLoadStatus = "ready" | "disabled" | "retry";
 
@@ -188,7 +187,6 @@ export class AgentChatStore extends BaseStore {
   routeRefreshRevision = 0;
   streamStatus: AgentStreamStatus = "idle";
   routeSyncStatus: AgentRouteSyncStatus = "idle";
-  autoOpenedPages = new Set<string>();
   isWorking = false;
   hasInSessionTerminalResult = false;
   private abortController: AbortController | null = null;
@@ -270,12 +268,12 @@ export class AgentChatStore extends BaseStore {
         canInterrupt: computed,
         hasPendingRouteReload: computed,
         open: action,
+        openWithDraft: action,
         close: action,
         toggle: action,
         toggleExpanded: action,
         setComposerDraft: action,
         submitDraft: action,
-        openForEmptyPage: action,
         editQueuedPrompt: action,
         removeQueuedPrompt: action,
         retryFailedTurn: action,
@@ -296,6 +294,12 @@ export class AgentChatStore extends BaseStore {
   open = () => {
     this.setOpenState(true);
     void this.loadConfig();
+  };
+
+  openWithDraft = (value: string) => {
+    this.isHistoryOpen = false;
+    this.composerDraft = value;
+    this.open();
   };
 
   get conversationTitle() {
@@ -401,28 +405,8 @@ export class AgentChatStore extends BaseStore {
     this.openStorageKey = storageKey;
     this.openPreference = readAgentChatOpenPreference(storageKey);
     this.isOpen = this.openOverride ?? this.openPreference === true;
-    this.autoOpenedPages.clear();
     this.demoAutoOpened = false;
   }
-
-  openForEmptyPage = (pathname: string) => {
-    this.syncOpenPreferenceScope();
-    if (
-      this.openOverride !== null ||
-      !this.enabled ||
-      this.isOpen ||
-      this.openPreference === false ||
-      this.autoOpenedPages.has(pathname)
-    )
-      return;
-    if (!this.counts) return;
-
-    const page = agentActionPageFromPathname(pathname);
-    if (!page || agentPageState(page, this.counts) !== "empty") return;
-
-    this.autoOpenedPages.add(pathname);
-    this.setOpenState(true);
-  };
 
   setComposerDraft = (value: string) => {
     this.composerDraft = value;
@@ -863,7 +847,6 @@ export class AgentChatStore extends BaseStore {
           this.historyRefreshError = false;
         }
       });
-      if (typeof window !== "undefined") this.openForEmptyPage(window.location.pathname);
       if (!this.conversationId && !this.isDraftConversationSelected && config.conversationId)
         await this.loadConversation(config.conversationId);
       if (

--- a/app/components/agent-chat/agent-chat.tsx
+++ b/app/components/agent-chat/agent-chat.tsx
@@ -73,10 +73,6 @@ export const AgentChat = observer(function AgentChat() {
   }, [pathname]);
 
   useEffect(() => {
-    store.openForEmptyPage(pathname);
-  }, [pathname, store, store.counts, store.enabled]);
-
-  useEffect(() => {
     agentUiControlStore.registerNavigate(async (path) => {
       const targetPathname = path.split("?")[0];
       if (pathnameRef.current === path) return "navigated";

--- a/app/components/agent-chat/suggested-questions.tsx
+++ b/app/components/agent-chat/suggested-questions.tsx
@@ -1,17 +1,21 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import { observer } from "mobx-react-lite";
 import { useLocale, useTranslations } from "next-intl";
 import { Compass, Link2, Plus, Search, Sparkles } from "lucide-react";
 import { Action, EntityType, Resource } from "@/generated/prisma";
 
-import { suggestionPageId } from "@/ee/agent-chat/agent-chat.schema";
+import { suggestionPageId, type SuggestionPageId } from "@/ee/agent-chat/agent-chat.schema";
 import { agentPageActions, agentPageState } from "@/ee/agent-chat/agent-page-actions";
 
 import { usePathname } from "@/i18n/navigation";
 import { useRootStore } from "@/core/stores/root-store.provider";
 import { Button } from "@/components/ui/button";
 import { useEntityTerminology } from "@/components/entity-terminology/use-entity-terminology";
+
+import { focusAgentComposer } from "./chat-ui";
 
 const SUGGESTION_ICONS = [
   { icon: Compass, match: /tour|explain|capabilities/ },
@@ -24,15 +28,33 @@ function suggestionIcon(id: string) {
   return SUGGESTION_ICONS.find((candidate) => candidate.match.test(id))?.icon ?? Sparkles;
 }
 
-export const SuggestedQuestions = observer(function SuggestedQuestions() {
+type Props = {
+  fallback?: ReactNode;
+  pageId?: SuggestionPageId;
+  state?: "data" | "empty";
+  surface?: "chat" | "page";
+};
+
+export const AgentStarterActions = observer(function AgentStarterActions({ fallback, ...props }: Props) {
+  const { agentChatStore: store, userStore } = useRootStore();
+  if (store?.enabled !== true || store.usage?.blockedReason || !userStore || (!props.state && !store.counts))
+    return fallback ?? null;
+
+  return <AvailableAgentStarterActions {...props} />;
+});
+
+const AvailableAgentStarterActions = observer(function AvailableAgentStarterActions({
+  pageId: explicitPageId,
+  state: explicitState,
+  surface = "chat",
+}: Omit<Props, "fallback">) {
   const { agentChatStore: store, userStore } = useRootStore();
   const { map } = useEntityTerminology();
   const t = useTranslations();
   const locale = useLocale();
   const pathname = usePathname();
-  if (!store.counts) return null;
 
-  const pageId = suggestionPageId(pathname);
+  const pageId = explicitPageId ?? suggestionPageId(pathname);
   const pageResource =
     pageId === "contacts"
       ? Resource.contacts
@@ -54,7 +76,13 @@ export const SuggestedQuestions = observer(function SuggestedQuestions() {
   const canCreate =
     pageId === "dashboard" ? canSetupWorkspace : Boolean(pageResource && userStore.can(pageResource, Action.create));
   const terminology = map();
-  const actions = agentPageActions(pageId, agentPageState(pageId, store.counts), t, locale, {
+  let state = explicitState;
+  if (!state) {
+    const counts = store.counts;
+    if (!counts) return null;
+    state = agentPageState(pageId, counts);
+  }
+  const actions = agentPageActions(pageId, state, t, locale, {
     canCreate,
     canSetupWorkspace,
     terminology: {
@@ -67,41 +95,47 @@ export const SuggestedQuestions = observer(function SuggestedQuestions() {
   });
 
   const choose = (prompt: string) => {
-    store.setComposerDraft(prompt);
-    requestAnimationFrame(() => {
-      const composer = document.getElementById("agent-composer") as HTMLTextAreaElement | null;
-      composer?.focus();
-      composer?.setSelectionRange(prompt.length, prompt.length);
-    });
+    store.openWithDraft(prompt);
+    focusAgentComposer();
   };
 
-  return (
+  const buttons = ([1, 2, 3] as const).map((index) => {
+    const action = actions[index - 1];
+    if (!action) return null;
+    const question = action.label;
+    const prompt = action.prompt;
+    const Icon = suggestionIcon(action.id);
+
+    return (
+      <Button
+        key={index}
+        className="h-auto gap-1.5 rounded-full px-3 py-2 text-xs font-normal whitespace-normal"
+        size="sm"
+        variant="secondary"
+        onClick={() => choose(prompt)}
+      >
+        <Icon aria-hidden="true" className="size-3.5" />
+
+        {question}
+      </Button>
+    );
+  });
+
+  return surface === "chat" ? (
     <div
       className="flex flex-wrap items-center justify-center gap-2"
       data-testid="agent-suggestions"
       id="agent-suggestions"
     >
-      {([1, 2, 3] as const).map((index) => {
-        const action = actions[index - 1];
-        if (!action) return null;
-        const question = action.label;
-        const prompt = action.prompt;
-        const Icon = suggestionIcon(action.id);
-
-        return (
-          <Button
-            key={index}
-            className="h-auto gap-1.5 rounded-full px-3 py-2 text-xs font-normal whitespace-normal"
-            size="sm"
-            variant="secondary"
-            onClick={() => choose(prompt)}
-          >
-            <Icon aria-hidden="true" className="size-3.5" />
-
-            {question}
-          </Button>
-        );
-      })}
+      {buttons}
+    </div>
+  ) : (
+    <div className="flex flex-wrap items-center justify-center gap-2" data-testid="empty-page-agent-suggestions">
+      {buttons}
     </div>
   );
 });
+
+export function SuggestedQuestions() {
+  return <AgentStarterActions />;
+}

--- a/components/data-view/data-view-empty.tsx
+++ b/components/data-view/data-view-empty.tsx
@@ -2,7 +2,7 @@
 
 import type { LucideIcon } from "lucide-react";
 import type { BaseDataViewStore, HasId } from "@/core/base/base-data-view.store";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import { Inbox } from "lucide-react";
 import { observer } from "mobx-react-lite";
@@ -23,6 +23,7 @@ export type EmptyStateDescriptor = {
 };
 
 type SharedProps<E extends HasId> = {
+  action?: ReactNode;
   store: BaseDataViewStore<E>;
   onAdd?: () => void;
   descriptor?: EmptyStateDescriptor;
@@ -45,6 +46,7 @@ export const DataViewEmpty = observer(function DataViewEmpty<E extends HasId>({
   reason,
   background,
   actionLabel,
+  action,
 }: Props<E>) {
   const t = useTranslations();
   const { singular, plural } = useEntityTerminology();
@@ -92,11 +94,12 @@ export const DataViewEmpty = observer(function DataViewEmpty<E extends HasId>({
   return (
     <PageState
       action={
-        canCreate ? (
+        action ??
+        (canCreate ? (
           <Button size="sm" variant="secondary" onClick={() => onAdd?.()}>
             {resolvedActionLabel}
           </Button>
-        ) : undefined
+        ) : undefined)
       }
       background={background}
       description={description}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ const domTestFiles = [
   "app/[locale]/(protected)/__tests__/protected-layout.test.ts",
   "app/components/agent-chat/__tests__/use-activity-group-state.test.ts",
   "app/components/agent-chat/__tests__/agent-route-reload.integration.test.ts",
+  "app/components/agent-chat/__tests__/suggested-questions.test.ts",
   "app/components/__tests__/shell-header.test.ts",
   "app/components/navigation/__tests__/navigation-switch.test.ts",
   "app/components/navigation/__tests__/public-navbar-menu.test.ts",


### PR DESCRIPTION
## Summary

- Replace the duplicated body CTA on empty Dashboard, Contacts, Organizations, Deals, Services, Tasks, Inbox, and Connected Accounts pages with localized Mate starter chips.
- Open Mate with the selected page-specific prompt prefilled and focused, without submitting it.
- Preserve each top-bar action and the existing manual CTA as a fallback when Mate is unavailable or disabled, and stop auto-opening Mate solely because a page is empty.

## Context

Empty pages repeated the same create/connect action already available in their top bar. The empty-state body is more useful as a set of contextual first actions that lead into Mate while leaving the user in control of submitting the prompt.

The authorized owner waived the ordinary Linear issue, claim, and status-transition gate for this bounded UI outcome. The consequence is that this change has no Linear execution record or issue linkage. The waiver does not alter review, verification, pull-request, preview, approval, or human-merge requirements. Evidence is recorded in this pull request's Validation section and required GitHub checks. Before merge, rollback is closing this pull request and deleting the unmerged branch; after merge, rollback is reverting the squash commit.

## Validation

- `yarn typecheck`
- `yarn lint`
- Full `yarn test` with `RUN_DATABASE_TESTS=true` against the disposable loopback database — 6,157 passed, 2 skipped
- `yarn vitest run tests/conventions` — 670 passed, 2 skipped
- Final targeted regression and convention verification — 127 passed
- `yarn build`
- Local browser verification on the disposable PostgreSQL sandbox: an empty Dashboard renders three contextual starters without auto-opening Mate; selecting “Set up my workspace” opens Mate, focuses the composer, and prefills the expected localized prompt without sending it.
- Independent read-only product review completed before the first push with no unresolved high- or medium-severity findings.

## Impact and rollback

This is a frontend-only behavior change with no schema, migration, API, environment-variable, or production-data impact. If Mate is unavailable or disabled, the existing manual empty-state CTA remains available. Revert the squash commit to restore the previous body CTA and empty-page auto-open behavior.

## Screenshots

The updated empty Dashboard and prefilled Mate interaction were visually verified in the local sandbox; no production or customer data was used.
