### PR TITLE
fix: harden production error paths

### DIFF
--- a/core/validation/validation.types.ts
+++ b/core/validation/validation.types.ts
@@ -32,6 +32,7 @@ export enum CustomErrorCode {
   emailLinkColourInvalid = "emailLinkColourInvalid",
   legalNoticeNotDelivered = "legalNoticeNotDelivered",
   termsNotAgreed = "termsNotAgreed",
+  privacyAcknowledgementRequired = "privacyAcknowledgementRequired",
   customColumnNotFound = "customColumnNotFound",
   customColumnIdNotFound = "customColumnIdNotFound",
   customColumnTypeMismatch = "customColumnTypeMismatch",

--- a/ee/messaging/ingest/reprocess-stuck-webhook-events.interactor.ts
+++ b/ee/messaging/ingest/reprocess-stuck-webhook-events.interactor.ts
@@ -1,11 +1,10 @@
-import type { WebhookEventRepo } from "../webhooks/webhook-event.repo";
+import { WEBHOOK_REPROCESS_MAX_ATTEMPTS, type WebhookEventRepo } from "../webhooks/webhook-event.repo";
 import type { ProcessUnipileWebhookInteractor } from "../webhooks/process-unipile-webhook.interactor";
 
 import { SystemInteractor } from "@/core/decorators/system-interactor.decorator";
 
 const REPROCESS_MIN_AGE_MS = 5 * 60 * 1000;
 const REPROCESS_MAX_AGE_DAYS = 30;
-const REPROCESS_MAX_ATTEMPTS = 10;
 const REPROCESS_BATCH_LIMIT = 500;
 
 @SystemInteractor
@@ -19,7 +18,7 @@ export class ReprocessStuckWebhookEventsInteractor {
     const ids = await this.repo.findReprocessableEventIdsUnscoped({
       olderThan: new Date(Date.now() - REPROCESS_MIN_AGE_MS),
       maxAgeDays: REPROCESS_MAX_AGE_DAYS,
-      maxAttempts: REPROCESS_MAX_ATTEMPTS,
+      maxAttempts: WEBHOOK_REPROCESS_MAX_ATTEMPTS,
       limit: REPROCESS_BATCH_LIMIT,
     });
 

--- a/ee/messaging/persistence/__tests__/webhook-retry-exhaustion.database.test.ts
+++ b/ee/messaging/persistence/__tests__/webhook-retry-exhaustion.database.test.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from "node:crypto";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { runWithoutTenant } from "@/core/decorators/tenant-context";
+import { getLocalDatabaseTestUrl } from "@/tests/helpers/database-test";
+import { PrismaUnipileWebhookRepo } from "../prisma-unipile-webhook.repository";
+import { WEBHOOK_INBOUND_SOURCE } from "../../webhooks/webhook-event.repo";
+
+const describeDatabase = getLocalDatabaseTestUrl() ? describe : describe.skip;
+const eventIds: string[] = [];
+
+const { prisma } = await import("@/prisma/db");
+
+afterAll(async () => {
+  await runWithoutTenant(() => prisma.messagingInboundEvent.deleteMany({ where: { id: { in: eventIds } } }));
+  await prisma.$disconnect();
+});
+
+describeDatabase("webhook retry exhaustion against a real database", () => {
+  it("returns distinct atomic attempt counts while preserving the retryable event", async () => {
+    const repo = new PrismaUnipileWebhookRepo();
+    const event = await repo.createWebhookEventUnscoped({
+      source: WEBHOOK_INBOUND_SOURCE,
+      payload: { type: "email.delete", account_id: `account-${randomUUID()}`, payload: {} },
+    });
+    eventIds.push(event.id);
+
+    const attempts = await Promise.all(
+      Array.from({ length: 11 }, () =>
+        repo.markWebhookEventFailedUnscoped({
+          id: event.id,
+          error: "retry later",
+          terminal: false,
+        }),
+      ),
+    );
+
+    expect(attempts.map(({ attemptCount }) => attemptCount).sort((left, right) => left - right)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    ]);
+    await expect(
+      runWithoutTenant(() =>
+        prisma.messagingInboundEvent.findUniqueOrThrow({
+          where: { id: event.id },
+          select: { attemptCount: true, error: true, processed: true, processedAt: true },
+        }),
+      ),
+    ).resolves.toEqual({
+      attemptCount: 11,
+      error: "retry later",
+      processed: false,
+      processedAt: null,
+    });
+  });
+});

--- a/ee/messaging/persistence/prisma-unipile-webhook.repository.ts
+++ b/ee/messaging/persistence/prisma-unipile-webhook.repository.ts
@@ -39,7 +39,7 @@ export class PrismaUnipileWebhookRepo extends BaseRepository implements WebhookE
 
   @BypassTenantGuard
   async markWebhookEventFailedUnscoped(args: RepoArgs<WebhookEventRepo, "markWebhookEventFailedUnscoped">) {
-    await this.prisma.messagingInboundEvent.update({
+    return this.prisma.messagingInboundEvent.update({
       where: { id: args.id },
       data: {
         processed: args.terminal,
@@ -49,6 +49,7 @@ export class PrismaUnipileWebhookRepo extends BaseRepository implements WebhookE
         attemptCount: { increment: 1 },
         ...(args.unipileMessageId != null ? { unipileMessageId: args.unipileMessageId } : {}),
       },
+      select: { attemptCount: true },
     });
   }
 

--- a/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
@@ -161,18 +161,29 @@ describe("ProcessEmailDeleteWebhookInteractor", () => {
     expect(eventService.publish).toHaveBeenCalledTimes(1);
   });
 
-  it("defers an unchanged row during a burst without calling Unipile", async () => {
+  it("defers an unchanged row during a burst, then reconciles it after the burst", async () => {
     vi.useFakeTimers();
-    const { interactor, ingest, eventService, messagingService } = build({ recentDeletes: 50 });
+    const { interactor, ingest, eventService, messagingService, events } = build({
+      recentDeletes: 50,
+      listEmails: () => Promise.resolve({ data: [relocatedEmail] }),
+    });
+    events.countRecentEmailDeletesUnscoped.mockResolvedValueOnce(50).mockResolvedValueOnce(1);
 
     const run = interactor.invoke(envelope).catch((err: unknown) => err);
     await vi.runAllTimersAsync();
     await expect(run).resolves.toBeInstanceOf(DeferredWebhookError);
-    vi.useRealTimers();
 
     expect(messagingService.listEmails).not.toHaveBeenCalled();
     expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
     expect(ingest.moveEmailMessageUnscoped).not.toHaveBeenCalled();
+    expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
+    expect(eventService.publish).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    await interactor.invoke(envelope);
+
+    expect(messagingService.listEmails).toHaveBeenCalledOnce();
+    expect(ingest.moveEmailMessageUnscoped).toHaveBeenCalledOnce();
     expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
     expect(eventService.publish).not.toHaveBeenCalled();
   });

--- a/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-email-delete-webhook.test.ts
@@ -161,56 +161,20 @@ describe("ProcessEmailDeleteWebhookInteractor", () => {
     expect(eventService.publish).toHaveBeenCalledTimes(1);
   });
 
-  it("still runs the single-call search during a burst and deletes a message that really went away", async () => {
+  it("defers an unchanged row during a burst without calling Unipile", async () => {
     vi.useFakeTimers();
     const { interactor, ingest, eventService, messagingService } = build({ recentDeletes: 50 });
-
-    const run = interactor.invoke(envelope);
-    await vi.runAllTimersAsync();
-    await run;
-    vi.useRealTimers();
-
-    expect(messagingService.listEmails).toHaveBeenCalledTimes(1);
-    expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
-    expect(ingest.deleteMessageUnscoped).toHaveBeenCalled();
-    expect(eventService.publish).toHaveBeenCalledTimes(1);
-  });
-
-  it("defers instead of destroying when a burst leaves the relocation unverifiable", async () => {
-    vi.useFakeTimers();
-    const { interactor, ingest, eventService, messagingService } = build({
-      recentDeletes: 50,
-      listEmails: () => Promise.reject(new UnipileRequestError(501, "api/not_implemented", "")),
-    });
 
     const run = interactor.invoke(envelope).catch((err: unknown) => err);
     await vi.runAllTimersAsync();
     await expect(run).resolves.toBeInstanceOf(DeferredWebhookError);
     vi.useRealTimers();
 
+    expect(messagingService.listEmails).not.toHaveBeenCalled();
     expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
     expect(ingest.moveEmailMessageUnscoped).not.toHaveBeenCalled();
     expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
     expect(eventService.publish).not.toHaveBeenCalled();
-  });
-
-  it("relocates during a burst when the single-call search finds the message", async () => {
-    vi.useFakeTimers();
-    const { interactor, ingest, messagingService } = build({
-      recentDeletes: 50,
-      listEmails: () => Promise.resolve({ data: [relocatedEmail] }),
-    });
-
-    const run = interactor.invoke(envelope);
-    await vi.runAllTimersAsync();
-    await run;
-    vi.useRealTimers();
-
-    expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
-    expect(ingest.moveEmailMessageUnscoped).toHaveBeenCalledWith(
-      expect.objectContaining({ newUnipileMessageId: "NEW_ID_ARCHIVE", folderIds: ["F_ARCHIVE"] }),
-    );
-    expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
   });
 
   it("does not destroy a row during a burst when the relocation adopted it under a new identifier", async () => {
@@ -226,6 +190,24 @@ describe("ProcessEmailDeleteWebhookInteractor", () => {
     expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
     expect(messagingService.listEmails).not.toHaveBeenCalled();
     expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
+  });
+
+  it("defers a burst row whose relocation cannot be correlated", async () => {
+    vi.useFakeTimers();
+    const { interactor, ingest, eventService, messagingService } = build({
+      existing: { ...existingRow, providerMessageId: null },
+      recentDeletes: 50,
+    });
+
+    const run = interactor.invoke(envelope).catch((err: unknown) => err);
+    await vi.runAllTimersAsync();
+    await expect(run).resolves.toBeInstanceOf(DeferredWebhookError);
+    vi.useRealTimers();
+
+    expect(messagingService.listEmails).not.toHaveBeenCalled();
+    expect(messagingService.listFolderEmails).not.toHaveBeenCalled();
+    expect(ingest.deleteMessageUnscoped).not.toHaveBeenCalled();
+    expect(eventService.publish).not.toHaveBeenCalled();
   });
 
   it("skips verification when the stored row has no rfc822 message id", async () => {

--- a/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
@@ -129,6 +129,27 @@ describe("ProcessUnipileWebhookInteractor classification", () => {
     );
   });
 
+  it.each([
+    [429, "api/too_many_requests"],
+    [500, "api/internal_error"],
+  ])("retries a known webhook provider failure (%i %s) without reporting it", async (status, errorType) => {
+    const providerError = new UnipileRequestError(status, errorType, '{"detail":"retry later"}');
+    const handler = { invoke: vi.fn().mockRejectedValue(providerError) };
+    const { interactor, events } = build(row({ type: "email.folder.update", account_id: "acc_1", payload: {} }), {
+      "email.folder.update": handler,
+    });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledWith({
+      id: EVENT_ID,
+      error: providerError.message,
+      terminal: false,
+    });
+    expect(events.markWebhookEventProcessedUnscoped).not.toHaveBeenCalled();
+  });
+
   it("still reports an unrelated Unipile rejection", async () => {
     const serverError = new UnipileRequestError(500, "api/unknown", '{"detail":"boom"}');
     const handler = { invoke: vi.fn().mockRejectedValue(serverError) };
@@ -139,6 +160,25 @@ describe("ProcessUnipileWebhookInteractor classification", () => {
     await invoke(interactor);
 
     expect(Sentry.captureException).toHaveBeenCalledOnce();
+  });
+
+  it("still reports an unrelated error with a 429-shaped status", async () => {
+    const unrelated = Object.assign(new Error("another dependency returned 429"), { status: 429 });
+    const handler = { invoke: vi.fn().mockRejectedValue(unrelated) };
+    const { interactor, events } = build(row({ type: "email.folder.update", account_id: "acc_1", payload: {} }), {
+      "email.folder.update": handler,
+    });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(unrelated, {
+      tags: { webhookEventId: EVENT_ID, eventType: "email.folder.update" },
+    });
+    expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledWith({
+      id: EVENT_ID,
+      error: unrelated.message,
+      terminal: false,
+    });
   });
 
   it("marks a transient handler error non-terminal, captures it once, and does not rethrow", async () => {

--- a/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
+++ b/ee/messaging/webhooks/__tests__/process-unipile-webhook.test.ts
@@ -29,7 +29,7 @@ function build(row: unknown, handlers: Record<string, { invoke: ReturnType<typeo
   const events = {
     findWebhookEventByIdOrThrowUnscoped: vi.fn().mockResolvedValue(row),
     markWebhookEventProcessedUnscoped: vi.fn().mockResolvedValue(undefined),
-    markWebhookEventFailedUnscoped: vi.fn().mockResolvedValue(undefined),
+    markWebhookEventFailedUnscoped: vi.fn().mockResolvedValue({ attemptCount: 1 }),
   };
   const interactor = new ProcessUnipileWebhookInteractor(events as any, handlers as any);
 
@@ -148,6 +148,75 @@ describe("ProcessUnipileWebhookInteractor classification", () => {
       terminal: false,
     });
     expect(events.markWebhookEventProcessedUnscoped).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [429, "api/too_many_requests"],
+    [500, "api/internal_error"],
+  ])("reports an exhausted known provider failure once (%i %s)", async (status, errorType) => {
+    const providerError = new UnipileRequestError(status, errorType, '{"detail":"retry later"}');
+    const handler = { invoke: vi.fn().mockRejectedValue(providerError) };
+    const { interactor, events } = build(row({ type: "email.folder.update", account_id: "acc_1", payload: {} }), {
+      "email.folder.update": handler,
+    });
+    events.markWebhookEventFailedUnscoped.mockResolvedValue({ attemptCount: 10 });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(providerError, {
+      tags: {
+        eventType: "email.folder.update",
+        webhookEventId: EVENT_ID,
+        webhookRetryExhausted: "true",
+      },
+    });
+    expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledWith({
+      id: EVENT_ID,
+      error: providerError.message,
+      terminal: false,
+    });
+    expect(events.markWebhookEventProcessedUnscoped).not.toHaveBeenCalled();
+  });
+
+  it("does not report an exhausted provider failure again after another concurrent increment", async () => {
+    const providerError = new UnipileRequestError(429, "api/too_many_requests", '{"detail":"retry later"}');
+    const handler = { invoke: vi.fn().mockRejectedValue(providerError) };
+    const { interactor, events } = build(row({ type: "email.folder.update", account_id: "acc_1", payload: {} }), {
+      "email.folder.update": handler,
+    });
+    events.markWebhookEventFailedUnscoped
+      .mockResolvedValueOnce({ attemptCount: 10 })
+      .mockResolvedValueOnce({ attemptCount: 11 });
+
+    await Promise.all([invoke(interactor), invoke(interactor)]);
+
+    expect(events.markWebhookEventFailedUnscoped).toHaveBeenCalledTimes(2);
+    expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(providerError, {
+      tags: {
+        eventType: "email.folder.update",
+        webhookEventId: EVENT_ID,
+        webhookRetryExhausted: "true",
+      },
+    });
+  });
+
+  it("reports an exhausted deferred webhook once", async () => {
+    const deferred = new DeferredWebhookError("burst");
+    const handler = { invoke: vi.fn().mockRejectedValue(deferred) };
+    const { interactor, events } = build(row({ type: "email.delete", account_id: "acc_1", payload: {} }), {
+      "email.delete": handler,
+    });
+    events.markWebhookEventFailedUnscoped.mockResolvedValue({ attemptCount: 10 });
+
+    await invoke(interactor);
+
+    expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(deferred, {
+      tags: {
+        eventType: "email.delete",
+        webhookEventId: EVENT_ID,
+        webhookRetryExhausted: "true",
+      },
+    });
   });
 
   it("still reports an unrelated Unipile rejection", async () => {

--- a/ee/messaging/webhooks/email/process-email-delete-webhook.interactor.ts
+++ b/ee/messaging/webhooks/email/process-email-delete-webhook.interactor.ts
@@ -151,7 +151,7 @@ export class ProcessEmailDeleteWebhookInteractor {
     envelope: Payload,
     burst: boolean,
   ): Promise<Relocation> {
-    if (!providerMessageId) return { status: "absent" };
+    if (!providerMessageId) return { status: burst ? "unsearchable" : "absent" };
 
     const folders = parseFolderCatalog(account.folders);
     const originFolderId = envelope.payload.folder_id ?? null;
@@ -186,6 +186,8 @@ export class ProcessEmailDeleteWebhookInteractor {
     const after = new Date(sentAt.getTime() - SEARCH_WINDOW_MS).toISOString();
     const before = new Date(sentAt.getTime() + SEARCH_WINDOW_MS).toISOString();
 
+    if (burst) return null;
+
     try {
       const page = await this.messagingService.listEmails({
         accountId: unipileAccountId,
@@ -199,8 +201,6 @@ export class ProcessEmailDeleteWebhookInteractor {
     } catch (err) {
       if (getUnipileStatus(err) !== 501) throw err;
     }
-
-    if (burst) return null;
 
     const candidates: Candidate[] = [];
     for (const folder of folders) {

--- a/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
+++ b/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
@@ -9,7 +9,12 @@ import type { UnipileWebhookEnvelope } from "../unipile.schema";
 
 import { UnipileWebhookEnvelopeSchema } from "../unipile.schema";
 import { DeferredWebhookError, UnmappableWebhookPayloadError } from "@/core/errors/app-errors";
-import { isUnipileDisconnectedAccount, isUnipileProviderUnprocessable, isUnipileTimeout } from "../messaging.service";
+import {
+  isUnipileDisconnectedAccount,
+  isUnipileProviderUnprocessable,
+  isUnipileTimeout,
+  UnipileRequestError,
+} from "../messaging.service";
 
 export type UnipileWebhookHandlerMap = Partial<
   Record<string, { invoke(envelope: UnipileWebhookEnvelope): Promise<void> }>
@@ -17,6 +22,13 @@ export type UnipileWebhookHandlerMap = Partial<
 
 const Schema = z.object({ id: z.uuid() });
 type ProcessUnipileWebhookPayload = z.infer<typeof Schema>;
+
+function isRetryableUnipileWebhookError(err: unknown): boolean {
+  return (
+    err instanceof UnipileRequestError &&
+    (err.status === 429 || (err.status === 500 && err.errorType === "api/internal_error"))
+  );
+}
 
 @SystemInteractor
 export class ProcessUnipileWebhookInteractor {
@@ -81,8 +93,12 @@ export class ProcessUnipileWebhookInteractor {
         return;
       }
 
-      if (isUnipileTimeout(err) || isUnipileProviderUnprocessable(err)) {
-        await this.events.markWebhookEventFailedUnscoped({ id, error: err.message, terminal: false });
+      if (isUnipileTimeout(err) || isUnipileProviderUnprocessable(err) || isRetryableUnipileWebhookError(err)) {
+        await this.events.markWebhookEventFailedUnscoped({
+          id,
+          error: err instanceof Error ? err.message : String(err),
+          terminal: false,
+        });
 
         return;
       }

--- a/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
+++ b/ee/messaging/webhooks/process-unipile-webhook.interactor.ts
@@ -4,7 +4,7 @@ import { Enforce } from "@/core/decorators/enforce.decorator";
 import { z } from "zod";
 import * as Sentry from "@sentry/node";
 
-import type { WebhookEventRepo } from "./webhook-event.repo";
+import { WEBHOOK_REPROCESS_MAX_ATTEMPTS, type WebhookEventRepo } from "./webhook-event.repo";
 import type { UnipileWebhookEnvelope } from "../unipile.schema";
 
 import { UnipileWebhookEnvelopeSchema } from "../unipile.schema";
@@ -82,7 +82,7 @@ export class ProcessUnipileWebhookInteractor {
       }
 
       if (err instanceof DeferredWebhookError) {
-        await this.events.markWebhookEventFailedUnscoped({ id, error: err.message, terminal: false });
+        await this.markRetryableFailure({ id, eventType: envelope.type, err });
 
         return;
       }
@@ -94,11 +94,7 @@ export class ProcessUnipileWebhookInteractor {
       }
 
       if (isUnipileTimeout(err) || isUnipileProviderUnprocessable(err) || isRetryableUnipileWebhookError(err)) {
-        await this.events.markWebhookEventFailedUnscoped({
-          id,
-          error: err instanceof Error ? err.message : String(err),
-          terminal: false,
-        });
+        await this.markRetryableFailure({ id, eventType: envelope.type, err });
 
         return;
       }
@@ -110,5 +106,22 @@ export class ProcessUnipileWebhookInteractor {
         terminal: err instanceof z.ZodError,
       });
     }
+  }
+
+  private async markRetryableFailure(args: { id: string; eventType: string; err: unknown }): Promise<void> {
+    const result = await this.events.markWebhookEventFailedUnscoped({
+      id: args.id,
+      error: args.err instanceof Error ? args.err.message : String(args.err),
+      terminal: false,
+    });
+    if (result.attemptCount !== WEBHOOK_REPROCESS_MAX_ATTEMPTS) return;
+
+    Sentry.captureException(args.err, {
+      tags: {
+        eventType: args.eventType,
+        webhookEventId: args.id,
+        webhookRetryExhausted: "true",
+      },
+    });
   }
 }

--- a/ee/messaging/webhooks/webhook-event.repo.ts
+++ b/ee/messaging/webhooks/webhook-event.repo.ts
@@ -1,6 +1,7 @@
 import { type MessagingInboundEvent, MessagingInboundEventSource } from "@/generated/prisma";
 
 export const WEBHOOK_INBOUND_SOURCE = MessagingInboundEventSource.webhook;
+export const WEBHOOK_REPROCESS_MAX_ATTEMPTS = 10;
 
 type InboundEventRow = Pick<MessagingInboundEvent, "id" | "payload" | "processed">;
 
@@ -16,7 +17,7 @@ export abstract class WebhookEventRepo {
     error: string;
     terminal: boolean;
     unipileMessageId?: string | null;
-  }): Promise<void>;
+  }): Promise<Pick<MessagingInboundEvent, "attemptCount">>;
   abstract findReprocessableEventIdsUnscoped(args: {
     olderThan: Date;
     maxAgeDays: number;

--- a/ee/operator/__tests__/operator-workspace-delete.transaction.test.ts
+++ b/ee/operator/__tests__/operator-workspace-delete.transaction.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MOCK_ENV_MODULE } from "@/tests/helpers/interactor-test-setup";
+
+const prismaMock = vi.hoisted(() => {
+  const transactionClient = {
+    $executeRaw: vi.fn().mockResolvedValue(0),
+    company: { findUnique: vi.fn().mockResolvedValue(null) },
+    auditLog: { createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    webhookDelivery: { createMany: vi.fn().mockResolvedValue({ count: 0 }) },
+  };
+
+  return {
+    transactionClient,
+    prisma: {
+      $transaction: vi.fn(
+        async (
+          callback: (tx: typeof transactionClient) => Promise<unknown>,
+          _options?: { timeout?: number; maxWait?: number },
+        ) => callback(transactionClient),
+      ),
+    },
+  };
+});
+
+vi.mock("@/env", () => MOCK_ENV_MODULE);
+vi.mock("@/prisma/db", () => ({ prisma: prismaMock.prisma }));
+
+import { runWithOperator } from "@/core/decorators/operator-context";
+
+import { PrismaOperatorRepo } from "../prisma-operator.repository";
+
+describe("PrismaOperatorRepo workspace deletion transaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.transactionClient.company.findUnique.mockResolvedValue(null);
+  });
+
+  it("uses the bulk-write budget and locks the target workspace before reading it", async () => {
+    const companyId = "00000000-0000-4000-8000-000000000001";
+
+    await expect(
+      runWithOperator(
+        {
+          authUserId: "operator-auth-user",
+          userId: "operator-user",
+          companyId: "00000000-0000-4000-8000-000000000002",
+          email: "operator@example.invalid",
+        },
+        () =>
+          new PrismaOperatorRepo().deleteWorkspaceUnscoped({
+            companyId,
+            confirmWorkspaceLabel: "workspace.invalid",
+            reason: "Local transaction contract test",
+          }),
+      ),
+    ).resolves.toBe("notFound");
+
+    expect(prismaMock.prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 30_000,
+      maxWait: 10_000,
+    });
+    expect(prismaMock.transactionClient.$executeRaw).toHaveBeenCalledWith(expect.any(Array), companyId);
+    expect(prismaMock.transactionClient.$executeRaw).toHaveBeenCalledBefore(
+      prismaMock.transactionClient.company.findUnique,
+    );
+  });
+});

--- a/ee/operator/prisma-operator.repository.ts
+++ b/ee/operator/prisma-operator.repository.ts
@@ -4,6 +4,7 @@ import { ConnectedAccountStatus, Status, SubscriptionPlan, SubscriptionStatus, T
 import { BaseRepository } from "@/core/base/base-repository";
 import { BypassTenantGuard } from "@/core/decorators/bypass-tenant.decorator";
 import { getOperatorActor } from "@/core/decorators/operator-context";
+import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator";
 import { runInTransaction } from "@/core/decorators/transaction-runner";
 import { AGENT_CREDIT_MICROCENTS, resolveAgentCreditEntitlement } from "@/ee/agent-chat/agent-credit-policy";
 import { env } from "@/env";
@@ -1129,7 +1130,7 @@ export class PrismaOperatorRepo extends BaseRepository implements OperatorRepo {
           deletedAuthIdentityCount: identityIds.length,
         };
       },
-      { companyId: data.companyId },
+      { ...BULK_WRITE_TRANSACTION, companyId: data.companyId },
     );
   }
 

--- a/features/contact/send-contact-inquiry.schema.ts
+++ b/features/contact/send-contact-inquiry.schema.ts
@@ -2,12 +2,16 @@ import type { Data } from "@/core/validation/validation.utils";
 
 import { z } from "zod";
 
+import { CustomErrorCode } from "@/core/validation/validation.types";
+
 export const SendContactInquirySchema = z.object({
   name: z.string().trim().min(1),
   email: z.email(),
   company: z.string().trim().max(200).optional(),
   message: z.string().trim().min(10).max(5000),
-  privacyAcknowledged: z.boolean().refine((value) => value),
+  privacyAcknowledged: z
+    .boolean()
+    .refine((value) => value, { params: { error: CustomErrorCode.privacyAcknowledgementRequired } }),
 });
 
 export type SendContactInquiryData = Data<typeof SendContactInquirySchema>;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1022,6 +1022,7 @@
       "passwordInvalid": "Das Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Zahl und ein Sonderzeichen enthalten.",
       "passwordMismatch": "Passwörter müssen übereinstimmen.",
       "permissionDenied": "Diese Aktion ist mit deinen aktuellen Berechtigungen nicht verfügbar.",
+      "privacyAcknowledgementRequired": "Bitte bestätigen Sie, dass Sie die Datenschutzerklärung gelesen haben.",
       "relationNotAllowed": "Die Beziehung '{relation}' ist für {entity} nicht erlaubt. Erlaubte Beziehungen: {allowed}.",
       "roleAssignedCannotDelete": "Eine Nutzern zugewiesene Rolle kann nicht gelöscht werden.",
       "roleNotFound": "Rollen-ID nicht gefunden oder nicht zugänglich.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1022,6 +1022,7 @@
       "passwordInvalid": "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character.",
       "passwordMismatch": "Passwords must match.",
       "permissionDenied": "This action is not available with your current permissions.",
+      "privacyAcknowledgementRequired": "Please confirm that you have read the Privacy Policy.",
       "relationNotAllowed": "Relation '{relation}' is not allowed on {entity}. Allowed relations: {allowed}.",
       "roleAssignedCannotDelete": "A role assigned to users cannot be deleted.",
       "roleNotFound": "Role ID not found or not accessible.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1022,6 +1022,7 @@
       "passwordInvalid": "La contraseña debe tener al menos 8 caracteres e incluir al menos una mayúscula, una minúscula, un número y un carácter especial.",
       "passwordMismatch": "Las contraseñas deben coincidir.",
       "permissionDenied": "Esta acción no está disponible con tus permisos actuales.",
+      "privacyAcknowledgementRequired": "Confirma que has leído la Política de privacidad.",
       "relationNotAllowed": "La relación '{relation}' no está permitida en {entity}. Relaciones permitidas: {allowed}.",
       "roleAssignedCannotDelete": "No se puede eliminar un rol asignado a usuarios.",
       "roleNotFound": "ID de rol no encontrado o no accesible.",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1022,6 +1022,7 @@
       "passwordInvalid": "Le mot de passe doit comporter au moins 8 caractères et contenir au moins une majuscule, une minuscule, un chiffre et un caractère spécial.",
       "passwordMismatch": "Les mots de passe doivent correspondre.",
       "permissionDenied": "Cette action n’est pas disponible avec vos autorisations actuelles.",
+      "privacyAcknowledgementRequired": "Veuillez confirmer que vous avez lu la politique de confidentialité.",
       "relationNotAllowed": "La relation '{relation}' n'est pas autorisée sur {entity}. Relations autorisées : {allowed}.",
       "roleAssignedCannotDelete": "Un rôle attribué à des utilisateurs ne peut pas être supprimé.",
       "roleNotFound": "ID de rôle introuvable ou inaccessible.",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1022,6 +1022,7 @@
       "passwordInvalid": "La password deve contenere almeno 8 caratteri e includere almeno una lettera maiuscola, una minuscola, un numero e un carattere speciale.",
       "passwordMismatch": "Le password devono coincidere.",
       "permissionDenied": "Questa azione non è disponibile con le tue autorizzazioni attuali.",
+      "privacyAcknowledgementRequired": "Conferma di aver letto l’Informativa sulla privacy.",
       "relationNotAllowed": "La relazione '{relation}' non è consentita su {entity}. Relazioni consentite: {allowed}.",
       "roleAssignedCannotDelete": "Un ruolo assegnato agli utenti non può essere eliminato.",
       "roleNotFound": "ID ruolo non trovato o non accessibile.",

--- a/tests/conventions/contact-privacy-contract.test.ts
+++ b/tests/conventions/contact-privacy-contract.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 
 import { SendContactInquirySchema } from "@/features/contact/send-contact-inquiry.schema";
 import { REGISTERED_LOCALES } from "@/i18n/locale-registry";
+import { createErrorHandler } from "@/core/validation/validation.utils";
+import { CustomErrorCode } from "@/core/validation/validation.types";
 import { REPO_ROOT } from "./walk";
 
 const validInquiry = {
@@ -20,12 +22,28 @@ function source(path: string) {
 
 describe("contact privacy acknowledgement", () => {
   it("requires acknowledgement at the server validation boundary", () => {
-    expect(
-      SendContactInquirySchema.safeParse({
+    const rejected = SendContactInquirySchema.safeParse(
+      {
         ...validInquiry,
         privacyAcknowledged: false,
-      }).success,
-    ).toBe(false);
+      },
+      {
+        error: createErrorHandler({
+          [CustomErrorCode.privacyAcknowledgementRequired]: "Privacy acknowledgement is required",
+        }),
+      },
+    );
+
+    expect(rejected.success).toBe(false);
+    if (!rejected.success)
+      expect(rejected.error.issues).toEqual([
+        expect.objectContaining({
+          code: "custom",
+          message: "Privacy acknowledgement is required",
+          params: { error: CustomErrorCode.privacyAcknowledgementRequired },
+          path: ["privacyAcknowledged"],
+        }),
+      ]);
     expect(
       SendContactInquirySchema.safeParse({
         ...validInquiry,

--- a/tests/conventions/operator-access-boundary.test.ts
+++ b/tests/conventions/operator-access-boundary.test.ts
@@ -89,6 +89,15 @@ describe("operator access boundary", () => {
     }
   });
 
+  it("gives destructive workspace deletion the bulk-write transaction budget", () => {
+    const repository = read("ee/operator/prisma-operator.repository.ts");
+    const deletion =
+      /async deleteWorkspaceUnscoped\([\s\S]*?\n  \}\n\n  @BypassTenantGuard/u.exec(repository)?.[0] ?? "";
+
+    expect(repository).toContain('import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator"');
+    expect(deletion).toContain("{ ...BULK_WRITE_TRANSACTION, companyId: data.companyId }");
+  });
+
   it("counts operator groups through the guarded Unscoped counts and never through prisma directly", () => {
     const listRepositories = [
       "ee/operator/prisma-operator-users.repository.ts",

--- a/tests/conventions/operator-access-boundary.test.ts
+++ b/tests/conventions/operator-access-boundary.test.ts
@@ -89,15 +89,6 @@ describe("operator access boundary", () => {
     }
   });
 
-  it("gives destructive workspace deletion the bulk-write transaction budget", () => {
-    const repository = read("ee/operator/prisma-operator.repository.ts");
-    const deletion =
-      /async deleteWorkspaceUnscoped\([\s\S]*?\n  \}\n\n  @BypassTenantGuard/u.exec(repository)?.[0] ?? "";
-
-    expect(repository).toContain('import { BULK_WRITE_TRANSACTION } from "@/core/decorators/transaction.decorator"');
-    expect(deletion).toContain("{ ...BULK_WRITE_TRANSACTION, companyId: data.companyId }");
-  });
-
   it("counts operator groups through the guarded Unscoped counts and never through prisma directly", () => {
     const listRepositories = [
       "ee/operator/prisma-operator-users.repository.ts",


### PR DESCRIPTION
## Summary

- Defer ambiguous email-delete burst events before calling the provider, preserving adopted rows until durable retry can reconcile them.
- Treat only exact retryable Unipile webhook failures (429 and `500 api/internal_error`) as durable retries, suppress intermediate noise, and emit one Sentry event when the tenth attempt exhausts.
- Give operator workspace deletion the existing bulk-write transaction budget while keeping the operation atomic.
- Return a dedicated, localized privacy-acknowledgement validation error from the contact form.

## Context

Tracks [CUS-328](https://linear.app/customermates/issue/CUS-328/harden-actionable-production-sentry-error-paths) and addresses Sentry groups CUSTOMERMATES-67, CUSTOMERMATES-5K, CUSTOMERMATES-42, CUSTOMERMATES-66, and CUSTOMERMATES-5P. CUSTOMERMATES-J is the client mirror of the same failed workspace-deletion request as CUSTOMERMATES-66, so this change keeps that client signal intact for correlation. It intentionally does not add broad client, transport, or browser-error suppression.

PR #145 also edits `core/validation/validation.types.ts`; this PR adds one enum value there, which is the only file overlap.

## Validation

- `yarn lint`
- `yarn typecheck`
- `RUN_DATABASE_TESTS=true yarn test` — 683 files passed, 1 skipped; 6,169 tests passed, 2 skipped
- `yarn build`
- Focused durable verification — 52 relevant tests passed, including the full operator-deletion database suite
- Real local PostgreSQL 17 retry test — 11 concurrent failure writes returned every atomic attempt count from 1 through 11; the row remained retryable with its error intact
- Real local PostgreSQL 17 timeout A/B — the same workspace with 1,000 child rows was blocked on its exact company advisory lock in both runs. The former 5,000 ms budget failed atomically after 5,532 ms with all data retained and no audit; the real current path succeeded after 5,642 ms with all target rows removed and exactly one audit
- Local browser E2E on `/de/contact` — unchecked privacy submission returned HTTP 200 with the exact German field and toast message, no Next.js error dialog, and no console errors
- Fresh Vercel preview for `ec2e879a` — `/de/contact` returned HTTP 200 and contained the expected German heading and privacy text
- Fresh GitHub checks — CI, PostgreSQL 16, rendered-page E2E, CodeQL, repository policy, and Vercel all passed
- Independent webhook, operator, and holistic reviews; no unresolved findings remain

## Impact and rollback

No schema or data migration. Webhook events remain durable and nonterminal for the existing hourly reprocessor; intermediate expected failures stay quiet, while final retry exhaustion is reported once. Workspace deletion remains atomic, and ordinary non-burst email deletions retain their existing behavior. Roll back by reverting this PR.
